### PR TITLE
Rename with_select() to select()

### DIFF
--- a/docs/06-api-reference/graph.md
+++ b/docs/06-api-reference/graph.md
@@ -5,7 +5,7 @@ A **Graph** defines a computation graph from nodes with automatic edge inference
 - **Automatic wiring** - Edges inferred from matching output/input names
 - **Build-time validation (`strict_types`)** - Type mismatches caught at construction when `strict_types=True`
 - **Hierarchical composition** - Graphs nest as nodes via `.as_node()`
-- **Immutable** - `bind()`, `with_select()`, and other methods return new instances
+- **Immutable** - `bind()`, `select()`, and other methods return new instances
 
 ```python
 from hypergraph import node, Graph
@@ -130,13 +130,13 @@ print(g.leaf_outputs)  # ('result',) - only add_one is a leaf
 
 ### `selected: tuple[str, ...] | None`
 
-Default output selection set via `with_select()`, or `None` if all outputs are returned.
+Default output selection set via `select()`, or `None` if all outputs are returned.
 
 ```python
 g = Graph([double, add_one])
 print(g.selected)  # None
 
-g2 = g.with_select("result")
+g2 = g.select("result")
 print(g2.selected)  # ('result',)
 ```
 
@@ -227,20 +227,20 @@ print(partial.inputs.bound)  # {'y': 10}
 
 **Returns:** New Graph with specified bindings removed
 
-### `with_select(*names) -> Graph`
+### `select(*names) -> Graph`
 
 Set a default output selection. Returns a new Graph (immutable pattern).
 
 This controls which outputs are returned by `runner.run()` and which outputs are exposed when the graph is used as a nested node via `as_node()`.
 
-All nodes still execute and all intermediate values are still computed internally. `with_select` only filters what is **returned to the caller**.
+All nodes still execute and all intermediate values are still computed internally. `select` only filters what is **returned to the caller**.
 
 ```python
 g = Graph([embed, retrieve, generate])
 print(g.outputs)  # ('embedding', 'docs', 'answer')
 
 # Only return "answer" by default
-g_selected = g.with_select("answer")
+g_selected = g.select("answer")
 result = runner.run(g_selected, {"text": "hello", "query": "what?"})
 print(result.values.keys())  # dict_keys(['answer'])
 
@@ -259,10 +259,10 @@ print(result.values.keys())  # dict_keys(['docs', 'answer'])
 
 #### Nested graph behavior
 
-When a graph with `with_select` is used as a nested node, only the selected outputs are visible to the parent graph. Unselected outputs cannot be wired to downstream nodes.
+When a graph with `select` is used as a nested node, only the selected outputs are visible to the parent graph. Unselected outputs cannot be wired to downstream nodes.
 
 ```python
-inner = Graph([embed, retrieve, generate], name="rag").with_select("answer")
+inner = Graph([embed, retrieve, generate], name="rag").select("answer")
 gn = inner.as_node()
 print(gn.outputs)  # ('answer',) — only "answer" is exposed
 
@@ -273,7 +273,7 @@ outer = Graph([gn, postprocess])  # postprocess must consume "answer", not "docs
 If the parent graph needs an intermediate output, add it to the selection:
 
 ```python
-inner = Graph([embed, retrieve, generate], name="rag").with_select("answer", "docs")
+inner = Graph([embed, retrieve, generate], name="rag").select("answer", "docs")
 ```
 
 ### `as_node(*, name=None) -> GraphNode`

--- a/docs/red-team/consolidated_red_team.md
+++ b/docs/red-team/consolidated_red_team.md
@@ -12,7 +12,6 @@
 
 | # | Issue | Severity | Source |
 |---|-------|----------|--------|
-| 10 | Deep nesting / infinite loops | HIGH | ✅ Fixed in PR #29 — Sole Producer Rule |
 | 29 | Cyclic gate→END infinite loop | HIGH | AMP (CY-005) |
 | 13 | GraphNode output leakage | MEDIUM | PR #23 |
 | 14 | Stale branch values persist | MEDIUM | PR #23 |
@@ -21,7 +20,7 @@
 | 26 | Map with empty list / zip mismatch | MEDIUM | PR #18 extended |
 | 28 | Async exception propagation | MEDIUM | PR #18 extended |
 | 30 | Type checking with renamed inputs | MEDIUM | AMP (TC-010) |
-| 31 | GraphNode name collision not detected | MEDIUM | ✅ Validated in PR #29 — detected |
+| 31 | GraphNode name collision not detected | MEDIUM | AMP (GN-008) |
 | 15 | Type subclass compatibility | LOW | PR #23 |
 | 17 | Empty/edge-case graphs | LOW | PR #23 |
 | 19 | Bind/unbind edge cases | LOW | PR #23 |
@@ -35,28 +34,11 @@
 
 **Deferred**: #3 runtime type checking (by design), #5 disconnected nodes (design decision), #12 kwargs detection (low priority)
 
-**Resolved**: #1, #2, #4, #6, #9, #11 in PR #25; #7, #8 already fixed
+**Resolved**: #1, #2, #4, #6, #9, #11 in PR #25; #7, #8 already fixed; #10, #31 in PR #29
 
 ---
 
 ## 🔴 OPEN — High Severity
-
-### 10. Deep Nesting / Multiple GraphNodes — Infinite Loops
-
-✅ **Fixed in [PR #29](https://github.com/gilad-rubin/hypergraph/pull/29)** via the **Sole Producer Rule**.
-
-| Scenario | Result |
-|----------|--------|
-| A: 4+ level nesting | **PASSES** (sync and async) |
-| B: Same inner graph used twice | **PASSES** with renames, validates conflicts |
-| C: Output name == input name (SM-007) | **✅ FIXED** — Sole Producer Rule prevents re-trigger |
-| D: GraphNode name collision (#31) | **PASSES** — validation catches it |
-
-**Sole Producer Rule**: When a node is the only producer of a value it also consumes (e.g., `add_response(messages) -> messages`), skip that value in the staleness check. This prevents infinite self-retriggering. Exception: gate-controlled nodes are exempt — gates explicitly drive cycle re-execution.
-
-**Design change**: Convergence loops (e.g., `counter_stop(count) -> count`) now require an explicit `@route` gate to cycle. Gateless self-loops run once and stop.
-
----
 
 ### 29. Cyclic Gate→END Infinite Loop
 

--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -462,7 +462,7 @@ class Graph:
         new_graph._bound = {k: v for k, v in self._bound.items() if k not in keys}
         return new_graph
 
-    def with_select(self, *names: str) -> "Graph":
+    def select(self, *names: str) -> "Graph":
         """Set default output selection. Returns new Graph (immutable).
 
         Controls which outputs are returned by runner.run() and which outputs
@@ -484,7 +484,7 @@ class Graph:
             ValueError: If any name is not a graph output.
 
         Example:
-            >>> graph = Graph([embed, retrieve, generate]).with_select("answer")
+            >>> graph = Graph([embed, retrieve, generate]).select("answer")
             >>> result = runner.run(graph, inputs)
             >>> assert list(result.keys()) == ["answer"]
 
@@ -500,7 +500,7 @@ class Graph:
             )
         if len(names) != len(set(names)):
             raise ValueError(
-                f"with_select() requires unique output names. Received: {names}"
+                f"select() requires unique output names. Received: {names}"
             )
 
         new_graph = self._shallow_copy()

--- a/tests/test_runners/test_sync_runner.py
+++ b/tests/test_runners/test_sync_runner.py
@@ -547,7 +547,7 @@ class TestSyncRunnerMap:
         sums = sorted(r["sum"] for r in results)
         assert sums == [11, 12, 21, 22]
 
-    def test_map_with_select(self):
+    def test_map_select(self):
         """Map respects select parameter."""
         graph = Graph([double, add.with_inputs(a="doubled")])
         runner = SyncRunner()


### PR DESCRIPTION
## Summary
- Rename `Graph.with_select()` → `Graph.select()` — the `with_` prefix implied a rename/transform pattern, but this method chooses which outputs to expose
- Rename test file `test_with_select.py` → `test_select.py`
- Update all references in docs and tests

## Test plan
- [x] `tests/test_select.py` — all 11 select tests pass
- [x] `tests/test_runners/test_sync_runner.py` — renamed test passes
- [x] Full suite: 914 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)