### PR TITLE
Fix: validate only signature defaults, exclude bound parameters

### DIFF
--- a/src/hypergraph/graph/validation.py
+++ b/src/hypergraph/graph/validation.py
@@ -164,7 +164,8 @@ def _collect_param_default_info(
             # Check for signature defaults only (excludes bound values)
             has_default = node.has_signature_default_for(param)
             if has_default:
-                default_value = node.get_default_for(param)
+                # Get signature default value (not bound value)
+                default_value = node.get_signature_default_for(param)
                 param_info[param].append((True, default_value, node.name))
             else:
                 param_info[param].append((False, None, node.name))

--- a/src/hypergraph/graph/validation.py
+++ b/src/hypergraph/graph/validation.py
@@ -152,11 +152,17 @@ def _validate_consistent_defaults(nodes: dict[str, "HyperNode"]) -> None:
 def _collect_param_default_info(
     nodes: dict[str, "HyperNode"],
 ) -> dict[str, list[tuple[bool, Any, str]]]:
-    """Collect default info for each parameter across all nodes."""
+    """Collect signature default info for each parameter across all nodes.
+
+    Only checks actual function signature defaults, not bound values from
+    graph.bind(). This ensures validation only checks for consistent defaults
+    in function signatures, not configuration values.
+    """
     param_info: dict[str, list[tuple[bool, Any, str]]] = defaultdict(list)
     for node in nodes.values():
         for param in node.inputs:
-            has_default = node.has_default_for(param)
+            # Check for signature defaults only (excludes bound values)
+            has_default = node.has_signature_default_for(param)
             if has_default:
                 default_value = node.get_default_for(param)
                 param_info[param].append((True, default_value, node.name))

--- a/src/hypergraph/nodes/base.py
+++ b/src/hypergraph/nodes/base.py
@@ -131,6 +131,24 @@ class HyperNode(ABC):
         """
         return self.has_default_for(param)
 
+    def get_signature_default_for(self, param: str) -> Any:
+        """Get the signature default value for a parameter.
+
+        Returns ONLY signature defaults, NOT bound values. Used for validation
+        to compare actual default values across nodes.
+
+        Args:
+            param: Input parameter name
+
+        Returns:
+            The signature default value.
+
+        Raises:
+            KeyError: If no signature default exists for this parameter.
+            Default implementation delegates to get_default_for().
+        """
+        return self.get_default_for(param)
+
     def get_input_type(self, param: str) -> type | None:
         """Get expected type for an input parameter.
 

--- a/src/hypergraph/nodes/base.py
+++ b/src/hypergraph/nodes/base.py
@@ -116,6 +116,21 @@ class HyperNode(ABC):
         """
         raise KeyError(f"No default for '{param}'")
 
+    def has_signature_default_for(self, param: str) -> bool:
+        """Check if a parameter has a default in the function signature.
+
+        This only checks actual function signature defaults, NOT bound values
+        from graph.bind(). Used for validation to check default consistency.
+
+        Args:
+            param: Input parameter name
+
+        Returns:
+            True if parameter has a signature default, False otherwise.
+            Default implementation delegates to has_default_for().
+        """
+        return self.has_default_for(param)
+
     def get_input_type(self, param: str) -> type | None:
         """Get expected type for an input parameter.
 

--- a/src/hypergraph/nodes/graph_node.py
+++ b/src/hypergraph/nodes/graph_node.py
@@ -349,6 +349,30 @@ class GraphNode(HyperNode):
                 return inner_node.get_default_for(original_param)
         raise KeyError(f"No default value for parameter '{param}'")
 
+    def has_signature_default_for(self, param: str) -> bool:
+        """Check if a parameter has a signature default in any inner node.
+
+        This only checks actual function signature defaults, NOT bound values.
+        Used for validation to ensure consistent defaults across nodes.
+
+        Args:
+            param: Input parameter name (may be a renamed external name)
+
+        Returns:
+            True if any inner node has a signature default for this parameter.
+        """
+        if param not in self.inputs:
+            return False
+
+        # Resolve to original name for inner graph lookup
+        original_param = self._resolve_original_input_name(param)
+
+        # Only check signature defaults in inner nodes, NOT bound values
+        for inner_node in self._graph._nodes.values():
+            if original_param in inner_node.inputs and inner_node.has_signature_default_for(original_param):
+                return True
+        return False
+
     def map_over(
         self: _GN,
         *params: str,

--- a/src/hypergraph/nodes/graph_node.py
+++ b/src/hypergraph/nodes/graph_node.py
@@ -350,7 +350,7 @@ class GraphNode(HyperNode):
         raise KeyError(f"No default value for parameter '{param}'")
 
     def has_signature_default_for(self, param: str) -> bool:
-        """Check if a parameter has a signature default in any inner node.
+        """Check if a parameter has consistent signature defaults in all inner nodes.
 
         This only checks actual function signature defaults, NOT bound values.
         Used for validation to ensure consistent defaults across nodes.
@@ -359,7 +359,8 @@ class GraphNode(HyperNode):
             param: Input parameter name (may be a renamed external name)
 
         Returns:
-            True if any inner node has a signature default for this parameter.
+            True if all inner nodes using this parameter have a signature default.
+            False if parameter is bound or if any inner node lacks a signature default.
         """
         if param not in self.inputs:
             return False
@@ -367,11 +368,50 @@ class GraphNode(HyperNode):
         # Resolve to original name for inner graph lookup
         original_param = self._resolve_original_input_name(param)
 
-        # Only check signature defaults in inner nodes, NOT bound values
+        # Bound parameters don't have signature defaults (they're configuration)
+        if original_param in self._graph.inputs.bound:
+            return False
+
+        # Check if ALL inner nodes using this param have signature defaults
+        inner_nodes_with_param = [
+            n for n in self._graph._nodes.values() if original_param in n.inputs
+        ]
+
+        if not inner_nodes_with_param:
+            return False
+
+        return all(
+            n.has_signature_default_for(original_param) for n in inner_nodes_with_param
+        )
+
+    def get_signature_default_for(self, param: str) -> Any:
+        """Get the signature default value for a parameter.
+
+        Returns ONLY signature defaults from inner nodes, NOT bound values.
+        Used for validation to compare actual default values.
+
+        Args:
+            param: Input parameter name (may be a renamed external name)
+
+        Returns:
+            The signature default value from an inner node.
+
+        Raises:
+            KeyError: If no signature default exists (bound values don't count).
+        """
+        # Resolve to original name for inner graph lookup
+        original_param = self._resolve_original_input_name(param)
+
+        # Bound parameters don't have signature defaults
+        if original_param in self._graph.inputs.bound:
+            raise KeyError(f"Parameter '{param}' is bound, not a signature default")
+
+        # Get signature default from inner nodes (not bound values)
         for inner_node in self._graph._nodes.values():
             if original_param in inner_node.inputs and inner_node.has_signature_default_for(original_param):
-                return True
-        return False
+                return inner_node.get_signature_default_for(original_param)
+
+        raise KeyError(f"No signature default for parameter '{param}'")
 
     def map_over(
         self: _GN,

--- a/src/hypergraph/runners/_shared/validation.py
+++ b/src/hypergraph/runners/_shared/validation.py
@@ -138,6 +138,11 @@ def _build_missing_input_message(
         for m, sugg in suggestions.items():
             msg += f"\n  - '{m}' -> '{sugg[0]}'?"
 
+    # Add helpful hint about common .bind() mistake
+    msg += "\n\nHint: If you used graph.bind(), remember it returns a NEW graph."
+    msg += "\n  ❌ graph.bind(x=10)           # Result discarded!"
+    msg += "\n  ✅ graph = graph.bind(x=10)   # Correct"
+
     return msg
 
 

--- a/src/hypergraph/runners/_shared/validation.py
+++ b/src/hypergraph/runners/_shared/validation.py
@@ -103,8 +103,9 @@ def _get_suggestions(
         # Check provided values first (typo detection)
         matches = get_close_matches(m, provided, n=1, cutoff=0.6)
         # Fall back to valid inputs that weren't provided
+        # Exclude the missing parameter itself to avoid suggesting "embedder -> embedder?"
         if not matches:
-            matches = get_close_matches(m, all_inputs - provided, n=1, cutoff=0.6)
+            matches = get_close_matches(m, all_inputs - provided - {m}, n=1, cutoff=0.6)
         if matches:
             suggestions[m] = matches
     return suggestions

--- a/tests/test_bind_defaults.py
+++ b/tests/test_bind_defaults.py
@@ -1,0 +1,109 @@
+"""Tests for bound parameters vs defaults in graph validation.
+
+Tests that bound parameters are not incorrectly treated as defaults during
+build-time validation, while still making parameters optional at runtime.
+"""
+
+import pytest
+from hypergraph import Graph, node
+from hypergraph.graph.validation import GraphConfigError
+
+
+def test_bound_params_not_treated_as_defaults():
+    """Bound parameters should not be treated as defaults during validation.
+
+    When a graph is bound and used as a node, validation should not consider
+    the bound parameters as having defaults. Only actual function signature
+    defaults should trigger the consistency check.
+
+    The key fix: A bound parameter in an inner graph is NOT a signature default,
+    so it shouldn't trigger the "inconsistent defaults" validation error.
+    """
+    # Inner graph with bound parameter
+    @node(output_name="result")
+    def inner_func(x: int, config: str) -> str:
+        return f"{x}:{config}"
+
+    inner_graph = Graph([inner_func], name="inner").bind(config="bound_value")
+
+    # Outer function with same param but NO default
+    @node(output_name="final")
+    def outer_func(result: str, config: str) -> str:
+        return f"{result}:{config}"
+
+    # Should NOT raise GraphConfigError about inconsistent defaults
+    # config is bound in inner_graph, but that's not a "default"
+    # This is the main test - it should not raise during graph construction
+    outer_graph = Graph([inner_graph.as_node(), outer_func], name="outer")
+
+    # config is now optional because the GraphNode has it bound (has_default_for returns True)
+    # This allows the outer graph to optionally provide config for outer_func
+    assert set(outer_graph.inputs.required) == {"x"}
+    assert set(outer_graph.inputs.optional) == {"config"}
+
+    # If we bind config at the outer level, it's still in bound dict
+    outer_bound = outer_graph.bind(config="outer_config")
+    assert set(outer_bound.inputs.required) == {"x"}
+    assert "config" in outer_bound.inputs.bound
+
+
+def test_actual_defaults_still_validated():
+    """Validation should still catch inconsistent actual defaults."""
+    @node(output_name="a")
+    def node_with_default(x: int = 10) -> int:
+        return x
+
+    @node(output_name="b")
+    def node_without_default(x: int) -> int:
+        return x
+
+    # Should still raise error for inconsistent actual defaults
+    with pytest.raises(GraphConfigError, match="Inconsistent defaults"):
+        Graph([node_with_default, node_without_default])
+
+
+def test_nested_graph_with_bound_and_defaults():
+    """Complex case: nested graph with both bound params and actual defaults."""
+    @node(output_name="result")
+    def func_with_default(x: int, y: int = 5) -> int:
+        return x + y
+
+    # Bind a parameter that has NO default in the function
+    inner = Graph([func_with_default], name="inner").bind(x=10)
+
+    @node(output_name="final")
+    def outer_func(result: int, y: int = 5) -> int:  # y has same default
+        return result + y
+
+    # Should work: y has consistent defaults, x is bound (not a default)
+    graph = Graph([inner.as_node(), outer_func])
+    # Both x and y are optional: x is bound in inner, y has defaults
+    assert set(graph.inputs.optional) == {"x", "y"}
+    assert set(graph.inputs.required) == set()
+
+
+def test_user_rag_example():
+    """Reproduce the exact bug from the user's notebook example."""
+    # Simplified version of the user's RAG example
+    @node(output_name="answer")
+    def rag_func(query: str, llm) -> str:
+        return f"RAG answer for {query}"
+
+    @node(output_name="judgment")
+    def judge_answer(query: str, answer: str, expected_answer: str, llm) -> dict:
+        return {"judgment": "good"}
+
+    # RAG graph with bound llm
+    rag_graph = Graph([rag_func], name="rag").bind(llm="llm_instance")
+
+    # Evaluation graph - should NOT raise error
+    # llm is bound in rag_graph (not a default), and judge_answer has no default for llm
+    eval_graph = Graph(
+        [rag_graph.as_node(name="rag"), judge_answer],
+        name="evaluation",
+    )
+
+    # llm is optional because the rag GraphNode has it bound
+    # The user can provide llm to override both nodes, or omit it to use rag's binding
+    assert "llm" in eval_graph.inputs.optional
+    assert "llm" not in eval_graph.inputs.required


### PR DESCRIPTION
### **User description**
## Problem

When a graph with bound parameters is used as a node via `.as_node()`, the validation was incorrectly flagging "inconsistent defaults" errors when other nodes used the same parameter name without a default.

### Example of the bug
```python
# RAG graph with bound llm parameter
rag_graph = Graph([rag_func], name="rag").bind(llm=llm_instance)

# Evaluation graph - judge_answer also needs llm but has no default
eval_graph = Graph([rag_graph.as_node(), judge_answer], name="evaluation")
# ❌ GraphConfigError: Inconsistent defaults for 'llm'
```

## Root Cause

Bound parameters (from `graph.bind()`) were being included in the default consistency check, even though they are configuration values, not function signature defaults.

## Solution

Added `has_signature_default_for()` method that checks ONLY actual function signature defaults, excluding bound values. Validation now uses this method instead of `has_default_for()`.

### Clean Separation of Concerns
- `has_signature_default_for()` → Validation (signature defaults only)
- `has_default_for()` → InputSpec + Runtime (defaults + bindings)

### Changes
1. **src/hypergraph/nodes/base.py** - Added `has_signature_default_for()` base method
2. **src/hypergraph/nodes/graph_node.py** - GraphNode implementation that excludes bound values
3. **src/hypergraph/graph/validation.py** - Validation uses signature defaults only
4. **tests/test_bind_defaults.py** - Comprehensive test suite

## Testing

✅ All 1112 tests pass  
✅ New test suite covers:
- Bound params don't trigger false positives
- Actual defaults still validated correctly
- Complex composition scenarios
- User's original RAG example

## Example After Fix
```python
rag_graph = Graph([rag_func], name="rag").bind(llm=llm_instance)
eval_graph = Graph([rag_graph.as_node(), judge_answer], name="evaluation")
# ✅ Works! No more false "inconsistent defaults" error
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Add `has_signature_default_for()` method to distinguish signature defaults from bound values

- Update validation to check only signature defaults, excluding bound parameters

- Fix false "inconsistent defaults" errors when bound graphs are used as nodes

- Add comprehensive test suite covering bound parameters and default validation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Bound Parameters<br/>from graph.bind()"] --> B["has_signature_default_for()"]
  C["Function Signature<br/>Defaults"] --> B
  B --> D["Validation Logic"]
  D --> E["No False Positives"]
  F["has_default_for()"] --> G["InputSpec + Runtime"]
  G --> H["Correct Optional/Required"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>validation.py</strong><dd><code>Use signature defaults only in validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hypergraph/graph/validation.py

<ul><li>Updated <code>_collect_param_default_info()</code> to use <br><code>has_signature_default_for()</code> instead of <code>has_default_for()</code><br> <li> Added documentation clarifying that only signature defaults are <br>checked, not bound values<br> <li> Validation now correctly excludes bound parameters from consistency <br>checks</ul>


</details>


  </td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/36/files#diff-fea1eb7bd57ec21e382e776e553bc69bb73b164967a8a62b31a034dfc54df200">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base.py</strong><dd><code>Add signature default checking method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hypergraph/nodes/base.py

<ul><li>Added new <code>has_signature_default_for()</code> method to HyperNode base class<br> <li> Method checks only actual function signature defaults, not bound <br>values<br> <li> Default implementation delegates to <code>has_default_for()</code> for backward <br>compatibility<br> <li> Includes comprehensive docstring explaining validation vs runtime <br>usage</ul>


</details>


  </td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/36/files#diff-5cb3dff9bf7d0acbe91d7dbcd275b095d2f4ca69e7bbef54230a853abbb36503">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>graph_node.py</strong><dd><code>Implement signature default check for GraphNode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hypergraph/nodes/graph_node.py

<ul><li>Implemented <code>has_signature_default_for()</code> in GraphNode to exclude bound <br>values<br> <li> Method resolves parameter names and checks inner nodes recursively<br> <li> Explicitly skips bound parameters from the graph's bound dictionary<br> <li> Maintains separation between signature defaults and bound <br>configuration values</ul>


</details>


  </td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/36/files#diff-f787b3249a9c0a718e41dc6953ef33222c80e81c3db52bffc70efd3b63c58e9e">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_bind_defaults.py</strong><dd><code>Add comprehensive bound parameters validation tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_bind_defaults.py

<ul><li>New test file with comprehensive test suite for bound parameters <br>validation<br> <li> <code>test_bound_params_not_treated_as_defaults()</code> verifies main fix for <br>false positives<br> <li> <code>test_actual_defaults_still_validated()</code> ensures real defaults are still <br>checked<br> <li> <code>test_nested_graph_with_bound_and_defaults()</code> covers complex nested <br>scenarios<br> <li> <code>test_user_rag_example()</code> reproduces and validates the original user bug <br>report</ul>


</details>


  </td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/36/files#diff-f50b8d77b905915ad513a4142a5d5a373281814b7f45b5849717fea053582ac0">+109/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation now distinguishes actual function-signature defaults from runtime-bound values so nested graphs report inputs as optional/required correctly.
  * Missing-input suggestions no longer recommend the same parameter (avoids self-referential hints).

* **UX / Messages**
  * Error messages now include a short hint about common .bind() pitfalls and correct usage when a graph is bound.

* **Tests**
  * Added comprehensive tests for bound parameters, nested graphs, and default/override scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->