### PR TITLE
feat: allow same output name for nodes in the same cycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ specs/*
 deprecated/*
 .doc-manager/*
 .auto-claude/*
+.env

--- a/docs/06-api-reference/graph.md
+++ b/docs/06-api-reference/graph.md
@@ -474,6 +474,8 @@ Graph([a, b])
 # GraphConfigError: Multiple nodes produce 'result'
 ```
 
+> **Exception**: Multiple nodes *can* produce the same output if they all belong to the same cycle. Cycles have deterministic execution order, so the consumer always gets the most recently produced value. See [Shared Outputs in a Cycle](../03-patterns/03-agentic-loops.md#shared-outputs-in-a-cycle).
+
 **Invalid identifiers:**
 ```python
 process.with_name("123-invalid")

--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -146,24 +146,32 @@ class Graph:
         return compute_input_spec(self._nodes, self._nx_graph, self._bound)
 
     @functools.cached_property
-    def sole_producers(self) -> dict[str, str]:
-        """Map output_name → node_name for outputs with exactly one producer.
+    def self_producers(self) -> dict[str, set[str]]:
+        """Map output_name → set of node names that produce it.
 
-        Used by the staleness detector to implement the Sole Producer Rule:
-        a node should not re-trigger from changes to values it produced itself.
-        This prevents infinite loops in accumulator patterns like
-        ``add_response(messages, response) -> messages`` and self-loops like
-        ``transform(x) -> x``.
+        Used by the staleness detector: a node skips staleness checks for
+        outputs it produces itself, even when other nodes in the same cycle
+        also produce that output. This prevents infinite loops in accumulator
+        patterns like ``add_response(messages) -> messages``.
 
-        Without this rule, the node's own output would make it appear stale,
-        causing immediate re-execution in an infinite loop. Cyclic re-execution
-        should instead be driven by gates (``@route``).
+        Cyclic re-execution should instead be driven by gates (``@route``).
         """
         output_sources = self._collect_output_sources(list(self._nodes.values()))
         return {
-            output: sources[0]
+            output: set(sources)
             for output, sources in output_sources.items()
-            if len(sources) == 1
+        }
+
+    @functools.cached_property
+    def sole_producers(self) -> dict[str, str]:
+        """Map output_name → node_name for outputs with exactly one producer.
+
+        Convenience accessor; prefer ``self_producers`` for staleness checks.
+        """
+        return {
+            output: next(iter(nodes))
+            for output, nodes in self.self_producers.items()
+            if len(nodes) == 1
         }
 
     def _get_edge_produced_values(self) -> set[str]:
@@ -259,6 +267,38 @@ class Graph:
                 return True
 
         return False
+
+    def _are_all_in_same_cycle(
+        self,
+        node_names: list[str],
+        G: nx.DiGraph,
+        nodes: list[HyperNode],
+        output_to_sources: dict[str, list[str]],
+    ) -> bool:
+        """Check if all given nodes are in at least one common cycle.
+
+        Builds a temporary graph with edges from ALL producers (not just the
+        first) so that cycles involving multiple producers of the same output
+        are detected correctly.
+        """
+        if len(node_names) < 2:
+            return True
+
+        # Build a temporary data graph with all producer edges
+        temp = nx.DiGraph()
+        temp.add_nodes_from(G.nodes())
+        # Add all existing data edges
+        for u, v, data in G.edges(data=True):
+            if data.get("edge_type") == "data":
+                temp.add_edge(u, v)
+        # Add edges from ALL producers (not just first)
+        for node in nodes:
+            for param in node.inputs:
+                for source in output_to_sources.get(param, []):
+                    temp.add_edge(source, node.name)
+
+        nodes_set = set(node_names)
+        return any(nodes_set.issubset(set(cycle)) for cycle in nx.simple_cycles(temp))
 
     def _compute_exclusive_reachability(
         self, G: nx.DiGraph, targets: list[str]
@@ -372,7 +412,10 @@ class Graph:
             if self._are_all_mutex(sources, expanded_groups):
                 continue  # All sources are mutually exclusive - OK
 
-            # Not all sources are mutex - this is an error
+            if self._are_all_in_same_cycle(sources, G, nodes, output_to_sources):
+                continue  # All sources are in the same cycle - OK
+
+            # Not all sources are mutex or in same cycle - this is an error
             raise GraphConfigError(
                 f"Multiple nodes produce '{output}'\n\n"
                 f"  -> {sources[0]} creates '{output}'\n"

--- a/src/hypergraph/graph/input_spec.py
+++ b/src/hypergraph/graph/input_spec.py
@@ -110,12 +110,24 @@ def _categorize_param(
     has_edge = param in edge_produced
 
     if has_edge:
-        return "seed" if param in cycle_params else None
+        if param in cycle_params:
+            return None if _is_interrupt_produced(param, nodes) else "seed"
+        return None
 
     if param in bound or _any_node_has_default(param, nodes):
         return "optional"
 
     return "required"
+
+
+def _is_interrupt_produced(param: str, nodes: dict[str, "HyperNode"]) -> bool:
+    """Check if param is produced by an InterruptNode."""
+    from hypergraph.nodes.interrupt import InterruptNode
+
+    return any(
+        isinstance(n, InterruptNode) and param in n.outputs
+        for n in nodes.values()
+    )
 
 
 def _any_node_has_default(param: str, nodes: dict[str, "HyperNode"]) -> bool:

--- a/src/hypergraph/nodes/gate.py
+++ b/src/hypergraph/nodes/gate.py
@@ -96,6 +96,7 @@ class GateNode(HyperNode):
     func: Callable
     _definition_hash: str
     _cache: bool
+    default_open: bool
 
     @property
     def cache(self) -> bool:
@@ -220,6 +221,7 @@ class RouteNode(GateNode):
         fallback: str | type[END] | None = None,
         multi_target: bool = False,
         cache: bool = False,
+        default_open: bool = True,
         name: str | None = None,
         rename_inputs: dict[str, str] | None = None,
     ) -> None:
@@ -287,6 +289,7 @@ class RouteNode(GateNode):
         self.fallback = fallback
         self.multi_target = multi_target
         self._cache = cache
+        self.default_open = default_open
         self._definition_hash = hash_definition(func)
 
         # Core HyperNode attributes
@@ -322,6 +325,7 @@ def route(
     fallback: str | type[END] | None = None,
     multi_target: bool = False,
     cache: bool = False,
+    default_open: bool = True,
     name: str | None = None,
     rename_inputs: dict[str, str] | None = None,
 ) -> Callable[[Callable], RouteNode]:
@@ -340,6 +344,9 @@ def route(
         cache: Cache the routing function's return value. On cache hit,
             the runner restores the routing decision without calling the
             function. Requires a cache backend on the runner.
+        default_open: If True, targets may execute before the gate runs the
+            first time. If False, targets are blocked until the gate executes
+            and records a decision.
         name: Node name (default: func.__name__)
         rename_inputs: Mapping to rename inputs {old: new}
 
@@ -363,6 +370,7 @@ def route(
             fallback=fallback,
             multi_target=multi_target,
             cache=cache,
+            default_open=default_open,
             name=name,
             rename_inputs=rename_inputs,
         )
@@ -409,6 +417,7 @@ class IfElseNode(GateNode):
         when_false: str | type[END],
         *,
         cache: bool = False,
+        default_open: bool = True,
         name: str | None = None,
         rename_inputs: dict[str, str] | None = None,
     ) -> None:
@@ -419,6 +428,9 @@ class IfElseNode(GateNode):
             when_true: Target to activate when func returns True
             when_false: Target to activate when func returns False
             cache: Whether to cache routing decisions (default: False)
+            default_open: If True, targets may execute before the gate runs
+                the first time. If False, targets are blocked until the gate
+                executes and records a decision.
             name: Node name (default: func.__name__)
             rename_inputs: Mapping to rename inputs {old: new}
 
@@ -448,6 +460,7 @@ class IfElseNode(GateNode):
         self.targets = [when_true, when_false]
         self.descriptions = {True: "True", False: "False"}
         self._cache = cache
+        self.default_open = default_open
         self._definition_hash = hash_definition(func)
 
         # Core HyperNode attributes
@@ -483,6 +496,7 @@ def ifelse(
     when_false: str | type[END],
     *,
     cache: bool = False,
+    default_open: bool = True,
     name: str | None = None,
     rename_inputs: dict[str, str] | None = None,
 ) -> Callable[[Callable[..., bool]], IfElseNode]:
@@ -500,6 +514,9 @@ def ifelse(
         cache: Cache the routing function's return value. On cache hit,
             the runner restores the routing decision without calling the
             function. Requires a cache backend on the runner.
+        default_open: If True, targets may execute before the gate runs the
+            first time. If False, targets are blocked until the gate executes
+            and records a decision.
         name: Node name (default: func.__name__)
         rename_inputs: Mapping to rename inputs {old: new}
 
@@ -522,6 +539,7 @@ def ifelse(
             when_true=when_true,
             when_false=when_false,
             cache=cache,
+            default_open=default_open,
             name=name,
             rename_inputs=rename_inputs,
         )

--- a/src/hypergraph/runners/_shared/helpers.py
+++ b/src/hypergraph/runners/_shared/helpers.py
@@ -290,13 +290,13 @@ def _is_stale(
     Gates explicitly drive cycle execution, so self-produced inputs should
     trigger re-execution when the gate routes back to the node.
     """
-    sole_producers = graph.sole_producers
+    self_producers = graph.self_producers
     is_gated = _is_controlled_by_gate(node, graph)
 
     for param in node.inputs:
-        # Apply Sole Producer Rule only to non-gated nodes
-        if not is_gated and sole_producers.get(param) == node.name:
-            continue  # Sole Producer Rule: skip self-produced inputs
+        # Self-Producer Rule: skip inputs this node produces itself (non-gated only)
+        if not is_gated and node.name in self_producers.get(param, set()):
+            continue
         current_version = state.get_version(param)
         consumed_version = last_exec.input_versions.get(param, 0)
         if current_version != consumed_version:

--- a/src/hypergraph/runners/_shared/helpers.py
+++ b/src/hypergraph/runners/_shared/helpers.py
@@ -189,6 +189,8 @@ def _get_activated_nodes(graph: "Graph", state: GraphState) -> set[str]:
                 if decision is None:
                     if gate_name not in state.node_executions:
                         gate = graph._nodes.get(gate_name)
+                        if gate is None:
+                            continue
                         default_open = getattr(gate, "default_open", True)
                         if default_open:
                             # Gate has never executed — default to open (configurable)

--- a/src/hypergraph/runners/_shared/types.py
+++ b/src/hypergraph/runners/_shared/types.py
@@ -54,6 +54,11 @@ class RunResult:
         """Whether execution is paused at an InterruptNode."""
         return self.status == RunStatus.PAUSED
 
+    @property
+    def completed(self) -> bool:
+        """Whether execution completed successfully."""
+        return self.status == RunStatus.COMPLETED
+
     def __getitem__(self, key: str) -> Any:
         """Dict-like access to values."""
         return self.values[key]

--- a/src/hypergraph/runners/async_/executors/interrupt_node.py
+++ b/src/hypergraph/runners/async_/executors/interrupt_node.py
@@ -24,7 +24,9 @@ class AsyncInterruptNodeExecutor:
         output_name = node.outputs[0]
 
         # Resume path: output already in state (provided via values dict)
-        if output_name in state.values:
+        # Skip pause only if value exists AND node hasn't executed yet this run
+        # (in cycles, the node re-executes and should pause again)
+        if output_name in state.values and node.name not in state.node_executions:
             return {output_name: state.values[output_name]}
 
         input_value = inputs[node.inputs[0]]

--- a/src/hypergraph/runners/async_/runner.py
+++ b/src/hypergraph/runners/async_/runner.py
@@ -178,8 +178,14 @@ class AsyncRunner(BaseRunner):
             )
             return result
         except PauseExecution as pause:
+            partial_state = getattr(pause, "_partial_state", None)
+            partial_values = (
+                filter_outputs(partial_state, graph, select)
+                if partial_state is not None
+                else {}
+            )
             return RunResult(
-                values={},
+                values=partial_values,
                 status=RunStatus.PAUSED,
                 pause=pause.pause_info,
             )
@@ -260,6 +266,9 @@ class AsyncRunner(BaseRunner):
                 if get_ready_nodes(graph, state):
                     raise InfiniteLoopError(max_iterations)
 
+        except PauseExecution as pause:
+            pause._partial_state = state  # type: ignore[attr-defined]
+            raise
         except Exception as e:
             if not hasattr(e, "_partial_state"):
                 e._partial_state = state  # type: ignore[attr-defined]

--- a/src/hypergraph/runners/async_/runner.py
+++ b/src/hypergraph/runners/async_/runner.py
@@ -187,6 +187,7 @@ class AsyncRunner(BaseRunner):
             return RunResult(
                 values=partial_values,
                 status=RunStatus.PAUSED,
+                run_id=run_id,
                 pause=pause.pause_info,
             )
         except Exception as e:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1712,3 +1712,87 @@ class TestStrictTypesWithNestedGraphNode:
         error_msg = str(exc_info.value)
         assert "Type mismatch" in error_msg
         assert "b" in error_msg
+
+
+class TestCycleSameOutput:
+    """Test that multiple nodes can produce the same output when in the same cycle."""
+
+    def test_same_cycle_same_output_allowed(self):
+        """Two nodes producing 'messages' in a cycle should not raise."""
+        from hypergraph.nodes.gate import route, END
+
+        @node(output_name="messages")
+        def accumulate_query(messages: list, query: str) -> list:
+            return messages + [{"role": "user", "content": query}]
+
+        @node(output_name="messages")
+        def accumulate_response(messages: list, response: str) -> list:
+            return messages + [{"role": "assistant", "content": response}]
+
+        @route(targets=["accumulate_query", END])
+        def should_continue(messages: list) -> str:
+            return END if len(messages) >= 4 else "accumulate_query"
+
+        # Should NOT raise GraphConfigError
+        graph = Graph([accumulate_query, accumulate_response, should_continue])
+        assert graph is not None
+
+    def test_same_cycle_same_output_runs(self):
+        """Same-output cycle nodes should execute end-to-end."""
+        from hypergraph.nodes.gate import route, END
+        from hypergraph.runners.sync import SyncRunner
+
+        @node(output_name="messages")
+        def accumulate_query(messages: list, query: str) -> list:
+            return messages + [{"role": "user", "content": query}]
+
+        @node(output_name="messages")
+        def accumulate_response(messages: list, response: str) -> list:
+            return messages + [{"role": "assistant", "content": response}]
+
+        @route(targets=["accumulate_query", END])
+        def should_continue(messages: list) -> str:
+            return END if len(messages) >= 4 else "accumulate_query"
+
+        graph = Graph([accumulate_query, accumulate_response, should_continue])
+        runner = SyncRunner()
+        result = runner.run(graph, {"messages": [], "query": "hi", "response": "hello"})
+        assert "messages" in result
+        assert len(result["messages"]) >= 2
+
+    def test_non_cycle_same_output_still_raises(self):
+        """Two nodes producing 'result' in a plain DAG should still raise."""
+
+        @node(output_name="result")
+        def producer_a(x: int) -> int:
+            return x + 1
+
+        @node(output_name="result")
+        def producer_b(y: int) -> int:
+            return y + 2
+
+        with pytest.raises(GraphConfigError):
+            Graph([producer_a, producer_b])
+
+    def test_self_producers_property(self):
+        """After the fix, graph should expose self_producers mapping output to producer sets."""
+        from hypergraph.nodes.gate import route, END
+
+        @node(output_name="messages")
+        def accumulate_query(messages: list, query: str) -> list:
+            return messages + [{"role": "user", "content": query}]
+
+        @node(output_name="messages")
+        def accumulate_response(messages: list, response: str) -> list:
+            return messages + [{"role": "assistant", "content": response}]
+
+        @route(targets=["accumulate_query", END])
+        def should_continue(messages: list) -> str:
+            return END if len(messages) >= 4 else "accumulate_query"
+
+        graph = Graph([accumulate_query, accumulate_response, should_continue])
+
+        # self_producers should map output names to sets of producer node names
+        assert hasattr(graph, "self_producers")
+        producers = graph.self_producers
+        assert producers["messages"] == {"accumulate_query", "accumulate_response"}

--- a/tests/test_interrupt_node.py
+++ b/tests/test_interrupt_node.py
@@ -458,8 +458,7 @@ class TestNestedInterruptPropagation:
 class TestInterruptNodeInCycle:
     """InterruptNode inside a cycle should pause on every iteration."""
 
-    @pytest.mark.asyncio
-    async def test_interrupt_output_not_classified_as_seed(self):
+    def test_interrupt_output_not_classified_as_seed(self):
         """Interrupt output in a cycle should NOT be a seed input."""
         ask_user = InterruptNode(
             name="ask_user", input_param="messages", output_param="query"

--- a/tests/test_nodes_gate.py
+++ b/tests/test_nodes_gate.py
@@ -420,6 +420,24 @@ class TestGateNodeBase:
         assert hasattr(decide, "descriptions")
         assert decide.descriptions["a"] == "Option A"
 
+    def test_gatenode_default_open_defaults_true(self):
+        """GateNode default_open should default to True."""
+
+        @route(targets=["a"])
+        def decide(x):
+            return "a"
+
+        assert decide.default_open is True
+
+    def test_gatenode_default_open_can_be_set(self):
+        """GateNode default_open should be configurable."""
+
+        @route(targets=["a"], default_open=False)
+        def decide(x):
+            return "a"
+
+        assert decide.default_open is False
+
 
 # =============================================================================
 # GateNode Type Annotation Tests


### PR DESCRIPTION
### **User description**
## Summary
- Relaxes output conflict validation so multiple nodes can produce the same output name when they're all in the same cycle
- Generalizes `sole_producers` → `self_producers` so the staleness detector correctly skips self-produced values even with multiple producers
- Nodes in a cycle have deterministic execution order, so there's no ambiguity about which value a consumer gets

## Test plan
- [ ] New tests in `TestCycleSameOutput`: same-cycle allowed, non-cycle still raises, end-to-end run, self_producers property
- [ ] Full test suite passes (4 pre-existing failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Allow multiple nodes to produce same output when in same cycle

- Generalize `sole_producers` to `self_producers` for multi-producer cycles

- Add cycle detection logic to validate output conflicts

- Document shared output names pattern in agentic loops


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Output Conflict Validation"] --> B["Check if all mutex"]
  B --> C["Check if all in same cycle"]
  C --> D["Allow or Raise Error"]
  E["sole_producers"] --> F["self_producers"]
  F --> G["Map output to producer sets"]
  H["Staleness Detector"] --> G
  H --> I["Skip self-produced inputs"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>core.py</strong><dd><code>Implement cycle detection and generalize producer tracking</code></dd></summary>
<hr>

src/hypergraph/graph/core.py

<ul><li>Renamed <code>sole_producers</code> to <code>self_producers</code> returning sets instead of <br>single node names<br> <li> Added <code>_are_all_in_same_cycle()</code> method to detect if nodes share a <br>common cycle<br> <li> Modified <code>_validate_output_conflicts()</code> to allow same output when nodes <br>are in same cycle<br> <li> Kept <code>sole_producers</code> as convenience accessor for backward compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/37/files#diff-187e378c017f7b11d453a19d86325b60ef3566887ba64472831b08b6493c0e48">+56/-13</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>helpers.py</strong><dd><code>Update staleness detector for multi-producer cycles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hypergraph/runners/_shared/helpers.py

<ul><li>Updated <code>_is_stale()</code> to use <code>self_producers</code> instead of <code>sole_producers</code><br> <li> Changed staleness check to handle multiple producers in same cycle<br> <li> Updated comments to reflect Self-Producer Rule for non-gated nodes</ul>


</details>


  </td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/37/files#diff-527974079a4ec295ee9c51c980e1d75db64c7f4e23f68f63e4b8530363665d8b">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_graph.py</strong><dd><code>Add tests for cycle same-output feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_graph.py

<ul><li>Added <code>TestCycleSameOutput</code> class with four comprehensive test cases<br> <li> Test same-cycle nodes allowed without raising error<br> <li> Test end-to-end execution of same-output cycle nodes<br> <li> Test non-cycle same-output still raises error<br> <li> Test <code>self_producers</code> property returns correct producer sets</ul>


</details>


  </td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/37/files#diff-e9352f44736d5b9e922852f07917f4d93bb6d4ca2e6d9743abf20194a5c414d5">+84/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>03-agentic-loops.md</strong><dd><code>Document shared outputs in cycles pattern</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/03-patterns/03-agentic-loops.md

<ul><li>Added new "Shared Outputs in a Cycle" section explaining the feature<br> <li> Provided code example showing two nodes producing same output in cycle<br> <li> Explained deterministic execution order guarantees</ul>


</details>


  </td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/37/files#diff-e3572c1a7b5225caf7095290ab13d91acb1eb50f502e604d1722f64bb9fb327d">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>graph.md</strong><dd><code>Add cycle exception to validation documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/06-api-reference/graph.md

<ul><li>Added exception note to output conflict validation section<br> <li> Clarified that multiple nodes can produce same output in cycles<br> <li> Linked to detailed pattern documentation</ul>


</details>


  </td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/37/files#diff-85823276de19103713cf7c6fca52be63d160406a180c7f70dcc2b28ce2789dc0">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multiple nodes in the same cycle may produce the same output name; deterministic ordering ensures the most recent value is observed.
  * Gate nodes gain a configurable default-open behavior.
  * Run results expose a completed flag; paused results now include partial output values and run identifiers.
  * Interrupt/pause behavior is cycle-aware (nodes can re-execute and pause again).

* **Documentation**
  * Added docs and API notes explaining shared outputs in cycles with examples.

* **Validation**
  * Ignore internal interrupt-produced outputs when checking for unexpected provided inputs.

* **Tests**
  * Added tests for same-output cycles, gate default_open, and InterruptNode behavior in cycles.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->