### PR TITLE
fix: deduplicate Graph.outputs for mutex branches

### DIFF
--- a/src/hypergraph/nodes/base.py
+++ b/src/hypergraph/nodes/base.py
@@ -267,7 +267,7 @@ class HyperNode(ABC):
                     raise clone._make_rename_error(old, attr)
                 clone._rename_history.append(RenameEntry(attr, old, new, batch_id))  # type: ignore[arg-type]
             new_values = tuple(mapping.get(v, v) for v in current)
-            _check_rename_introduces_duplicates(current, new_values, attr, mapping)
+            _check_rename_duplicates(new_values, attr)
             setattr(clone, attr, new_values)
 
         return clone
@@ -311,44 +311,12 @@ class HyperNode(ABC):
         return chain
 
 
-def _check_rename_introduces_duplicates(
-    old_values: tuple[str, ...],
-    new_values: tuple[str, ...],
-    attr: str,
-    mapping: dict[str, str],
-) -> None:
-    """Raise RenameError only if the rename *introduced* new duplicates.
-
-    Pre-existing duplicates (e.g., mutex branches producing the same output
-    in a GraphNode) are allowed through.
-    """
-    if len(new_values) == len(set(new_values)):
+def _check_rename_duplicates(values: tuple[str, ...], attr: str) -> None:
+    """Raise RenameError if a rename produces duplicate names."""
+    if len(values) == len(set(values)):
         return
-
-    from collections import Counter
-
-    old_counts = Counter(old_values)
-    new_counts = Counter(new_values)
-
-    # A new value is a problem only if its count exceeds the max old count
-    # of any single old value that maps to it.
-    new_dupes: list[str] = []
-    for val, count in new_counts.items():
-        if count <= 1:
-            continue
-        # Find the max count of any single old value that renamed to this val
-        max_old = max(
-            (old_counts[old_val]
-             for old_val in old_counts
-             if mapping.get(old_val, old_val) == val),
-            default=0
-        )
-        if count > max_old:
-            new_dupes.append(val)
-
-    if not new_dupes:
-        return
+    dupes = sorted({v for v in values if values.count(v) > 1})
     raise RenameError(
-        f"Rename produces duplicate {attr}: {sorted(new_dupes)}. "
+        f"Rename produces duplicate {attr}: {dupes}. "
         f"Each name must be unique."
     )

--- a/tests/test_red_team_fixes.py
+++ b/tests/test_red_team_fixes.py
@@ -261,27 +261,61 @@ class TestRenameCollision:
         renamed = split.with_outputs(left="a", right="b")
         assert renamed.outputs == ("a", "b")
 
-    def test_graphnode_mutex_duplicates_allowed(self):
-        """GraphNode with mutex branches producing the same output can be renamed."""
+    def test_mutex_graphnode_in_outer_graph(self):
+        """GraphNode with mutex branches sharing an output composes into outer graph.
 
-        @node(output_name="result")
-        def skip_document(reason: str) -> str:
-            return f"skipped: {reason}"
+        Reproduces: GraphConfigError: Multiple nodes produce 'index_results'
+          -> process_all_documents creates 'index_results'
+          -> process_all_documents creates 'index_results'
+        """
 
-        @node(output_name="result")
-        def process_document(text: str) -> str:
-            return text.upper()
+        @node(output_name="index_results")
+        def skip_document(reason: str) -> dict:
+            return {"status": "skipped", "reason": reason}
+
+        @node(output_name="index_results")
+        def process_document(text: str, config: dict) -> dict:
+            return {"status": "indexed", "chunks": len(text) // 100}
 
         @route(targets=["skip_document", "process_document"])
-        def check(text: str) -> str:
-            return "skip_document" if not text else "process_document"
+        def check_document(text: str) -> str:
+            return "skip_document" if len(text) < 10 else "process_document"
 
-        inner = Graph(nodes=[check, skip_document, process_document], name="inner")
+        process_all_documents = Graph(
+            nodes=[check_document, skip_document, process_document],
+            name="process_all_documents",
+        )
+
+        @node(output_name="summary")
+        def summarize(index_results: dict) -> str:
+            return f"Done: {index_results['status']}"
+
+        pipeline = Graph(nodes=[process_all_documents.as_node(), summarize])
+        assert "summary" in pipeline.outputs
+
+    def test_mutex_graphnode_rename(self):
+        """GraphNode with mutex outputs can be renamed via with_outputs."""
+
+        @node(output_name="index_results")
+        def skip_document(reason: str) -> dict:
+            return {"status": "skipped"}
+
+        @node(output_name="index_results")
+        def process_document(text: str) -> dict:
+            return {"status": "indexed"}
+
+        @route(targets=["skip_document", "process_document"])
+        def check_document(text: str) -> str:
+            return "skip_document" if len(text) < 10 else "process_document"
+
+        inner = Graph(
+            nodes=[check_document, skip_document, process_document],
+            name="process_all_documents",
+        )
         graph_node = inner.as_node()
 
-        # Pre-existing duplicate "result" from mutex branches — should not raise
-        renamed = graph_node.with_outputs(result="index_result")
-        assert "index_result" in renamed.outputs
+        renamed = graph_node.with_outputs(index_results="all_results")
+        assert "all_results" in renamed.outputs
 
 
 # === Fix #9: Control-only cycles don't require seed inputs ===


### PR DESCRIPTION
## Summary

Cleans up PR #27 — replaces the 4 scattered band-aid fixes with a single root fix.

- **Root fix**: `Graph.outputs` and `Graph.leaf_outputs` now deduplicate via `_unique_outputs` helper. Since `GraphNode.outputs = graph.outputs`, this prevents duplicates from propagating anywhere.
- **Reverted**: `_check_rename_introduces_duplicates` (complex Counter logic) back to the simple `_check_rename_duplicates` — no longer needed.
- **Tests**: Replaced stub test with two realistic reproductions of the actual CLI error (`process_all_documents` GraphNode with mutex branches both producing `index_results`).

## Test plan

- [x] Both new tests fail without the fix, pass with it
- [x] Existing rename collision tests still pass
- [x] Full suite passes (893 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved output deduplication and order preservation in graph operations.
  * Simplified and strengthened duplicate detection during node renaming.
  
* **Tests**
  * Added tests verifying proper composition of graphs with shared outputs and correct output propagation across graph boundaries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->