### PR TITLE
fix(graph-node): translate renamed inputs/outputs in map_over execution

### DIFF
--- a/src/hypergraph/nodes/graph_node.py
+++ b/src/hypergraph/nodes/graph_node.py
@@ -3,6 +3,7 @@
 from typing import Any, Literal, TYPE_CHECKING, TypeVar
 
 from hypergraph.nodes.base import HyperNode, RenameEntry
+from hypergraph.nodes._rename import build_reverse_rename_map
 
 # TypeVar for self-referential return types (Python 3.10 compatible)
 _GN = TypeVar("_GN", bound="GraphNode")
@@ -231,6 +232,56 @@ class GraphNode(HyperNode):
             if entry.kind == "inputs" and entry.new == current:
                 current = entry.old
         return current
+
+    def map_inputs_to_params(self, inputs: dict[str, Any]) -> dict[str, Any]:
+        """Map renamed input names back to original inner graph parameter names.
+
+        When a GraphNode's inputs are renamed (via with_inputs), this method
+        maps the current/renamed names back to the original parameter names
+        expected by the inner graph.
+
+        Args:
+            inputs: Dict with current (potentially renamed) input names as keys
+
+        Returns:
+            Dict with original inner graph parameter names as keys
+        """
+        reverse_map = build_reverse_rename_map(self._rename_history, "inputs")
+        if not reverse_map:
+            return inputs
+
+        return {reverse_map.get(key, key): value for key, value in inputs.items()}
+
+    def _original_map_params(self) -> list[str] | None:
+        """Get map_over params translated to original inner graph names.
+
+        Returns:
+            List of original param names if map_over is set, else None.
+        """
+        if self._map_over is None:
+            return None
+        return [self._resolve_original_input_name(p) for p in self._map_over]
+
+    def map_outputs_from_original(self, outputs: dict[str, Any]) -> dict[str, Any]:
+        """Map original inner graph output names to renamed external names.
+
+        When a GraphNode's outputs are renamed (via with_outputs), this method
+        maps the original names produced by the inner graph to the renamed names
+        expected by the outer graph.
+
+        Args:
+            outputs: Dict with original inner graph output names as keys
+
+        Returns:
+            Dict with renamed (external) output names as keys
+        """
+        reverse_map = build_reverse_rename_map(self._rename_history, "outputs")
+        if not reverse_map:
+            return outputs
+
+        # Build forward map (original -> renamed) by inverting reverse map
+        forward_map = {v: k for k, v in reverse_map.items()}
+        return {forward_map.get(key, key): value for key, value in outputs.items()}
 
     def has_default_for(self, param: str) -> bool:
         """Check if a parameter has a default or bound value in the inner graph.

--- a/src/hypergraph/nodes/graph_node.py
+++ b/src/hypergraph/nodes/graph_node.py
@@ -255,12 +255,19 @@ class GraphNode(HyperNode):
     def _original_map_params(self) -> list[str] | None:
         """Get map_over params translated to original inner graph names.
 
+        Uses build_reverse_rename_map() to handle parallel renames correctly
+        (e.g., with_inputs(x='y', y='x')), matching the semantics of
+        map_inputs_to_params().
+
         Returns:
             List of original param names if map_over is set, else None.
         """
         if self._map_over is None:
             return None
-        return [self._resolve_original_input_name(p) for p in self._map_over]
+        reverse_map = build_reverse_rename_map(self._rename_history, "inputs")
+        if not reverse_map:
+            return list(self._map_over)
+        return [reverse_map.get(p, p) for p in self._map_over]
 
     def map_outputs_from_original(self, outputs: dict[str, Any]) -> dict[str, Any]:
         """Map original inner graph output names to renamed external names.

--- a/src/hypergraph/runners/sync/executors/graph_node.py
+++ b/src/hypergraph/runners/sync/executors/graph_node.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from hypergraph.runners._shared.helpers import map_inputs_to_func_params
 from hypergraph.runners._shared.types import RunResult, RunStatus
 
 if TYPE_CHECKING:
@@ -44,14 +45,21 @@ class SyncGraphNodeExecutor:
         Returns:
             Dict mapping output names to their values
         """
+        # Translate renamed input keys back to original inner graph names
+        inner_inputs = map_inputs_to_func_params(node, inputs)
+
         map_config = node.map_config
 
         if map_config:
-            params, mode = map_config
-            results = self.runner.map(node.graph, inputs, map_over=params, map_mode=mode)
-            return self._collect_as_lists(results, node.outputs)
+            _, mode = map_config
+            # Use original param names for map_over (inner graph expects these)
+            original_params = node._original_map_params()
+            results = self.runner.map(
+                node.graph, inner_inputs, map_over=original_params, map_mode=mode
+            )
+            return self._collect_as_lists(results, node)
 
-        result = self.runner.run(node.graph, inputs)
+        result = self.runner.run(node.graph, inner_inputs)
         if result.status == RunStatus.FAILED:
             raise result.error or RuntimeError("Nested graph execution failed")
         return result.values
@@ -59,22 +67,27 @@ class SyncGraphNodeExecutor:
     def _collect_as_lists(
         self,
         results: list[RunResult],
-        outputs: tuple[str, ...],
+        node: "GraphNode",
     ) -> dict[str, list]:
         """Collect multiple RunResults into lists per output.
 
+        Handles output name translation: inner graph produces original names,
+        but we need to return renamed names to match the GraphNode's interface.
+
         Args:
             results: List of RunResult from runner.map()
-            outputs: Output names to collect
+            node: The GraphNode (used for output name translation)
 
         Returns:
-            Dict mapping output names to lists of values
+            Dict mapping renamed output names to lists of values
         """
-        collected: dict[str, list] = {name: [] for name in outputs}
+        collected: dict[str, list] = {name: [] for name in node.outputs}
         for result in results:
             if result.status == RunStatus.FAILED:
                 raise result.error or RuntimeError("Nested graph execution failed")
-            for name in outputs:
-                if name in result.values:
-                    collected[name].append(result.values[name])
+            # Translate original output names to renamed names
+            renamed_values = node.map_outputs_from_original(result.values)
+            for name in node.outputs:
+                if name in renamed_values:
+                    collected[name].append(renamed_values[name])
         return collected


### PR DESCRIPTION
## Summary
- **Fixes bug** where `map_over()` failed when combined with `with_inputs()` rename on GraphNode
- Inner graph expected original param names but received renamed names, causing `None` outputs
- Adds input/output name translation in GraphNode executors

## The Bug
When a GraphNode used both rename and map_over:
```python
inner = Graph([process_item], name="inner")  # expects "item"
mapped = inner.as_node().with_inputs(item="items").map_over("items")
outer = Graph([produce_items, mapped])  # produce_items outputs "items"
```
Result: Warning about "internal parameters", `items = None`, `results = None`

## The Fix
- Add `map_inputs_to_params()` to GraphNode (mirrors FunctionNode)
- Add `map_outputs_from_original()` for output name translation
- Add `_original_map_params()` helper for map_over param translation  
- Update both Sync and Async executors to translate names before/after inner graph execution

## Test plan
- [x] Added 6 new tests in `TestMapOverRenameExecution` class
- [x] All 865 tests pass (859 original + 6 new)
- [x] Verified fix with reproduction script

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * map_over now correctly handles renamed input and output parameters across graph execution, translating names between external and inner-graph representations and preserving behavior in both sync and async runners; output collection reflects renamed outputs.

* **Tests**
  * Added a comprehensive test suite validating map_over with renamed inputs/outputs, including sync/async paths, chained renames, broadcasting, zip/product modes, and concurrency scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->