### PR TITLE
feat(graph): partial input semantics — with_entrypoint + select-aware InputSpec

### DIFF
--- a/dev/CODE-CONVENTIONS.md
+++ b/dev/CODE-CONVENTIONS.md
@@ -58,7 +58,7 @@ def with_name(self, name: str) -> Self:
 | Node types | PascalCase, descriptive | `FunctionNode`, `GraphNode`, `RouteNode` |
 | Decorators | lowercase, verb-like | `@node`, `@route`, `@ifelse`, `@interrupt` |
 | Properties | snake_case, `@cached_property` when expensive | `input_spec`, `output_names` |
-| Internal helpers | `_` prefix | `_resolve_outputs()`, `_validate_names()` |
+| Internal helpers | `_` prefix (see [Module Naming](#module-naming) for `_shared/` exception) | `_resolve_outputs()`, `_validate_names()` |
 | Constants | UPPER_SNAKE_CASE | `END` |
 
 **Reserved characters**: `.` and `/` cannot appear in node or output names.

--- a/dev/CODE-CONVENTIONS.md
+++ b/dev/CODE-CONVENTIONS.md
@@ -49,6 +49,7 @@ def with_name(self, name: str) -> Self:
 - Internal modules: `_` prefix (`_callable.py`, `_rename.py`, `_conflict.py`, `_shared/`)
 - Public modules: no prefix
 - Everything in `__init__.py` with `__all__` is public API
+- **Cross-module internal APIs**: Functions within `_shared/` that are imported across sibling modules (e.g., `validation.py` → `template_sync.py`) should **not** have a `_` prefix. The underscore signals "don't depend on this" — if multiple modules already depend on it, drop the underscore. Example: `resolve_runtime_selected` (not `_resolve_runtime_selected`).
 
 ## Naming Conventions
 

--- a/dev/CORE-BELIEFS.md
+++ b/dev/CORE-BELIEFS.md
@@ -38,7 +38,7 @@ Errors caught at `Graph()` construction, not hours into a run. Invalid targets, 
 
 ## 5. Immutability
 
-`with_*`, `bind`, `select`, `unbind` return new instances. No in-place mutation.
+`with_*`, `bind`, `select`, `unbind`, `with_entrypoint` return new instances. No in-place mutation.
 
 **What breaks**: In-place mutation creates spooky action at a distance. `base = Graph([a, b, c]); configured = base.bind(x=1)` — if `bind` mutates `base`, anyone holding a reference to `base` gets the binding unexpectedly.
 

--- a/dev/REVIEW-CHECKLIST.md
+++ b/dev/REVIEW-CHECKLIST.md
@@ -34,6 +34,7 @@ When reviewing code changes:
 - [ ] Functions remain testable as plain Python (`node.func(x)` works)?
 - [ ] No unnecessary state mutation?
 - [ ] Composition used instead of configuration flags?
+- [ ] Active-set enforcement: does `with_entrypoint` / `select` properly scope both validation AND execution? (Not just one or the other)
 
 ### Code Quality
 - [ ] Error messages follow three-part structure? (Problem → Context → How to fix)

--- a/docs/06-api-reference/inputspec.md
+++ b/docs/06-api-reference/inputspec.md
@@ -2,29 +2,52 @@
 
 **InputSpec** describes what inputs a graph needs and how they must be provided.
 
-- **required** - Must provide at runtime (no default, not bound)
-- **optional** - Can omit (has default value)
-- **entrypoints** - Cycle entrypoints grouped by node
-- **bound** - Pre-filled via `graph.bind()`
+What counts as "required" depends on four dimensions that narrow the active subgraph:
+
+| Dimension | Method | Narrows from | Effect on `required` |
+|-----------|--------|-------------|---------------------|
+| **Entrypoint** (start) | `with_entrypoint(...)` | The front | Excludes upstream nodes |
+| **Select** (end) | `select(...)` | The back | Excludes nodes not needed for selected outputs |
+| **Bind** (pre-fill) | `bind(...)` | Individual params | Moves params from required to optional |
+| **Defaults** (fallback) | Function signatures | Individual params | Params with defaults are optional |
 
 ```python
 from hypergraph import node, Graph
 
-@node(output_name="doubled")
-def double(x: int) -> int:
-    return x * 2
+@node(output_name="embedding")
+def embed(text: str) -> list[float]:
+    return [0.1, 0.2, 0.3]
 
-@node(output_name="result")
-def add(doubled: int, offset: int = 10) -> int:
-    return doubled + offset
+@node(output_name="docs")
+def retrieve(embedding: list[float], top_k: int = 5) -> list[str]:
+    return ["doc1", "doc2"]
 
-g = Graph([double, add])
+@node(output_name="answer")
+def generate(docs: list[str], query: str) -> str:
+    return f"Answer based on {len(docs)} docs"
 
-# InputSpec categorizes parameters
-print(g.inputs.required)      # ('x',) - must provide
-print(g.inputs.optional)      # ('offset',) - has default
-print(g.inputs.entrypoints)  # {} - no cycles in this graph
-print(g.inputs.bound)         # {} - none bound
+g = Graph([embed, retrieve, generate])
+
+# Full graph: all inputs
+print(g.inputs.required)  # ('text', 'query')
+print(g.inputs.optional)  # ('top_k',)
+
+# Entrypoint narrows from the front
+g2 = g.with_entrypoint("retrieve")
+print(g2.inputs.required)  # ('embedding', 'query') - text no longer needed
+
+# Select narrows from the back
+g3 = g.select("docs")
+print(g3.inputs.required)  # ('text',) - query no longer needed
+
+# Bind pre-fills a value
+g4 = g.bind(query="What is RAG?")
+print(g4.inputs.required)  # ('text',)
+
+# All four compose
+configured = g.with_entrypoint("retrieve").select("answer").bind(top_k=10)
+print(configured.inputs.required)  # ('embedding', 'query')
+print(configured.inputs.optional)  # ('top_k',)
 ```
 
 ## The InputSpec Dataclass
@@ -112,7 +135,11 @@ print(bound.inputs.required)  # () - x is no longer required
 
 ## How Categories Are Determined
 
-The categorization follows the "edge cancels default" rule:
+Categorization happens in two phases:
+
+**Phase 1: Scope narrowing.** Determine which nodes are active using entrypoints (forward-reachable) and select (backward-reachable). Only active nodes contribute parameters to InputSpec.
+
+**Phase 2: Parameter classification.** For each parameter in the active subgraph, apply the "edge cancels default" rule:
 
 | Condition | Category |
 |-----------|----------|
@@ -121,6 +148,7 @@ The categorization follows the "edge cancels default" rule:
 | Has incoming edge from cycle | **entrypoint** (grouped by node) |
 | Has incoming edge from another node | Not in InputSpec |
 | Is bound via `bind()` | In `bound` dict, moves from required to optional |
+| Node excluded by `with_entrypoint()` or `select()` | Not in InputSpec |
 
 ### Edge Cancels Default
 
@@ -152,6 +180,41 @@ def update(state: dict, input: int) -> dict:
 g = Graph([update])
 print(g.inputs.required)      # ('input',)
 print(g.inputs.entrypoints)  # {'update': ('state',)}
+```
+
+### Scope Narrowing (Entrypoint and Select)
+
+`with_entrypoint()` and `select()` narrow which nodes are considered when computing InputSpec. Parameters from excluded nodes do not appear in `required`, `optional`, or `entrypoints`.
+
+```python
+from hypergraph import node, Graph
+
+@node(output_name="a_val")
+def step_a(x: int) -> int:
+    return x * 2
+
+@node(output_name="b_val")
+def step_b(a_val: int, y: int) -> int:
+    return a_val + y
+
+@node(output_name="c_val")
+def step_c(b_val: int) -> int:
+    return b_val * 3
+
+g = Graph([step_a, step_b, step_c])
+print(g.inputs.required)  # ('x', 'y')
+
+# Entrypoint: skip step_a, start at step_b
+g2 = g.with_entrypoint("step_b")
+print(g2.inputs.required)  # ('a_val', 'y') - a_val is now a user input
+
+# Select: only need b_val, not c_val
+g3 = g.select("b_val")
+print(g3.inputs.required)  # ('x', 'y') - same, since step_a is still needed
+
+# Both: start at step_b, only need b_val
+g4 = g.with_entrypoint("step_b").select("b_val")
+print(g4.inputs.required)  # ('a_val', 'y')
 ```
 
 ## Accessing InputSpec

--- a/docs/06-api-reference/runners.md
+++ b/docs/06-api-reference/runners.md
@@ -64,7 +64,7 @@ Execute a graph once.
 **Args:**
 - `graph` - The graph to execute
 - `values` - Optional input values as `{param_name: value}`
-- `select` - Which outputs to return. `"**"` (default) returns all outputs. Pass a list of names for specific outputs.
+- `select` - Which outputs to return. `"**"` (default) returns all outputs. Pass a list of names for specific outputs. Also narrows input validation -- only inputs needed to produce the selected outputs are required. See [InputSpec](inputspec.md) for details on scope narrowing.
 - `on_missing` - How to handle missing selected outputs:
   - `"ignore"` (default): silently omit missing outputs
   - `"warn"`: warn about missing outputs, return what's available
@@ -90,7 +90,7 @@ result = runner.run(graph, {"query": "What is RAG?"})
 # kwargs shorthand
 result = runner.run(graph, query="What is RAG?")
 
-# Select specific outputs
+# Select specific outputs (also narrows required inputs)
 result = runner.run(graph, values, select=["final_answer"])
 
 # Limit iterations for cyclic graphs
@@ -254,7 +254,7 @@ Execute a graph asynchronously.
 **Args:**
 - `graph` - The graph to execute
 - `values` - Optional input values
-- `select` - Which outputs to return. `"**"` (default) returns all outputs.
+- `select` - Which outputs to return. `"**"` (default) returns all outputs. Also narrows input validation to only what's needed for the selected outputs.
 - `on_missing` - How to handle missing selected outputs (`"ignore"`, `"warn"`, or `"error"`)
 - `entrypoint` - Optional explicit cycle entrypoint node name
 - `max_iterations` - Max supersteps for cyclic graphs (default: 1000)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## February 2026
+
+### Added
+
+- **`with_entrypoint(*node_names)`** — Graph method that narrows execution to start at specific nodes, skipping upstream. Works for DAGs and cycles. Returns a new Graph (immutable, chainable). Upstream nodes are excluded from the active set and never execute at runtime.
+- **Select-aware InputSpec** — `graph.select("a").inputs.required` now shows only what's needed to produce output "a", not the full graph. Previously `select()` only filtered returned outputs.
+- **Runtime select narrowing** — `runner.run(graph, values, select="a")` validates only the inputs needed for output "a". Passing `select` at runtime recomputes InputSpec scoped to the selected outputs.
+- **`entrypoints_config` property** — `graph.entrypoints_config` returns the configured entry point node names, or `None` if all nodes are active.
+
+### Changed
+
+- **InputSpec is now scope-aware** — `graph.inputs` considers both `with_entrypoint()` (forward-reachable) and `select()` (backward-reachable) when determining required, optional, and entrypoint parameters. Parameters from excluded nodes no longer appear in InputSpec.
+
 ## January 2026
 
 ### Added

--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -655,15 +655,15 @@ class Graph:
 
         Preserves: name, strict_types, nodes, nx_graph, cached_hash
         Creates new: _bound dict (to allow independent modifications)
-        Clears: cached inputs (depends on _bound which may differ)
+        Clears: cached inputs (depends on _bound, _selected, _entrypoints)
         """
         import copy
 
         new_graph = copy.copy(self)
         new_graph._bound = dict(self._bound)
-        # Clear cached_property values that depend on _bound
+        # Clear cached_property values that depend on _bound / _selected / _entrypoints
         new_graph.__dict__.pop("inputs", None)
-        # _selected is an immutable tuple (or None), safe to share via copy.copy
+        # _selected and _entrypoints are immutable tuples (or None), safe to share via copy.copy
         # All other attributes preserved: _strict_types, _nodes, _nx_graph, _cached_hash
         return new_graph
 

--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -469,9 +469,10 @@ class Graph:
         Controls which outputs are returned by runner.run() and which outputs
         are exposed when this graph is used as a nested node via as_node().
 
-        This does NOT affect internal graph execution — all nodes still run
-        and all intermediate values are still computed. It only filters what
-        is returned to the caller.
+        Also narrows ``graph.inputs`` to only parameters needed to produce
+        the selected outputs. Nodes that don't contribute are excluded from
+        InputSpec computation. However, at execution time all reachable nodes
+        still run — use ``with_entrypoint()`` to skip upstream execution.
 
         A runtime ``select=`` passed to runner.run() overrides this default.
 

--- a/src/hypergraph/graph/input_spec.py
+++ b/src/hypergraph/graph/input_spec.py
@@ -262,7 +262,7 @@ def _compute_active_scope(
         active = _active_from_selection(selected, active, nodes, nx_graph)
 
     active_nodes = {name: nodes[name] for name in nodes if name in active}
-    active_subgraph = nx_graph.subgraph(active)
+    active_subgraph = nx_graph.subgraph(active).copy()
     return active_nodes, active_subgraph
 
 
@@ -299,11 +299,12 @@ def _active_from_selection(
     selected_set = set(selected_outputs)
     producers = {name for name in active_set if set(nodes[name].outputs) & selected_set}
     if not producers:
-        # No active node produces the selected outputs — return full active set
-        # as a graceful fallback. graph.select() validates output names at
-        # construction time, so this path only triggers via runtime select with
-        # entrypoints that exclude the producer (defense-in-depth).
-        return active_set
+        # No active node produces the selected outputs — return empty set.
+        # graph.select() validates output names at construction time; runtime
+        # select names are validated in resolve_runtime_selected(). This path
+        # only triggers when entrypoints exclude the output's producer, in which
+        # case no nodes are needed for this selection.
+        return set()
 
     sub = nx_graph.subgraph(active_set)
     needed: set[str] = set()

--- a/src/hypergraph/graph/input_spec.py
+++ b/src/hypergraph/graph/input_spec.py
@@ -299,6 +299,10 @@ def _active_from_selection(
     selected_set = set(selected_outputs)
     producers = {name for name in active_set if set(nodes[name].outputs) & selected_set}
     if not producers:
+        # No active node produces the selected outputs — return full active set
+        # as a graceful fallback. graph.select() validates output names at
+        # construction time, so this path only triggers via runtime select with
+        # entrypoints that exclude the producer (defense-in-depth).
         return active_set
 
     sub = nx_graph.subgraph(active_set)

--- a/src/hypergraph/graph/input_spec.py
+++ b/src/hypergraph/graph/input_spec.py
@@ -256,9 +256,9 @@ def _compute_active_scope(
        (with pessimistic gate expansion)
     """
     active = set(nodes)
-    if entrypoints:
+    if entrypoints is not None:
         active = _active_from_entrypoints(entrypoints, nodes, nx_graph)
-    if selected:
+    if selected is not None:
         active = _active_from_selection(selected, active, nodes, nx_graph)
 
     active_nodes = {name: nodes[name] for name in nodes if name in active}

--- a/src/hypergraph/graph/input_spec.py
+++ b/src/hypergraph/graph/input_spec.py
@@ -51,40 +51,56 @@ def compute_input_spec(
     nodes: dict[str, HyperNode],
     nx_graph: nx.DiGraph,
     bound: dict[str, Any],
+    *,
+    entrypoints: tuple[str, ...] | None = None,
+    selected: tuple[str, ...] | None = None,
 ) -> InputSpec:
     """Compute input specification for a graph.
+
+    Required inputs depend on four dimensions:
+    - Entrypoints (start): which nodes execute
+    - Selection (end): which outputs are needed
+    - Bindings (pre-fill): which params have fixed values
+    - Defaults (fallback): which params have function-level fallbacks
 
     Args:
         nodes: Map of node name -> HyperNode
         nx_graph: The NetworkX directed graph
         bound: Currently bound values
+        entrypoints: Optional entry point node names (narrows to forward-reachable)
+        selected: Optional output names to produce (narrows to backward-reachable)
 
     Returns:
-        InputSpec with categorized parameters
+        InputSpec with categorized parameters scoped to the active subgraph
     """
-    edge_produced = get_edge_produced_values(nx_graph)
-    entrypoints = _compute_entrypoints(nodes, nx_graph, edge_produced, bound)
-    # Flat set of all entrypoint params (for categorization)
-    all_entry_params = {p for params in entrypoints.values() for p in params}
+    active_nodes, active_subgraph = _compute_active_scope(
+        nodes,
+        nx_graph,
+        entrypoints=entrypoints,
+        selected=selected,
+    )
+
+    edge_produced = get_edge_produced_values(active_subgraph)
+    cycle_entrypoints = _compute_entrypoints(active_nodes, active_subgraph, edge_produced, bound)
+    all_entry_params = {p for params in cycle_entrypoints.values() for p in params}
 
     required, optional = [], []
 
-    for param in _unique_params(nodes):
+    for param in _unique_params(active_nodes):
         if param in all_entry_params:
             continue  # Handled by entrypoints
-        category = _categorize_param(param, edge_produced, bound, nodes)
+        category = _categorize_param(param, edge_produced, bound, active_nodes)
         if category == "required":
             required.append(param)
         elif category == "optional":
             optional.append(param)
 
-    # Merge bound values from nested GraphNodes
-    all_bound = _collect_bound_values(nodes, bound)
+    all_bound = _collect_bound_values(active_nodes, bound)
 
     return InputSpec(
         required=tuple(required),
         optional=tuple(optional),
-        entrypoints=entrypoints,
+        entrypoints=cycle_entrypoints,
         bound=all_bound,
     )
 
@@ -218,6 +234,101 @@ def _data_only_subgraph(nx_graph: nx.DiGraph) -> nx.DiGraph:
     subgraph.add_nodes_from(nx_graph.nodes())
     subgraph.add_edges_from(data_edges)
     return subgraph
+
+
+# =============================================================================
+# Active Subgraph Computation
+# =============================================================================
+
+
+def _compute_active_scope(
+    nodes: dict[str, HyperNode],
+    nx_graph: nx.DiGraph,
+    *,
+    entrypoints: tuple[str, ...] | None = None,
+    selected: tuple[str, ...] | None = None,
+) -> tuple[dict[str, HyperNode], nx.DiGraph]:
+    """Compute active node set and induced subgraph.
+
+    The active set is determined by:
+    1. Forward-reachable from entrypoints (or all nodes if none)
+    2. Narrowed to backward-reachable from selected outputs
+       (with pessimistic gate expansion)
+    """
+    active = set(nodes)
+    if entrypoints:
+        active = _active_from_entrypoints(entrypoints, nodes, nx_graph)
+    if selected:
+        active = _active_from_selection(selected, active, nodes, nx_graph)
+
+    active_nodes = {name: nodes[name] for name in nodes if name in active}
+    active_subgraph = nx_graph.subgraph(active)
+    return active_nodes, active_subgraph
+
+
+def _active_from_entrypoints(
+    entrypoint_nodes: tuple[str, ...],
+    nodes: dict[str, HyperNode],
+    nx_graph: nx.DiGraph,
+) -> set[str]:
+    """Compute active nodes by forward reachability from entrypoints.
+
+    Everything upstream of entrypoints is excluded. Only the entrypoint
+    nodes and their downstream descendants are active.
+    """
+    active = set(entrypoint_nodes)
+    for ep in entrypoint_nodes:
+        active.update(nx.descendants(nx_graph, ep))
+    return active & set(nodes)
+
+
+def _active_from_selection(
+    selected_outputs: tuple[str, ...],
+    active_set: set[str],
+    nodes: dict[str, HyperNode],
+    nx_graph: nx.DiGraph,
+) -> set[str]:
+    """Narrow active set to nodes needed for selected outputs.
+
+    Walks backward from output producers. When a gate is encountered,
+    pessimistically includes ALL its targets and their descendants
+    (since routing decisions are made at runtime).
+    """
+    from hypergraph.nodes.gate import END, GateNode
+
+    selected_set = set(selected_outputs)
+    producers = {name for name in active_set if set(nodes[name].outputs) & selected_set}
+    if not producers:
+        return active_set
+
+    sub = nx_graph.subgraph(active_set)
+    needed: set[str] = set()
+    worklist = list(producers)
+
+    while worklist:
+        name = worklist.pop()
+        if name in needed or name not in active_set:
+            continue
+        needed.add(name)
+
+        # Backward: include predecessors
+        for pred in sub.predecessors(name):
+            if pred not in needed:
+                worklist.append(pred)
+
+        # Pessimistic gate expansion: all targets might execute
+        node = nodes.get(name)
+        if isinstance(node, GateNode):
+            for target in node.targets:
+                if target is END or target not in active_set:
+                    continue
+                if target not in needed:
+                    worklist.append(target)
+                    for desc in nx.descendants(sub, target):
+                        if desc not in needed:
+                            worklist.append(desc)
+
+    return needed
 
 
 def _collect_bound_values(

--- a/src/hypergraph/runners/_shared/helpers.py
+++ b/src/hypergraph/runners/_shared/helpers.py
@@ -29,12 +29,12 @@ def compute_active_node_set(graph: Graph) -> set[str] | None:
     Delegates to input_spec._active_from_entrypoints to avoid duplicating
     the forward-reachability logic.
     """
-    if graph._entrypoints is None:
+    if graph.entrypoints_config is None:
         return None
 
     from hypergraph.graph.input_spec import _active_from_entrypoints
 
-    return _active_from_entrypoints(graph._entrypoints, graph._nodes, graph._nx_graph)
+    return _active_from_entrypoints(graph.entrypoints_config, graph._nodes, graph._nx_graph)
 
 
 class ValueSource(Enum):

--- a/src/hypergraph/runners/_shared/helpers.py
+++ b/src/hypergraph/runners/_shared/helpers.py
@@ -28,6 +28,12 @@ def compute_active_node_set(graph: Graph) -> set[str] | None:
     Returns None when no entrypoints are configured (all nodes active).
     Delegates to input_spec._active_from_entrypoints to avoid duplicating
     the forward-reachability logic.
+
+    Note: This only considers entrypoints, not select. This is intentional —
+    ``with_entrypoint()`` narrows *execution* (which nodes run), while
+    ``select()`` narrows *validation* (which inputs are required) and
+    *output filtering* (what run() returns). Use ``with_entrypoint()`` when
+    you need to skip upstream node execution entirely.
     """
     if graph.entrypoints_config is None:
         return None

--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -28,6 +28,7 @@ from hypergraph.runners._shared.types import (
     _generate_run_id,
 )
 from hypergraph.runners._shared.validation import (
+    _resolve_runtime_selected,
     validate_inputs,
     validate_map_compatible,
     validate_node_types,
@@ -158,7 +159,13 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
 
         validate_runner_compatibility(graph, self.capabilities)
         validate_node_types(graph, self.supported_node_types)
-        validate_inputs(graph, normalized_values, entrypoint=entrypoint)
+        effective_selected = _resolve_runtime_selected(select, graph)
+        validate_inputs(
+            graph,
+            normalized_values,
+            entrypoint=entrypoint,
+            selected=effective_selected,
+        )
         _validate_on_missing(on_missing)
 
         max_iter = max_iterations or self.default_max_iterations

--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -28,7 +28,7 @@ from hypergraph.runners._shared.types import (
     _generate_run_id,
 )
 from hypergraph.runners._shared.validation import (
-    _resolve_runtime_selected,
+    resolve_runtime_selected,
     validate_inputs,
     validate_map_compatible,
     validate_node_types,
@@ -159,7 +159,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
 
         validate_runner_compatibility(graph, self.capabilities)
         validate_node_types(graph, self.supported_node_types)
-        effective_selected = _resolve_runtime_selected(select, graph)
+        effective_selected = resolve_runtime_selected(select, graph)
         validate_inputs(
             graph,
             normalized_values,

--- a/src/hypergraph/runners/_shared/template_sync.py
+++ b/src/hypergraph/runners/_shared/template_sync.py
@@ -20,6 +20,7 @@ from hypergraph.runners._shared.input_normalization import (
 )
 from hypergraph.runners._shared.types import ErrorHandling, GraphState, RunResult, RunStatus
 from hypergraph.runners._shared.validation import (
+    _resolve_runtime_selected,
     validate_inputs,
     validate_map_compatible,
     validate_node_types,
@@ -130,7 +131,13 @@ class SyncRunnerTemplate(BaseRunner, ABC):
 
         validate_runner_compatibility(graph, self.capabilities)
         validate_node_types(graph, self.supported_node_types)
-        validate_inputs(graph, normalized_values, entrypoint=entrypoint)
+        effective_selected = _resolve_runtime_selected(select, graph)
+        validate_inputs(
+            graph,
+            normalized_values,
+            entrypoint=entrypoint,
+            selected=effective_selected,
+        )
         _validate_on_missing(on_missing)
 
         max_iter = max_iterations or self.default_max_iterations

--- a/src/hypergraph/runners/_shared/template_sync.py
+++ b/src/hypergraph/runners/_shared/template_sync.py
@@ -20,7 +20,7 @@ from hypergraph.runners._shared.input_normalization import (
 )
 from hypergraph.runners._shared.types import ErrorHandling, GraphState, RunResult, RunStatus
 from hypergraph.runners._shared.validation import (
-    _resolve_runtime_selected,
+    resolve_runtime_selected,
     validate_inputs,
     validate_map_compatible,
     validate_node_types,
@@ -131,7 +131,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
 
         validate_runner_compatibility(graph, self.capabilities)
         validate_node_types(graph, self.supported_node_types)
-        effective_selected = _resolve_runtime_selected(select, graph)
+        effective_selected = resolve_runtime_selected(select, graph)
         validate_inputs(
             graph,
             normalized_values,

--- a/src/hypergraph/runners/_shared/validation.py
+++ b/src/hypergraph/runners/_shared/validation.py
@@ -451,7 +451,7 @@ def _resolve_effective_input_spec(
     ``graph.selected``, we recompute InputSpec so validation uses the
     narrower scope. Otherwise, return the cached ``graph.inputs``.
     """
-    if selected is None or selected == graph.selected:
+    if selected == graph.selected:
         return graph.inputs
 
     from hypergraph.graph.input_spec import compute_input_spec

--- a/src/hypergraph/runners/sync/runner.py
+++ b/src/hypergraph/runners/sync/runner.py
@@ -11,7 +11,7 @@ from hypergraph.nodes.base import HyperNode
 from hypergraph.nodes.function import FunctionNode
 from hypergraph.nodes.gate import IfElseNode, RouteNode
 from hypergraph.nodes.graph_node import GraphNode
-from hypergraph.runners._shared.helpers import get_ready_nodes, initialize_state
+from hypergraph.runners._shared.helpers import compute_active_node_set, get_ready_nodes, initialize_state
 from hypergraph.runners._shared.protocols import NodeExecutor
 from hypergraph.runners._shared.template_sync import SyncRunnerTemplate
 from hypergraph.runners._shared.types import GraphState, RunnerCapabilities, _generate_run_id
@@ -107,9 +107,10 @@ class SyncRunner(SyncRunnerTemplate):
         On failure, raises ExecutionError wrapping the cause and partial state.
         """
         state = initialize_state(graph, values)
+        active_nodes = compute_active_node_set(graph)
 
         for _ in range(max_iterations):
-            ready_nodes = get_ready_nodes(graph, state)
+            ready_nodes = get_ready_nodes(graph, state, active_nodes=active_nodes)
 
             if not ready_nodes:
                 break  # No more nodes to execute
@@ -134,7 +135,7 @@ class SyncRunner(SyncRunnerTemplate):
 
         else:
             # Loop completed without break = hit max_iterations
-            if get_ready_nodes(graph, state):
+            if get_ready_nodes(graph, state, active_nodes=active_nodes):
                 raise ExecutionError(
                     InfiniteLoopError(max_iterations),
                     state,

--- a/tests/test_partial_inputs.py
+++ b/tests/test_partial_inputs.py
@@ -1,0 +1,343 @@
+"""Tests for partial input semantics: active subgraph, entrypoints, and select-aware InputSpec."""
+
+import pytest
+
+from hypergraph import Graph, node
+from hypergraph.graph.validation import GraphConfigError
+
+# === Shared test nodes ===
+
+
+@node(output_name="r1")
+def root1(x):
+    return x
+
+
+@node(output_name="r2")
+def root2(y):
+    return y
+
+
+@node(output_name="r3")
+def root3(z=10):
+    return z
+
+
+@node(output_name="a")
+def merge_node(r1, r2, r3):
+    return f"{r1}-{r2}-{r3}"
+
+
+@node(output_name="b")
+def process_node(a):
+    return a.upper()
+
+
+# === Select-aware InputSpec ===
+
+
+class TestSelectReducesRequired:
+    """select() should narrow InputSpec to only what's needed."""
+
+    def test_select_single_output_reduces_required(self):
+        """B(a, y) depends on A(x)->a. select("a") only needs x."""
+
+        @node(output_name="a_val")
+        def node_a(x):
+            return x
+
+        @node(output_name="b_val")
+        def node_b(a_val, y):
+            return f"{a_val}-{y}"
+
+        graph = Graph([node_a, node_b])
+        assert set(graph.inputs.required) == {"x", "y"}
+
+        selected = graph.select("a_val")
+        assert set(selected.inputs.required) == {"x"}
+
+    def test_select_all_same_as_no_select(self):
+        """Selecting all outputs == no select."""
+        graph = Graph([root1, root2, root3, merge_node, process_node])
+        all_selected = graph.select(*graph.outputs)
+
+        assert set(graph.inputs.required) == set(all_selected.inputs.required)
+        assert set(graph.inputs.optional) == set(all_selected.inputs.optional)
+
+    def test_select_leaf_output_includes_full_chain(self):
+        """Selecting leaf 'b' needs the full chain."""
+        graph = Graph([root1, root2, root3, merge_node, process_node])
+        selected = graph.select("b")
+
+        # Same as full graph: x, y required, z optional
+        assert set(selected.inputs.required) == {"x", "y"}
+
+    def test_select_intermediate_hides_downstream(self):
+        """Selecting 'a' excludes process_node from active set."""
+        graph = Graph([root1, root2, root3, merge_node, process_node])
+        selected = graph.select("a")
+
+        # a is produced by merge_node; still needs all roots
+        assert set(selected.inputs.required) == {"x", "y"}
+
+    def test_select_root_output_excludes_everything_downstream(self):
+        """Selecting a root output needs only that root's inputs."""
+
+        @node(output_name="out1")
+        def first(x):
+            return x
+
+        @node(output_name="out2")
+        def second(out1, y):
+            return f"{out1}-{y}"
+
+        graph = Graph([first, second])
+        assert set(graph.inputs.required) == {"x", "y"}
+
+        selected = graph.select("out1")
+        assert set(selected.inputs.required) == {"x"}
+        assert "y" not in set(selected.inputs.required) | set(selected.inputs.optional)
+
+
+# === Select with gates ===
+
+
+class TestSelectWithGate:
+    """Pessimistic gate expansion when gates are in the needed set."""
+
+    def test_select_with_gate_pessimistic(self):
+        """Gate in needed set -> all branches' inputs required."""
+        from hypergraph import ifelse
+
+        @node(output_name="val")
+        def producer(raw):
+            return raw
+
+        @ifelse(when_true="branch_a_node", when_false="branch_b_node")
+        def my_gate(val):
+            return val > 0
+
+        @node(output_name="result_a")
+        def branch_a_node(val):
+            return val * 2
+
+        @node(output_name="result_b")
+        def branch_b_node(val, extra):
+            return val * 3 + extra
+
+        @node(output_name="final")
+        def consumer(result_a):
+            return result_a
+
+        graph = Graph([producer, my_gate, branch_a_node, branch_b_node, consumer])
+        # select("final") -> consumer -> branch_a -> gate -> pessimistic -> branch_b
+        selected = graph.select("final")
+        assert "raw" in selected.inputs.required
+        # branch_b_node's "extra" is required due to pessimistic gate expansion
+        assert "extra" in selected.inputs.required
+
+
+# === Entrypoint narrows active set ===
+
+
+class TestEntrypointNarrowsActiveSet:
+    """with_entrypoint() should narrow InputSpec."""
+
+    def test_entrypoint_skips_upstream(self):
+        """with_entrypoint at merge skips root nodes."""
+        graph = Graph([root1, root2, root3, merge_node, process_node])
+
+        g2 = graph.with_entrypoint("merge_node")
+        # merge_node's inputs become user-provided (roots are skipped)
+        assert "r1" in g2.inputs.required
+        assert "r2" in g2.inputs.required
+        assert "r3" in g2.inputs.required
+        # Root inputs should NOT appear
+        assert "x" not in set(g2.inputs.required) | set(g2.inputs.optional)
+        assert "y" not in set(g2.inputs.required) | set(g2.inputs.optional)
+
+    def test_entrypoint_at_leaf_requires_only_leaf_inputs(self):
+        """with_entrypoint at leaf node requires only its inputs."""
+        graph = Graph([root1, root2, root3, merge_node, process_node])
+
+        g2 = graph.with_entrypoint("process_node")
+        assert set(g2.inputs.required) == {"a"}
+
+    def test_entrypoint_dag_skips_upstream(self):
+        """with_entrypoint in DAG -> required = entry node's inputs."""
+
+        @node(output_name="mid")
+        def dag_first(x):
+            return x
+
+        @node(output_name="out")
+        def dag_second(mid):
+            return mid * 2
+
+        graph = Graph([dag_first, dag_second])
+        assert set(graph.inputs.required) == {"x"}
+
+        g2 = graph.with_entrypoint("dag_second")
+        assert set(g2.inputs.required) == {"mid"}
+        assert "x" not in set(g2.inputs.required) | set(g2.inputs.optional)
+
+
+# === Entrypoint + select composition ===
+
+
+class TestEntrypointAndSelectCompose:
+    """Both with_entrypoint and select narrow together."""
+
+    def test_entrypoint_and_select_compose(self):
+        """with_entrypoint + select narrows from both ends."""
+
+        @node(output_name="mid")
+        def compose_a(x):
+            return x
+
+        @node(output_name="out")
+        def compose_b(mid):
+            return mid
+
+        @node(output_name="other")
+        def compose_c(mid):
+            return mid
+
+        graph = Graph([compose_a, compose_b, compose_c])
+        # with_entrypoint("compose_a") -> active = {compose_a, compose_b, compose_c}
+        # .select("out") -> only compose_b needed -> active = {compose_a, compose_b}
+        g2 = graph.with_entrypoint("compose_a").select("out")
+        assert set(g2.inputs.required) == {"x"}
+
+    def test_entrypoint_bind_compose(self):
+        """with_entrypoint + bind reduces required."""
+        graph = Graph([root1, root2, root3, merge_node, process_node])
+
+        g2 = graph.with_entrypoint("merge_node").bind(r2=5)
+        assert "r1" in g2.inputs.required
+        assert "r2" not in g2.inputs.required  # bound
+        assert "r3" in g2.inputs.required
+
+    def test_all_four_dimensions(self):
+        """entrypoint + select + bind + default all compose."""
+
+        @node(output_name="m")
+        def merge_4d(a, b, c, d=99):
+            return a + b + c + d
+
+        @node(output_name="out")
+        def final_4d(m):
+            return m
+
+        @node(output_name="side")
+        def side_4d(m):
+            return m
+
+        @node(output_name="a")
+        def root_a(x):
+            return x
+
+        graph = Graph([root_a, merge_4d, final_4d, side_4d])
+        # entrypoint at merge_4d -> skip root_a
+        # select("out") -> skip side_4d
+        # bind(b=10) -> b is optional
+        # d has default -> optional
+        g = graph.with_entrypoint("merge_4d").select("out").bind(b=10)
+        assert set(g.inputs.required) == {"a", "c"}
+
+
+# === Multi-entrypoint ===
+
+
+class TestMultiEntrypoint:
+    """Multiple entry points."""
+
+    def test_multi_entrypoint_independent_branches(self):
+        """with_entrypoint("root1", "root2") activates both plus downstream."""
+        graph = Graph([root1, root2, root3, merge_node, process_node])
+
+        g2 = graph.with_entrypoint("root1", "root2")
+        assert "x" in g2.inputs.required
+        assert "y" in g2.inputs.required
+        # root3 is skipped, so r3 is not produced -> required by merge_node
+        assert "r3" in g2.inputs.required
+        # z should not appear (root3 not active)
+        assert "z" not in set(g2.inputs.required) | set(g2.inputs.optional)
+
+    def test_multi_entrypoint_chained(self):
+        """Chaining with_entrypoint == passing all at once."""
+        graph = Graph([root1, root2, root3, merge_node, process_node])
+
+        g_once = graph.with_entrypoint("root1", "root2")
+        g_chained = graph.with_entrypoint("root1").with_entrypoint("root2")
+
+        assert set(g_once.inputs.required) == set(g_chained.inputs.required)
+        assert set(g_once.inputs.optional) == set(g_chained.inputs.optional)
+
+    def test_redundant_entrypoint_accepted(self):
+        """Redundant entry points (one reachable from another) are accepted."""
+        graph = Graph([root1, root2, root3, merge_node, process_node])
+
+        # merge_node is downstream of root1 — both accepted silently
+        g2 = graph.with_entrypoint("root1", "merge_node")
+        assert "x" in g2.inputs.required
+
+
+# === with_entrypoint validation ===
+
+
+class TestEntrypointValidation:
+    """Validation of with_entrypoint arguments."""
+
+    def test_unknown_node_raises(self):
+        graph = Graph([root1])
+        with pytest.raises(GraphConfigError, match="Unknown entry point"):
+            graph.with_entrypoint("nonexistent")
+
+    def test_gate_node_raises(self):
+        from hypergraph import ifelse
+
+        @ifelse(when_true="root1", when_false="root2")
+        def gate_val(x):
+            return x > 0
+
+        graph = Graph([gate_val, root1, root2])
+        with pytest.raises(GraphConfigError, match="gate"):
+            graph.with_entrypoint("gate_val")
+
+
+# === Immutability ===
+
+
+class TestImmutability:
+    """with_entrypoint returns new graph, doesn't mutate original."""
+
+    def test_with_entrypoint_is_immutable(self):
+        graph = Graph([root1, root2, root3, merge_node, process_node])
+        original_required = set(graph.inputs.required)
+
+        g2 = graph.with_entrypoint("merge_node")
+        # Original unchanged
+        assert set(graph.inputs.required) == original_required
+        # New graph is different
+        assert set(g2.inputs.required) != original_required
+
+    def test_entrypoints_config_property(self):
+        graph = Graph([root1, process_node])
+        assert graph.entrypoints_config is None
+
+        g2 = graph.with_entrypoint("process_node")
+        assert g2.entrypoints_config == ("process_node",)
+
+    def test_add_nodes_resets_entrypoints(self):
+        """add_nodes creates fresh graph without entrypoints."""
+        graph = Graph([root1, process_node])
+        g2 = graph.with_entrypoint("process_node")
+        assert g2.entrypoints_config is not None
+
+        @node(output_name="extra")
+        def extra_node(a):
+            return a
+
+        g3 = g2.add_nodes(extra_node)
+        assert g3.entrypoints_config is None


### PR DESCRIPTION
### **User description**
## Summary

- **`with_entrypoint(*node_names)`** — Graph method that narrows execution to start at specific nodes, skipping upstream. Works for both DAGs and cycles. Returns new Graph (immutable, chainable).
- **Select-aware InputSpec** — `graph.select("a").inputs.required` now shows only what's needed for output "a". Previously `select()` only affected output filtering, not InputSpec computation.
- **Runtime select narrowing** — `runner.run(graph, values, select="a")` validates only inputs needed for "a", not the full graph.
- **Active-set enforcement** — `with_entrypoint` prevents upstream nodes from executing at the scheduling level via `get_ready_nodes` filter.

### Four-dimension model

`InputSpec.required` is now a function of:

| Dimension | API | Narrows by |
|-----------|-----|-----------|
| Entrypoint | `with_entrypoint(...)` | Which nodes execute (forward from start) |
| Select | `select(...)` | Which outputs needed (backward from end) |
| Bind | `bind(...)` | Which params pre-filled |
| Defaults | Function signatures | Which params have fallbacks |

### Files changed (18 files, +1175 / -57)

**Core implementation** (5 files):
- `graph/core.py` — `_entrypoints` field, `with_entrypoint()`, `entrypoints_config`
- `graph/input_spec.py` — `_compute_active_scope()`, `_active_from_entrypoints()`, `_active_from_selection()` with pessimistic gate expansion
- `runners/_shared/validation.py` — `resolve_runtime_selected()`, `_resolve_effective_input_spec()`, InputSpec threading
- `runners/_shared/helpers.py` — `compute_active_node_set()`, `active_nodes` filter in `get_ready_nodes()`
- `runners/_shared/template_{sync,async}.py` — Thread runtime select into validation

**Runner changes** (2 files): Both sync and async runners pass `active_nodes` to `get_ready_nodes()`

**Tests** (1 file): `test_partial_inputs.py` — 30 tests covering select narrowing, entrypoint narrowing, composition, execution enforcement, cycles, async path, validation, immutability

**Documentation** (4 files): API reference updates for graph, inputspec, runners + changelog

**Dev guides** (5 files): Architecture, conventions, beliefs, review checklist, testing guide updated with learnings

## Test plan

- [x] All 1385 non-viz tests pass (`uv run pytest --ignore=tests/viz`)
- [x] Lint clean (`uv run ruff check src/ tests/`)
- [x] Pre-push hooks pass (ruff check + format on all files)
- [x] Select narrows InputSpec (2 tests)
- [x] with_entrypoint narrows active set for DAGs (3 tests)
- [x] Entrypoint + select + bind compose (3 tests)
- [x] Multi-entrypoint (3 tests)
- [x] Entrypoint validation (2 tests)
- [x] Immutability preserved (3 tests)
- [x] Runtime select narrows validation (2 tests)
- [x] Execution enforcement — upstream never fires (4 tests)
- [x] Cycle + entrypoint interaction (2 tests)
- [x] Async runner path (2 tests)
- [x] Gate pessimistic expansion (1 test)
- [x] Backward compat — all existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Add `with_entrypoint()` method to narrow graph execution to specific start nodes

- Make InputSpec select-aware: `select()` now narrows required inputs, not just outputs

- Thread runtime `select` parameter through validation for narrowed input requirements

- Enforce active-set filtering at scheduling level via `get_ready_nodes()` to prevent upstream execution


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Graph Config<br/>with_entrypoint + select + bind"] -->|"Forward + Backward<br/>Reachability"| B["Active Subgraph<br/>Computation"]
  B -->|"Scope narrowing"| C["InputSpec<br/>required/optional/entrypoints"]
  A -->|"Runtime select"| D["Validation<br/>resolve_effective_input_spec"]
  D -->|"Narrowed scope"| E["Input Validation"]
  C -->|"Active nodes set"| F["Scheduling<br/>get_ready_nodes filter"]
  F -->|"Prevent upstream<br/>execution"| G["Execution<br/>Enforcement"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>core.py</strong><dd><code>Add with_entrypoint method and entrypoints field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/54/files#diff-187e378c017f7b11d453a19d86325b60ef3566887ba64472831b08b6493c0e48">+63/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>input_spec.py</strong><dd><code>Compute active scope from entrypoints and selection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/54/files#diff-9bacc96380e98dfe15699ebe6ea2640693ef29e6e980e52b44261bf89c3b65b7">+125/-10</a></td>

</tr>

<tr>
  <td><strong>helpers.py</strong><dd><code>Add active-set computation and filtering to scheduling</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/54/files#diff-527974079a4ec295ee9c51c980e1d75db64c7f4e23f68f63e4b8530363665d8b">+27/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>validation.py</strong><dd><code>Resolve runtime select and scope InputSpec computation</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/54/files#diff-77c351d52fa45973c2d3654d426b8d3e25c4ee418bbe9a2ec86af9513c369771">+65/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>template_sync.py</strong><dd><code>Thread runtime select into validation pipeline</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/54/files#diff-2c1d33c530c559cb6cddd7b491c379e45ca778404c2ff1c2f61aa4b3bda65afb">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>template_async.py</strong><dd><code>Thread runtime select into async validation pipeline</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/54/files#diff-ff91f27bd8e68e8dd4fc3f5d28d6901eadcac60d593a7a436077382b62822bfc">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runner.py</strong><dd><code>Pass active nodes to scheduling in sync runner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/54/files#diff-9442c2f8c84a3c421d874c46c02b2483b0badb1ee5c9b23873c88069f8e2eec3">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runner.py</strong><dd><code>Pass active nodes to scheduling in async runner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/54/files#diff-0ba28c1be337274a8fc258307d28a8c0e8d6ccc56b0a498cca91820261acb996">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>test_partial_inputs.py</strong><dd><code>Comprehensive test suite for partial input semantics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/54/files#diff-e33d19e920ccd81f552964b56c9e10e48f23bdf01836f25fe601c1fbe9a3795e">+602/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td><strong>ARCHITECTURE.md</strong><dd><code>Document InputSpec scope narrowing and active subgraph computation</code></dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/54/files#diff-181b094fb3083465046c6211c82d5a943c63b1d80ee5b903904a754a7cf08df1">+12/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CODE-CONVENTIONS.md</strong><dd><code>Clarify cross-module internal API naming conventions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/54/files#diff-d64048b20ae83a1ea9d48f68cd8b4931f03d8e3f5255680d7dc65acd5c4f639a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CORE-BELIEFS.md</strong><dd><code>Add with_entrypoint to immutability principle</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/54/files#diff-cdb414efc2bced3cd69f650d606ec6ac1a821d55155fe10d52f71188c53f44f2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>REVIEW-CHECKLIST.md</strong><dd><code>Add active-set enforcement review criteria</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/54/files#diff-2b9fff82454daccc45467ce1cd63a06d46e34b9016b22414b1d17cc03dd4453d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TESTING-GUIDE.md</strong><dd><code>Document cycle testing gotchas and with_entrypoint patterns</code></dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/54/files#diff-bcfc480504670a6cb080bb1b77e49af502cd6f67665bf1ca67f7ec16e0fd1d88">+31/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>graph.md</strong><dd><code>Document with_entrypoint API and entrypoints_config property</code></dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/54/files#diff-85823276de19103713cf7c6fca52be63d160406a180c7f70dcc2b28ce2789dc0">+127/-2</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>inputspec.md</strong><dd><code>Document four-dimension InputSpec scoping model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/54/files#diff-e0051d9ef5cc6141c393406381568a0b88202d106e788c924af7f194d401c41a">+80/-17</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>runners.md</strong><dd><code>Document runtime select narrowing in runner APIs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/54/files#diff-56c9ed459757844ea23c5ca70f3a761fb9225f0592b12a873a0c34a55c261860">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>changelog.md</strong><dd><code>Add changelog entries for partial input semantics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/54/files#diff-77f023b99d3d58008351d3e82fc06e6d06ba1bc2da9e41be6329b7fa4f419f05">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added immutable entry-point configuration (with_entrypoint) and entrypoints_config.
  * InputSpec now scopes required inputs by entrypoints and selected outputs.
  * Runners apply runtime selection to narrow input validation.
  * Invalid selects now raise a configuration error.

* **Documentation**
  * Updated API reference, input-spec guide, runners docs, and testing guide to reflect entry-point and scope-aware input semantics.

* **Tests**
  * Added comprehensive tests for partial inputs, entrypoints, select composition, and runner behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->