### PR TITLE
fix: hash_definition fallback for dynamic and builtin functions

### DIFF
--- a/src/hypergraph/_utils.py
+++ b/src/hypergraph/_utils.py
@@ -70,7 +70,10 @@ def hash_definition(func: Callable) -> str:
         closure = getattr(func, "__closure__", None)
         if closure:
             for cell in closure:
-                h.update(repr(cell.cell_contents).encode())
+                try:
+                    h.update(repr(cell.cell_contents).encode())
+                except ValueError:
+                    h.update(b"<empty_cell>")
 
         return h.hexdigest()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -68,11 +68,6 @@ class TestHashDefinition:
 
         assert hash_definition(foo) != hash_definition(bar)
 
-    def test_builtin_function_raises_value_error(self):
-        """Built-in functions raise ValueError."""
-        with pytest.raises(ValueError, match="Cannot hash function"):
-            hash_definition(len)
-
     def test_nested_function(self):
         """Nested functions can be hashed."""
 
@@ -114,3 +109,45 @@ class TestHashDefinition:
         fn = lambda x: x * 2  # noqa: E731
         result = hash_definition(fn)
         assert len(result) == 64
+
+    # --- Bytecode fallback tests ---
+
+    def test_exec_created_function_returns_hash(self):
+        """Functions created via exec() should fall back to bytecode hashing."""
+        namespace = {}
+        exec("def dynamic(x): return x + 1", namespace)
+        fn = namespace["dynamic"]
+
+        result = hash_definition(fn)
+        assert len(result) == 64
+        assert all(c in "0123456789abcdef" for c in result)
+
+    def test_exec_created_function_is_deterministic(self):
+        """Same exec'd function hashed twice gives the same result."""
+        namespace = {}
+        exec("def dynamic(x): return x + 1", namespace)
+        fn = namespace["dynamic"]
+
+        assert hash_definition(fn) == hash_definition(fn)
+
+    def test_exec_different_body_different_hash(self):
+        """exec'd functions with different bodies produce different hashes."""
+        ns1, ns2 = {}, {}
+        exec("def f(x): return x + 1", ns1)
+        exec("def f(x): return x * 2", ns2)
+
+        assert hash_definition(ns1["f"]) != hash_definition(ns2["f"])
+
+    def test_builtin_function_returns_hash(self):
+        """Built-in functions should produce a stable hash, not raise."""
+        result = hash_definition(len)
+        assert len(result) == 64
+        assert all(c in "0123456789abcdef" for c in result)
+
+    def test_builtin_is_deterministic(self):
+        """Same built-in hashed twice gives the same result."""
+        assert hash_definition(len) == hash_definition(len)
+
+    def test_different_builtins_different_hash(self):
+        """Different built-ins produce different hashes."""
+        assert hash_definition(len) != hash_definition(print)


### PR DESCRIPTION
### **User description**
## Summary
- `hash_definition` previously raised `ValueError` for dynamically created functions (`exec`/`eval`) and builtins — now uses a 3-tier fallback strategy
- **Tier 1**: Source code via `inspect.getsource()` (unchanged, most precise)
- **Tier 2**: Bytecode (`co_code` + `co_consts`) for `exec`/`eval`/Jupyter-defined functions
- **Tier 3**: Qualified name (`module:qualname`) for builtins/C extensions

This unblocks using `@node(cache=True)` with dynamically created functions and builtins.

## Test plan
- [x] 6 new tests covering bytecode and builtin fallback paths
- [x] Removed `test_builtin_function_raises_value_error` (behavior changed from raising to returning hash)
- [x] All 155 existing utils/node tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Implement 3-tier fallback strategy for `hash_definition` function
  - Tier 1: Source code via `inspect.getsource()` (most precise)
  - Tier 2: Bytecode (`co_code` + `co_consts`) for dynamic functions
  - Tier 3: Qualified name for builtins/C extensions

- Remove `ValueError` exception, enabling `@node(cache=True)` with dynamic/builtin functions

- Add 6 new tests covering bytecode and builtin fallback paths

- Remove test expecting `ValueError` for builtins (behavior changed)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  func["Function to hash"]
  tier1["Tier 1: Source code<br/>inspect.getsource"]
  tier2["Tier 2: Bytecode<br/>co_code + co_consts"]
  tier3["Tier 3: Qualified name<br/>module:qualname"]
  hash["SHA256 hash"]
  
  func --> tier1
  tier1 -->|Success| hash
  tier1 -->|OSError/TypeError| tier2
  tier2 -->|Has __code__| hash
  tier2 -->|No __code__| tier3
  tier3 --> hash
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_utils.py</strong><dd><code>Implement fallback hashing for dynamic functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hypergraph/_utils.py

<ul><li>Replace single-path hashing with 3-tier fallback strategy<br> <li> Remove <code>ValueError</code> exception for dynamic/builtin functions<br> <li> Add bytecode hashing using <code>co_code</code> and <code>co_consts</code><br> <li> Add name-based fallback using <code>module:qualname</code> for builtins<br> <li> Update docstring to document fallback behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/49/files#diff-31fc34c9288e0de131ed2e48d08a45dc84a23dd1c1d87e7a597fd7c2c1ad778c">+23/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_utils.py</strong><dd><code>Add tests for fallback hashing paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_utils.py

<ul><li>Remove <code>test_builtin_function_raises_value_error</code> test<br> <li> Add 6 new tests for bytecode fallback path<br> <li> Add 3 new tests for builtin function hashing<br> <li> Test determinism and differentiation for exec'd functions<br> <li> Test determinism and differentiation for builtins</ul>


</details>


  </td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/49/files#diff-33c13e0b177bacd2f02e29bcb8aea5b49e7ce34901fd8f41fefb65defba1bd33">+42/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Function hashing no longer raises for built-ins or partials and handles edge cases gracefully.

* **New Features**
  * Multi-tier hashing with deterministic fallbacks for more reliable function identification.

* **Tests**
  * Expanded tests to ensure deterministic, distinct hashes across varied function types and defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->