### PR TITLE
feat(graph): add with_select() for default output selection

### DIFF
--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -442,6 +442,10 @@ class Graph:
                 f"Cannot select {invalid}: not graph outputs. "
                 f"Valid outputs: {self.outputs}"
             )
+        if len(names) != len(set(names)):
+            raise ValueError(
+                f"with_select() requires unique output names. Received: {names}"
+            )
 
         new_graph = self._shallow_copy()
         new_graph._selected = names

--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -68,6 +68,7 @@ class Graph:
         self.name = name
         self._strict_types = strict_types
         self._bound: dict[str, Any] = {}
+        self._selected: tuple[str, ...] | None = None
         self._nodes = self._build_nodes_dict(nodes)
         self._nx_graph = self._build_graph(nodes)
         self._cached_hash: str | None = None
@@ -405,6 +406,52 @@ class Graph:
         new_graph._bound = {k: v for k, v in self._bound.items() if k not in keys}
         return new_graph
 
+    def with_select(self, *names: str) -> "Graph":
+        """Set default output selection. Returns new Graph (immutable).
+
+        Controls which outputs are returned by runner.run() and which outputs
+        are exposed when this graph is used as a nested node via as_node().
+
+        This does NOT affect internal graph execution — all nodes still run
+        and all intermediate values are still computed. It only filters what
+        is returned to the caller.
+
+        A runtime ``select=`` passed to runner.run() overrides this default.
+
+        Args:
+            *names: Output names to include. Must be valid graph outputs.
+
+        Returns:
+            New Graph with default selection set.
+
+        Raises:
+            ValueError: If any name is not a graph output.
+
+        Example:
+            >>> graph = Graph([embed, retrieve, generate]).with_select("answer")
+            >>> result = runner.run(graph, inputs)
+            >>> assert list(result.keys()) == ["answer"]
+
+            >>> # As nested node, only "answer" is visible to the parent graph
+            >>> outer = Graph([graph.as_node(), postprocess])
+        """
+        all_outputs = set(self.outputs)
+        invalid = [n for n in names if n not in all_outputs]
+        if invalid:
+            raise ValueError(
+                f"Cannot select {invalid}: not graph outputs. "
+                f"Valid outputs: {self.outputs}"
+            )
+
+        new_graph = self._shallow_copy()
+        new_graph._selected = names
+        return new_graph
+
+    @property
+    def selected(self) -> tuple[str, ...] | None:
+        """Default output selection, or None if all outputs are returned."""
+        return self._selected
+
     @property
     def has_cycles(self) -> bool:
         """True if graph contains cycles."""
@@ -460,6 +507,7 @@ class Graph:
 
         new_graph = copy.copy(self)
         new_graph._bound = dict(self._bound)
+        # _selected is an immutable tuple (or None), safe to share via copy.copy
         # All other attributes preserved: _strict_types, _nodes, _nx_graph, _cached_hash
         return new_graph
 

--- a/src/hypergraph/nodes/graph_node.py
+++ b/src/hypergraph/nodes/graph_node.py
@@ -91,7 +91,7 @@ class GraphNode(HyperNode):
         # Core HyperNode attributes
         self.name = resolved_name
         self.inputs = graph.inputs.all
-        self.outputs = graph.outputs
+        self.outputs = graph.selected if graph.selected is not None else graph.outputs
 
     @property
     def graph(self) -> "Graph":

--- a/src/hypergraph/runners/_shared/helpers.py
+++ b/src/hypergraph/runners/_shared/helpers.py
@@ -292,10 +292,13 @@ def filter_outputs(
     Warns:
         UserWarning: If select contains names not found in state values
     """
-    if select is not None:
+    # Runtime select= overrides graph-level default
+    effective_select = select if select is not None else graph.selected
+
+    if effective_select is not None:
         result = {}
         missing = []
-        for k in select:
+        for k in effective_select:
             if k in state.values:
                 result[k] = state.values[k]
             else:

--- a/tests/test_with_select.py
+++ b/tests/test_with_select.py
@@ -1,0 +1,116 @@
+"""Tests for Graph.with_select() — default output selection."""
+
+import pytest
+from hypergraph.graph import Graph
+from hypergraph.nodes.function import node
+from hypergraph.runners.sync.runner import SyncRunner
+
+
+@node(output_name="doubled")
+def double(x: int) -> int:
+    return x * 2
+
+
+@node(output_name="sum")
+def add(doubled: int, b: int) -> int:
+    return doubled + b
+
+
+@node(output_name="final")
+def finalize(sum: int) -> str:
+    return f"result={sum}"
+
+
+def _build_graph():
+    return Graph([double, add, finalize])
+
+
+class TestWithSelectGraph:
+    """Graph-level with_select behavior."""
+
+    def test_selected_is_none_by_default(self):
+        g = _build_graph()
+        assert g.selected is None
+
+    def test_with_select_returns_new_graph(self):
+        g = _build_graph()
+        g2 = g.with_select("final")
+        assert g2 is not g
+        assert g.selected is None
+        assert g2.selected == ("final",)
+
+    def test_with_select_validates_names(self):
+        g = _build_graph()
+        with pytest.raises(ValueError, match="not graph outputs"):
+            g.with_select("nonexistent")
+
+    def test_with_select_multiple_outputs(self):
+        g = _build_graph().with_select("doubled", "final")
+        assert g.selected == ("doubled", "final")
+
+    def test_chained_with_select_last_wins(self):
+        g = _build_graph().with_select("doubled").with_select("final")
+        assert g.selected == ("final",)
+
+    def test_outputs_property_unchanged(self):
+        """with_select does not alter the outputs property."""
+        g = _build_graph()
+        g2 = g.with_select("final")
+        assert g2.outputs == g.outputs
+
+
+class TestWithSelectRunner:
+    """Runner respects graph-level selection."""
+
+    def test_run_returns_only_selected(self):
+        g = _build_graph().with_select("final")
+        result = SyncRunner().run(g, {"x": 5, "b": 3})
+        assert set(result.values.keys()) == {"final"}
+
+    def test_runtime_select_overrides_graph_default(self):
+        g = _build_graph().with_select("final")
+        result = SyncRunner().run(g, {"x": 5, "b": 3}, select=["doubled", "sum"])
+        assert set(result.values.keys()) == {"doubled", "sum"}
+
+    def test_no_select_returns_all(self):
+        g = _build_graph()
+        result = SyncRunner().run(g, {"x": 5, "b": 3})
+        assert set(result.values.keys()) == {"doubled", "sum", "final"}
+
+
+class TestWithSelectNested:
+    """with_select controls what a GraphNode exposes to the parent graph."""
+
+    def test_graph_node_exposes_only_selected(self):
+        inner = Graph([double, add], name="inner").with_select("sum")
+        gn = inner.as_node()
+        assert gn.outputs == ("sum",)
+
+    def test_graph_node_exposes_all_without_select(self):
+        inner = Graph([double, add], name="inner")
+        gn = inner.as_node()
+        assert set(gn.outputs) == {"doubled", "sum"}
+
+    def test_nested_graph_runs_with_select(self):
+        inner = Graph([double, add], name="inner").with_select("sum")
+
+        @node(output_name="formatted")
+        def fmt(sum: int) -> str:
+            return f"val={sum}"
+
+        outer = Graph([inner.as_node(), fmt])
+        result = SyncRunner().run(outer, {"x": 5, "b": 3})
+        assert result.values["formatted"] == "val=13"
+
+    def test_nested_graph_hides_unselected_from_parent(self):
+        """Parent can't wire to an output the inner graph didn't select."""
+        inner = Graph([double, add], name="inner").with_select("sum")
+
+        @node(output_name="oops")
+        def use_doubled(doubled: int) -> int:
+            return doubled + 1
+
+        # "doubled" is not exposed by inner — so use_doubled gets no edge.
+        # It becomes a required input of the outer graph.
+        outer = Graph([inner.as_node(), use_doubled])
+        assert "doubled" in outer.inputs.required

--- a/tests/test_with_select.py
+++ b/tests/test_with_select.py
@@ -44,6 +44,11 @@ class TestWithSelectGraph:
         with pytest.raises(ValueError, match="not graph outputs"):
             g.with_select("nonexistent")
 
+    def test_with_select_rejects_duplicates(self):
+        g = _build_graph()
+        with pytest.raises(ValueError, match="unique output names"):
+            g.with_select("final", "final")
+
     def test_with_select_multiple_outputs(self):
         g = _build_graph().with_select("doubled", "final")
         assert g.selected == ("doubled", "final")


### PR DESCRIPTION
## Summary
- Adds `Graph.with_select(*names)` method that sets a default output selection, following the same immutable pattern as `bind()`
- `filter_outputs()` respects `graph.selected` as a default, with runtime `select=` overriding it
- `GraphNode` uses `graph.selected` to control which outputs are exposed to the parent graph

## Test plan
- [x] 13 new tests covering graph-level API, runner behavior, and nested graph wiring
- [x] Full test suite passes (889 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Graphs can define a default output selection to control which outputs are returned by default; runtime selections override this.
  * Selections affect which outputs nested graphs expose to their parents.

* **Tests**
  * Added extensive tests covering selection defaults, overrides, chaining, and nested-graph wiring.

* **Documentation**
  * API reference updated with selection usage, examples, and nested-graph behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->