### PR TITLE
feat: allow same output names in mutually exclusive branches

### DIFF
--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -142,81 +142,46 @@ class Graph:
             result[node.name] = node
         return result
 
-    def _build_graph(self, nodes: list[HyperNode]) -> nx.DiGraph:
-        """Build NetworkX DiGraph from nodes with edge inference."""
-        G = nx.DiGraph()
-        output_to_source = self._create_output_source_mapping(nodes)
-        self._add_nodes_to_graph(G, nodes)
-        self._add_data_edges(G, nodes, output_to_source)
-        self._add_control_edges(G, nodes)
-        return G
+    def _collect_output_sources(self, nodes: list[HyperNode]) -> dict[str, list[str]]:
+        """Collect all nodes that produce each output name.
 
-    def _create_output_source_mapping(
-        self, nodes: list[HyperNode]
-    ) -> dict[str, str]:
-        """Map each output name to its source node name.
-
-        Multiple nodes can produce the same output if they are in mutex paths
-        controlled by a gate with multi_target=False.
+        Returns a mapping from output name to list of node names that produce it.
+        Used for detecting duplicate outputs before validating mutex exclusivity.
         """
-        from hypergraph.nodes.gate import GateNode, RouteNode
-
-        # First pass: find which nodes are mutex via gate control
-        mutex_groups = self._find_mutex_output_groups(nodes)
-
-        result: dict[str, str] = {}
-        output_sources: dict[str, list[str]] = {}  # output -> [node_names]
-
+        output_sources: dict[str, list[str]] = {}
         for node in nodes:
             for output in node.outputs:
                 output_sources.setdefault(output, []).append(node.name)
+        return output_sources
 
-        for output, sources in output_sources.items():
-            if len(sources) == 1:
-                result[output] = sources[0]
-            elif self._are_all_mutex(sources, mutex_groups):
-                # All sources are mutually exclusive - pick first for edge building
-                result[output] = sources[0]
-            else:
-                raise GraphConfigError(
-                    f"Multiple nodes produce '{output}'\n\n"
-                    f"  -> {sources[0]} creates '{output}'\n"
-                    f"  -> {sources[1]} creates '{output}'\n\n"
-                    f"How to fix: Rename one output to avoid conflict"
-                )
-        return result
+    def _build_graph(self, nodes: list[HyperNode]) -> nx.DiGraph:
+        """Build NetworkX DiGraph from nodes with edge inference.
 
-    def _find_mutex_output_groups(
-        self, nodes: list[HyperNode]
-    ) -> list[set[str]]:
-        """Find groups of nodes that are mutually exclusive via gate control.
+        Process:
+        1. Add nodes to graph
+        2. Collect all output sources (allowing duplicates temporarily)
+        3. Build edges using first source for each output
+        4. Add control edges
+        5. Validate output conflicts with full graph structure (using reachability)
 
-        Nodes in the same group are mutex if they are targets of a gate
-        with multi_target=False (RouteNode) or always-exclusive (IfElseNode).
+        This ordering allows mutex branch detection using graph reachability analysis.
         """
-        from hypergraph.nodes.gate import RouteNode, IfElseNode, END
+        G = nx.DiGraph()
+        self._add_nodes_to_graph(G, nodes)
 
-        mutex_groups: list[set[str]] = []
+        # Collect all output sources (allowing duplicates temporarily)
+        output_to_sources = self._collect_output_sources(nodes)
 
-        for node in nodes:
-            # RouteNode with multi_target=False: targets are mutually exclusive
-            if isinstance(node, RouteNode) and not node.multi_target:
-                targets = {
-                    t for t in node.targets
-                    if t is not END and isinstance(t, str)
-                }
-                if len(targets) >= 2:
-                    mutex_groups.append(targets)
-            # IfElseNode: targets are always mutually exclusive (binary gate)
-            elif isinstance(node, IfElseNode):
-                targets = {
-                    t for t in node.targets
-                    if t is not END and isinstance(t, str)
-                }
-                if len(targets) >= 2:
-                    mutex_groups.append(targets)
+        # Use first source for each output when building edges
+        output_to_source = {k: v[0] for k, v in output_to_sources.items()}
+        self._add_data_edges(G, nodes, output_to_source)
+        self._add_control_edges(G, nodes)
 
-        return mutex_groups
+        # Validate output conflicts with full graph structure
+        # This allows mutex branch detection using reachability analysis
+        self._validate_output_conflicts(G, nodes, output_to_sources)
+
+        return G
 
     def _are_all_mutex(
         self, node_names: list[str], mutex_groups: list[set[str]]
@@ -231,6 +196,118 @@ class Graph:
             if node_set <= group:  # All nodes are in this group
                 return True
         return False
+
+    def _compute_exclusive_reachability(
+        self, G: nx.DiGraph, targets: list[str]
+    ) -> dict[str, set[str]]:
+        """For each target, find nodes reachable ONLY through that target.
+
+        This is used to expand mutex groups to include downstream nodes.
+        A node is "exclusively reachable" from target T if:
+        - It is reachable from T (via graph edges)
+        - It is NOT reachable from any other target
+
+        Args:
+            G: The NetworkX directed graph
+            targets: List of gate target node names
+
+        Returns:
+            Mapping from target name to set of exclusively reachable node names
+        """
+        # Get all reachable nodes from each target (including the target itself)
+        reachable: dict[str, set[str]] = {
+            t: set(nx.descendants(G, t)) | {t} for t in targets
+        }
+
+        # For each target, exclude nodes reachable from other targets
+        exclusive: dict[str, set[str]] = {}
+        for t in targets:
+            others = set().union(*(reachable[o] for o in targets if o != t))
+            exclusive[t] = reachable[t] - others
+
+        return exclusive
+
+    def _expand_mutex_groups(
+        self, G: nx.DiGraph, nodes: list[HyperNode]
+    ) -> list[set[str]]:
+        """Expand mutex groups to include downstream exclusive nodes.
+
+        For each gate with mutually exclusive targets (RouteNode with multi_target=False
+        or IfElseNode), this expands the mutex relationship to include all nodes
+        that are exclusively reachable through each target.
+
+        Two nodes are considered mutex if they are in different exclusive branches
+        of the same gate - meaning they can never both execute in the same run.
+
+        Args:
+            G: The NetworkX directed graph (with edges already added)
+            nodes: List of all nodes in the graph
+
+        Returns:
+            List of mutex groups, where each group contains node names that are
+            mutually exclusive with each other.
+        """
+        from hypergraph.nodes.gate import RouteNode, IfElseNode, END
+
+        expanded_groups: list[set[str]] = []
+
+        for node in nodes:
+            # Only process gates with mutex targets
+            if isinstance(node, RouteNode):
+                if node.multi_target:
+                    continue  # multi_target means branches can run together
+            elif not isinstance(node, IfElseNode):
+                continue  # Not a gate node
+
+            # Get real targets (filter out END sentinel)
+            targets = [t for t in node.targets if t is not END and isinstance(t, str)]
+            if len(targets) < 2:
+                continue  # Need at least 2 targets for mutex relationship
+
+            # Compute exclusively reachable nodes for each target
+            exclusive_sets = self._compute_exclusive_reachability(G, targets)
+
+            # Create expanded mutex group from union of all exclusive sets
+            # Nodes from different exclusive sets are mutex with each other
+            expanded_groups.append(set().union(*exclusive_sets.values()))
+
+        return expanded_groups
+
+    def _validate_output_conflicts(
+        self, G: nx.DiGraph, nodes: list[HyperNode], output_to_sources: dict[str, list[str]]
+    ) -> None:
+        """Validate that duplicate outputs are in mutually exclusive branches.
+
+        This is called after the graph structure is built (edges added) so we can
+        use graph reachability to determine if nodes producing the same output
+        are in mutex branches.
+
+        Args:
+            G: The NetworkX directed graph (with edges)
+            nodes: List of all nodes in the graph
+            output_to_sources: Mapping from output name to list of nodes producing it
+
+        Raises:
+            GraphConfigError: If multiple nodes produce the same output and they
+                are not in mutually exclusive branches.
+        """
+        # Get expanded mutex groups (includes downstream nodes)
+        expanded_groups = self._expand_mutex_groups(G, nodes)
+
+        for output, sources in output_to_sources.items():
+            if len(sources) <= 1:
+                continue  # No conflict possible
+
+            if self._are_all_mutex(sources, expanded_groups):
+                continue  # All sources are mutually exclusive - OK
+
+            # Not all sources are mutex - this is an error
+            raise GraphConfigError(
+                f"Multiple nodes produce '{output}'\n\n"
+                f"  -> {sources[0]} creates '{output}'\n"
+                f"  -> {sources[1]} creates '{output}'\n\n"
+                f"How to fix: Rename one output to avoid conflict"
+            )
 
     def _add_nodes_to_graph(self, G: nx.DiGraph, nodes: list[HyperNode]) -> None:
         """Add all nodes with their attributes to the graph."""
@@ -375,7 +452,7 @@ class Graph:
     def _validate(self) -> None:
         """Run all build-time validations."""
         # Note: Duplicate node names caught in _build_nodes_dict()
-        # Note: Duplicate outputs caught in _create_output_source_mapping()
+        # Note: Duplicate outputs caught in _validate_output_conflicts()
         validate_graph(self._nodes, self._nx_graph, self.name, self._strict_types)
 
     def as_node(self, *, name: str | None = None) -> "GraphNode":

--- a/tests/test_runners/test_routing.py
+++ b/tests/test_runners/test_routing.py
@@ -631,3 +631,142 @@ class TestControlEdges:
         # Check that there's only one edge (the data edge from start)
         edges_to_end = list(graph._nx_graph.in_edges("end_node", data=True))
         assert len(edges_to_end) >= 1  # At least the data edge from start
+
+
+# =============================================================================
+# Mutex Branch Outputs Tests
+# =============================================================================
+
+
+class TestMutexBranchOutputs:
+    """Tests for same output names in mutex branches."""
+
+    def test_ifelse_downstream_same_output_allowed(self):
+        """Downstream nodes in different ifelse branches can share output names."""
+        from hypergraph.nodes.gate import ifelse
+
+        @ifelse(when_true="skip", when_false="process_start")
+        def check(x: int) -> bool:
+            return x == 0
+
+        @node(output_name="result")
+        def skip(x: int) -> str:
+            return "skipped"
+
+        @node(output_name="intermediate")
+        def process_start(x: int) -> int:
+            return x * 2
+
+        @node(output_name="result")  # Same as skip!
+        def process_end(intermediate: int) -> str:
+            return f"processed: {intermediate}"
+
+        # This should NOT raise - branches are mutually exclusive
+        graph = Graph([check, skip, process_start, process_end])
+
+        # Test true branch (x == 0)
+        result = SyncRunner().run(graph, {"x": 0})
+        assert result.status == RunStatus.COMPLETED
+        assert result["result"] == "skipped"
+
+        # Test false branch (x != 0)
+        result = SyncRunner().run(graph, {"x": 5})
+        assert result.status == RunStatus.COMPLETED
+        assert result["result"] == "processed: 10"
+
+    def test_route_downstream_same_output_allowed(self):
+        """Downstream nodes in different route branches can share output names."""
+
+        @node(output_name="a")
+        def start(x: int) -> int:
+            return x
+
+        @route(targets=["path_a_start", "path_b_start"])
+        def decide(a: int) -> str:
+            return "path_a_start" if a > 0 else "path_b_start"
+
+        @node(output_name="intermediate_a")
+        def path_a_start(a: int) -> int:
+            return a * 2
+
+        @node(output_name="result")  # Same output name
+        def path_a_end(intermediate_a: int) -> str:
+            return f"path_a: {intermediate_a}"
+
+        @node(output_name="intermediate_b")
+        def path_b_start(a: int) -> int:
+            return a * -1
+
+        @node(output_name="result")  # Same output name!
+        def path_b_end(intermediate_b: int) -> str:
+            return f"path_b: {intermediate_b}"
+
+        # Should NOT raise
+        graph = Graph([start, decide, path_a_start, path_a_end, path_b_start, path_b_end])
+
+        # Test path A
+        result = SyncRunner().run(graph, {"x": 5})
+        assert result.status == RunStatus.COMPLETED
+        assert result["result"] == "path_a: 10"
+
+        # Test path B
+        result = SyncRunner().run(graph, {"x": -3})
+        assert result.status == RunStatus.COMPLETED
+        assert result["result"] == "path_b: 3"
+
+    def test_multi_target_downstream_same_output_rejected(self):
+        """multi_target=True with downstream same outputs should fail."""
+
+        @route(targets=["path_a", "path_b"], multi_target=True)
+        def decide(x: int) -> list:
+            return ["path_a", "path_b"]
+
+        @node(output_name="intermediate_a")
+        def path_a(x: int) -> int:
+            return x * 2
+
+        @node(output_name="result")
+        def end_a(intermediate_a: int) -> str:
+            return "a"
+
+        @node(output_name="intermediate_b")
+        def path_b(x: int) -> int:
+            return x * 3
+
+        @node(output_name="result")  # Same as end_a - should fail!
+        def end_b(intermediate_b: int) -> str:
+            return "b"
+
+        # Should raise because multi_target=True means both can run
+        with pytest.raises(GraphConfigError, match="Multiple nodes produce"):
+            Graph([decide, path_a, end_a, path_b, end_b])
+
+    def test_diamond_merge_node_cannot_share_output(self):
+        """A node reachable from both branches cannot share output with branch-exclusive nodes."""
+
+        @route(targets=["path_a", "path_b"])
+        def decide(x: int) -> str:
+            return "path_a" if x > 0 else "path_b"
+
+        @node(output_name="from_a")
+        def path_a(x: int) -> int:
+            return x * 2
+
+        @node(output_name="from_b")
+        def path_b(x: int) -> int:
+            return x * 3
+
+        # merge is reachable from BOTH branches
+        @node(output_name="result")
+        def merge(from_a: int, from_b: int) -> int:
+            return from_a + from_b
+
+        # another_result is also on path_a branch
+        @node(output_name="result")  # Same as merge - but merge is shared!
+        def another_result(from_a: int) -> int:
+            return from_a
+
+        # This should fail because merge is reachable from both branches
+        # so it's not exclusively in path_a's mutex group
+        with pytest.raises(GraphConfigError, match="Multiple nodes produce"):
+            Graph([decide, path_a, path_b, merge, another_result])


### PR DESCRIPTION
## Summary

- Enable nodes in different branches of `@ifelse` or `@route` gates to produce the same output name
- Previously failed with `GraphConfigError: Multiple nodes produce 'X'` even when branches are mutually exclusive
- Now validates using graph reachability analysis to detect exclusive branches

## Problem

When using `@ifelse` or `@route` with mutually exclusive branches, downstream nodes in different branches couldn't produce the same output name:

```python
@ifelse(when_true="skip_existing", when_false="load_file")
def document_exists(...) -> bool: ...

@node(output_name="index_result")  # Branch 1 endpoint
def skip_existing(...): ...

# Branch 2: load_file → ... → index_to_vector_store
@node(output_name="index_result")  # Branch 2 endpoint - PREVIOUSLY FAILED!
def index_to_vector_store(...): ...
```

## Solution

Use graph reachability analysis to determine if nodes are in mutually exclusive branches:

1. **Build graph structure first** (nodes + edges)
2. **Compute exclusive reachability** - for each gate target, find nodes reachable *only* through that target
3. **Expand mutex groups** to include all exclusively reachable downstream nodes
4. **Validate conflicts** using expanded mutex groups

### Algorithm

```
For gate with targets [A, B]:
  reachable[A] = {A} ∪ descendants(A)
  reachable[B] = {B} ∪ descendants(B)
  
  exclusive[A] = reachable[A] - reachable[B]  # Nodes only reachable through A
  exclusive[B] = reachable[B] - reachable[A]  # Nodes only reachable through B
  
  Nodes in exclusive[A] are mutex with nodes in exclusive[B]
```

## Changes

| File | Changes |
|------|---------|
| `src/hypergraph/graph/core.py` | Added 4 methods, restructured `_build_graph()`, removed 2 obsolete methods |
| `tests/test_runners/test_routing.py` | Added `TestMutexBranchOutputs` class with 4 tests |

### New Methods

- `_collect_output_sources()` - Collects all nodes producing each output
- `_compute_exclusive_reachability()` - Finds nodes reachable only through each gate target
- `_expand_mutex_groups()` - Expands mutex groups to include downstream exclusive nodes
- `_validate_output_conflicts()` - Validates duplicates using expanded mutex groups

## Test plan

- [x] All existing tests pass (31 routing tests, 140 graph tests)
- [x] New tests for mutex branch outputs:
  - `test_ifelse_downstream_same_output_allowed` - Downstream nodes in ifelse branches can share outputs
  - `test_route_downstream_same_output_allowed` - Downstream nodes in route branches can share outputs
  - `test_multi_target_downstream_same_output_rejected` - multi_target=True correctly rejects
  - `test_diamond_merge_node_cannot_share_output` - Shared merge nodes correctly rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of invalid duplicate outputs so only truly mutually exclusive branches may share output names; same-branch duplicates now raise errors.

* **Refactor**
  * Reworked graph build and validation order to use reachability-based mutex checks for more accurate edge and conflict handling.

* **Tests**
  * Added tests covering mutex/branch output semantics, including same-branch duplicate rejection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->