### PR TITLE
feat: replace seeds with entrypoints, simplify bind, add on_missing

### DIFF
--- a/docs/03-patterns/03-agentic-loops.md
+++ b/docs/03-patterns/03-agentic-loops.md
@@ -231,19 +231,26 @@ def should_continue(messages: list) -> str:
 
 **Validation**: emit names must not overlap with `output_name`, and wait_for names must not overlap with function parameters. Referencing a nonexistent emit/output in `wait_for` raises `GraphConfigError` at build time.
 
-## Seed Inputs
+## Entry Points
 
-When a parameter is both an input and output of a cycle (like `history` or `iteration`), it becomes a **seed** — an initial value needed to start the first iteration. Provide seeds in the `values` dict when calling `runner.run()`:
+When a parameter is both an input and output of a cycle (like `history` or `iteration`), it becomes an **entry point parameter** — an initial value needed to start the first iteration. Provide these in the `values` dict when calling `runner.run()`:
 
 ```python
 result = runner.run(graph, {
     "prompt": "...",
-    "history": [],       # Seed: initial value before first iteration
-    "iteration": 0,      # Seed: starting counter
+    "history": [],       # Entry point: initial value before first iteration
+    "iteration": 0,      # Entry point: starting counter
 })
 ```
 
-You can check what seeds a graph needs via `graph.inputs.seeds`. For full details, see [InputSpec](../06-api-reference/inputspec.md).
+You can check what entry points a graph has via `graph.inputs.entry_points`. This returns a dict mapping node names to the cycle parameters they need:
+
+```python
+print(graph.inputs.entry_points)
+# {'accumulate_history': ('history',), 'increment': ('iteration',)}
+```
+
+Pick ONE entry point per cycle and provide its parameters. For full details, see [InputSpec](../06-api-reference/inputspec.md).
 
 ## Tracking State Across Iterations
 

--- a/docs/03-patterns/03-agentic-loops.md
+++ b/docs/03-patterns/03-agentic-loops.md
@@ -233,7 +233,7 @@ def should_continue(messages: list) -> str:
 
 ## Entry Points
 
-When a parameter is both an input and output of a cycle (like `history` or `iteration`), it becomes an **entry point parameter** — an initial value needed to start the first iteration. Provide these in the `values` dict when calling `runner.run()`:
+When a parameter is both an input and output of a cycle (like `history` or `iteration`), it becomes an **entrypoint parameter** — an initial value needed to start the first iteration. Provide these in the `values` dict when calling `runner.run()`:
 
 ```python
 result = runner.run(graph, {
@@ -243,14 +243,14 @@ result = runner.run(graph, {
 })
 ```
 
-You can check what entry points a graph has via `graph.inputs.entry_points`. This returns a dict mapping node names to the cycle parameters they need:
+You can check what entrypoints a graph has via `graph.inputs.entrypoints`. This returns a dict mapping node names to the cycle parameters they need:
 
 ```python
-print(graph.inputs.entry_points)
+print(graph.inputs.entrypoints)
 # {'accumulate_history': ('history',), 'increment': ('iteration',)}
 ```
 
-Pick ONE entry point per cycle and provide its parameters. For full details, see [InputSpec](../06-api-reference/inputspec.md).
+Pick ONE entrypoint per cycle and provide its parameters. For full details, see [InputSpec](../06-api-reference/inputspec.md).
 
 ## Tracking State Across Iterations
 

--- a/docs/06-api-reference/graph.md
+++ b/docs/06-api-reference/graph.md
@@ -223,8 +223,8 @@ print(g.inputs.required)  # ('x',)
 **Returns:** New Graph with bindings applied
 
 **Raises:**
-- `ValueError` - If binding a name that is an output of another node
-- `ValueError` - If binding a name not in `graph.inputs.all`
+- `ValueError` - If binding a name not recognized as a graph input or output
+- `ValueError` - If binding an emit-only output (ordering signal, not data)
 
 #### Shared State and Non-Copyable Objects
 

--- a/docs/06-api-reference/nodes.md
+++ b/docs/06-api-reference/nodes.md
@@ -749,7 +749,7 @@ The node name. Either from `graph.name` or explicitly provided to `as_node()`.
 
 #### `inputs: tuple[str, ...]`
 
-All inputs of the wrapped graph (required + optional + seeds).
+All inputs of the wrapped graph (required + optional + entry point params).
 
 ```python
 gn = inner.as_node()

--- a/docs/06-api-reference/runners.md
+++ b/docs/06-api-reference/runners.md
@@ -119,6 +119,7 @@ def map(
     map_mode: Literal["zip", "product"] = "zip",
     select: str | list[str] = "**",
     on_missing: Literal["ignore", "warn", "error"] = "ignore",
+    entry_point: str | None = None,
     error_handling: Literal["raise", "continue"] = "raise",
     event_processors: list[EventProcessor] | None = None,
     **input_values: Any,
@@ -134,6 +135,7 @@ Execute a graph multiple times with different inputs.
 - `map_mode` - `"zip"` for parallel iteration, `"product"` for cartesian product
 - `select` - Which outputs to return. `"**"` (default) returns all outputs.
 - `on_missing` - How to handle missing selected outputs (`"ignore"`, `"warn"`, or `"error"`)
+- `entry_point` - Optional explicit cycle entry point (passed to each `run()` call)
 - `error_handling` - How to handle failures:
   - `"raise"` (default): Stop on first failure and raise the exception
   - `"continue"`: Collect all results, including failures as `RunResult` with `status=FAILED`
@@ -312,6 +314,7 @@ async def map(
     map_mode: Literal["zip", "product"] = "zip",
     select: str | list[str] = "**",
     on_missing: Literal["ignore", "warn", "error"] = "ignore",
+    entry_point: str | None = None,
     max_concurrency: int | None = None,
     error_handling: Literal["raise", "continue"] = "raise",
     event_processors: list[EventProcessor] | None = None,
@@ -328,6 +331,7 @@ Execute graph multiple times concurrently.
 - `map_mode` - `"zip"` or `"product"`
 - `select` - Which outputs to return. `"**"` (default) returns all outputs.
 - `on_missing` - How to handle missing selected outputs (`"ignore"`, `"warn"`, or `"error"`)
+- `entry_point` - Optional explicit cycle entry point (passed to each `run()` call)
 - `max_concurrency` - Shared limit across all executions
 - `error_handling` - How to handle failures:
   - `"raise"` (default): Stop on first failure and raise the exception

--- a/docs/06-api-reference/runners.md
+++ b/docs/06-api-reference/runners.md
@@ -50,7 +50,9 @@ def run(
     graph: Graph,
     values: dict[str, Any] | None = None,
     *,
-    select: list[str] | None = None,
+    select: str | list[str] = "**",
+    on_missing: Literal["ignore", "warn", "error"] = "ignore",
+    entry_point: str | None = None,
     max_iterations: int | None = None,
     event_processors: list[EventProcessor] | None = None,
     **input_values: Any,
@@ -62,7 +64,12 @@ Execute a graph once.
 **Args:**
 - `graph` - The graph to execute
 - `values` - Optional input values as `{param_name: value}`
-- `select` - Optional list of output names to return (default: all outputs)
+- `select` - Which outputs to return. `"**"` (default) returns all outputs. Pass a list of names for specific outputs.
+- `on_missing` - How to handle missing selected outputs:
+  - `"ignore"` (default): silently omit missing outputs
+  - `"warn"`: warn about missing outputs, return what's available
+  - `"error"`: raise error if any selected output is missing
+- `entry_point` - Optional explicit cycle entry point node name. Disambiguates when multiple entry points match.
 - `max_iterations` - Max supersteps for cyclic graphs (default: 1000)
 - `event_processors` - Optional list of [event processors](events.md) to observe execution
 - `**input_values` - Input shorthand (merged with `values`)
@@ -72,6 +79,7 @@ Execute a graph once.
 **Raises:**
 - `MissingInputError` - Required input not provided
 - `IncompatibleRunnerError` - Graph contains async nodes
+- `ValueError` - If `entry_point` is invalid or ambiguous
 
 **Example:**
 
@@ -88,6 +96,12 @@ result = runner.run(graph, values, select=["final_answer"])
 # Limit iterations for cyclic graphs
 result = runner.run(cyclic_graph, values, max_iterations=50)
 
+# Strict output checking
+result = runner.run(graph, values, select=["answer"], on_missing="error")
+
+# Explicit cycle entry point
+result = runner.run(cyclic_graph, {"messages": []}, entry_point="generate")
+
 # With progress bars
 from hypergraph import RichProgressProcessor
 result = runner.run(graph, values, event_processors=[RichProgressProcessor()])
@@ -103,7 +117,8 @@ def map(
     *,
     map_over: str | list[str],
     map_mode: Literal["zip", "product"] = "zip",
-    select: list[str] | None = None,
+    select: str | list[str] = "**",
+    on_missing: Literal["ignore", "warn", "error"] = "ignore",
     error_handling: Literal["raise", "continue"] = "raise",
     event_processors: list[EventProcessor] | None = None,
     **input_values: Any,
@@ -117,7 +132,8 @@ Execute a graph multiple times with different inputs.
 - `values` - Optional input values. Parameters in `map_over` should be lists
 - `map_over` - Parameter name(s) to iterate over
 - `map_mode` - `"zip"` for parallel iteration, `"product"` for cartesian product
-- `select` - Optional list of outputs to return
+- `select` - Which outputs to return. `"**"` (default) returns all outputs.
+- `on_missing` - How to handle missing selected outputs (`"ignore"`, `"warn"`, or `"error"`)
 - `error_handling` - How to handle failures:
   - `"raise"` (default): Stop on first failure and raise the exception
   - `"continue"`: Collect all results, including failures as `RunResult` with `status=FAILED`
@@ -221,7 +237,9 @@ async def run(
     graph: Graph,
     values: dict[str, Any] | None = None,
     *,
-    select: list[str] | None = None,
+    select: str | list[str] = "**",
+    on_missing: Literal["ignore", "warn", "error"] = "ignore",
+    entry_point: str | None = None,
     max_iterations: int | None = None,
     max_concurrency: int | None = None,
     event_processors: list[EventProcessor] | None = None,
@@ -234,7 +252,9 @@ Execute a graph asynchronously.
 **Args:**
 - `graph` - The graph to execute
 - `values` - Optional input values
-- `select` - Optional list of output names to return
+- `select` - Which outputs to return. `"**"` (default) returns all outputs.
+- `on_missing` - How to handle missing selected outputs (`"ignore"`, `"warn"`, or `"error"`)
+- `entry_point` - Optional explicit cycle entry point node name
 - `max_iterations` - Max supersteps for cyclic graphs (default: 1000)
 - `max_concurrency` - Max parallel node executions (default: unlimited)
 - `event_processors` - Optional list of [event processors](events.md) to observe execution (supports `AsyncEventProcessor`)
@@ -290,7 +310,8 @@ async def map(
     *,
     map_over: str | list[str],
     map_mode: Literal["zip", "product"] = "zip",
-    select: list[str] | None = None,
+    select: str | list[str] = "**",
+    on_missing: Literal["ignore", "warn", "error"] = "ignore",
     max_concurrency: int | None = None,
     error_handling: Literal["raise", "continue"] = "raise",
     event_processors: list[EventProcessor] | None = None,
@@ -305,7 +326,8 @@ Execute graph multiple times concurrently.
 - `values` - Optional input values
 - `map_over` - Parameter name(s) to iterate over
 - `map_mode` - `"zip"` or `"product"`
-- `select` - Optional list of outputs to return
+- `select` - Which outputs to return. `"**"` (default) returns all outputs.
+- `on_missing` - How to handle missing selected outputs (`"ignore"`, `"warn"`, or `"error"`)
 - `max_concurrency` - Shared limit across all executions
 - `error_handling` - How to handle failures:
   - `"raise"` (default): Stop on first failure and raise the exception

--- a/docs/06-api-reference/runners.md
+++ b/docs/06-api-reference/runners.md
@@ -52,7 +52,7 @@ def run(
     *,
     select: str | list[str] = "**",
     on_missing: Literal["ignore", "warn", "error"] = "ignore",
-    entry_point: str | None = None,
+    entrypoint: str | None = None,
     max_iterations: int | None = None,
     event_processors: list[EventProcessor] | None = None,
     **input_values: Any,
@@ -69,7 +69,7 @@ Execute a graph once.
   - `"ignore"` (default): silently omit missing outputs
   - `"warn"`: warn about missing outputs, return what's available
   - `"error"`: raise error if any selected output is missing
-- `entry_point` - Optional explicit cycle entry point node name. Disambiguates when multiple entry points match.
+- `entrypoint` - Optional explicit cycle entrypoint node name. Disambiguates when multiple entrypoints match.
 - `max_iterations` - Max supersteps for cyclic graphs (default: 1000)
 - `event_processors` - Optional list of [event processors](events.md) to observe execution
 - `**input_values` - Input shorthand (merged with `values`)
@@ -79,7 +79,7 @@ Execute a graph once.
 **Raises:**
 - `MissingInputError` - Required input not provided
 - `IncompatibleRunnerError` - Graph contains async nodes
-- `ValueError` - If `entry_point` is invalid or ambiguous
+- `ValueError` - If `entrypoint` is invalid or ambiguous
 
 **Example:**
 
@@ -99,8 +99,8 @@ result = runner.run(cyclic_graph, values, max_iterations=50)
 # Strict output checking
 result = runner.run(graph, values, select=["answer"], on_missing="error")
 
-# Explicit cycle entry point
-result = runner.run(cyclic_graph, {"messages": []}, entry_point="generate")
+# Explicit cycle entrypoint
+result = runner.run(cyclic_graph, {"messages": []}, entrypoint="generate")
 
 # With progress bars
 from hypergraph import RichProgressProcessor
@@ -119,7 +119,7 @@ def map(
     map_mode: Literal["zip", "product"] = "zip",
     select: str | list[str] = "**",
     on_missing: Literal["ignore", "warn", "error"] = "ignore",
-    entry_point: str | None = None,
+    entrypoint: str | None = None,
     error_handling: Literal["raise", "continue"] = "raise",
     event_processors: list[EventProcessor] | None = None,
     **input_values: Any,
@@ -135,7 +135,7 @@ Execute a graph multiple times with different inputs.
 - `map_mode` - `"zip"` for parallel iteration, `"product"` for cartesian product
 - `select` - Which outputs to return. `"**"` (default) returns all outputs.
 - `on_missing` - How to handle missing selected outputs (`"ignore"`, `"warn"`, or `"error"`)
-- `entry_point` - Optional explicit cycle entry point (passed to each `run()` call)
+- `entrypoint` - Optional explicit cycle entrypoint (passed to each `run()` call)
 - `error_handling` - How to handle failures:
   - `"raise"` (default): Stop on first failure and raise the exception
   - `"continue"`: Collect all results, including failures as `RunResult` with `status=FAILED`
@@ -241,7 +241,7 @@ async def run(
     *,
     select: str | list[str] = "**",
     on_missing: Literal["ignore", "warn", "error"] = "ignore",
-    entry_point: str | None = None,
+    entrypoint: str | None = None,
     max_iterations: int | None = None,
     max_concurrency: int | None = None,
     event_processors: list[EventProcessor] | None = None,
@@ -256,7 +256,7 @@ Execute a graph asynchronously.
 - `values` - Optional input values
 - `select` - Which outputs to return. `"**"` (default) returns all outputs.
 - `on_missing` - How to handle missing selected outputs (`"ignore"`, `"warn"`, or `"error"`)
-- `entry_point` - Optional explicit cycle entry point node name
+- `entrypoint` - Optional explicit cycle entrypoint node name
 - `max_iterations` - Max supersteps for cyclic graphs (default: 1000)
 - `max_concurrency` - Max parallel node executions (default: unlimited)
 - `event_processors` - Optional list of [event processors](events.md) to observe execution (supports `AsyncEventProcessor`)
@@ -314,7 +314,7 @@ async def map(
     map_mode: Literal["zip", "product"] = "zip",
     select: str | list[str] = "**",
     on_missing: Literal["ignore", "warn", "error"] = "ignore",
-    entry_point: str | None = None,
+    entrypoint: str | None = None,
     max_concurrency: int | None = None,
     error_handling: Literal["raise", "continue"] = "raise",
     event_processors: list[EventProcessor] | None = None,
@@ -331,7 +331,7 @@ Execute graph multiple times concurrently.
 - `map_mode` - `"zip"` or `"product"`
 - `select` - Which outputs to return. `"**"` (default) returns all outputs.
 - `on_missing` - How to handle missing selected outputs (`"ignore"`, `"warn"`, or `"error"`)
-- `entry_point` - Optional explicit cycle entry point (passed to each `run()` call)
+- `entrypoint` - Optional explicit cycle entrypoint (passed to each `run()` call)
 - `max_concurrency` - Shared limit across all executions
 - `error_handling` - How to handle failures:
   - `"raise"` (default): Stop on first failure and raise the exception

--- a/docs/07-design/guiding-principles.md
+++ b/docs/07-design/guiding-principles.md
@@ -188,19 +188,19 @@ def should_continue(score: float) -> str:
 
 ---
 
-## 7. Cycles Require Seeds
+## 7. Cycles Require Entry Points
 
-When a value participates in a cycle, the first iteration needs an initial seed value.
+When a value participates in a cycle, the first iteration needs an initial value. Entry points group these by the node where execution starts.
 
 ### Explicit signals
 
-- InputSpec docs define `seeds` for cyclic inputs.
+- InputSpec docs define `entry_points` for cyclic inputs, grouped by node name.
 
 ### Implicit invariants
 
-- Cycle parameters are classified as seeds.
-- Missing seeds fail input validation.
-- Edge-produced values (including seeds) cannot be bound with `bind()`.
+- Cycle parameters are classified as entry point parameters.
+- Missing entry point values fail input validation.
+- Entry point values can be bound with `bind()` or provided at `runner.run()` time.
 
 ### Good example
 

--- a/docs/07-design/guiding-principles.md
+++ b/docs/07-design/guiding-principles.md
@@ -194,12 +194,12 @@ When a value participates in a cycle, the first iteration needs an initial value
 
 ### Explicit signals
 
-- InputSpec docs define `entry_points` for cyclic inputs, grouped by node name.
+- InputSpec docs define `entrypoints` for cyclic inputs, grouped by node name.
 
 ### Implicit invariants
 
-- Cycle parameters are classified as entry point parameters.
-- Missing entry point values fail input validation.
+- Cycle parameters are classified as entrypoint parameters.
+- Missing entrypoint values fail input validation.
 - Entry point values can be bound with `bind()` or provided at `runner.run()` time.
 
 ### Good example
@@ -210,7 +210,7 @@ result = runner.run(graph, {"messages": [], "query": "..."})
 
 ### Break example
 
-- Running cyclic flows without initializing entry point values.
+- Running cyclic flows without initializing entrypoint values.
 
 ---
 

--- a/docs/07-design/guiding-principles.md
+++ b/docs/07-design/guiding-principles.md
@@ -210,7 +210,7 @@ result = runner.run(graph, {"messages": [], "query": "..."})
 
 ### Break example
 
-- Running cyclic flows without initializing seed inputs.
+- Running cyclic flows without initializing entry point values.
 
 ---
 

--- a/scripts/test_api_docs.py
+++ b/scripts/test_api_docs.py
@@ -79,7 +79,7 @@ def retrieve(embedding: list[float], top_k: int = 5) -> list[str]:
 g4 = Graph([embed, retrieve])
 print(f"required: {g4.inputs.required}")
 print(f"optional: {g4.inputs.optional}")
-print(f"seeds: {g4.inputs.seeds}")
+print(f"entry_points: {g4.inputs.entry_points}")
 print(f"bound: {g4.inputs.bound}")
 print(f"all: {g4.inputs.all}")
 

--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -50,7 +50,7 @@ class Graph:
         nodes: Map of node name → HyperNode
         outputs: All output names produced by nodes
         leaf_outputs: Outputs from terminal nodes (no downstream destinations)
-        inputs: InputSpec describing required/optional/entry point parameters
+        inputs: InputSpec describing required/optional/entrypoint parameters
         has_cycles: True if graph contains cycles
         has_async_nodes: True if any FunctionNode is async
         strict_types: If True, type validation between nodes is enabled
@@ -637,7 +637,7 @@ class Graph:
             "required": input_spec.required,
             "optional": input_spec.optional,
             "bound": dict(input_spec.bound),
-            "entry_points": {k: list(v) for k, v in input_spec.entry_points.items()},
+            "entrypoints": {k: list(v) for k, v in input_spec.entrypoints.items()},
         }
         G.graph["output_to_sources"] = output_to_sources
         return G

--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -191,6 +191,15 @@ class Graph:
         """Get all value names that are produced by data edges."""
         return get_edge_produced_values(self._nx_graph)
 
+    def _get_emit_only_outputs(self) -> set[str]:
+        """Get outputs that are only emitted (ordering signals, not data)."""
+        data_outputs: set[str] = set()
+        all_outputs: set[str] = set()
+        for node in self._nodes.values():
+            data_outputs.update(node.data_outputs)
+            all_outputs.update(node.outputs)
+        return all_outputs - data_outputs
+
     def _sources_of(self, output: str) -> list[str]:
         """Get all nodes that produce the given output."""
         return sources_of(output, self._nodes)
@@ -336,30 +345,28 @@ class Graph:
     def bind(self, **values: Any) -> "Graph":
         """Bind default values. Returns new Graph (immutable).
 
+        Accepts any graph input or output name. Bound values act as
+        pre-filled run() values — overridable at run time.
+
         Raises:
-            ValueError: If attempting to bind an output of another node
-            ValueError: If attempting to bind a key not in graph.inputs.all
+            ValueError: If key is not a valid graph input or output
+            ValueError: If key is an emit-only output (ordering signal)
         """
-        # Validate: no bound key is edge-produced
-        edge_produced = self._get_edge_produced_values()
+        valid_names = set(self.inputs.all) | set(self.outputs)
+        emit_only = self._get_emit_only_outputs()
+        valid_names -= emit_only
+
         for key in values:
-            if key in edge_produced:
-                # Find which node produces it
-                sources = self._sources_of(key)
+            if key in emit_only:
                 raise ValueError(
-                    f"Cannot bind '{key}': output of node '{sources[0]}'"
+                    f"Cannot bind '{key}': emit-only output (ordering signal, not data)"
+                )
+            if key not in valid_names:
+                raise ValueError(
+                    f"Cannot bind '{key}': not a graph input or output. "
+                    f"Valid names: {sorted(valid_names)}"
                 )
 
-        # Validate: all keys must be valid graph inputs
-        all_inputs = set(self.inputs.all)
-        for key in values:
-            if key not in all_inputs:
-                raise ValueError(
-                    f"Cannot bind '{key}': not a graph input. "
-                    f"Valid inputs: {self.inputs.all}"
-                )
-
-        # Create new graph with merged bindings
         new_graph = self._shallow_copy()
         new_graph._bound = {**self._bound, **values}
         return new_graph
@@ -630,7 +637,7 @@ class Graph:
             "required": input_spec.required,
             "optional": input_spec.optional,
             "bound": dict(input_spec.bound),
-            "seeds": input_spec.seeds,
+            "entry_points": {k: list(v) for k, v in input_spec.entry_points.items()},
         }
         G.graph["output_to_sources"] = output_to_sources
         return G

--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -50,7 +50,7 @@ class Graph:
         nodes: Map of node name → HyperNode
         outputs: All output names produced by nodes
         leaf_outputs: Outputs from terminal nodes (no downstream destinations)
-        inputs: InputSpec describing required/optional/seed parameters
+        inputs: InputSpec describing required/optional/entry point parameters
         has_cycles: True if graph contains cycles
         has_async_nodes: True if any FunctionNode is async
         strict_types: If True, type validation between nodes is enabled

--- a/src/hypergraph/graph/input_spec.py
+++ b/src/hypergraph/graph/input_spec.py
@@ -98,7 +98,6 @@ def _unique_params(nodes: dict[str, "HyperNode"]) -> Iterator[str]:
                 yield param
 
 
-
 def _categorize_param(
     param: str,
     edge_produced: set[str],
@@ -169,12 +168,14 @@ def _compute_entry_points(
             if isinstance(node, GateNode):
                 continue  # Gates control cycles, not start them
 
-            # Params this node needs that are cycle-produced (minus bound, minus interrupt-produced)
+            # Params this node needs that are cycle-produced
+            # (minus bound, minus interrupt-produced, minus defaulted)
             needed = tuple(
                 p for p in node.inputs
                 if p in cycle_params
                 and p not in bound
                 and not _is_interrupt_produced(p, nodes)
+                and not node.has_default_for(p)
             )
             if needed:  # Only include if node needs user-provided cycle params
                 entry_points[node_name] = needed

--- a/src/hypergraph/graph/input_spec.py
+++ b/src/hypergraph/graph/input_spec.py
@@ -1,7 +1,7 @@
 """Input specification calculation for graphs.
 
 This module contains the InputSpec dataclass and logic for computing
-which parameters are required, optional, or seed values.
+which parameters are required, optional, or cycle entry points.
 """
 
 from __future__ import annotations

--- a/src/hypergraph/nodes/graph_node.py
+++ b/src/hypergraph/nodes/graph_node.py
@@ -30,7 +30,7 @@ class GraphNode(HyperNode):
 
     Attributes:
         name: Node name (from graph.name or explicit override)
-        inputs: All graph inputs (required + optional + seeds)
+        inputs: All graph inputs (required + optional + entry point params)
         outputs: All graph outputs
         graph: The wrapped Graph instance
 

--- a/src/hypergraph/runners/_shared/helpers.py
+++ b/src/hypergraph/runners/_shared/helpers.py
@@ -600,6 +600,9 @@ def _collect_selected_outputs(
     return result
 
 
+_VALID_ON_MISSING = ("ignore", "warn", "error")
+
+
 def _handle_missing_outputs(
     missing: list[str],
     state: GraphState,
@@ -607,6 +610,11 @@ def _handle_missing_outputs(
     on_missing: str,
 ) -> None:
     """Handle missing outputs per policy: ignore, warn, or error."""
+    if on_missing not in _VALID_ON_MISSING:
+        raise ValueError(
+            f"Invalid on_missing={on_missing!r}. "
+            f"Expected one of: {', '.join(_VALID_ON_MISSING)}"
+        )
     if on_missing == "ignore":
         return
 

--- a/src/hypergraph/runners/_shared/helpers.py
+++ b/src/hypergraph/runners/_shared/helpers.py
@@ -550,6 +550,12 @@ def filter_outputs(
     Returns:
         Dict of output values
     """
+    if on_missing not in _VALID_ON_MISSING:
+        raise ValueError(
+            f"Invalid on_missing={on_missing!r}. "
+            f"Expected one of: {', '.join(_VALID_ON_MISSING)}"
+        )
+
     from hypergraph.nodes.base import _EMIT_SENTINEL
 
     effective = _resolve_select(select, graph)
@@ -603,6 +609,15 @@ def _collect_selected_outputs(
 _VALID_ON_MISSING = ("ignore", "warn", "error")
 
 
+def _validate_on_missing(on_missing: str) -> None:
+    """Validate on_missing parameter eagerly (before execution)."""
+    if on_missing not in _VALID_ON_MISSING:
+        raise ValueError(
+            f"Invalid on_missing={on_missing!r}. "
+            f"Expected one of: {', '.join(_VALID_ON_MISSING)}"
+        )
+
+
 def _handle_missing_outputs(
     missing: list[str],
     state: GraphState,
@@ -626,6 +641,7 @@ def _handle_missing_outputs(
 
     if on_missing == "warn":
         import warnings
+        # stacklevel=6: _handle → _collect_selected → filter_outputs → run → user
         warnings.warn(msg, UserWarning, stacklevel=6)
     elif on_missing == "error":
         raise ValueError(msg)

--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -137,7 +137,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
         *,
         select: "str | list[str]" = _UNSET_SELECT,
         on_missing: Literal["ignore", "warn", "error"] = "ignore",
-        entry_point: str | None = None,
+        entrypoint: str | None = None,
         max_iterations: int | None = None,
         max_concurrency: int | None = None,
         event_processors: list["EventProcessor"] | None = None,
@@ -153,7 +153,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
 
         validate_runner_compatibility(graph, self.capabilities)
         validate_node_types(graph, self.supported_node_types)
-        validate_inputs(graph, normalized_values, entry_point=entry_point)
+        validate_inputs(graph, normalized_values, entrypoint=entrypoint)
         _validate_on_missing(on_missing)
 
         max_iter = max_iterations or self.default_max_iterations
@@ -232,7 +232,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
         map_mode: Literal["zip", "product"] = "zip",
         select: "str | list[str]" = _UNSET_SELECT,
         on_missing: Literal["ignore", "warn", "error"] = "ignore",
-        entry_point: str | None = None,
+        entrypoint: str | None = None,
         max_concurrency: int | None = None,
         error_handling: ErrorHandling = "raise",
         event_processors: list["EventProcessor"] | None = None,
@@ -284,7 +284,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                     variation_inputs,
                     select=select,
                     on_missing=on_missing,
-                    entry_point=entry_point,
+                    entrypoint=entrypoint,
                     max_concurrency=max_concurrency,
                     event_processors=event_processors,
                     _parent_span_id=map_span_id,

--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -8,7 +8,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Literal
 
 from hypergraph.exceptions import ExecutionError
-from hypergraph.runners._shared.helpers import _UNSET_SELECT, filter_outputs, generate_map_inputs
+from hypergraph.runners._shared.helpers import _UNSET_SELECT, _validate_on_missing, filter_outputs, generate_map_inputs
 from hypergraph.runners._shared.input_normalization import (
     ASYNC_MAP_RESERVED_OPTION_NAMES,
     ASYNC_RUN_RESERVED_OPTION_NAMES,
@@ -154,6 +154,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
         validate_runner_compatibility(graph, self.capabilities)
         validate_node_types(graph, self.supported_node_types)
         validate_inputs(graph, normalized_values, entry_point=entry_point)
+        _validate_on_missing(on_missing)
 
         max_iter = max_iterations or self.default_max_iterations
         dispatcher = self._create_dispatcher(event_processors)
@@ -231,6 +232,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
         map_mode: Literal["zip", "product"] = "zip",
         select: "str | list[str]" = _UNSET_SELECT,
         on_missing: Literal["ignore", "warn", "error"] = "ignore",
+        entry_point: str | None = None,
         max_concurrency: int | None = None,
         error_handling: ErrorHandling = "raise",
         event_processors: list["EventProcessor"] | None = None,
@@ -282,6 +284,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                     variation_inputs,
                     select=select,
                     on_missing=on_missing,
+                    entry_point=entry_point,
                     max_concurrency=max_concurrency,
                     event_processors=event_processors,
                     _parent_span_id=map_span_id,

--- a/src/hypergraph/runners/_shared/template_sync.py
+++ b/src/hypergraph/runners/_shared/template_sync.py
@@ -7,7 +7,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Literal
 
 from hypergraph.exceptions import ExecutionError
-from hypergraph.runners._shared.helpers import _UNSET_SELECT, filter_outputs, generate_map_inputs
+from hypergraph.runners._shared.helpers import _UNSET_SELECT, _validate_on_missing, filter_outputs, generate_map_inputs
 from hypergraph.runners._shared.input_normalization import (
     ASYNC_MAP_RESERVED_OPTION_NAMES,
     ASYNC_RUN_RESERVED_OPTION_NAMES,
@@ -126,6 +126,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
         validate_runner_compatibility(graph, self.capabilities)
         validate_node_types(graph, self.supported_node_types)
         validate_inputs(graph, normalized_values, entry_point=entry_point)
+        _validate_on_missing(on_missing)
 
         max_iter = max_iterations or self.default_max_iterations
         dispatcher = self._create_dispatcher(event_processors)
@@ -187,6 +188,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
         map_mode: Literal["zip", "product"] = "zip",
         select: "str | list[str]" = _UNSET_SELECT,
         on_missing: Literal["ignore", "warn", "error"] = "ignore",
+        entry_point: str | None = None,
         error_handling: ErrorHandling = "raise",
         event_processors: list["EventProcessor"] | None = None,
         _parent_span_id: str | None = None,
@@ -226,6 +228,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
                     variation_inputs,
                     select=select,
                     on_missing=on_missing,
+                    entry_point=entry_point,
                     event_processors=event_processors,
                     _parent_span_id=map_span_id,
                 )

--- a/src/hypergraph/runners/_shared/template_sync.py
+++ b/src/hypergraph/runners/_shared/template_sync.py
@@ -110,7 +110,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
         *,
         select: "str | list[str]" = _UNSET_SELECT,
         on_missing: Literal["ignore", "warn", "error"] = "ignore",
-        entry_point: str | None = None,
+        entrypoint: str | None = None,
         max_iterations: int | None = None,
         event_processors: list["EventProcessor"] | None = None,
         _parent_span_id: str | None = None,
@@ -125,7 +125,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
 
         validate_runner_compatibility(graph, self.capabilities)
         validate_node_types(graph, self.supported_node_types)
-        validate_inputs(graph, normalized_values, entry_point=entry_point)
+        validate_inputs(graph, normalized_values, entrypoint=entrypoint)
         _validate_on_missing(on_missing)
 
         max_iter = max_iterations or self.default_max_iterations
@@ -188,7 +188,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
         map_mode: Literal["zip", "product"] = "zip",
         select: "str | list[str]" = _UNSET_SELECT,
         on_missing: Literal["ignore", "warn", "error"] = "ignore",
-        entry_point: str | None = None,
+        entrypoint: str | None = None,
         error_handling: ErrorHandling = "raise",
         event_processors: list["EventProcessor"] | None = None,
         _parent_span_id: str | None = None,
@@ -228,7 +228,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
                     variation_inputs,
                     select=select,
                     on_missing=on_missing,
-                    entry_point=entry_point,
+                    entrypoint=entrypoint,
                     event_processors=event_processors,
                     _parent_span_id=map_span_id,
                 )

--- a/src/hypergraph/runners/_shared/validation.py
+++ b/src/hypergraph/runners/_shared/validation.py
@@ -187,14 +187,18 @@ def _check_cycle_entry(
         )
 
     if len(satisfied) > 1:
-        lines = [
-            "Ambiguous cycle entry — provided values match multiple entry points:"
-        ]
-        for name in satisfied:
-            params = ", ".join(entry_points[name])
-            lines.append(f"  {name} (needs: {params})")
-        lines.append("Provide values for exactly one entry point.")
-        raise ValueError("\n".join(lines))
+        # If all satisfied entry points need the same params, it's not ambiguous —
+        # the user is seeding the cycle regardless of which node runs first.
+        distinct_param_sets = {entry_points[name] for name in satisfied}
+        if len(distinct_param_sets) > 1:
+            lines = [
+                "Ambiguous cycle entry — provided values match multiple entry points:"
+            ]
+            for name in satisfied:
+                params = ", ".join(entry_points[name])
+                lines.append(f"  {name} (needs: {params})")
+            lines.append("Provide values for exactly one entry point.")
+            raise ValueError("\n".join(lines))
 
 
 def _get_suggestions(

--- a/src/hypergraph/runners/base.py
+++ b/src/hypergraph/runners/base.py
@@ -43,7 +43,7 @@ class BaseRunner(ABC):
         *,
         select: "str | list[str]" = _UNSET_SELECT,
         on_missing: Literal["ignore", "warn", "error"] = "ignore",
-        entry_point: str | None = None,
+        entrypoint: str | None = None,
         max_iterations: int | None = None,
         event_processors: list[EventProcessor] | None = None,
         **input_values: Any,
@@ -55,7 +55,7 @@ class BaseRunner(ABC):
             values: Optional input values dict
             select: Which outputs to return. "**" (default) = all outputs.
             on_missing: How to handle missing selected outputs.
-            entry_point: Optional explicit cycle entry point node name.
+            entrypoint: Optional explicit cycle entry point node name.
             max_iterations: Max iterations for cyclic graphs (None = default)
             event_processors: Optional list of event processors to receive execution events
             **input_values: Input values shorthand (merged with values)

--- a/src/hypergraph/runners/base.py
+++ b/src/hypergraph/runners/base.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Literal
 
+from hypergraph.runners._shared.helpers import _UNSET_SELECT
 from hypergraph.runners._shared.types import RunnerCapabilities, RunResult
 
 if TYPE_CHECKING:
@@ -40,7 +41,9 @@ class BaseRunner(ABC):
         graph: "Graph",
         values: dict[str, Any] | None = None,
         *,
-        select: list[str] | None = None,
+        select: "str | list[str]" = _UNSET_SELECT,
+        on_missing: Literal["ignore", "warn", "error"] = "ignore",
+        entry_point: str | None = None,
         max_iterations: int | None = None,
         event_processors: list[EventProcessor] | None = None,
         **input_values: Any,
@@ -50,7 +53,9 @@ class BaseRunner(ABC):
         Args:
             graph: The graph to execute
             values: Optional input values dict
-            select: Optional list of outputs to return (None = all)
+            select: Which outputs to return. "**" (default) = all outputs.
+            on_missing: How to handle missing selected outputs.
+            entry_point: Optional explicit cycle entry point node name.
             max_iterations: Max iterations for cyclic graphs (None = default)
             event_processors: Optional list of event processors to receive execution events
             **input_values: Input values shorthand (merged with values)
@@ -68,7 +73,8 @@ class BaseRunner(ABC):
         *,
         map_over: str | list[str],
         map_mode: Literal["zip", "product"] = "zip",
-        select: list[str] | None = None,
+        select: "str | list[str]" = _UNSET_SELECT,
+        on_missing: Literal["ignore", "warn", "error"] = "ignore",
         event_processors: list[EventProcessor] | None = None,
         **input_values: Any,
     ) -> list[RunResult]:
@@ -79,7 +85,8 @@ class BaseRunner(ABC):
             values: Optional input values dict (some should be lists for map_over)
             map_over: Parameter name(s) to iterate over
             map_mode: "zip" for parallel iteration, "product" for cartesian
-            select: Optional list of outputs to return
+            select: Which outputs to return. "**" (default) = all outputs.
+            on_missing: How to handle missing selected outputs.
             event_processors: Optional list of event processors to receive execution events
             **input_values: Input values shorthand (merged with values)
 

--- a/src/hypergraph/viz/mermaid.py
+++ b/src/hypergraph/viz/mermaid.py
@@ -28,7 +28,7 @@ from hypergraph.viz._common import (
 from hypergraph.viz.renderer._format import format_type
 from hypergraph.viz.renderer.nodes import build_input_groups, has_end_routing
 from hypergraph.viz.renderer.scope import (
-    find_container_entry_points,
+    find_container_entrypoints,
     find_internal_producer_for_output,
 )
 
@@ -436,9 +436,9 @@ def _resolve_control_target(
     actual_target = target
     target_attrs = flat_graph.nodes.get(target, {})
     if target_attrs.get("node_type") == "GRAPH" and expansion_state.get(target, False):
-        entry_points = find_container_entry_points(target, flat_graph, expansion_state)
-        if entry_points:
-            actual_target = entry_points[0]
+        entrypoints = find_container_entrypoints(target, flat_graph, expansion_state)
+        if entrypoints:
+            actual_target = entrypoints[0]
     if not is_node_visible(actual_target, flat_graph, expansion_state):
         return None
     return actual_target
@@ -490,7 +490,7 @@ def _resolve_data_target(
             if internal:
                 actual_target = internal[0]
             else:
-                entry = find_container_entry_points(target, flat_graph, expansion_state)
+                entry = find_container_entrypoints(target, flat_graph, expansion_state)
                 if entry:
                     actual_target = entry[0]
     if not is_node_visible(actual_target, flat_graph, expansion_state):

--- a/src/hypergraph/viz/renderer/edges.py
+++ b/src/hypergraph/viz/renderer/edges.py
@@ -23,7 +23,7 @@ from hypergraph.viz.renderer.nodes import (
     is_data_node_visible,
 )
 from hypergraph.viz.renderer.scope import (
-    find_container_entry_points,
+    find_container_entrypoints,
     find_internal_producer_for_output,
 )
 
@@ -97,11 +97,11 @@ def add_merged_output_edges(
             is_target_expanded = expansion_state.get(target, False)
 
             if is_target_container and is_target_expanded:
-                entry_points = find_container_entry_points(
+                entrypoints = find_container_entrypoints(
                     target, flat_graph, expansion_state
                 )
-                if entry_points:
-                    actual_target = entry_points[0]
+                if entrypoints:
+                    actual_target = entrypoints[0]
 
             if not is_node_visible(actual_target, flat_graph, expansion_state):
                 continue
@@ -190,11 +190,11 @@ def add_merged_output_edges(
                     if internal_consumers:
                         actual_target = internal_consumers[0]
                     else:
-                        entry_points = find_container_entry_points(
+                        entrypoints = find_container_entrypoints(
                             target, flat_graph, expansion_state
                         )
-                        if entry_points:
-                            actual_target = entry_points[0]
+                        if entrypoints:
+                            actual_target = entrypoints[0]
 
             if not is_node_visible(actual_source, flat_graph, expansion_state):
                 continue
@@ -355,11 +355,11 @@ def add_separate_output_edges(
                 is_target_expanded = expansion_state.get(target, False)
 
                 if is_target_container and is_target_expanded:
-                    entry_points = find_container_entry_points(
+                    entrypoints = find_container_entrypoints(
                         target, flat_graph, expansion_state
                     )
-                    if entry_points:
-                        actual_target = entry_points[0]
+                    if entrypoints:
+                        actual_target = entrypoints[0]
 
             if source == actual_target:
                 continue

--- a/src/hypergraph/viz/renderer/scope.py
+++ b/src/hypergraph/viz/renderer/scope.py
@@ -168,7 +168,7 @@ def build_graph_output_visibility(flat_graph: nx.DiGraph) -> dict[str, set[str]]
     return visibility
 
 
-def find_container_entry_points(
+def find_container_entrypoints(
     container_id: str,
     flat_graph: nx.DiGraph,
     expansion_state: dict[str, bool],
@@ -186,7 +186,7 @@ def find_container_entry_points(
         for output in attrs.get("outputs", ()):
             internal_outputs.add(output)
 
-    entry_points = []
+    entrypoints = []
     for node_id in direct_children:
         attrs = flat_graph.nodes.get(node_id, {})
         inputs = set(attrs.get("inputs", ()))
@@ -195,9 +195,9 @@ def find_container_entry_points(
 
         if not consumes_internal:
             if is_node_visible(node_id, flat_graph, expansion_state):
-                entry_points.append(node_id)
+                entrypoints.append(node_id)
 
-    return entry_points
+    return entrypoints
 
 
 def find_container_exit_points(

--- a/tests/test_bind_edge_cases.py
+++ b/tests/test_bind_edge_cases.py
@@ -157,15 +157,15 @@ class TestBindMultiple:
         assert "x" in g2.inputs.required
 
 
-class TestBindCycleSeeds:
-    """Test bind() interaction with cycle seeds (BIND-03).
+class TestBindCycleEntryPoints:
+    """Test bind() interaction with cycle entry points (BIND-03).
 
-    Edge-produced values (including cycle seeds) cannot be bound because
-    they are outputs of nodes, not external inputs.
+    Cycle params (entry points) CAN be bound — they act as initial values
+    for the first iteration, then the cycle produces subsequent values.
     """
 
-    def test_bind_seed_param_rejected(self):
-        """Binding a seed param raises ValueError because it's edge-produced."""
+    def test_bind_entry_point_param_accepted(self):
+        """Binding an entry point param is accepted (bootstraps the cycle)."""
 
         @node(output_name="count")
         def counter(count: int) -> int:
@@ -173,17 +173,15 @@ class TestBindCycleSeeds:
 
         g = Graph([counter])
 
-        # count is a seed (self-loop cycle)
-        assert "count" in g.inputs.seeds
+        # count is an entry point param (self-loop cycle)
+        assert "counter" in g.inputs.entry_points
 
-        # Attempting to bind raises ValueError
-        with pytest.raises(ValueError) as exc_info:
-            g.bind(count=0)
+        # Binding is allowed — acts as first-iteration bootstrap
+        configured = g.bind(count=0)
+        assert configured.inputs.bound["count"] == 0
 
-        assert "output of node" in str(exc_info.value)
-
-    def test_seed_not_bindable_multi_node_cycle(self):
-        """Multi-node cycle seed also not bindable."""
+    def test_bind_multi_node_cycle_param(self):
+        """Multi-node cycle params are bindable."""
 
         @node(output_name="a")
         def node_a(b: int) -> int:
@@ -195,18 +193,17 @@ class TestBindCycleSeeds:
 
         g = Graph([node_a, node_b])
 
-        # Both a and b are cycle-related
         assert g.has_cycles
 
-        # Attempting to bind either should fail (they're edge-produced)
-        with pytest.raises(ValueError):
-            g.bind(a=0)
+        # Both a and b are cycle params — binding is allowed
+        configured = g.bind(a=0)
+        assert configured.inputs.bound["a"] == 0
 
-        with pytest.raises(ValueError):
-            g.bind(b=0)
+        configured = g.bind(b=0)
+        assert configured.inputs.bound["b"] == 0
 
-    def test_non_seed_edge_produced_not_bindable(self):
-        """Regular edge-produced values (not seeds) also not bindable."""
+    def test_bind_node_output_accepted(self):
+        """Node outputs can be bound (bypass if producer doesn't run)."""
 
         @node(output_name="x")
         def producer(input_val: int) -> int:
@@ -218,14 +215,11 @@ class TestBindCycleSeeds:
 
         g = Graph([producer, consumer])
 
-        # x is produced by producer, consumed by consumer
-        # Only input_val is a valid input
         assert "input_val" in g.inputs.required
-        assert "x" not in g.inputs.all
 
-        # Can't bind x (it's an output)
-        with pytest.raises(ValueError):
-            g.bind(x=10)
+        # Binding an output is allowed — acts as fallback when producer can't run
+        configured = g.bind(x=10)
+        assert configured.inputs.bound["x"] == 10
 
 
 class TestUnbindRestoresStatus:

--- a/tests/test_bind_edge_cases.py
+++ b/tests/test_bind_edge_cases.py
@@ -158,14 +158,14 @@ class TestBindMultiple:
 
 
 class TestBindCycleEntryPoints:
-    """Test bind() interaction with cycle entry points (BIND-03).
+    """Test bind() interaction with cycle entrypoints (BIND-03).
 
-    Cycle params (entry points) CAN be bound — they act as initial values
+    Cycle params (entrypoints) CAN be bound — they act as initial values
     for the first iteration, then the cycle produces subsequent values.
     """
 
-    def test_bind_entry_point_param_accepted(self):
-        """Binding an entry point param is accepted (bootstraps the cycle)."""
+    def test_bind_entrypoint_param_accepted(self):
+        """Binding an entrypoint param is accepted (bootstraps the cycle)."""
 
         @node(output_name="count")
         def counter(count: int) -> int:
@@ -173,8 +173,8 @@ class TestBindCycleEntryPoints:
 
         g = Graph([counter])
 
-        # count is an entry point param (self-loop cycle)
-        assert "counter" in g.inputs.entry_points
+        # count is an entrypoint param (self-loop cycle)
+        assert "counter" in g.inputs.entrypoints
 
         # Binding is allowed — acts as first-iteration bootstrap
         configured = g.bind(count=0)

--- a/tests/test_code_review_fixes.py
+++ b/tests/test_code_review_fixes.py
@@ -431,10 +431,10 @@ class TestInputValidationOverrides:
 
 
 class TestMultiCycleEntryPointValidation:
-    """Explicit entry_point must still validate other independent cycles."""
+    """Explicit entrypoint must still validate other independent cycles."""
 
-    def test_explicit_entry_point_validates_other_cycles(self):
-        """Providing entry_point for cycle A must still check cycle B."""
+    def test_explicit_entrypoint_validates_other_cycles(self):
+        """Providing entrypoint for cycle A must still check cycle B."""
 
         @node(output_name="a")
         def node_a(b: int) -> int:
@@ -463,12 +463,12 @@ class TestMultiCycleEntryPointValidation:
         graph = Graph([node_a, node_b, gate_ab, node_x, node_y, gate_xy])
         runner = SyncRunner()
 
-        # Cycle A entry point satisfied (b=1 for node_a), but cycle B has no entry
+        # Cycle A entrypoint satisfied (b=1 for node_a), but cycle B has no entry
         from hypergraph.exceptions import MissingInputError
         with pytest.raises((ValueError, MissingInputError)):
-            runner.run(graph, {"b": 1}, entry_point="node_a")
+            runner.run(graph, {"b": 1}, entrypoint="node_a")
 
-    def test_explicit_entry_point_passes_with_both_cycles_satisfied(self):
+    def test_explicit_entrypoint_passes_with_both_cycles_satisfied(self):
         """Both cycles satisfied: explicit on A, implicit on B."""
 
         @node(output_name="a")
@@ -499,14 +499,14 @@ class TestMultiCycleEntryPointValidation:
         runner = SyncRunner()
 
         # Both cycles satisfied (node_a needs b, node_x needs y)
-        result = runner.run(graph, {"b": 1, "y": 1}, entry_point="node_a")
+        result = runner.run(graph, {"b": 1, "y": 1}, entrypoint="node_a")
         assert result.status.value == "completed"
 
 
 class TestDefaultedCycleParams:
-    """Cycle params with defaults should not require entry point values."""
+    """Cycle params with defaults should not require entrypoint values."""
 
-    def test_defaulted_cycle_param_excluded_from_entry_point(self):
+    def test_defaulted_cycle_param_excluded_from_entrypoint(self):
         """If a cycle param has a default, it's not required for entry."""
 
         @node(output_name="b")
@@ -523,9 +523,9 @@ class TestDefaultedCycleParams:
 
         graph = Graph([node_a, node_b, gate])
 
-        # extra has a default, so node_b's entry point should only need 'b'
+        # extra has a default, so node_b's entrypoint should only need 'b'
         # (not 'b' AND 'extra')
-        ep = graph.inputs.entry_points
+        ep = graph.inputs.entrypoints
         if "node_b" in ep:
             assert "extra" not in ep["node_b"]
 

--- a/tests/test_code_review_fixes.py
+++ b/tests/test_code_review_fixes.py
@@ -15,8 +15,9 @@ TDD tests for issues identified in the code review:
 import warnings
 import pytest
 
-from hypergraph import Graph
+from hypergraph import END, Graph
 from hypergraph.nodes.function import FunctionNode, node
+from hypergraph.nodes.gate import route
 from hypergraph.runners.sync import SyncRunner
 
 
@@ -299,7 +300,7 @@ class TestSelectParameterValidation:
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            result = runner.run(graph, {"x": 10}, select=["typo_result"], on_missing="warn")
+            runner.run(graph, {"x": 10}, select=["typo_result"], on_missing="warn")
 
             assert len(w) >= 1
             assert any("typo_result" in str(warning.message) for warning in w)
@@ -427,3 +428,121 @@ class TestInputValidationOverrides:
             # Should at least warn about overriding internal value
             assert len(w) >= 1
             assert any("intermediate" in str(warning.message) for warning in w)
+
+
+class TestMultiCycleEntryPointValidation:
+    """Explicit entry_point must still validate other independent cycles."""
+
+    def test_explicit_entry_point_validates_other_cycles(self):
+        """Providing entry_point for cycle A must still check cycle B."""
+
+        @node(output_name="a")
+        def node_a(b: int) -> int:
+            return b + 1
+
+        @node(output_name="b")
+        def node_b(a: int) -> int:
+            return a + 1
+
+        @route(targets=["node_a", END])
+        def gate_ab(a: int) -> str:
+            return END if a > 3 else "node_a"
+
+        @node(output_name="x")
+        def node_x(y: int) -> int:
+            return y + 1
+
+        @node(output_name="y")
+        def node_y(x: int) -> int:
+            return x + 1
+
+        @route(targets=["node_x", END])
+        def gate_xy(x: int) -> str:
+            return END if x > 3 else "node_x"
+
+        graph = Graph([node_a, node_b, gate_ab, node_x, node_y, gate_xy])
+        runner = SyncRunner()
+
+        # Cycle A entry point satisfied (b=1 for node_a), but cycle B has no entry
+        from hypergraph.exceptions import MissingInputError
+        with pytest.raises((ValueError, MissingInputError)):
+            runner.run(graph, {"b": 1}, entry_point="node_a")
+
+    def test_explicit_entry_point_passes_with_both_cycles_satisfied(self):
+        """Both cycles satisfied: explicit on A, implicit on B."""
+
+        @node(output_name="a")
+        def node_a(b: int) -> int:
+            return b + 1
+
+        @node(output_name="b")
+        def node_b(a: int) -> int:
+            return a + 1
+
+        @route(targets=["node_a", END])
+        def gate_ab(a: int) -> str:
+            return END if a > 3 else "node_a"
+
+        @node(output_name="x")
+        def node_x(y: int) -> int:
+            return y + 1
+
+        @node(output_name="y")
+        def node_y(x: int) -> int:
+            return x + 1
+
+        @route(targets=["node_x", END])
+        def gate_xy(x: int) -> str:
+            return END if x > 3 else "node_x"
+
+        graph = Graph([node_a, node_b, gate_ab, node_x, node_y, gate_xy])
+        runner = SyncRunner()
+
+        # Both cycles satisfied (node_a needs b, node_x needs y)
+        result = runner.run(graph, {"b": 1, "y": 1}, entry_point="node_a")
+        assert result.status.value == "completed"
+
+
+class TestDefaultedCycleParams:
+    """Cycle params with defaults should not require entry point values."""
+
+    def test_defaulted_cycle_param_excluded_from_entry_point(self):
+        """If a cycle param has a default, it's not required for entry."""
+
+        @node(output_name="b")
+        def node_a(a: int) -> int:
+            return a + 1
+
+        @node(output_name="a")
+        def node_b(b: int, extra: int = 0) -> int:
+            return b + extra
+
+        @route(targets=["node_a", END])
+        def gate(a: int) -> str:
+            return END if a > 3 else "node_a"
+
+        graph = Graph([node_a, node_b, gate])
+
+        # extra has a default, so node_b's entry point should only need 'b'
+        # (not 'b' AND 'extra')
+        ep = graph.inputs.entry_points
+        if "node_b" in ep:
+            assert "extra" not in ep["node_b"]
+
+
+class TestEarlyOnMissingValidation:
+    """on_missing should be validated eagerly, even when no outputs are missing."""
+
+    def test_invalid_on_missing_fails_even_when_all_outputs_present(self):
+        """Invalid on_missing raises immediately, not only when outputs miss."""
+        from hypergraph.runners._shared.helpers import filter_outputs
+
+        @node(output_name="result")
+        def identity(x: int) -> int:
+            return x
+
+        graph = Graph([identity])
+        runner = SyncRunner()
+
+        with pytest.raises(ValueError, match="Invalid on_missing"):
+            runner.run(graph, {"x": 10}, select=["result"], on_missing="raise")

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -14,13 +14,13 @@ class TestInputSpec:
         spec = InputSpec(
             required=("param1", "param2"),
             optional=("param3",),
-            entry_points={"node_a": ("param4",)},
+            entrypoints={"node_a": ("param4",)},
             bound={"param5": 42},
         )
 
         assert spec.required == ("param1", "param2")
         assert spec.optional == ("param3",)
-        assert spec.entry_points == {"node_a": ("param4",)}
+        assert spec.entrypoints == {"node_a": ("param4",)}
         assert spec.bound == {"param5": 42}
 
     def test_input_spec_all_property(self):
@@ -28,7 +28,7 @@ class TestInputSpec:
         spec = InputSpec(
             required=("a", "b"),
             optional=("c",),
-            entry_points={"node_a": ("d",)},
+            entrypoints={"node_a": ("d",)},
             bound={},
         )
 
@@ -39,13 +39,13 @@ class TestInputSpec:
         spec = InputSpec(
             required=(),
             optional=(),
-            entry_points={},
+            entrypoints={},
             bound={},
         )
 
         assert spec.required == ()
         assert spec.optional == ()
-        assert spec.entry_points == {}
+        assert spec.entrypoints == {}
         assert spec.bound == {}
         assert spec.all == ()
 
@@ -54,7 +54,7 @@ class TestInputSpec:
         spec = InputSpec(
             required=("param1",),
             optional=(),
-            entry_points={},
+            entrypoints={},
             bound={},
         )
 
@@ -62,11 +62,11 @@ class TestInputSpec:
             spec.required = ("param2",)
 
     def test_input_spec_all_preserves_order(self):
-        """Test .all property preserves order: required + optional + entry point params."""
+        """Test .all property preserves order: required + optional + entrypoint params."""
         spec = InputSpec(
             required=("r1", "r2"),
             optional=("o1", "o2"),
-            entry_points={"node_a": ("s1",), "node_b": ("s2",)},
+            entrypoints={"node_a": ("s1",), "node_b": ("s2",)},
             bound={},
         )
 
@@ -313,7 +313,7 @@ class TestGraphInputs:
 
         assert g.inputs.required == ("a", "b", "c")
         assert g.inputs.optional == ()
-        assert g.inputs.entry_points == {}
+        assert g.inputs.entrypoints == {}
         assert g.inputs.bound == {}
 
     def test_with_defaults_become_optional(self):
@@ -327,7 +327,7 @@ class TestGraphInputs:
 
         assert g.inputs.required == ("a",)
         assert g.inputs.optional == ("b", "c")
-        assert g.inputs.entry_points == {}
+        assert g.inputs.entrypoints == {}
         assert g.inputs.bound == {}
 
     def test_edge_connected_not_in_inputs(self):
@@ -348,8 +348,8 @@ class TestGraphInputs:
         assert "a" in g.inputs.all
         assert "b" in g.inputs.all
 
-    def test_cycle_creates_entry_point(self):
-        """Test parameter in cycle becomes an entry point."""
+    def test_cycle_creates_entrypoint(self):
+        """Test parameter in cycle becomes an entrypoint."""
 
         @node(output_name="count")
         def counter(count):
@@ -357,9 +357,9 @@ class TestGraphInputs:
 
         g = Graph([counter])
 
-        # 'count' is both consumed and produced by same node -> cycle -> entry point
-        assert "counter" in g.inputs.entry_points
-        assert "count" in g.inputs.entry_points["counter"]
+        # 'count' is both consumed and produced by same node -> cycle -> entrypoint
+        assert "counter" in g.inputs.entrypoints
+        assert "count" in g.inputs.entrypoints["counter"]
         assert g.inputs.required == ()
         assert g.inputs.optional == ()
 

--- a/tests/test_graph_topologies.py
+++ b/tests/test_graph_topologies.py
@@ -159,8 +159,8 @@ class TestMultiNodeCycle:
 
         assert g.has_cycles is True
 
-    def test_three_node_cycle_entry_points(self):
-        """Three-node cycle computes entry points for cycle nodes."""
+    def test_three_node_cycle_entrypoints(self):
+        """Three-node cycle computes entrypoints for cycle nodes."""
 
         @node(output_name="a")
         def node_a(c: int) -> int:
@@ -176,10 +176,10 @@ class TestMultiNodeCycle:
 
         g = Graph([node_a, node_b, node_c])
 
-        # Each non-gate cycle node is an entry point
-        assert len(g.inputs.entry_points) > 0
-        # All cycle nodes should appear as entry points
-        all_ep_params = {p for params in g.inputs.entry_points.values() for p in params}
+        # Each non-gate cycle node is an entrypoint
+        assert len(g.inputs.entrypoints) > 0
+        # All cycle nodes should appear as entrypoints
+        all_ep_params = {p for params in g.inputs.entrypoints.values() for p in params}
         cycle_params = {"a", "b", "c"}
         for param in cycle_params:
             assert param in all_ep_params or param not in g.inputs.all
@@ -205,7 +205,7 @@ class TestMultiNodeCycle:
         assert g.inputs.required == ()
 
     def test_cycle_with_external_input(self):
-        """Cycle with external input: x is required, cycle params are entry points."""
+        """Cycle with external input: x is required, cycle params are entrypoints."""
 
         @node(output_name="a")
         def node_a(c: int, x: int) -> int:
@@ -223,8 +223,8 @@ class TestMultiNodeCycle:
 
         # 'x' is external input
         assert "x" in g.inputs.required
-        # Cycle parameters appear in entry points
-        assert len(g.inputs.entry_points) > 0
+        # Cycle parameters appear in entrypoints
+        assert len(g.inputs.entrypoints) > 0
 
 
 class TestMultipleCycles:
@@ -264,7 +264,7 @@ class TestMultipleCycles:
 
         assert g.has_cycles is True
 
-    def test_two_independent_cycles_entry_points(self):
+    def test_two_independent_cycles_entrypoints(self):
         """Entry points from both cycles are detected."""
 
         @node(output_name="x")
@@ -289,8 +289,8 @@ class TestMultipleCycles:
 
         g = Graph([x_node, y_node, p_node, q_node, r_node])
 
-        # Both cycles need entry points — at least one node per cycle
-        assert len(g.inputs.entry_points) >= 2
+        # Both cycles need entrypoints — at least one node per cycle
+        assert len(g.inputs.entrypoints) >= 2
 
     def test_cycles_with_shared_external_input(self):
         """Two cycles sharing external input 'config'."""
@@ -317,9 +317,9 @@ class TestMultipleCycles:
 
         g = Graph([x_node, y_node, p_node, q_node, r_node])
 
-        # 'config' is required (external), cycle nodes have entry points
+        # 'config' is required (external), cycle nodes have entrypoints
         assert "config" in g.inputs.required
-        assert len(g.inputs.entry_points) > 0
+        assert len(g.inputs.entrypoints) > 0
 
 
 class TestIsolatedSubgraphs:

--- a/tests/test_graph_topologies.py
+++ b/tests/test_graph_topologies.py
@@ -205,7 +205,7 @@ class TestMultiNodeCycle:
         assert g.inputs.required == ()
 
     def test_cycle_with_external_input(self):
-        """Cycle with external input: x is required, cycle params are seeds."""
+        """Cycle with external input: x is required, cycle params are entry points."""
 
         @node(output_name="a")
         def node_a(c: int, x: int) -> int:
@@ -264,8 +264,8 @@ class TestMultipleCycles:
 
         assert g.has_cycles is True
 
-    def test_two_independent_cycles_seeds(self):
-        """Seeds from both cycles are detected."""
+    def test_two_independent_cycles_entry_points(self):
+        """Entry points from both cycles are detected."""
 
         @node(output_name="x")
         def x_node(y: int) -> int:

--- a/tests/test_graph_topologies.py
+++ b/tests/test_graph_topologies.py
@@ -159,8 +159,8 @@ class TestMultiNodeCycle:
 
         assert g.has_cycles is True
 
-    def test_three_node_cycle_seeds(self):
-        """Three-node cycle computes seeds for cycle parameters."""
+    def test_three_node_cycle_entry_points(self):
+        """Three-node cycle computes entry points for cycle nodes."""
 
         @node(output_name="a")
         def node_a(c: int) -> int:
@@ -176,13 +176,13 @@ class TestMultiNodeCycle:
 
         g = Graph([node_a, node_b, node_c])
 
-        # Cycle parameters should appear as seeds
-        # The exact set depends on implementation, but at least one entry point needed
-        assert len(g.inputs.seeds) > 0
-        # All cycle params are either seeds or internal
+        # Each non-gate cycle node is an entry point
+        assert len(g.inputs.entry_points) > 0
+        # All cycle nodes should appear as entry points
+        all_ep_params = {p for params in g.inputs.entry_points.values() for p in params}
         cycle_params = {"a", "b", "c"}
         for param in cycle_params:
-            assert param in g.inputs.seeds or param not in g.inputs.all
+            assert param in all_ep_params or param not in g.inputs.all
 
     def test_three_node_cycle_no_required_inputs(self):
         """If all inputs are from cycle, required should be empty."""
@@ -223,8 +223,8 @@ class TestMultiNodeCycle:
 
         # 'x' is external input
         assert "x" in g.inputs.required
-        # Cycle parameters are seeds
-        assert len(g.inputs.seeds) > 0
+        # Cycle parameters appear in entry points
+        assert len(g.inputs.entry_points) > 0
 
 
 class TestMultipleCycles:
@@ -289,8 +289,8 @@ class TestMultipleCycles:
 
         g = Graph([x_node, y_node, p_node, q_node, r_node])
 
-        # Both cycles need seeds
-        assert len(g.inputs.seeds) >= 2  # At least one from each cycle
+        # Both cycles need entry points — at least one node per cycle
+        assert len(g.inputs.entry_points) >= 2
 
     def test_cycles_with_shared_external_input(self):
         """Two cycles sharing external input 'config'."""
@@ -317,9 +317,9 @@ class TestMultipleCycles:
 
         g = Graph([x_node, y_node, p_node, q_node, r_node])
 
-        # 'config' is required (external), cycle params are seeds
+        # 'config' is required (external), cycle nodes have entry points
         assert "config" in g.inputs.required
-        assert len(g.inputs.seeds) > 0
+        assert len(g.inputs.entry_points) > 0
 
 
 class TestIsolatedSubgraphs:

--- a/tests/test_interrupt_node.py
+++ b/tests/test_interrupt_node.py
@@ -804,9 +804,10 @@ class TestInterruptNodeInCycle:
             return END if len(messages) > 2 else "ask_user"
 
         graph = Graph([ask_user, process, accumulate, decide])
-        # query should NOT be in seeds since it's produced by an InterruptNode
-        assert "query" not in graph.inputs.seeds
-        assert "messages" in graph.inputs.seeds
+        # query should NOT be an entry point param since it's produced by an InterruptNode
+        all_ep_params = {p for params in graph.inputs.entry_points.values() for p in params}
+        assert "query" not in all_ep_params
+        assert "messages" in all_ep_params
 
     @pytest.mark.asyncio
     async def test_cycle_interrupt_pauses_first_run(self):

--- a/tests/test_interrupt_node.py
+++ b/tests/test_interrupt_node.py
@@ -804,8 +804,8 @@ class TestInterruptNodeInCycle:
             return END if len(messages) > 2 else "ask_user"
 
         graph = Graph([ask_user, process, accumulate, decide])
-        # query should NOT be an entry point param since it's produced by an InterruptNode
-        all_ep_params = {p for params in graph.inputs.entry_points.values() for p in params}
+        # query should NOT be an entrypoint param since it's produced by an InterruptNode
+        all_ep_params = {p for params in graph.inputs.entrypoints.values() for p in params}
         assert "query" not in all_ep_params
         assert "messages" in all_ep_params
 

--- a/tests/test_red_team_fixes.py
+++ b/tests/test_red_team_fixes.py
@@ -339,10 +339,10 @@ class TestControlOnlyCycles:
         assert "data" in graph.inputs.required, (
             f"'data' should be required, got: {graph.inputs.required}"
         )
-        # 'data' should not be an entry point param (it's required, not a cycle param)
-        all_ep_params = {p for params in graph.inputs.entry_points.values() for p in params}
+        # 'data' should not be an entrypoint param (it's required, not a cycle param)
+        all_ep_params = {p for params in graph.inputs.entrypoints.values() for p in params}
         assert "data" not in all_ep_params, (
-            f"'data' should NOT be an entry point param: {graph.inputs.entry_points}"
+            f"'data' should NOT be an entrypoint param: {graph.inputs.entrypoints}"
         )
 
 

--- a/tests/test_red_team_fixes.py
+++ b/tests/test_red_team_fixes.py
@@ -339,8 +339,10 @@ class TestControlOnlyCycles:
         assert "data" in graph.inputs.required, (
             f"'data' should be required, got: {graph.inputs.required}"
         )
-        assert "data" not in graph.inputs.seeds, (
-            f"'data' should NOT be a seed: {graph.inputs.seeds}"
+        # 'data' should not be an entry point param (it's required, not a cycle param)
+        all_ep_params = {p for params in graph.inputs.entry_points.values() for p in params}
+        assert "data" not in all_ep_params, (
+            f"'data' should NOT be an entry point param: {graph.inputs.entry_points}"
         )
 
 

--- a/tests/test_runners/test_execution.py
+++ b/tests/test_runners/test_execution.py
@@ -618,20 +618,44 @@ class TestFilterOutputs:
         result = filter_outputs(state, graph, select=["sum"])
         assert result == {"sum": 15}
 
-    def test_select_none_returns_all_outputs(self):
-        """No select returns all graph outputs."""
+    def test_select_all_returns_all_outputs(self):
+        """select="**" returns all graph outputs."""
         graph = Graph([double])
         state = GraphState(values={"doubled": 10, "x": 5})
 
-        result = filter_outputs(state, graph, select=None)
+        result = filter_outputs(state, graph, select="**")
         # Only graph outputs, not inputs
         assert result == {"doubled": 10}
 
-    def test_missing_select_key_ignored(self):
-        """Select keys not in state are ignored with warning."""
+    def test_default_select_returns_all_outputs(self):
+        """No select argument returns all graph outputs."""
+        graph = Graph([double])
+        state = GraphState(values={"doubled": 10, "x": 5})
+
+        result = filter_outputs(state, graph)
+        assert result == {"doubled": 10}
+
+    def test_missing_select_key_ignored_by_default(self):
+        """Missing select keys silently omitted with on_missing='ignore' (default)."""
+        graph = Graph([double])
+        state = GraphState(values={"doubled": 10})
+
+        result = filter_outputs(state, graph, select=["doubled", "nonexistent"])
+        assert result == {"doubled": 10}
+
+    def test_missing_select_key_warns(self):
+        """on_missing='warn' emits warning for missing select keys."""
         graph = Graph([double])
         state = GraphState(values={"doubled": 10})
 
         with pytest.warns(UserWarning, match="Requested outputs not found"):
-            result = filter_outputs(state, graph, select=["doubled", "nonexistent"])
+            result = filter_outputs(state, graph, select=["doubled", "nonexistent"], on_missing="warn")
         assert result == {"doubled": 10}
+
+    def test_missing_select_key_errors(self):
+        """on_missing='error' raises ValueError for missing select keys."""
+        graph = Graph([double])
+        state = GraphState(values={"doubled": 10})
+
+        with pytest.raises(ValueError, match="Requested outputs not found"):
+            filter_outputs(state, graph, select=["doubled", "nonexistent"], on_missing="error")

--- a/tests/test_runners/test_execution.py
+++ b/tests/test_runners/test_execution.py
@@ -635,6 +635,22 @@ class TestFilterOutputs:
         result = filter_outputs(state, graph)
         assert result == {"doubled": 10}
 
+    def test_single_string_select(self):
+        """select="name" (single string) works as shorthand for select=["name"]."""
+        graph = Graph([double, add.with_inputs(a="doubled")])
+        state = GraphState(values={"doubled": 10, "sum": 15, "x": 5, "b": 5})
+
+        result = filter_outputs(state, graph, select="sum")
+        assert result == {"sum": 15}
+
+    def test_invalid_on_missing_raises(self):
+        """Invalid on_missing value raises ValueError."""
+        graph = Graph([double])
+        state = GraphState(values={"doubled": 10})
+
+        with pytest.raises(ValueError, match="Invalid on_missing"):
+            filter_outputs(state, graph, select=["nonexistent"], on_missing="raise")
+
     def test_missing_select_key_ignored_by_default(self):
         """Missing select keys silently omitted with on_missing='ignore' (default)."""
         graph = Graph([double])

--- a/tests/test_runners/test_validation.py
+++ b/tests/test_runners/test_validation.py
@@ -84,8 +84,8 @@ class TestValidateInputs:
         with pytest.raises(MissingInputError):
             validate_inputs(graph, {})
 
-    def test_seed_input_provided_passes(self):
-        """No error when seed input is provided."""
+    def test_entry_point_input_provided_passes(self):
+        """No error when entry point input is provided."""
         graph = Graph([counter])
         validate_inputs(graph, {"count": 0})
 

--- a/tests/test_runners/test_validation.py
+++ b/tests/test_runners/test_validation.py
@@ -72,17 +72,17 @@ class TestValidateInputs:
         # a is bound, only b is required
         validate_inputs(graph, {"b": 10})
 
-    def test_seed_input_required_for_cycles(self):
-        """Seed inputs must be provided for cyclic graphs."""
+    def test_entry_point_required_for_cycles(self):
+        """Entry point params must be provided for cyclic graphs."""
         # Create a cycle: counter -> counter
         # count is both input and output
         graph = Graph([counter])
-        # count should be a seed (cycle input)
-        assert "count" in graph.inputs.seeds
+        # count should be an entry point param
+        assert "counter" in graph.inputs.entry_points
+        assert "count" in graph.inputs.entry_points["counter"]
 
-        with pytest.raises(MissingInputError) as exc_info:
+        with pytest.raises(MissingInputError):
             validate_inputs(graph, {})
-        assert "count" in exc_info.value.missing
 
     def test_seed_input_provided_passes(self):
         """No error when seed input is provided."""

--- a/tests/test_runners/test_validation.py
+++ b/tests/test_runners/test_validation.py
@@ -72,20 +72,20 @@ class TestValidateInputs:
         # a is bound, only b is required
         validate_inputs(graph, {"b": 10})
 
-    def test_entry_point_required_for_cycles(self):
+    def test_entrypoint_required_for_cycles(self):
         """Entry point params must be provided for cyclic graphs."""
         # Create a cycle: counter -> counter
         # count is both input and output
         graph = Graph([counter])
-        # count should be an entry point param
-        assert "counter" in graph.inputs.entry_points
-        assert "count" in graph.inputs.entry_points["counter"]
+        # count should be an entrypoint param
+        assert "counter" in graph.inputs.entrypoints
+        assert "count" in graph.inputs.entrypoints["counter"]
 
         with pytest.raises(MissingInputError):
             validate_inputs(graph, {})
 
-    def test_entry_point_input_provided_passes(self):
-        """No error when entry point input is provided."""
+    def test_entrypoint_input_provided_passes(self):
+        """No error when entrypoint input is provided."""
         graph = Graph([counter])
         validate_inputs(graph, {"count": 0})
 

--- a/tests/viz/conftest.py
+++ b/tests/viz/conftest.py
@@ -141,7 +141,7 @@ def _viz_cache_key(
         graph.name,
         input_spec.required,
         input_spec.optional,
-        tuple(sorted(input_spec.entry_points.keys())),
+        tuple(sorted(input_spec.entrypoints.keys())),
         bound_items,
         depth,
         theme,

--- a/tests/viz/conftest.py
+++ b/tests/viz/conftest.py
@@ -141,7 +141,7 @@ def _viz_cache_key(
         graph.name,
         input_spec.required,
         input_spec.optional,
-        input_spec.seeds,
+        tuple(sorted(input_spec.entry_points.keys())),
         bound_items,
         depth,
         theme,

--- a/tests/viz/test_complex_nested_graphs.py
+++ b/tests/viz/test_complex_nested_graphs.py
@@ -130,7 +130,7 @@ def test_rag_style_retrieval_output_routes_from_internal_producer() -> None:
     assert sources == {"retrieval/rag_limit_docs"}
 
 
-def test_rag_style_control_edge_routes_to_entry_point_when_expanded() -> None:
+def test_rag_style_control_edge_routes_to_entrypoint_when_expanded() -> None:
     graph = make_rag_style_graph()
     result = render_graph(graph.to_flat_graph(), depth=0)
     edges = _expanded_edges(result)


### PR DESCRIPTION
### **User description**
## Summary

- **`seeds` → `entry_points`**: Cycle parameters are now grouped by the node where execution starts (`dict[str, tuple[str, ...]]` instead of flat `tuple[str, ...]`). Users pick ONE entry point per cycle instead of providing ALL seed values.
- **`bind()` simplified**: Now accepts any graph input or output (not just inputs). Emit-only outputs are blocked. `bind()` = pre-filling `run()` values.
- **`on_missing` parameter**: New parameter on `run()` and `map()` controlling how missing selected outputs are handled (`"ignore"` / `"warn"` / `"error"`, default `"ignore"`).
- **`entry_point` parameter**: Optional explicit cycle entry point on `run()` for disambiguation.
- **`select` type changed**: From `list[str] | None` to `str | list[str]`, default `"**"` (all outputs).
- **SCC-based cycle grouping**: Multi-cycle graphs detect ambiguity per-cycle using actual strongly connected components.
- **Docs updated**: InputSpec, Runners, Graph, Agentic Loops, Guiding Principles pages all updated.

## Test plan

- [x] All 1574 existing tests pass (excluding pre-existing unrelated failure in untracked test file)
- [x] Entry point matching works for single and multi-cycle graphs
- [x] Ambiguity detection is per-cycle (SCC-based), not cross-cycle
- [x] `bind()` accepts outputs and cycle entry point params
- [x] `bind()` rejects emit-only outputs
- [x] `on_missing="ignore"` silently omits missing outputs (new default)
- [x] `on_missing="warn"` warns about missing outputs
- [x] `on_missing="error"` raises on missing outputs
- [x] Bypass detection excludes cycle entry point params
- [x] InterruptNode outputs excluded from entry points
- [x] Empty `needed` tuples skipped (InterruptNode edge case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Replace `seeds` with `entry_points` dict grouped by cycle node

- Simplify `bind()` to accept graph inputs and outputs (not just inputs)

- Add `on_missing` parameter to control missing output handling

- Add `entry_point` parameter for explicit cycle disambiguation

- Change `select` type from `list[str] | None` to `str | list[str]`

- Implement SCC-based cycle entry point detection and validation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["InputSpec.seeds<br/>tuple"] -->|"replaced by"| B["InputSpec.entry_points<br/>dict[node → params]"]
  C["bind() restrictions<br/>inputs only"] -->|"simplified to"| D["bind() accepts<br/>inputs + outputs"]
  E["select: list | None"] -->|"changed to"| F["select: str | list<br/>default: '**'"]
  G["filter_outputs()<br/>no missing handling"] -->|"enhanced with"| H["on_missing parameter<br/>ignore/warn/error"]
  I["run() signature"] -->|"updated with"| J["entry_point, on_missing<br/>select parameters"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>input_spec.py</strong><dd><code>Replace seeds tuple with entry_points dict structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/47/files#diff-9bacc96380e98dfe15699ebe6ea2640693ef29e6e980e52b44261bf89c3b65b7">+80/-23</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>core.py</strong><dd><code>Simplify bind() to accept inputs and outputs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/47/files#diff-187e378c017f7b11d453a19d86325b60ef3566887ba64472831b08b6493c0e48">+24/-17</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>helpers.py</strong><dd><code>Add on_missing parameter to filter_outputs function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/47/files#diff-527974079a4ec295ee9c51c980e1d75db64c7f4e23f68f63e4b8530363665d8b">+76/-32</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>validation.py</strong><dd><code>Implement SCC-based cycle entry point validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/47/files#diff-77c351d52fa45973c2d3654d426b8d3e25c4ee418bbe9a2ec86af9513c369771">+157/-47</a></td>

</tr>

<tr>
  <td><strong>template_sync.py</strong><dd><code>Add entry_point and on_missing to sync runner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/47/files#diff-2c1d33c530c559cb6cddd7b491c379e45ca778404c2ff1c2f61aa4b3bda65afb">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>template_async.py</strong><dd><code>Add entry_point and on_missing to async runner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/47/files#diff-ff91f27bd8e68e8dd4fc3f5d28d6901eadcac60d593a7a436077382b62822bfc">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>base.py</strong><dd><code>Update base runner signatures with new parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/47/files#diff-59f26995a12fb85035a7326a292b5283709387419b10d53b492716d90009af13">+11/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>test_bind_edge_cases.py</strong><dd><code>Update bind tests for entry points and outputs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/47/files#diff-77a2c5f6bc00377ff63a29aba3fdb9e66abefa49d9a9900f577cd87c7ee23651">+23/-29</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_graph.py</strong><dd><code>Update graph tests for entry_points structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/47/files#diff-e9352f44736d5b9e922852f07917f4d93bb6d4ca2e6d9743abf20194a5c414d5">+23/-22</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_graph_topologies.py</strong><dd><code>Update topology tests for entry_points</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/47/files#diff-856638b187ea296b211d7a93f1aeac43a0004b1ad85cd8a489eedc0c63f04dbc">+13/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_interrupt_node.py</strong><dd><code>Update interrupt node tests for entry_points</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/47/files#diff-68e097f9278db08fbe2f26c993951dab019d2f87b0329fd4a65134299fb8d428">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_red_team_fixes.py</strong><dd><code>Update red team tests for entry_points</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/47/files#diff-a1275d48ffeefe914d35a226b0ea74603217d1260129c4fda375db023a185e8e">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_code_review_fixes.py</strong><dd><code>Update select parameter validation tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/47/files#diff-375d0a40e4653c27e5b90a49b1b7d4b5fea05705b15c1d6c147ca65ddec0fc18">+18/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_execution.py</strong><dd><code>Update filter_outputs tests for on_missing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/47/files#diff-af721b73142cc610bdbb531087c414d180c13c7bf3fb2002202b7195fcf48346">+30/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_validation.py</strong><dd><code>Update validation tests for entry_points</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/47/files#diff-88cac1e9f2274f40020adcdf9dfcd4cbd5ecde9ee65d4db935de62b3b78c60ca">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>conftest.py</strong><dd><code>Update viz cache key for entry_points</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/47/files#diff-e590e602cfd0658773338875bc55c4e3110b85e0497e56e5d690002a0c25315e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_api_docs.py</strong><dd><code>Update test script to use entry_points</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/47/files#diff-973aa961b20a50e4d3bff9ab406e4615023ca1069cb0cb146512d188a9afbc2a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>03-agentic-loops.md</strong><dd><code>Update documentation from seeds to entry points</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/47/files#diff-e3572c1a7b5225caf7095290ab13d91acb1eb50f502e604d1722f64bb9fb327d">+12/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>inputspec.md</strong><dd><code>Update InputSpec API docs for entry_points</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/47/files#diff-e0051d9ef5cc6141c393406381568a0b88202d106e788c924af7f194d401c41a">+58/-49</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>graph.md</strong><dd><code>Update bind() documentation and error messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/47/files#diff-85823276de19103713cf7c6fca52be63d160406a180c7f70dcc2b28ce2789dc0">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>nodes.md</strong><dd><code>Update node inputs documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/47/files#diff-d9dd5d9626ec596e1fb0e47cc6531ff5a36723264eb44aa813847611be3c6ef1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runners.md</strong><dd><code>Update runner signatures and select/on_missing docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/47/files#diff-56c9ed459757844ea23c5ca70f3a761fb9225f0592b12a873a0c34a55c261860">+30/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>guiding-principles.md</strong><dd><code>Update cycle principles for entry_points</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/47/files#diff-0a6c3472933de3b13263eb29746b1dd50051a43849f14ee0444f60acf8f81a59">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduces cycle entry points (replacing "seeds") and a runner entrypoint option to disambiguate cycles.
  * Runners support select shorthand ("**" and single-string) and on_missing policies ("ignore" | "warn" | "error").

* **API Changes**
  * Public input spec renamed from seeds → entrypoints.
  * Runner run/map signatures extended to accept select, on_missing, and entrypoint.

* **Bug Fixes**
  * Clearer binding validation and explicit rejection of emit-only (non-data) signals.

* **Documentation**
  * Docs updated to reflect entrypoint terminology and new runner/select/on_missing semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->