### PR TITLE
⚡ Optimize mutex reachability calculation

### DIFF
--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import networkx as nx
+from collections import Counter
 from typing import Any, TYPE_CHECKING
 
 from hypergraph.nodes.base import HyperNode
@@ -232,11 +233,18 @@ class Graph:
             t: set(nx.descendants(G, t)) | {t} for t in targets
         }
 
-        # For each target, exclude nodes reachable from other targets
+        # Count how many targets can reach each node
+        # Optimization: Instead of N^2 set operations, count node occurrences
+        # A node is exclusive to a target if it appears exactly once across all reachable sets
+        all_reachable_nodes = [node for nodes in reachable.values() for node in nodes]
+        node_counts = Counter(all_reachable_nodes)
+
+        # For each target, select nodes that are only reachable from this target (count == 1)
         exclusive: dict[str, set[str]] = {}
         for t in targets:
-            others = set().union(*(reachable[o] for o in targets if o != t))
-            exclusive[t] = reachable[t] - others
+            exclusive[t] = {
+                node for node in reachable[t] if node_counts[node] == 1
+            }
 
         return exclusive
 


### PR DESCRIPTION
Optimized the `_compute_exclusive_reachability` method in `src/hypergraph/graph/core.py`.
The previous implementation calculated the union of all other targets' reachable nodes for every target, resulting in quadratic complexity.
The new implementation counts the frequency of each reachable node across all targets. Nodes with a frequency of 1 are exclusive to their respective target.
This change significantly improves performance for graphs with many branches/targets, achieving linear scaling.

---
*PR created automatically by Jules for task [2486426376316467134](https://jules.google.com/task/2486426376316467134) started by @gilad-rubin*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced the algorithm for determining node relationships in graph structures, resulting in more efficient processing of target path analysis.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->