### PR TITLE
feat(runners): compact RunResult display for large outputs

### DIFF
--- a/src/hypergraph/runners/_shared/types.py
+++ b/src/hypergraph/runners/_shared/types.py
@@ -75,7 +75,20 @@ def _compact_mapping(mapping: dict[Any, Any], depth: int, seen: set[int]) -> str
 def _compact_sequence(values: list[Any], sequence_type: str, depth: int, seen: set[int]) -> str:
     """Return a compact representation for long sequence-like values."""
     if len(values) <= _MAX_SEQUENCE_PREVIEW:
-        return "[" + ", ".join(_compact_value(v, depth + 1, seen) for v in values) + "]"
+        compact_items = [_compact_value(v, depth + 1, seen) for v in values]
+        if sequence_type == "tuple":
+            if len(compact_items) == 1:
+                return f"({compact_items[0]},)"
+            return "(" + ", ".join(compact_items) + ")"
+        if sequence_type == "set":
+            if not compact_items:
+                return "set()"
+            return "{" + ", ".join(compact_items) + "}"
+        if sequence_type == "frozenset":
+            if not compact_items:
+                return "frozenset()"
+            return "frozenset({" + ", ".join(compact_items) + "})"
+        return "[" + ", ".join(compact_items) + "]"
     preview = ", ".join(_compact_value(v, depth + 1, seen) for v in values[:_MAX_SEQUENCE_PREVIEW])
     return f"<{sequence_type} len={len(values)} preview=[{preview}, ...]>"
 

--- a/src/hypergraph/runners/_shared/types.py
+++ b/src/hypergraph/runners/_shared/types.py
@@ -3,11 +3,17 @@
 from __future__ import annotations
 
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields, is_dataclass
 from enum import Enum
 from typing import Any, Literal
 
 ErrorHandling = Literal["raise", "continue"]
+
+_MAX_STRING_PREVIEW = 120
+_MAX_SEQUENCE_PREVIEW = 6
+_MAX_MAPPING_PREVIEW = 6
+_MAX_VALUE_REPR = 240
+_MAX_RUN_RESULT_REPR = 4_000
 
 
 class RunStatus(Enum):
@@ -27,6 +33,106 @@ class RunStatus(Enum):
 def _generate_run_id() -> str:
     """Generate a unique run ID."""
     return f"run-{uuid.uuid4().hex[:12]}"
+
+
+def _truncate_text(text: str, max_length: int) -> str:
+    """Truncate text to max_length and append an ellipsis when needed."""
+    if len(text) <= max_length:
+        return text
+    return text[: max_length - 3] + "..."
+
+
+def _safe_repr(value: Any) -> str:
+    """Return repr(value), falling back to a safe placeholder."""
+    try:
+        return repr(value)
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        return f"<unreprable {type(value).__name__}: {exc}>"
+
+
+def _compact_string(text: str) -> str:
+    """Compact long strings while preserving quote style."""
+    if len(text) <= _MAX_STRING_PREVIEW:
+        return repr(text)
+    preview = _truncate_text(text, _MAX_STRING_PREVIEW)
+    return f"{preview!r} (len={len(text)})"
+
+
+def _compact_mapping(mapping: dict[Any, Any], depth: int, seen: set[int]) -> str:
+    """Return a compact representation for dict-like values."""
+    items = list(mapping.items())
+    preview_items = items[:_MAX_MAPPING_PREVIEW]
+    parts = [
+        f"{_truncate_text(_safe_repr(k), 80)}: {_compact_value(v, depth + 1, seen)}"
+        for k, v in preview_items
+    ]
+    remaining = len(items) - len(preview_items)
+    if remaining > 0:
+        parts.append(f"... (+{remaining} more)")
+    return "{" + ", ".join(parts) + "}"
+
+
+def _compact_sequence(values: list[Any], sequence_type: str, depth: int, seen: set[int]) -> str:
+    """Return a compact representation for long sequence-like values."""
+    if len(values) <= _MAX_SEQUENCE_PREVIEW:
+        return "[" + ", ".join(_compact_value(v, depth + 1, seen) for v in values) + "]"
+    preview = ", ".join(_compact_value(v, depth + 1, seen) for v in values[:_MAX_SEQUENCE_PREVIEW])
+    return f"<{sequence_type} len={len(values)} preview=[{preview}, ...]>"
+
+
+def _compact_value(value: Any, depth: int = 0, seen: set[int] | None = None) -> str:
+    """Build a compact, recursion-safe representation for nested values."""
+    if seen is None:
+        seen = set()
+
+    if isinstance(value, str):
+        return _compact_string(value)
+
+    if isinstance(value, (int, float, bool, type(None))):
+        return repr(value)
+
+    if isinstance(value, bytes):
+        return _truncate_text(repr(value), _MAX_VALUE_REPR)
+
+    if depth >= 2:
+        return _truncate_text(_safe_repr(value), _MAX_VALUE_REPR)
+
+    is_recursive_candidate = isinstance(value, (dict, list, tuple, set, frozenset)) or (
+        is_dataclass(value) and not isinstance(value, type)
+    )
+    if is_recursive_candidate:
+        object_id = id(value)
+        if object_id in seen:
+            return f"<recursive {type(value).__name__}>"
+        seen.add(object_id)
+
+    try:
+        if is_dataclass(value) and not isinstance(value, type):
+            field_map = {f.name: getattr(value, f.name) for f in fields(value)}
+            return f"<{type(value).__name__} {_compact_mapping(field_map, depth, seen)}>"
+
+        if isinstance(value, dict):
+            return _compact_mapping(value, depth, seen)
+
+        if isinstance(value, list):
+            return _compact_sequence(value, "list", depth, seen)
+
+        if isinstance(value, tuple):
+            return _compact_sequence(list(value), "tuple", depth, seen)
+
+        if isinstance(value, (set, frozenset)):
+            preview_list = list(value)
+            return _compact_sequence(preview_list, type(value).__name__, depth, seen)
+
+        shape = getattr(value, "shape", None)
+        if shape is not None and hasattr(value, "dtype"):
+            dtype = getattr(value, "dtype", None)
+            return f"<{type(value).__name__} shape={shape!r} dtype={dtype!r}>"
+
+        return _truncate_text(_safe_repr(value), _MAX_VALUE_REPR)
+    finally:
+        if is_recursive_candidate:
+            seen.discard(id(value))
 
 
 @dataclass
@@ -70,6 +176,27 @@ class RunResult:
     def get(self, key: str, default: Any = None) -> Any:
         """Get value with default."""
         return self.values.get(key, default)
+
+    def __repr__(self) -> str:
+        """Compact repr to avoid extremely large notebook output."""
+        text = (
+            "RunResult("
+            f"status={self.status.value}, "
+            f"values={_compact_value(self.values)}, "
+            f"run_id={self.run_id!r}, "
+            f"workflow_id={self.workflow_id!r}, "
+            f"error={_compact_value(self.error)}, "
+            f"pause={_compact_value(self.pause)}"
+            ")"
+        )
+        return _truncate_text(text, _MAX_RUN_RESULT_REPR)
+
+    def _repr_pretty_(self, pretty_printer: Any, cycle: bool) -> None:
+        """Use the compact repr for IPython pretty display."""
+        if cycle:
+            pretty_printer.text("RunResult(...)")
+            return
+        pretty_printer.text(repr(self))
 
 
 @dataclass

--- a/tests/test_runners/test_types.py
+++ b/tests/test_runners/test_types.py
@@ -124,6 +124,25 @@ class TestRunResult:
         assert "values={'x': 1, 'y': 'hello'}" in text
         assert "status=completed" in text
 
+    def test_repr_preserves_short_container_types(self):
+        result = RunResult(
+            values={
+                "tuple_value": (1, 2),
+                "single_tuple": (1,),
+                "set_value": {1, 2},
+                "frozenset_value": frozenset({1, 2}),
+            },
+            status=RunStatus.COMPLETED,
+        )
+        text = repr(result)
+
+        assert "'tuple_value': (1, 2)" in text
+        assert "'single_tuple': (1,)" in text
+        assert "'set_value': {" in text
+        assert "'frozenset_value': frozenset({" in text
+        assert "'tuple_value': [1, 2]" not in text
+        assert "'set_value': [1, 2]" not in text
+
     def test_repr_compacts_failed_and_paused_runs(self):
         error = ValueError("x" * 500)
         pause = PauseInfo(


### PR DESCRIPTION
### **User description**
## Summary
- add compact  display to avoid huge notebook output for large values (e.g. embedding vectors)
- include compact formatting for nested mappings, long strings, long sequences, dataclass values, and array-like shape/dtype previews
- add global repr length guard and  integration for IPython/Jupyter
- fix container-type fidelity bug so short tuples/sets/frozensets keep correct delimiters instead of appearing as lists

## Why
 was a plain dataclass repr, so values like large embedding vectors flooded notebook cell output.

## Testing
- bringing up nodes...
bringing up nodes...

.................................                                        [100%]
33 passed in 1.31s
  - result: 33 passed

## Notes
-  behavior is unchanged; only display semantics were updated.


___

### **PR Type**
Enhancement


___

### **Description**
- Add compact repr for RunResult to prevent huge notebook output

- Implement recursive value compaction with depth limits and cycle detection

- Preserve container type delimiters (tuple, set, frozenset) in compact display

- Add IPython/Jupyter integration via _repr_pretty_ method

- Include comprehensive tests for large embeddings, nested structures, and edge cases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["RunResult values<br/>with large data"] -->|"_compact_value()"| B["Recursive compaction<br/>with depth/cycle guards"]
  B -->|"_compact_string()"| C["Truncated strings<br/>with length info"]
  B -->|"_compact_sequence()"| D["Preview sequences<br/>preserving types"]
  B -->|"_compact_mapping()"| E["Limited dict items<br/>with overflow count"]
  C --> F["__repr__()<br/>max 4000 chars"]
  D --> F
  E --> F
  F -->|"_repr_pretty_()"| G["IPython/Jupyter<br/>display"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>types.py</strong><dd><code>Add compact repr system for RunResult display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hypergraph/runners/_shared/types.py

<ul><li>Add five module-level constants for truncation limits <br>(_MAX_STRING_PREVIEW, _MAX_SEQUENCE_PREVIEW, _MAX_MAPPING_PREVIEW, <br>_MAX_VALUE_REPR, _MAX_RUN_RESULT_REPR)<br> <li> Implement _truncate_text() helper to safely truncate strings with <br>ellipsis<br> <li> Implement _safe_repr() wrapper for exception-safe repr() calls<br> <li> Implement _compact_string() for long string preview with length <br>annotation<br> <li> Implement _compact_mapping() for dict-like values with item limit and <br>overflow indicator<br> <li> Implement _compact_sequence() for list/tuple/set/frozenset with type <br>preservation and preview mode<br> <li> Implement _compact_value() recursive function with depth limiting, <br>cycle detection, and special handling for dataclasses and array-like <br>objects<br> <li> Add __repr__() method to RunResult class using _compact_value() with <br>4000 char limit<br> <li> Add _repr_pretty_() method to RunResult for IPython/Jupyter <br>integration</ul>


</details>


  </td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/45/files#diff-27b22644a63dbb842dd4c9dec90c0fbac2e38bbd45eb0f7788b373339e7bed17">+141/-1</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_types.py</strong><dd><code>Add comprehensive tests for compact repr</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_runners/test_types.py

<ul><li>Add PauseInfo to imports<br> <li> Add test_repr_is_compact_for_large_embedding() to verify large lists <br>are compacted with length info<br> <li> Add test_repr_keeps_small_payloads_readable() to ensure small values <br>remain fully visible<br> <li> Add test_repr_preserves_short_container_types() to verify <br>tuple/set/frozenset delimiters are preserved<br> <li> Add test_repr_compacts_failed_and_paused_runs() to test error and <br>pause field compaction<br> <li> Add test_repr_pretty_uses_compact_repr() to verify IPython pretty <br>printer integration</ul>


</details>


  </td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/45/files#diff-2ff275d6dbb3e2b879d5153cff491c260e8c88b97c76534817804c42b704c64f">+85/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PauseInfo is now publicly available for use in external applications and libraries.

* **Improvements**
  * Enhanced RunResult object representation with automatic text truncation and compact formatting designed to handle large and complex nested data structures efficiently.
  * Added IPython-compatible pretty printing support for improved readability in Jupyter notebooks and IPython environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->