### PR TITLE
Add pre-commit hooks configuration with nbstripout

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/kynan/nbstripout
+    rev: 0.9.0
+    hooks:
+      - id: nbstripout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,9 @@ Issues = "https://github.com/gilad-rubin/hypergraph/issues"
 [dependency-groups]
 dev = [
     "allpairspy>=2.5.1",
+    "nbstripout>=0.9.0",
     "playwright>=1.56.0",
+    "pre-commit>=4.0.0",
     "pytest>=8.4.2",
     "pytest-asyncio>=1.3.0",
     "pytest-xdist>=3.5.0",


### PR DESCRIPTION
### **User description**
## Summary
This PR adds pre-commit framework integration to the project with nbstripout to automatically strip output from Jupyter notebooks.

## Changes
- Added `.pre-commit-config.yaml` configuration file with nbstripout hook (v0.9.0)
- Updated `pyproject.toml` dev dependencies:
  - Added `nbstripout>=0.9.0` for notebook output stripping
  - Added `pre-commit>=4.0.0` for managing git hooks

## Details
The pre-commit framework will automatically run nbstripout before commits to ensure Jupyter notebooks are committed without execution outputs, reducing repository bloat and avoiding merge conflicts from cell outputs. This improves collaboration and keeps the repository clean.

Developers can install the hooks locally by running `pre-commit install` after pulling this change.

https://claude.ai/code/session_01RwSycdEXyHn8oNgbS5i2ME


___

### **PR Type**
Enhancement


___

### **Description**
- Add pre-commit framework integration with nbstripout hook

- Automatically strip outputs from Jupyter notebooks before commits

- Add nbstripout and pre-commit to dev dependencies


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Pre-commit Framework"] -- "configures" --> B["nbstripout Hook"]
  B -- "strips outputs from" --> C["Jupyter Notebooks"]
  D["pyproject.toml"] -- "adds dependencies" --> A
  D -- "adds dependencies" --> B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.pre-commit-config.yaml</strong><dd><code>Add pre-commit configuration with nbstripout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.pre-commit-config.yaml

<ul><li>New configuration file for pre-commit framework<br> <li> Configures nbstripout hook version 0.9.0<br> <li> Automatically strips outputs from Jupyter notebooks before commits</ul>


</details>


  </td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/41/files#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Add pre-commit and nbstripout dev dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

<ul><li>Add <code>nbstripout>=0.9.0</code> to dev dependencies<br> <li> Add <code>pre-commit>=4.0.0</code> to dev dependencies<br> <li> Maintains alphabetical ordering of dependencies</ul>


</details>


  </td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/41/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added pre-commit hook configuration to automatically strip outputs from notebooks during commits.
  * Added development dependencies to support notebook output management and pre-commit infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->