### PR TITLE
fix: address 6 red-team findings

### DIFF
--- a/docs/red-team/consolidated_red_team.md
+++ b/docs/red-team/consolidated_red_team.md
@@ -1,0 +1,289 @@
+# Consolidated Red-Team Findings
+
+> **Sources**: Jules ([PR #18](https://github.com/gilad-rubin/hypergraph/pull/18)), Gemini (`red_team_gemini.md`), Codex (`new_codex.md`), AMP subfolder (`How to Red-Team a Codebase for Potential Issues/`)
+>
+> **Test files**: `test_critical_flaws.py`, `codex_tests_might_not_fail.py`, subfolder `test_red_team*.py`, `test_nodes_gate.py`, `test_routing.py`
+>
+> **Resolution PR**: [#25](https://github.com/gilad-rubin/hypergraph/pull/25) — fixes #1, #2, #4, #6, #9, #11
+
+---
+
+## Status Summary
+
+| # | Issue | Severity | Status |
+|---|-------|----------|--------|
+| 1 | Mutable defaults shared | CRITICAL | ✅ **RESOLVED** in PR #25 |
+| 2 | Cycle off-by-one | HIGH | ✅ **RESOLVED** in PR #25 |
+| 3 | Runtime type checking | MEDIUM-HIGH | ⏸️ **DEFERRED** — by design |
+| 4 | Intermediate injection | HIGH | ✅ **RESOLVED** in PR #25 |
+| 5 | Disconnected nodes | HIGH | ⏸️ **DEFERRED** — design decision |
+| 6 | Rename collision | MEDIUM | ✅ **RESOLVED** in PR #25 |
+| 7 | Invalid gate target | MEDIUM | ✅ **ALREADY FIXED** — validation exists |
+| 8 | Mutex branch outputs | MEDIUM | ✅ **ALREADY FIXED** — in PR #8 |
+| 9 | Control-only cycles | MEDIUM | ✅ **RESOLVED** in PR #25 |
+| 10 | Deep nesting loops | HIGH | 🔴 **OPEN** — needs investigation |
+| 11 | Rename propagation | MEDIUM | ✅ **RESOLVED** in PR #25 |
+| 12 | kwargs detection | LOW | ⏸️ **DEFERRED** — low priority |
+
+---
+
+## ✅ RESOLVED Issues
+
+### 1. Mutable Default Arguments Shared Across Runs
+
+| | |
+|---|---|
+| **Severity** | CRITICAL |
+| **Status** | ✅ **RESOLVED** in [PR #25](https://github.com/gilad-rubin/hypergraph/pull/25) |
+| **Sources** | Jules PR #18 (B1), Gemini (V1), Codex (issue 7) |
+| **Tests** | `tests/test_red_team_fixes.py::TestMutableDefaults` |
+
+**Problem**: A node with a mutable default (list, dict) reuses the same object across runs.
+
+**Fix**: Added `copy.deepcopy()` in `_resolve_input()` at `helpers.py:210` when returning function defaults.
+
+---
+
+### 2. Cycle Termination Off-by-One
+
+| | |
+|---|---|
+| **Severity** | HIGH |
+| **Status** | ✅ **RESOLVED** in [PR #25](https://github.com/gilad-rubin/hypergraph/pull/25) |
+| **Sources** | Jules PR #18 (B2), Gemini (CYCLE-1) |
+| **Tests** | `tests/test_red_team_fixes.py::TestCycleTermination` |
+
+**Problem**: A loop governed by a `@route` gate executes one extra iteration after returning `END`.
+
+**Fix**: Added `_clear_stale_gate_decisions()` helper in `helpers.py:50-64` that removes routing decisions for gates about to re-execute, preventing old decisions from prematurely activating targets.
+
+---
+
+### 4. Intermediate Value Injection Doesn't Work
+
+| | |
+|---|---|
+| **Severity** | HIGH |
+| **Status** | ✅ **RESOLVED** in [PR #25](https://github.com/gilad-rubin/hypergraph/pull/25) |
+| **Sources** | Jules PR #18 (D3), Gemini (INT-1), Codex (issue 2) |
+| **Tests** | `tests/test_red_team_fixes.py::TestIntermediateInjection` |
+
+**Problem**: Providing an intermediate output value failed with `MissingInputError` for upstream inputs.
+
+**Fix**: Added `_find_bypassed_inputs()` in `validation.py:189-222` to identify inputs exclusively needed by nodes whose outputs are user-provided, excluding them from required validation.
+
+---
+
+### 6. Rename Collision Silently Allowed
+
+| | |
+|---|---|
+| **Severity** | MEDIUM |
+| **Status** | ✅ **RESOLVED** in [PR #25](https://github.com/gilad-rubin/hypergraph/pull/25) |
+| **Sources** | Codex (issue 5), AMP subfolder (RN-005) |
+| **Tests** | `tests/test_red_team_fixes.py::TestRenameCollision` |
+
+**Problem**: Renaming two outputs to the same name didn't raise an error.
+
+**Fix**: Added `_check_rename_duplicates()` helper in `base.py:314-322` that raises `RenameError` when `with_inputs()`/`with_outputs()` would create duplicate names.
+
+---
+
+### 7. Gate Returning Invalid Target Not Caught at Runtime
+
+| | |
+|---|---|
+| **Severity** | MEDIUM |
+| **Status** | ✅ **ALREADY FIXED** — validation exists |
+| **Sources** | AMP subfolder (GT-003) |
+
+**Investigation**: Runtime validation already exists in `routing_validation.py:76-88`. The `_validate_single_target` function checks if a target is in `node.targets` and raises `ValueError` if not. Both sync and async route executors call `validate_routing_decision()`.
+
+The red-team report was based on an older version of the codebase.
+
+---
+
+### 8. Mutex Branch-Local Consumers — Validation False Positive
+
+| | |
+|---|---|
+| **Severity** | MEDIUM |
+| **Status** | ✅ **ALREADY FIXED** in [PR #8](https://github.com/gilad-rubin/hypergraph/pull/8) |
+| **Sources** | Jules PR #18 (G4), AMP subfolder (G4, G4c, GN-005) |
+| **Tests** | `tests/test_runners/test_routing.py::TestMutexBranchOutputs` |
+
+**Investigation**: The `feat/mutex-branch-outputs` branch was merged. Implementation in `core.py` includes:
+- `_collect_output_sources` — gathers all nodes producing each output
+- `_expand_mutex_groups` — identifies gate nodes and computes exclusive reachability
+- `_are_all_mutex` — checks that duplicate-output producers fall in different branches
+- `_validate_output_conflicts` — only errors if producers are NOT mutually exclusive
+
+---
+
+### 9. Control-Only Cycles Incorrectly Require Seed Inputs
+
+| | |
+|---|---|
+| **Severity** | MEDIUM |
+| **Status** | ✅ **RESOLVED** in [PR #25](https://github.com/gilad-rubin/hypergraph/pull/25) |
+| **Sources** | Codex (issue 4) |
+| **Tests** | `tests/test_red_team_fixes.py::TestControlOnlyCycles` |
+
+**Problem**: Cycle detection included control edges, marking parameters as "seeds" even when only control (not data) flowed back.
+
+**Fix**: Added `_data_only_subgraph()` helper in `input_spec.py:167-178` that filters to data edges before running `nx.simple_cycles()`.
+
+---
+
+### 11. Output Rename Propagation Failure
+
+| | |
+|---|---|
+| **Severity** | MEDIUM |
+| **Status** | ✅ **RESOLVED** in [PR #25](https://github.com/gilad-rubin/hypergraph/pull/25) |
+| **Sources** | AMP subfolder (RN-006, RN-007, R6) |
+| **Tests** | `tests/test_red_team_fixes.py::TestOutputRenamePropagation` |
+
+**Problem**: `with_outputs()` on a GraphNode didn't translate inner output names to renamed external names in the non-map execution path.
+
+**Fix**: Changed `return result.values` to `return node.map_outputs_from_original(result.values)` in both:
+- `runners/sync/executors/graph_node.py:65`
+- `runners/async_/executors/graph_node.py:71`
+
+---
+
+## 🔴 OPEN Issues — Needs Investigation
+
+### 10. Deep Nesting / Multiple GraphNodes — Infinite Loops
+
+| | |
+|---|---|
+| **Severity** | HIGH |
+| **Status** | 🔴 **OPEN** — needs investigation |
+| **Sources** | AMP subfolder (GN-001, GN-003, SM-007, GN-008) |
+
+Several nesting scenarios cause `InfiniteLoopError` or hang:
+- 4+ level nested graphs
+- Two `GraphNode` instances from the same inner graph in one outer graph
+- A node whose output has the same name as its input (staleness loop)
+- A `GraphNode` with the same name as another node in the outer graph
+
+**Investigation notes**:
+- The planning agent hit API overload errors before completing analysis
+- Likely related to staleness detection not properly handling nested graph boundaries
+- May require changes to how `node_executions` tracks GraphNode execution vs inner node execution
+- Consider adding tests with `--timeout=10` to catch hangs early
+
+**Next steps**:
+1. Write isolated failing tests for each scenario
+2. Add tracing/logging to staleness detection during nested execution
+3. Investigate if `GraphState.copy()` needs deeper isolation for nested runs
+
+---
+
+## ⏸️ DEFERRED Issues — By Design or Low Priority
+
+### 3. Runtime Inputs Not Type-Checked (`strict_types`)
+
+| | |
+|---|---|
+| **Severity** | MEDIUM-HIGH |
+| **Status** | ⏸️ **DEFERRED** — by design |
+| **Sources** | Jules PR #18 (B3), Gemini (T1), Codex (issue 6) |
+
+**Problem**: `strict_types=True` only validates node-to-node edges at build time. Values passed via `runner.run()` are never checked.
+
+**Why deferred**:
+- Adding runtime type checking would add overhead to every run
+- Could use `beartype` or similar for opt-in runtime validation
+- Current behavior matches many frameworks (types as documentation, not enforcement)
+
+**Future consideration**: Add an optional `validate_inputs=True` parameter to `runner.run()`.
+
+---
+
+### 5. Disconnected / Unreachable Nodes Force All Inputs
+
+| | |
+|---|---|
+| **Severity** | HIGH |
+| **Status** | ⏸️ **DEFERRED** — design decision |
+| **Sources** | Jules PR #18 (D1, D2), Gemini (SPLIT-1, UNR-1), Codex (issue 3) |
+
+**Problem**: The runner demands inputs for every node, even if unreachable from provided inputs.
+
+**Why deferred**:
+- This is arguably correct behavior: a graph should be self-contained
+- "Library graph" pattern is unusual and could be achieved with separate graphs
+- Computing reachability at runtime adds complexity and overhead
+- Would need to define "reachable from" semantics clearly
+
+**Future consideration**: Add a `select_subgraph(outputs=[...])` method to extract runnable subgraphs.
+
+---
+
+### 12. `**kwargs` Not Detected as Graph Inputs
+
+| | |
+|---|---|
+| **Severity** | LOW |
+| **Status** | ⏸️ **DEFERRED** — low priority |
+| **Sources** | Jules PR #18 (D4) |
+
+**Problem**: Nodes using `**kwargs` can't receive extra inputs via the graph.
+
+**Why deferred**:
+- Relatively rare use case
+- Workaround: use explicit parameters or a dict parameter
+- Would require significant changes to input spec computation
+
+---
+
+## Confirmed Working (Not Bugs)
+
+| Area | Detail |
+|---|---|
+| Async parallel execution | `AsyncRunner` correctly runs independent async nodes concurrently |
+| Mixed sync/async | `AsyncRunner` handles both sync and async nodes in one graph |
+| Rename swap | `with_inputs(a='b', b='a')` swaps atomically |
+| Chained renames | `with_inputs(x='y').with_inputs(y='z')` composes correctly |
+| Union type compatibility | `int` → `int \| str` passes `strict_types` |
+| State isolation between runs | Basic state (non-mutable-default) is isolated |
+| Duplicate node name detection | Caught at build time |
+
+---
+
+## Ideas & Meta: How to Red-Team in the Future
+
+### What Worked
+
+| Technique | Why it helped |
+|---|---|
+| **`xfail(strict=True)` tests** | Creates a "living spec" of known bugs. As bugs are fixed, tests auto-transition from xfail to passing — no manual cleanup. |
+| **Outside-in examples** | Starting from user-visible failures (not implementation details) keeps findings grounded in real usage. |
+| **Cross-framework research** | Mining GitHub issues from LangGraph, Pydantic-Graph, Mastra for keywords like "routing", "seed", "cycle" revealed common failure patterns to probe. |
+| **Systematic ID schemes** | Prefixed IDs (B1, D2, GT-003, RN-005) make issues trackable across documents and conversations. |
+| **Iterative deepening** | When V1 (mutable defaults) was confirmed, follow-up probes V1a (dict), V1b (nested mutable), V1e (class instance) tested variants. |
+
+### What to Add Next
+
+| Technique | Description |
+|---|---|
+| **Property-based testing** | Use Hypothesis to generate random graph topologies, rename sequences, and input values. Verify properties: termination, type safety, state isolation, determinism. |
+| **Mutation testing** | Run `mutmut` or `cosmic-ray` on validation, rename mapping, and gate decision logic to verify tests catch real mutations. |
+| **Capability matrix expansion** | Add dimensions to `tests/capabilities/matrix.py`: routing type (none/route/ifelse/nested), reachability (connected/disconnected/gated-off), defaults (immutable/mutable), output collisions. |
+| **Differential testing** | Implement the same workflow in hypergraph and a competing framework — compare edge-case behavior. |
+| **Fuzzing inputs** | Test with `None`, empty collections, very large values, unicode, nested structures at graph boundaries. |
+| **Concurrency stress** | Run many parallel executions with random delays to expose race conditions in shared state. |
+
+### File Index
+
+| File | Description |
+|---|---|
+| `jules_red_team.md` | Points to [PR #18](https://github.com/gilad-rubin/hypergraph/pull/18) — 3 confirmed bugs, 3 design flaws, test suites |
+| `red_team_gemini.md` | Gemini findings — 6 confirmed, 2 not reproduced |
+| `new_codex.md` | Codex red-team plan — 7 hypotheses with suggested tests |
+| `test_critical_flaws.py` | 8 tests covering the core issues (mutable defaults, types, cycles, splits, intermediates, mutex) |
+| `codex_tests_might_not_fail.py` | 3 exploratory tests (input override, disconnected subgraph, rename collision) |
+| `How to Red-Team…/*.md` | AMP multi-phase reports — 218 tests, 68 failures, cross-framework research |
+| `How to Red-Team…/test_red_team*.py` | Batched test suites (gates, renames, types, nesting, defaults, map, generators, async, caching, bind, errors) |

--- a/src/hypergraph/runners/_shared/validation.py
+++ b/src/hypergraph/runners/_shared/validation.py
@@ -51,12 +51,18 @@ def validate_inputs(
             stacklevel=3,  # Point to caller's caller (run method)
         )
 
-    # Required inputs must be provided
+    # If the user provided intermediate values (internal outputs),
+    # upstream nodes that produce those values don't need to run,
+    # so their inputs shouldn't be required.
     required = set(inputs_spec.required)
-    missing_required = required - provided
-
-    # Seed inputs must also be provided (for cyclic graphs)
     seeds = set(inputs_spec.seeds)
+
+    # Remove inputs that belong to nodes bypassed by intermediate injection
+    bypassed_inputs = _find_bypassed_inputs(graph, provided)
+    required -= bypassed_inputs
+    seeds -= bypassed_inputs
+
+    missing_required = required - provided
     missing_seeds = seeds - provided
 
     missing = sorted(missing_required | missing_seeds)
@@ -184,6 +190,44 @@ def validate_map_compatible(graph: "Graph") -> None:
     # Phase 2: Check for interrupt nodes
     # For now, all graphs are map-compatible
     pass
+
+
+def _find_bypassed_inputs(graph: "Graph", provided: set[str]) -> set[str]:
+    """Find inputs that belong to nodes bypassed by intermediate value injection.
+
+    When a user provides a value that is normally produced by a node,
+    that node doesn't need to run — so its exclusive inputs shouldn't
+    be required.
+    """
+    import networkx as nx
+
+    # Find which nodes are bypassed (their outputs are provided)
+    output_to_node = {
+        output: node.name
+        for node in graph._nodes.values()
+        for output in node.outputs
+    }
+    bypassed_nodes = {
+        output_to_node[v] for v in provided
+        if v in output_to_node
+    }
+
+    if not bypassed_nodes:
+        return set()
+
+    # Collect inputs exclusively needed by bypassed nodes
+    # (not needed by any non-bypassed node)
+    bypassed_inputs: set[str] = set()
+    for node_name in bypassed_nodes:
+        node = graph._nodes[node_name]
+        bypassed_inputs.update(node.inputs)
+
+    # Remove inputs that are also consumed by non-bypassed nodes
+    for node in graph._nodes.values():
+        if node.name not in bypassed_nodes:
+            bypassed_inputs -= set(node.inputs)
+
+    return bypassed_inputs
 
 
 def validate_node_types(

--- a/src/hypergraph/runners/async_/executors/graph_node.py
+++ b/src/hypergraph/runners/async_/executors/graph_node.py
@@ -68,7 +68,7 @@ class AsyncGraphNodeExecutor:
         result = await self.runner.run(node.graph, inner_inputs)
         if result.status == RunStatus.FAILED:
             raise result.error or RuntimeError("Nested graph execution failed")
-        return result.values
+        return node.map_outputs_from_original(result.values)
 
     def _collect_as_lists(
         self,

--- a/src/hypergraph/runners/sync/executors/graph_node.py
+++ b/src/hypergraph/runners/sync/executors/graph_node.py
@@ -62,7 +62,7 @@ class SyncGraphNodeExecutor:
         result = self.runner.run(node.graph, inner_inputs)
         if result.status == RunStatus.FAILED:
             raise result.error or RuntimeError("Nested graph execution failed")
-        return result.values
+        return node.map_outputs_from_original(result.values)
 
     def _collect_as_lists(
         self,

--- a/tests/test_red_team_fixes.py
+++ b/tests/test_red_team_fixes.py
@@ -1,0 +1,219 @@
+"""Tests for red-team findings fixes.
+
+Each test validates a specific issue from the consolidated red-team report.
+Tests are written to fail before the fix and pass after.
+"""
+
+import pytest
+
+from hypergraph import Graph, node, route, END, SyncRunner
+from hypergraph.nodes._rename import RenameError
+
+
+# === Fix #1: Mutable default arguments shared across runs ===
+
+
+class TestMutableDefaults:
+    def test_list_default_not_shared_across_runs(self):
+        """A mutable list default must not leak between runs."""
+
+        @node(output_name="result")
+        def append_to_list(item: str, container: list = []) -> list:
+            container.append(item)
+            return container
+
+        graph = Graph(nodes=[append_to_list])
+        runner = SyncRunner()
+
+        res1 = runner.run(graph, {"item": "A"})
+        res2 = runner.run(graph, {"item": "B"})
+
+        assert res1["result"] == ["A"]
+        assert res2["result"] == ["B"], "List default leaked from run 1 to run 2"
+
+    def test_dict_default_not_shared_across_runs(self):
+        """A mutable dict default must not leak between runs."""
+
+        @node(output_name="result")
+        def update_dict(key: str, val: int, d: dict = {}) -> dict:
+            d[key] = val
+            return d
+
+        graph = Graph(nodes=[update_dict])
+        runner = SyncRunner()
+
+        res1 = runner.run(graph, {"key": "a", "val": 1})
+        res2 = runner.run(graph, {"key": "b", "val": 2})
+
+        assert res1["result"] == {"a": 1}
+        assert res2["result"] == {"b": 2}, "Dict default leaked"
+
+
+# === Fix #2: Cycle termination off-by-one ===
+
+
+class TestCycleTermination:
+    def test_no_extra_iteration_after_end(self):
+        """Gate returning END must stop the loop immediately."""
+
+        @node(output_name="count")
+        def increment(count: int) -> int:
+            return count + 1
+
+        @route(targets=["increment", END])
+        def check(count: int) -> str:
+            return END if count >= 3 else "increment"
+
+        graph = Graph(nodes=[increment, check])
+        runner = SyncRunner()
+        result = runner.run(graph, {"count": 0})
+
+        assert result["count"] == 3, (
+            f"Expected count=3, got count={result['count']}. "
+            "Extra iteration after END."
+        )
+
+    def test_single_iteration_loop(self):
+        """Loop that should execute exactly once."""
+
+        @node(output_name="count")
+        def increment(count: int) -> int:
+            return count + 1
+
+        @route(targets=["increment", END])
+        def check(count: int) -> str:
+            return END if count >= 1 else "increment"
+
+        graph = Graph(nodes=[increment, check])
+        runner = SyncRunner()
+        result = runner.run(graph, {"count": 0})
+
+        assert result["count"] == 1
+
+
+# === Fix #4: Intermediate value injection ===
+
+
+class TestIntermediateInjection:
+    def test_skip_upstream_with_intermediate_value(self):
+        """Providing an intermediate output should skip upstream nodes."""
+
+        @node(output_name="mid")
+        def step1(start: str) -> str:
+            return start + "_mid"
+
+        @node(output_name="end")
+        def step2(mid: str) -> str:
+            return mid + "_end"
+
+        graph = Graph(nodes=[step1, step2])
+        runner = SyncRunner()
+
+        # Provide "mid" directly — step1 should be skipped
+        result = runner.run(graph, {"mid": "SKIP"})
+        assert result["end"] == "SKIP_end"
+
+    def test_normal_execution_still_works(self):
+        """Normal execution (no intermediate injection) still works."""
+
+        @node(output_name="mid")
+        def step1(start: str) -> str:
+            return start + "_mid"
+
+        @node(output_name="end")
+        def step2(mid: str) -> str:
+            return mid + "_end"
+
+        graph = Graph(nodes=[step1, step2])
+        runner = SyncRunner()
+
+        result = runner.run(graph, {"start": "hello"})
+        assert result["end"] == "hello_mid_end"
+
+
+# === Fix #6: Rename collision silently allowed ===
+
+
+class TestRenameCollision:
+    def test_duplicate_output_rename_raises(self):
+        """Renaming two outputs to the same name must raise."""
+
+        @node(output_name=("left", "right"))
+        def split(x: int) -> tuple[int, int]:
+            return x, x + 1
+
+        with pytest.raises(RenameError, match="duplicate"):
+            split.with_outputs(left="dup", right="dup")
+
+    def test_duplicate_input_rename_raises(self):
+        """Renaming two inputs to the same name must raise."""
+
+        @node(output_name="result")
+        def add(a: int, b: int) -> int:
+            return a + b
+
+        with pytest.raises(RenameError, match="duplicate"):
+            add.with_inputs(a="same", b="same")
+
+    def test_non_colliding_rename_works(self):
+        """Non-colliding renames still work fine."""
+
+        @node(output_name=("left", "right"))
+        def split(x: int) -> tuple[int, int]:
+            return x, x + 1
+
+        renamed = split.with_outputs(left="a", right="b")
+        assert renamed.outputs == ("a", "b")
+
+
+# === Fix #9: Control-only cycles don't require seed inputs ===
+
+
+class TestControlOnlyCycles:
+    def test_control_only_cycle_no_false_seeds(self):
+        """A control-only cycle should not mark data inputs as seeds."""
+
+        @node(output_name="result")
+        def process(data: str) -> str:
+            return data.upper()
+
+        @route(targets=["process", END])
+        def check(result: str) -> str:
+            return END if len(result) > 5 else "process"
+
+        graph = Graph(nodes=[process, check])
+
+        # "data" feeds process but is NOT part of any data cycle
+        assert "data" in graph.inputs.required, (
+            f"'data' should be required, got: {graph.inputs.required}"
+        )
+        assert "data" not in graph.inputs.seeds, (
+            f"'data' should NOT be a seed: {graph.inputs.seeds}"
+        )
+
+
+# === Fix #11: Output rename propagation in GraphNode ===
+
+
+class TestOutputRenamePropagation:
+    def test_graphnode_with_outputs_propagates(self):
+        """with_outputs() on a GraphNode must translate output names."""
+
+        @node(output_name="inner_out")
+        def inner_step(x: int) -> int:
+            return x * 2
+
+        inner_graph = Graph(nodes=[inner_step], name="inner")
+        graph_node = inner_graph.as_node().with_outputs(inner_out="renamed_out")
+
+        @node(output_name="final")
+        def outer_step(renamed_out: int) -> int:
+            return renamed_out + 1
+
+        outer_graph = Graph(nodes=[graph_node, outer_step])
+        runner = SyncRunner()
+        result = runner.run(outer_graph, {"x": 5})
+
+        assert result["final"] == 11, (
+            f"Expected 11 (5*2+1), got {result['final']}"
+        )


### PR DESCRIPTION
## Summary

Addresses 6 critical/high severity findings from the consolidated red-team report (`docs/red-team/consolidated_red_team.md`):

| Finding | Severity | Fix |
|---------|----------|-----|
| RT-1: Mutable defaults shared | CRITICAL | Deep-copy mutable defaults in `_resolve_input()` |
| RT-2: Cycle off-by-one | HIGH | Clear stale gate decisions before activation |
| RT-4: Intermediate injection | HIGH | Skip validation for nodes bypassed by intermediate values |
| RT-6: Rename collision | MEDIUM | Reject renames that produce duplicate names |
| RT-9: Control-only cycles | MEDIUM | Exclude control edges from cycle detection |
| RT-11: Rename propagation | MEDIUM | Apply output rename mapping in GraphNode executors |

### Findings Already Fixed (confirmed during investigation)
- **RT-7** (invalid gate target) — Already validated at runtime via `routing_validation.py`
- **RT-8** (mutex branch outputs) — Already implemented in PR #8

### Not Addressed in This PR
- **RT-3** (runtime type checking) — Lower priority, would add overhead
- **RT-5** (disconnected nodes) — Design decision, not a bug
- **RT-10** (deep nesting) — Needs further investigation
- **RT-12** (kwargs detection) — Low severity limitation

## Files Changed

- `src/hypergraph/runners/_shared/helpers.py` — RT-1, RT-2 fixes
- `src/hypergraph/runners/_shared/validation.py` — RT-4 fix
- `src/hypergraph/nodes/base.py` — RT-6 fix
- `src/hypergraph/graph/input_spec.py` — RT-9 fix
- `src/hypergraph/runners/sync/executors/graph_node.py` — RT-11 fix
- `src/hypergraph/runners/async_/executors/graph_node.py` — RT-11 fix
- `tests/test_red_team_fixes.py` — 11 new tests
- `docs/red-team/consolidated_red_team.md` — Updated status tracker

## Test plan
- [x] All 11 new tests in `test_red_team_fixes.py` pass
- [x] All 887 existing tests pass
- [ ] Manual verification of cycle termination behavior
- [ ] Manual verification of intermediate injection with complex graphs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cycle detection now considers only data dependencies (ignores control edges)
  * Prevents duplicate names during input/output renames
  * Clears stale gate routing decisions on re-execution
  * Avoids shared mutable defaults across runs (non-copyable defaults emit a warning)
  * Skips upstream nodes when intermediate outputs are provided
  * Nested-graph outputs are consistently translated

* **Tests**
  * Added comprehensive tests covering these fixes and edge cases

* **Documentation**
  * Added consolidated red-team findings and status report

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->