### PR TITLE
feat(graph): add explicit edges mode for cyclic graphs with shared output names

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,8 +18,10 @@ repos:
         stages: [pre-push]
         args: [--no-fix]
         pass_filenames: false
+        always_run: true
       - id: ruff-format
         name: ruff format (all files, pre-push)
         stages: [pre-push]
         args: [--check]
         pass_filenames: false
+        always_run: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,17 @@ repos:
       - id: ruff
         args: [--fix]
       - id: ruff-format
+  # Full-repo lint check before push — catches post-rebase formatting drift
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.2
+    hooks:
+      - id: ruff
+        name: ruff check (all files, pre-push)
+        stages: [pre-push]
+        args: [--no-fix]
+        pass_filenames: false
+      - id: ruff-format
+        name: ruff format (all files, pre-push)
+        stages: [pre-push]
+        args: [--check]
+        pass_filenames: false

--- a/dev/CONTRIBUTING.md
+++ b/dev/CONTRIBUTING.md
@@ -15,8 +15,9 @@ git clone https://github.com/gilad-rubin/hypergraph.git
 cd hypergraph
 uv sync --group dev
 
-# Install pre-commit hooks
+# Install pre-commit and pre-push hooks
 uv run pre-commit install
+uv run pre-commit install --hook-type pre-push
 
 # Enable session tracking (captures agent transcripts as Git checkpoints)
 entire enable

--- a/docs/03-patterns/03-agentic-loops.md
+++ b/docs/03-patterns/03-agentic-loops.md
@@ -280,7 +280,11 @@ result = runner.run(graph, {
 
 ## Shared Outputs in a Cycle
 
-Multiple nodes can produce the same output name when they are **provably ordered** via `emit`/`wait_for` or placed in **mutually exclusive gate branches**. Ordering ensures the consumer always receives the most recently produced value. Without ordering, two producers in the same cycle could both fire in the same superstep, creating ambiguity.
+When multiple nodes produce the same output name in a cycle — like two nodes both producing `messages` — the graph needs to know their execution order. There are two approaches: ordering signals (`emit`/`wait_for`) and explicit edges.
+
+### With emit/wait_for
+
+Use `emit`/`wait_for` to prove ordering between same-name producers. This keeps auto-inference for edge wiring while adding ordering constraints:
 
 ```python
 @node(output_name="query")
@@ -312,6 +316,55 @@ graph = Graph([
     should_continue,
 ])
 ```
+
+### With Explicit Edges
+
+When cycles share common output names like `messages`, `df`, or `state`, explicit edges let you declare the topology directly instead of inventing signal names. Pass `edges` to `Graph()` to disable auto-inference and wire edges manually:
+
+```python
+from hypergraph import Graph, node, route, END
+
+@node(output_name="messages")
+def add_query(messages: list, query: str) -> list:
+    return [*messages, {"role": "user", "content": query}]
+
+@node(output_name="response")
+def generate(messages: list) -> str:
+    return llm.chat(messages)
+
+@node(output_name="messages")
+def add_response(messages: list, response: str) -> list:
+    return [*messages, {"role": "assistant", "content": response}]
+
+@route(targets=["add_query", END])
+def should_continue(messages: list) -> str:
+    return END if len(messages) >= 10 else "add_query"
+
+chat = Graph(
+    [add_query, generate, add_response, should_continue],
+    edges=[
+        (add_query, generate),                   # messages
+        (generate, add_response),                # response
+        (add_response, should_continue),         # messages
+        (should_continue, add_query),            # control (route)
+        (add_response, add_query),               # messages (cycle)
+    ],
+)
+```
+
+Each edge is a `(source, target)` tuple. Values are auto-detected from the intersection of source outputs and target inputs. When there's no overlap, the edge becomes ordering-only (structural dependency, no data flow).
+
+You can also use 3-tuples to specify values explicitly: `(source, target, "messages")` or `(source, target, ["messages", "response"])`.
+
+**When to use which approach:**
+
+| Situation | Use |
+|-----------|-----|
+| DAGs (no cycles) | Auto-inference (no `edges` needed) |
+| Cycles with unique output names | Auto-inference + `emit`/`wait_for` for ordering |
+| Cycles with shared output names (`messages`, `state`) | Explicit edges |
+
+For more on the `edges` parameter, see the [Graph API reference](../06-api-reference/graph.md#explicit-edges).
 
 ## Preventing Infinite Loops
 

--- a/docs/03-patterns/03-agentic-loops.md
+++ b/docs/03-patterns/03-agentic-loops.md
@@ -346,7 +346,6 @@ chat = Graph(
         (add_query, generate),                   # messages
         (generate, add_response),                # response
         (add_response, should_continue),         # messages
-        (should_continue, add_query),            # control (route)
         (add_response, add_query),               # messages (cycle)
     ],
 )

--- a/docs/06-api-reference/graph.md
+++ b/docs/06-api-reference/graph.md
@@ -26,7 +26,7 @@ Edges are inferred automatically: if node A produces output "x" and node B has i
 
 ## Constructor
 
-### `Graph(nodes, *, name=None, strict_types=False)`
+### `Graph(nodes, *, edges=None, name=None, strict_types=False)`
 
 Create a graph from nodes.
 
@@ -37,7 +37,7 @@ from hypergraph import node, Graph
 def process(x: int) -> int:
     return x * 2
 
-# Basic usage
+# Basic usage — edges inferred from matching names
 g = Graph([process])
 
 # With name (required for nesting)
@@ -49,12 +49,13 @@ g = Graph([process], strict_types=True)
 
 **Args:**
 - `nodes` (list[HyperNode]): List of nodes to include in the graph
+- `edges` (list[tuple] | None): Explicit edge declarations. Disables auto-inference when provided. See [Explicit Edges](#explicit-edges) below.
 - `name` (str | None): Optional graph name. Required if using `as_node()` for composition.
 - `strict_types` (bool): If True, validate type compatibility between connected nodes at construction time. Default: False.
 
 **Raises:**
 - `GraphConfigError` - If duplicate node names exist
-- `GraphConfigError` - If multiple nodes produce the same output name
+- `GraphConfigError` - If multiple nodes produce the same output name (in auto-inference mode without ordering)
 - `GraphConfigError` - If `strict_types=True` and types are incompatible or missing
 
 ## Properties
@@ -493,7 +494,10 @@ Graph([a, b])
 # GraphConfigError: Multiple nodes produce 'result'
 ```
 
-> **Exception**: Multiple nodes *can* produce the same output if they are **provably ordered** (via `emit`/`wait_for`) or in **mutually exclusive gate branches**. See [Shared Outputs in a Cycle](../03-patterns/03-agentic-loops.md#shared-outputs-in-a-cycle).
+Three ways to resolve this:
+1. **`emit`/`wait_for`** — Prove ordering between the producers. See [Shared Outputs in a Cycle](../03-patterns/03-agentic-loops.md#shared-outputs-in-a-cycle).
+2. **Explicit edges** — Declare the full topology manually via `edges=[...]`. See [Explicit Edges](#explicit-edges) below.
+3. **Mutually exclusive gate branches** — Place producers in different branches of an `@ifelse` or `@route` gate.
 
 **Invalid identifiers:**
 ```python
@@ -512,6 +516,63 @@ def b(value: int) -> int: return value  # No default!
 Graph([a, b])
 # GraphConfigError: Inconsistent defaults for 'value'
 ```
+
+## Explicit Edges
+
+By default, `Graph` infers edges from matching output/input names. Pass `edges` to disable auto-inference and declare the graph topology manually.
+
+```python
+from hypergraph import Graph, node
+
+@node(output_name="messages")
+def add_query(messages: list, query: str) -> list:
+    return [*messages, {"role": "user", "content": query}]
+
+@node(output_name="response")
+def generate(messages: list) -> str:
+    return llm.chat(messages)
+
+@node(output_name="messages")
+def add_response(messages: list, response: str) -> list:
+    return [*messages, {"role": "assistant", "content": response}]
+
+chat = Graph(
+    [add_query, generate, add_response],
+    edges=[
+        (add_query, generate),         # messages
+        (generate, add_response),      # response
+        (add_response, add_query),     # messages (cycle)
+    ],
+)
+```
+
+Both `add_query` and `add_response` produce `messages`. With auto-inference this would raise `GraphConfigError`. Explicit edges make the topology unambiguous.
+
+### Edge Format
+
+Each edge is a tuple of `(source, target)` or `(source, target, values)`:
+
+| Format | Behavior |
+|--------|----------|
+| `(source, target)` | Values auto-detected from intersection of `source.outputs` and `target.inputs` |
+| `(source, target, "name")` | Explicit single value |
+| `(source, target, ["a", "b"])` | Explicit multiple values |
+
+Source and target can be node objects or string names:
+
+```python
+# These are equivalent
+Graph([a, b], edges=[(a, b)])
+Graph([a, b], edges=[("a", "b")])
+```
+
+When a 2-tuple has no overlapping output/input names, it becomes an **ordering-only edge** — a structural dependency with no data flow.
+
+### Restrictions
+
+- `add_nodes()` raises `GraphConfigError` on a graph with explicit edges. Create a new `Graph` with the complete node and edge lists instead.
+- Auto-inference and explicit edges don't mix. When `edges` is provided, only declared edges exist.
+- Gate control edges and `emit`/`wait_for` ordering edges are still auto-wired in explicit mode.
 
 ### `visualize(*, depth=0, theme="auto", show_types=False, separate_outputs=False, filepath=None)`
 

--- a/docs/06-api-reference/graph.md
+++ b/docs/06-api-reference/graph.md
@@ -572,7 +572,7 @@ When a 2-tuple has no overlapping output/input names, it becomes an **ordering-o
 
 - `add_nodes()` raises `GraphConfigError` on a graph with explicit edges. Create a new `Graph` with the complete node and edge lists instead.
 - Auto-inference and explicit edges don't mix. When `edges` is provided, only declared edges exist.
-- Gate control edges and `emit`/`wait_for` ordering edges are still auto-wired in explicit mode.
+- Gate control edges and `emit`/`wait_for` ordering edges are still auto-wired in explicit mode. Don't declare edges from gate nodes to their targets — the explicit edge would override the auto-wired control edge type, affecting visualization.
 
 ### `visualize(*, depth=0, theme="auto", show_types=False, separate_outputs=False, filepath=None)`
 

--- a/notebooks/04_cycles.ipynb
+++ b/notebooks/04_cycles.ipynb
@@ -211,7 +211,15 @@
    "outputs": [],
    "source": [
     "chat_graph = Graph(\n",
-    "    [ask_user, rag_graph.as_node(name=\"rag\"), add_user_message, add_assistant_message],\n",
+    "    [ask_user, add_user_message, rag_graph.as_node(name=\"rag\"), add_assistant_message],\n",
+    "    edges=[\n",
+    "        (ask_user, add_user_message),       # query\n",
+    "        (ask_user, \"rag\"),                   # query\n",
+    "        (add_user_message, \"rag\"),           # messages\n",
+    "        (\"rag\", add_assistant_message),      # response\n",
+    "        (add_assistant_message, ask_user),   # messages\n",
+    "        (\"rag\", ask_user),                   # response\n",
+    "    ],\n",
     "    name=\"rag_chat\",\n",
     ")"
    ]

--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -44,8 +44,13 @@ class Graph:
     Graph is a pure structure definition - it describes what nodes exist and how
     they connect.
 
-    Edges are inferred automatically: if node A produces output "x" and node B
-    has input "x", an edge A→B is created.
+    By default, edges are inferred automatically: if node A produces output "x"
+    and node B has input "x", an edge A→B is created.
+
+    For cyclic graphs with shared output names, use ``edges`` to declare
+    topology explicitly::
+
+        Graph([a, b, c], edges=[(a, b), (b, c), (c, a)])
 
     Attributes:
         name: Optional graph name (required for nesting via as_node)
@@ -76,6 +81,7 @@ class Graph:
         self,
         nodes: list[HyperNode],
         *,
+        edges: list[tuple] | None = None,
         name: str | None = None,
         strict_types: bool = False,
     ) -> None:
@@ -83,6 +89,14 @@ class Graph:
 
         Args:
             nodes: List of HyperNode objects
+            edges: Explicit edge declarations. Each edge is a tuple of
+                ``(source, target)`` or ``(source, target, values)`` where
+                source/target are node names (str) or node objects, and values
+                is a str or list of str specifying which outputs flow on the
+                edge. If omitted on a 2-tuple, values are auto-detected from
+                the intersection of source outputs and target inputs. Edges
+                with no matching values become ordering-only edges.
+                When ``edges`` is provided, auto-inference is disabled.
             name: Optional graph name for nesting
             strict_types: If True, validate type compatibility between connected
                          nodes at graph construction time. Calls _validate_types()
@@ -94,6 +108,7 @@ class Graph:
         self._bound: dict[str, Any] = {}
         self._selected: tuple[str, ...] | None = None
         self._nodes = self._build_nodes_dict(nodes)
+        self._explicit_edges = self._normalize_edges(edges) if edges is not None else None
         self._nx_graph = self._build_graph(nodes)
         self._cached_hash: str | None = None
         self._controlled_by: dict[str, list[str]] | None = None
@@ -221,33 +236,128 @@ class Graph:
                 output_sources.setdefault(output, []).append(node.name)
         return output_sources
 
+    def _normalize_edges(
+        self,
+        edges: list[tuple],
+    ) -> tuple[tuple[str, str, tuple[str, ...]], ...]:
+        """Normalize edge specs to frozen (source, target, value_names) triples.
+
+        Supports:
+        - 2-tuple: (source, target) — values inferred from output/input overlap
+        - 3-tuple: (source, target, values) — explicit value names
+
+        Source/target can be node name strings or HyperNode objects.
+        """
+        normalized: list[tuple[str, str, tuple[str, ...]]] = []
+        for edge in edges:
+            if not isinstance(edge, tuple) or len(edge) not in (2, 3):
+                raise GraphConfigError(
+                    f"Edge must be a 2-tuple or 3-tuple, got {type(edge).__name__} "
+                    f"with {len(edge) if isinstance(edge, tuple) else '?'} elements"
+                )
+
+            src_raw, dst_raw = edge[0], edge[1]
+            src = src_raw.name if isinstance(src_raw, HyperNode) else src_raw
+            dst = dst_raw.name if isinstance(dst_raw, HyperNode) else dst_raw
+
+            if src not in self._nodes:
+                raise GraphConfigError(
+                    f"Edge references unknown source node '{src}'"
+                )
+            if dst not in self._nodes:
+                raise GraphConfigError(
+                    f"Edge references unknown target node '{dst}'"
+                )
+
+            if len(edge) == 3:
+                values = edge[2]
+                if isinstance(values, str):
+                    values = [values]
+                src_outputs = set(self._nodes[src].outputs)
+                dst_inputs = set(self._nodes[dst].inputs)
+                for v in values:
+                    if v not in src_outputs:
+                        raise GraphConfigError(
+                            f"Edge ({src}, {dst}): '{v}' is not an output of '{src}'. "
+                            f"Outputs: {self._nodes[src].outputs}"
+                        )
+                    if v not in dst_inputs:
+                        raise GraphConfigError(
+                            f"Edge ({src}, {dst}): '{v}' is not an input of '{dst}'. "
+                            f"Inputs: {self._nodes[dst].inputs}"
+                        )
+                value_names = tuple(dict.fromkeys(values))
+            else:
+                # Infer from intersection (preserve target input order)
+                src_outputs = set(self._nodes[src].outputs)
+                value_names = tuple(
+                    v for v in self._nodes[dst].inputs if v in src_outputs
+                )
+                # Empty intersection is allowed — creates ordering-only edge
+
+            normalized.append((src, dst, value_names))
+
+        return tuple(normalized)
+
+    def _add_explicit_data_edges(
+        self,
+        G: nx.DiGraph,
+        normalized_edges: tuple[tuple[str, str, tuple[str, ...]], ...],
+    ) -> None:
+        """Add user-declared edges to the graph.
+
+        Edges with values get edge_type="data". Edges with no values
+        (empty intersection) get edge_type="ordering" (structural dependency).
+        """
+        from collections import defaultdict
+
+        data_edges: dict[tuple[str, str], list[str]] = defaultdict(list)
+        ordering_pairs: set[tuple[str, str]] = set()
+
+        for src, dst, value_names in normalized_edges:
+            if value_names:
+                data_edges[(src, dst)].extend(value_names)
+            else:
+                ordering_pairs.add((src, dst))
+
+        # Add data edges (dedup value_names per pair)
+        G.add_edges_from(
+            (src, dst, {"edge_type": "data",
+                        "value_names": list(dict.fromkeys(names))})
+            for (src, dst), names in data_edges.items()
+        )
+
+        # Add ordering-only edges (skip if data edge already exists)
+        for src, dst in ordering_pairs:
+            if not G.has_edge(src, dst):
+                G.add_edge(src, dst, edge_type="ordering", value_names=[])
+
     def _build_graph(self, nodes: list[HyperNode]) -> nx.DiGraph:
-        """Build NetworkX DiGraph from nodes with edge inference.
+        """Build NetworkX DiGraph from nodes.
 
-        Process:
-        1. Add nodes to graph
-        2. Collect all output sources (allowing duplicates temporarily)
-        3. Build edges using first source for each output
-        4. Add control edges
-        5. Validate output conflicts with full graph structure (using reachability)
-
-        This ordering allows mutex branch detection using graph reachability analysis.
+        Uses explicit edges if provided, otherwise infers edges from
+        matching output/input names.
         """
         G = nx.DiGraph()
         self._add_nodes_to_graph(G, nodes)
 
-        # Collect all output sources (allowing duplicates temporarily)
         output_to_sources = self._collect_output_sources(nodes)
-
-        # Use first source for each output when building edges
         output_to_source = {k: v[0] for k, v in output_to_sources.items()}
-        self._add_data_edges(G, nodes, output_to_source)
-        self._add_control_edges(G, nodes)
-        self._add_ordering_edges(G, nodes, output_to_source)
 
-        # Validate output conflicts with full graph structure
-        # This allows mutex branch detection using reachability analysis
-        validate_output_conflicts(G, nodes, output_to_sources)
+        if self._explicit_edges is not None:
+            # Explicit mode: user-declared data edges
+            self._add_explicit_data_edges(G, self._explicit_edges)
+            self._add_control_edges(G, nodes)
+            self._add_ordering_edges(G, nodes, output_to_source)
+            validate_output_conflicts(
+                G, nodes, output_to_sources, explicit_edges=True,
+            )
+        else:
+            # Auto-inference mode (default)
+            self._add_data_edges(G, nodes, output_to_source)
+            self._add_control_edges(G, nodes)
+            self._add_ordering_edges(G, nodes, output_to_source)
+            validate_output_conflicts(G, nodes, output_to_sources)
 
         return G
 
@@ -406,10 +516,17 @@ class Graph:
         Equivalent to rebuilding the graph with the combined node list,
         then replaying bind/select.
 
+        Raises GraphConfigError if graph was constructed with explicit edges.
         Raises ValueError if existing bindings become invalid after
         adding nodes (e.g., a bound key becomes emit-only).
         Fix: call unbind() before add_nodes().
         """
+        if self._explicit_edges is not None:
+            raise GraphConfigError(
+                "Cannot use add_nodes() on a graph with explicit edges.\n"
+                "Create a new Graph with the complete node and edge lists instead."
+            )
+
         if not nodes:
             return self
 

--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -252,8 +252,7 @@ class Graph:
         for edge in edges:
             if not isinstance(edge, tuple) or len(edge) not in (2, 3):
                 raise GraphConfigError(
-                    f"Edge must be a 2-tuple or 3-tuple, got {type(edge).__name__} "
-                    f"with {len(edge) if isinstance(edge, tuple) else '?'} elements"
+                    f"Edge must be a 2-tuple or 3-tuple, got {type(edge).__name__} with {len(edge) if isinstance(edge, tuple) else '?'} elements"
                 )
 
             src_raw, dst_raw = edge[0], edge[1]
@@ -261,13 +260,9 @@ class Graph:
             dst = dst_raw.name if isinstance(dst_raw, HyperNode) else dst_raw
 
             if src not in self._nodes:
-                raise GraphConfigError(
-                    f"Edge references unknown source node '{src}'"
-                )
+                raise GraphConfigError(f"Edge references unknown source node '{src}'")
             if dst not in self._nodes:
-                raise GraphConfigError(
-                    f"Edge references unknown target node '{dst}'"
-                )
+                raise GraphConfigError(f"Edge references unknown target node '{dst}'")
 
             if len(edge) == 3:
                 values = edge[2]
@@ -277,22 +272,14 @@ class Graph:
                 dst_inputs = set(self._nodes[dst].inputs)
                 for v in values:
                     if v not in src_outputs:
-                        raise GraphConfigError(
-                            f"Edge ({src}, {dst}): '{v}' is not an output of '{src}'. "
-                            f"Outputs: {self._nodes[src].outputs}"
-                        )
+                        raise GraphConfigError(f"Edge ({src}, {dst}): '{v}' is not an output of '{src}'. Outputs: {self._nodes[src].outputs}")
                     if v not in dst_inputs:
-                        raise GraphConfigError(
-                            f"Edge ({src}, {dst}): '{v}' is not an input of '{dst}'. "
-                            f"Inputs: {self._nodes[dst].inputs}"
-                        )
+                        raise GraphConfigError(f"Edge ({src}, {dst}): '{v}' is not an input of '{dst}'. Inputs: {self._nodes[dst].inputs}")
                 value_names = tuple(dict.fromkeys(values))
             else:
                 # Infer from intersection (preserve target input order)
                 src_outputs = set(self._nodes[src].outputs)
-                value_names = tuple(
-                    v for v in self._nodes[dst].inputs if v in src_outputs
-                )
+                value_names = tuple(v for v in self._nodes[dst].inputs if v in src_outputs)
                 # Empty intersection is allowed — creates ordering-only edge
 
             normalized.append((src, dst, value_names))
@@ -321,11 +308,7 @@ class Graph:
                 ordering_pairs.add((src, dst))
 
         # Add data edges (dedup value_names per pair)
-        G.add_edges_from(
-            (src, dst, {"edge_type": "data",
-                        "value_names": list(dict.fromkeys(names))})
-            for (src, dst), names in data_edges.items()
-        )
+        G.add_edges_from((src, dst, {"edge_type": "data", "value_names": list(dict.fromkeys(names))}) for (src, dst), names in data_edges.items())
 
         # Add ordering-only edges (skip if data edge already exists)
         for src, dst in ordering_pairs:
@@ -350,7 +333,10 @@ class Graph:
             self._add_control_edges(G, nodes)
             self._add_ordering_edges(G, nodes, output_to_source)
             validate_output_conflicts(
-                G, nodes, output_to_sources, explicit_edges=True,
+                G,
+                nodes,
+                output_to_sources,
+                explicit_edges=True,
             )
         else:
             # Auto-inference mode (default)
@@ -523,8 +509,7 @@ class Graph:
         """
         if self._explicit_edges is not None:
             raise GraphConfigError(
-                "Cannot use add_nodes() on a graph with explicit edges.\n"
-                "Create a new Graph with the complete node and edge lists instead."
+                "Cannot use add_nodes() on a graph with explicit edges.\nCreate a new Graph with the complete node and edge lists instead."
             )
 
         if not nodes:

--- a/tests/test_explicit_edges.py
+++ b/tests/test_explicit_edges.py
@@ -2,8 +2,7 @@
 
 import pytest
 
-from hypergraph import Graph, GraphConfigError, SyncRunner, node, route, END
-
+from hypergraph import END, Graph, GraphConfigError, SyncRunner, node, route
 
 # ── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -132,13 +131,12 @@ class TestExplicitEdgesConstruction:
         )
         assert g.has_cycles
         # Both add_query and add_response produce "messages"
-        producers = [
-            n for n in g.nodes.values() if "messages" in n.outputs
-        ]
+        producers = [n for n in g.nodes.values() if "messages" in n.outputs]
         assert len(producers) == 2
 
     def test_no_synthetic_edges_in_explicit(self):
         """Undeclared name-match edges don't appear in explicit mode."""
+
         # double produces "y", add_one consumes "y" — but we don't declare
         # that edge. Only declare double→square (no overlap = ordering)
         @node(output_name="unrelated")
@@ -192,9 +190,7 @@ class TestExplicitEdgesInputSpec:
             ],
         )
         # messages is a cycle seed (produced and consumed within cycle)
-        assert "messages" in {
-            p for params in g.inputs.entrypoints.values() for p in params
-        }
+        assert "messages" in {p for params in g.inputs.entrypoints.values() for p in params}
 
 
 # ── Execution tests ──────────────────────────────────────────────────────────
@@ -247,6 +243,7 @@ class TestExplicitEdgesWithEmitWaitFor:
 
     def test_emit_wait_for_works(self):
         """Ordering edges from emit/wait_for are still created."""
+
         @node(output_name="x", emit=("ready",))
         def producer(val: int) -> int:
             return val
@@ -266,6 +263,7 @@ class TestExplicitEdgesWithEmitWaitFor:
 
     def test_control_edges_work(self):
         """Gate nodes still auto-wire control edges."""
+
         @node(output_name="x")
         def start(val: int) -> int:
             return val
@@ -331,6 +329,7 @@ class TestExplicitEdgesSubgraph:
 
     def test_subgraph_pattern(self):
         """Inner auto-inference + outer explicit edges works."""
+
         @node(output_name="query")
         def _ask() -> str:
             return "hello"
@@ -398,6 +397,7 @@ class TestExplicitEdgesErrors:
 
     def test_invalid_value_not_in_target_raises(self):
         """3-tuple with value not in target inputs → error."""
+
         @node(output_name=("a", "b"))
         def multi_out(x: int) -> tuple[int, int]:
             return x, x + 1
@@ -428,6 +428,7 @@ class TestExplicitEdgesErrors:
 
     def test_unordered_same_output_raises(self):
         """Two same-name producers with no path between them → raises."""
+
         @node(output_name="x")
         def producer_a() -> int:
             return 1
@@ -482,7 +483,7 @@ class TestExplicitEdgesVisualization:
             edges=[(ask_user, generate), (generate, ask_user)],
         )
         flat = g.to_flat_graph()
-        for u, v, data in flat.edges(data=True):
+        for u, _v, data in flat.edges(data=True):
             if u == "ask_user":
                 # ask_user → generate: ask_user has no matching outputs for generate's inputs
                 # actually ask_user has output "query" and generate has input "messages" — no overlap

--- a/tests/test_explicit_edges.py
+++ b/tests/test_explicit_edges.py
@@ -1,0 +1,492 @@
+"""Tests for explicit edges mode in Graph."""
+
+import pytest
+
+from hypergraph import Graph, GraphConfigError, SyncRunner, node, route, END
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+@node(output_name="y")
+def double(x: int) -> int:
+    return x * 2
+
+
+@node(output_name="z")
+def add_one(y: int) -> int:
+    return y + 1
+
+
+@node(output_name="result")
+def square(z: int) -> int:
+    return z**2
+
+
+@node(output_name="query")
+def ask_user() -> str:
+    return "hello"
+
+
+@node(output_name="messages")
+def add_query(messages: list, query: str) -> list:
+    return [*messages, {"role": "user", "content": query}]
+
+
+@node(output_name="response")
+def generate(messages: list) -> str:
+    return f"reply to {len(messages)} messages"
+
+
+@node(output_name="messages")
+def add_response(messages: list, response: str) -> list:
+    return [*messages, {"role": "assistant", "content": response}]
+
+
+# ── Construction tests ───────────────────────────────────────────────────────
+
+
+class TestExplicitEdgesConstruction:
+    """Graph construction with explicit edges."""
+
+    def test_basic_linear(self):
+        """Simple A→B→C with explicit edges."""
+        g = Graph(
+            [double, add_one, square],
+            edges=[(double, add_one), (add_one, square)],
+        )
+        assert g.inputs.required == ("x",)
+        assert set(g.outputs) == {"y", "z", "result"}
+
+    def test_node_refs(self):
+        """Edge tuples using node objects resolve to names."""
+        g = Graph(
+            [double, add_one],
+            edges=[(double, add_one)],
+        )
+        edges = list(g.nx_graph.edges(data=True))
+        assert len(edges) == 1
+        assert edges[0][0] == "double"
+        assert edges[0][1] == "add_one"
+
+    def test_string_names(self):
+        """Edge tuples using string names."""
+        g = Graph(
+            [double, add_one],
+            edges=[("double", "add_one")],
+        )
+        edges = list(g.nx_graph.edges(data=True))
+        assert len(edges) == 1
+        assert edges[0][:2] == ("double", "add_one")
+
+    def test_explicit_value_names(self):
+        """3-tuple with explicit values."""
+        g = Graph(
+            [double, add_one],
+            edges=[("double", "add_one", "y")],
+        )
+        edge_data = g.nx_graph.edges["double", "add_one"]
+        assert edge_data["edge_type"] == "data"
+        assert edge_data["value_names"] == ["y"]
+
+    def test_explicit_value_names_list(self):
+        """3-tuple with list of explicit values."""
+        g = Graph(
+            [double, add_one],
+            edges=[("double", "add_one", ["y"])],
+        )
+        edge_data = g.nx_graph.edges["double", "add_one"]
+        assert edge_data["value_names"] == ["y"]
+
+    def test_inferred_value_names(self):
+        """2-tuple correctly infers values from output/input overlap."""
+        g = Graph(
+            [double, add_one],
+            edges=[(double, add_one)],
+        )
+        edge_data = g.nx_graph.edges["double", "add_one"]
+        assert edge_data["edge_type"] == "data"
+        assert edge_data["value_names"] == ["y"]
+
+    def test_ordering_only_edge(self):
+        """2-tuple with no overlap creates ordering-only edge."""
+        g = Graph(
+            [ask_user, generate],
+            edges=[(generate, ask_user)],
+        )
+        edge_data = g.nx_graph.edges["generate", "ask_user"]
+        assert edge_data["edge_type"] == "ordering"
+        assert edge_data["value_names"] == []
+
+    def test_same_output_name_allowed(self):
+        """Two producers of 'messages' with explicit ordering — no error."""
+        g = Graph(
+            [ask_user, add_query, generate, add_response],
+            edges=[
+                (ask_user, add_query),
+                (add_query, generate),
+                (generate, add_response),
+                (add_response, ask_user),
+                (add_response, add_query),
+            ],
+        )
+        assert g.has_cycles
+        # Both add_query and add_response produce "messages"
+        producers = [
+            n for n in g.nodes.values() if "messages" in n.outputs
+        ]
+        assert len(producers) == 2
+
+    def test_no_synthetic_edges_in_explicit(self):
+        """Undeclared name-match edges don't appear in explicit mode."""
+        # double produces "y", add_one consumes "y" — but we don't declare
+        # that edge. Only declare double→square (no overlap = ordering)
+        @node(output_name="unrelated")
+        def unrelated(z: int) -> int:
+            return z
+
+        g = Graph(
+            [double, add_one, unrelated],
+            edges=[(double, unrelated)],
+        )
+        # Even though double.outputs={y} and add_one.inputs={y}, no edge exists
+        assert not g.nx_graph.has_edge("double", "add_one")
+
+    def test_cycle_detected(self):
+        """Explicit edges correctly create cycles."""
+        g = Graph(
+            [ask_user, add_query, generate, add_response],
+            edges=[
+                (ask_user, add_query),
+                (add_query, generate),
+                (generate, add_response),
+                (add_response, add_query),
+            ],
+        )
+        assert g.has_cycles
+
+
+# ── Input spec tests ─────────────────────────────────────────────────────────
+
+
+class TestExplicitEdgesInputSpec:
+    """InputSpec computed from explicit edges."""
+
+    def test_input_spec_linear(self):
+        """Unconnected inputs become graph-level required inputs."""
+        g = Graph(
+            [double, add_one, square],
+            edges=[(double, add_one), (add_one, square)],
+        )
+        assert g.inputs.required == ("x",)
+
+    def test_input_spec_with_entrypoints(self):
+        """Cycle entrypoint seeds are detected correctly."""
+        g = Graph(
+            [ask_user, add_query, generate, add_response],
+            edges=[
+                (ask_user, add_query),
+                (add_query, generate),
+                (generate, add_response),
+                (add_response, add_query),
+            ],
+        )
+        # messages is a cycle seed (produced and consumed within cycle)
+        assert "messages" in {
+            p for params in g.inputs.entrypoints.values() for p in params
+        }
+
+
+# ── Execution tests ──────────────────────────────────────────────────────────
+
+
+class TestExplicitEdgesExecution:
+    """End-to-end execution with explicit edges."""
+
+    def test_linear_execution(self):
+        """Simple linear graph executes correctly."""
+        g = Graph(
+            [double, add_one, square],
+            edges=[(double, add_one), (add_one, square)],
+        )
+        runner = SyncRunner()
+        result = runner.run(g, {"x": 3})
+        assert result["y"] == 6
+        assert result["z"] == 7
+        assert result["result"] == 49
+
+    def test_same_output_name_graph_topology(self):
+        """Chat pattern graph topology is correct with shared 'messages'."""
+        g = Graph(
+            [ask_user, add_query, generate, add_response],
+            edges=[
+                (ask_user, add_query),
+                (add_query, generate),
+                (generate, add_response),
+                (add_response, add_query),
+                (add_response, ask_user),
+            ],
+        )
+        # Both add_query and add_response produce "messages" — graph constructs
+        assert g.has_cycles
+        # Verify edges
+        assert g.nx_graph.has_edge("ask_user", "add_query")
+        assert g.nx_graph.has_edge("add_query", "generate")
+        assert g.nx_graph.has_edge("generate", "add_response")
+        assert g.nx_graph.has_edge("add_response", "add_query")
+        # add_response → ask_user is ordering-only (no overlap)
+        edge_data = g.nx_graph.edges["add_response", "ask_user"]
+        assert edge_data["edge_type"] == "ordering"
+
+
+# ── Emit/wait_for interaction ────────────────────────────────────────────────
+
+
+class TestExplicitEdgesWithEmitWaitFor:
+    """emit/wait_for ordering edges still work in explicit mode."""
+
+    def test_emit_wait_for_works(self):
+        """Ordering edges from emit/wait_for are still created."""
+        @node(output_name="x", emit=("ready",))
+        def producer(val: int) -> int:
+            return val
+
+        @node(output_name="y", wait_for=("ready",))
+        def consumer(x: int) -> int:
+            return x + 1
+
+        g = Graph(
+            [producer, consumer],
+            edges=[(producer, consumer)],
+        )
+        # Data edge from explicit declaration
+        data = g.nx_graph.edges["producer", "consumer"]
+        assert data["edge_type"] == "data"
+        assert "x" in data["value_names"]
+
+    def test_control_edges_work(self):
+        """Gate nodes still auto-wire control edges."""
+        @node(output_name="x")
+        def start(val: int) -> int:
+            return val
+
+        @route(targets=["do_thing", END])
+        def gate(x: int) -> str | type[END]:
+            return "do_thing"
+
+        @node(output_name="result")
+        def do_thing(x: int) -> int:
+            return x * 2
+
+        g = Graph(
+            [start, gate, do_thing],
+            edges=[(start, gate)],
+        )
+        # gate → do_thing should be a control edge (auto-wired from gate targets)
+        assert g.nx_graph.has_edge("gate", "do_thing")
+
+
+# ── Bind / select / add_nodes ────────────────────────────────────────────────
+
+
+class TestExplicitEdgesModifiers:
+    """bind(), select(), and add_nodes() behavior."""
+
+    def test_bind_preserves_edges(self):
+        """bind() carries explicit edges through shallow copy."""
+        g = Graph(
+            [double, add_one],
+            edges=[(double, add_one)],
+        )
+        bound = g.bind(x=5)
+        assert bound.inputs.bound == {"x": 5}
+        # Edges still present
+        assert bound.nx_graph.has_edge("double", "add_one")
+
+    def test_select_preserves_edges(self):
+        """select() carries explicit edges through."""
+        g = Graph(
+            [double, add_one],
+            edges=[(double, add_one)],
+        )
+        selected = g.select("z")
+        assert selected.selected == ("z",)
+        assert selected.nx_graph.has_edge("double", "add_one")
+
+    def test_add_nodes_raises(self):
+        """add_nodes() on explicit-edge graph raises error."""
+        g = Graph(
+            [double, add_one],
+            edges=[(double, add_one)],
+        )
+        with pytest.raises(GraphConfigError, match="Cannot use add_nodes"):
+            g.add_nodes(square)
+
+
+# ── Subgraph pattern ─────────────────────────────────────────────────────────
+
+
+class TestExplicitEdgesSubgraph:
+    """Subgraph (GraphNode) interaction with explicit edges."""
+
+    def test_subgraph_pattern(self):
+        """Inner auto-inference + outer explicit edges works."""
+        @node(output_name="query")
+        def _ask() -> str:
+            return "hello"
+
+        @node(output_name="messages")
+        def _add_query(messages: list, query: str) -> list:
+            return [*messages, {"role": "user", "content": query}]
+
+        @node(output_name="response")
+        def _generate(messages: list) -> str:
+            return "world"
+
+        @node(output_name="messages")
+        def _add_response(messages: list, response: str) -> list:
+            return [*messages, {"role": "assistant", "content": response}]
+
+        # Inner graphs use auto-inference
+        ask_phase = Graph([_ask, _add_query], name="ask")
+        respond_phase = Graph([_generate, _add_response], name="respond")
+
+        # Outer graph uses explicit edges
+        chat = Graph(
+            [ask_phase.as_node(), respond_phase.as_node()],
+            edges=[
+                ("ask", "respond"),
+                ("respond", "ask"),
+            ],
+        )
+        assert chat.has_cycles
+        # ask outputs messages, respond consumes messages
+        edge_data = chat.nx_graph.edges["ask", "respond"]
+        assert edge_data["edge_type"] == "data"
+        assert "messages" in edge_data["value_names"]
+
+
+# ── Error cases ──────────────────────────────────────────────────────────────
+
+
+class TestExplicitEdgesErrors:
+    """Error handling for invalid edge specs."""
+
+    def test_unknown_source_raises(self):
+        """Invalid source node → GraphConfigError."""
+        with pytest.raises(GraphConfigError, match="unknown source"):
+            Graph(
+                [double, add_one],
+                edges=[("nonexistent", "add_one")],
+            )
+
+    def test_unknown_target_raises(self):
+        """Invalid target node → GraphConfigError."""
+        with pytest.raises(GraphConfigError, match="unknown target"):
+            Graph(
+                [double, add_one],
+                edges=[("double", "nonexistent")],
+            )
+
+    def test_invalid_value_not_in_source_raises(self):
+        """3-tuple with value not in source outputs → error."""
+        with pytest.raises(GraphConfigError, match="not an output"):
+            Graph(
+                [double, add_one],
+                edges=[("double", "add_one", "nonexistent")],
+            )
+
+    def test_invalid_value_not_in_target_raises(self):
+        """3-tuple with value not in target inputs → error."""
+        @node(output_name=("a", "b"))
+        def multi_out(x: int) -> tuple[int, int]:
+            return x, x + 1
+
+        @node(output_name="c")
+        def consumer(a: int) -> int:
+            return a
+
+        with pytest.raises(GraphConfigError, match="not an input"):
+            Graph(
+                [multi_out, consumer],
+                edges=[(multi_out, consumer, "b")],
+            )
+
+    def test_bad_tuple_arity_raises(self):
+        """1-tuple or 4-tuple → error."""
+        with pytest.raises(GraphConfigError, match="2-tuple or 3-tuple"):
+            Graph(
+                [double, add_one],
+                edges=[("double",)],
+            )
+
+        with pytest.raises(GraphConfigError, match="2-tuple or 3-tuple"):
+            Graph(
+                [double, add_one],
+                edges=[("double", "add_one", "y", "extra")],
+            )
+
+    def test_unordered_same_output_raises(self):
+        """Two same-name producers with no path between them → raises."""
+        @node(output_name="x")
+        def producer_a() -> int:
+            return 1
+
+        @node(output_name="x")
+        def producer_b() -> int:
+            return 2
+
+        @node(output_name="result")
+        def consumer(x: int) -> int:
+            return x
+
+        with pytest.raises(GraphConfigError, match="Multiple nodes produce 'x'"):
+            Graph(
+                [producer_a, producer_b, consumer],
+                edges=[
+                    (producer_a, consumer),
+                    (producer_b, consumer),
+                ],
+            )
+
+    def test_non_tuple_edge_raises(self):
+        """Edge that is not a tuple → error."""
+        with pytest.raises(GraphConfigError, match="2-tuple or 3-tuple"):
+            Graph(
+                [double, add_one],
+                edges=["double->add_one"],
+            )
+
+
+# ── Visualization ────────────────────────────────────────────────────────────
+
+
+class TestExplicitEdgesVisualization:
+    """Visualization renders correctly with explicit edges."""
+
+    def test_visualize_works(self):
+        """Visualization doesn't crash with explicit edges."""
+        g = Graph(
+            [double, add_one, square],
+            edges=[(double, add_one), (add_one, square)],
+        )
+        # to_flat_graph is the canonical viz input — should not error
+        flat = g.to_flat_graph()
+        assert len(flat.nodes) == 3
+        assert len(flat.edges) == 2
+
+    def test_flat_graph_preserves_edge_types(self):
+        """Flattened graph preserves data/ordering edge types."""
+        g = Graph(
+            [ask_user, generate],
+            edges=[(ask_user, generate), (generate, ask_user)],
+        )
+        flat = g.to_flat_graph()
+        for u, v, data in flat.edges(data=True):
+            if u == "ask_user":
+                # ask_user → generate: ask_user has no matching outputs for generate's inputs
+                # actually ask_user has output "query" and generate has input "messages" — no overlap
+                assert data["edge_type"] == "ordering"
+            elif u == "generate":
+                # generate → ask_user: generate has output "response", ask_user has no inputs
+                assert data["edge_type"] == "ordering"


### PR DESCRIPTION
### **User description**
## Summary

- Add `edges` parameter to `Graph()` for declaring topology manually instead of auto-inferring from name-matching
- Solves `GraphConfigError` in cyclic graphs where multiple nodes produce the same output name (e.g. `messages`, `state`, `df`)
- Edges are `(source, target)` tuples with values auto-detected from the intersection of outputs and inputs; empty intersection creates ordering-only edges

## Motivation

The auto-inference edge system breaks when cycles share output names. Previously this required inventing unique signal names or using `emit`/`wait_for` workarounds. Now:

```python
# Two nodes both produce "messages" — works cleanly with explicit edges
chat = Graph(
    [ask_user, add_query, generate, add_response],
    edges=[
        (ask_user, add_query),       # query
        (add_query, generate),        # messages
        (generate, add_response),     # response
        (add_response, add_query),    # messages (cycle)
        (add_response, ask_user),     # ordering only (no overlap)
    ],
)
```

## Changes

- `src/hypergraph/graph/core.py` — `edges` param, `_normalize_edges`, `_add_explicit_data_edges`, `_build_graph` branching, `add_nodes()` guard
- `src/hypergraph/graph/_conflict.py` — `explicit_edges` flag in `validate_output_conflicts` (trusts declared topology, skips contested-edge pruning)
- `tests/test_explicit_edges.py` — 29 new tests (construction, input spec, execution, emit/wait_for, bind/select/add_nodes, subgraph, errors, viz)
- `notebooks/04_cycles.ipynb` — fixed broken chat cycle example
- `docs/03-patterns/03-agentic-loops.md` — new "With Explicit Edges" section + decision table
- `docs/03-patterns/07-human-in-the-loop.md` — alternative explicit edges example for multi-turn chat
- `docs/06-api-reference/graph.md` — updated constructor docs + new "Explicit Edges" section

## Test plan

- [x] 29 new tests in `tests/test_explicit_edges.py` — all pass
- [x] All existing graph tests pass (backward compatible — `edges=None` default)
- [x] Smoke test: motivating chat example constructs without `GraphConfigError`
- [x] Ordering-only edges (empty intersection) work correctly
- [x] `add_nodes()` raises `GraphConfigError` in explicit mode
- [x] Validation: unknown nodes, bad values, wrong tuple arity all raise clear errors
- [x] `bind()` and `select()` carry explicit edges through shallow copy
- [x] Code review: APPROVED (0 critical, 0 high)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Add `edges` parameter to `Graph()` for explicit topology declaration
  - Solves `GraphConfigError` in cyclic graphs with shared output names
  - Edges are `(source, target)` tuples with auto-detected values
  - Empty intersection creates ordering-only edges

- Implement edge normalization and validation in core graph builder
  - Support 2-tuple (inferred values) and 3-tuple (explicit values) formats
  - Validate node references and output/input compatibility

- Update conflict validation to trust declared topology in explicit mode
  - Skip contested-edge pruning when `explicit_edges=True`

- Add comprehensive test suite and documentation
  - 29 new tests covering construction, execution, modifiers, errors
  - Update API reference and pattern guides with examples
  - Fix broken chat cycle example in notebook


___

### Diagram Walkthrough


```mermaid
flowchart LR
  User["User declares edges<br/>(source, target) tuples"]
  Normalize["_normalize_edges()<br/>Validate & infer values"]
  AddEdges["_add_explicit_data_edges()<br/>Add to NetworkX graph"]
  Validate["validate_output_conflicts()<br/>explicit_edges=True"]
  Build["_build_graph()<br/>Branch on explicit_edges flag"]
  
  User --> Normalize
  Normalize --> AddEdges
  AddEdges --> Build
  Build --> Validate
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>core.py</strong><dd><code>Add explicit edges parameter and graph builder branching</code>&nbsp; </dd></summary>
<hr>

src/hypergraph/graph/core.py

<ul><li>Add <code>edges</code> parameter to <code>Graph.__init__()</code> with documentation<br> <li> Implement <code>_normalize_edges()</code> to parse and validate edge tuples<br> <li> Implement <code>_add_explicit_data_edges()</code> to add user-declared edges to <br>graph<br> <li> Branch <code>_build_graph()</code> to use explicit edges or auto-inference<br> <li> Add guard in <code>add_nodes()</code> to raise error in explicit mode</ul>


</details>


  </td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/53/files#diff-187e378c017f7b11d453a19d86325b60ef3566887ba64472831b08b6493c0e48">+137/-20</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>_conflict.py</strong><dd><code>Add explicit edges flag to conflict validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hypergraph/graph/_conflict.py

<ul><li>Add <code>explicit_edges</code> parameter to <code>validate_output_conflicts()</code><br> <li> Implement explicit mode validation that trusts declared topology<br> <li> Skip contested-edge pruning in explicit mode<br> <li> Preserve auto-inference mode validation logic</ul>


</details>


  </td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/53/files#diff-64af43682e812413c886dde485f5064cd767b3149f992f0126611fb3d3cc18f9">+29/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_explicit_edges.py</strong><dd><code>Add comprehensive test suite for explicit edges</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_explicit_edges.py

<ul><li>Add 29 comprehensive tests for explicit edges feature<br> <li> Cover construction with node refs, string names, inferred/explicit <br>values<br> <li> Test ordering-only edges and same-output-name graphs<br> <li> Test input spec computation, linear execution, emit/wait_for <br>interaction<br> <li> Test bind/select/add_nodes behavior and subgraph patterns<br> <li> Test error cases: unknown nodes, invalid values, bad tuple arity<br> <li> Test visualization compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/53/files#diff-84444d896dece0f4d02ec572f49e0b951095b2e799d3bee3f34115e641755c77">+492/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>04_cycles.ipynb</strong><dd><code>Fix chat cycle example with explicit edges</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

notebooks/04_cycles.ipynb

<ul><li>Fix broken chat cycle example by adding explicit edges declaration<br> <li> Reorder nodes to match edge topology<br> <li> Declare all edges including ordering-only edges</ul>


</details>


  </td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/53/files#diff-cd72e1d5f2c972c3dfafb80a44b7ebb4785affdaea82c440cf8eb87d88e23be2">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>03-agentic-loops.md</strong><dd><code>Add explicit edges section to agentic loops guide</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/03-patterns/03-agentic-loops.md

<ul><li>Add "With Explicit Edges" section to shared outputs guide<br> <li> Provide complete chat example using explicit edges<br> <li> Add decision table comparing auto-inference, emit/wait_for, explicit <br>edges<br> <li> Link to API reference for more details</ul>


</details>


  </td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/53/files#diff-e3572c1a7b5225caf7095290ab13d91acb1eb50f502e604d1722f64bb9fb327d">+54/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>07-human-in-the-loop.md</strong><dd><code>Add explicit edges alternative to human-in-the-loop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/03-patterns/07-human-in-the-loop.md

<ul><li>Add "Alternative: Explicit Edges" section to human-in-the-loop pattern<br> <li> Provide multi-turn chat example using explicit edges instead of <br>signals<br> <li> Explain ordering-only edges in context of interrupt patterns</ul>


</details>


  </td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/53/files#diff-04f09715946a65380e9a946a9e6ef62399bf072f98648d0864de5459ac8e1a36">+48/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>graph.md</strong><dd><code>Update Graph API reference with explicit edges documentation</code></dd></summary>
<hr>

docs/06-api-reference/graph.md

<ul><li>Update constructor signature to include <code>edges</code> parameter<br> <li> Add <code>edges</code> to Args section with detailed description<br> <li> Add new "Explicit Edges" section with format table and examples<br> <li> Update error documentation to mention explicit edges as resolution<br> <li> Add restrictions section for explicit mode limitations</ul>


</details>


  </td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/53/files#diff-85823276de19103713cf7c6fca52be63d160406a180c7f70dcc2b28ce2789dc0">+65/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

