### PR TITLE
feat(runners): make run() raise on failure by default

### DIFF
--- a/src/hypergraph/__init__.py
+++ b/src/hypergraph/__init__.py
@@ -43,6 +43,7 @@ from hypergraph.nodes import (
 from hypergraph.runners import (
     AsyncRunner,
     BaseRunner,
+    ErrorHandling,
     PauseInfo,
     RunResult,
     RunStatus,
@@ -70,6 +71,7 @@ __all__ = [
     "SyncRunner",
     "AsyncRunner",
     "BaseRunner",
+    "ErrorHandling",
     "PauseInfo",
     "RunResult",
     "RunStatus",

--- a/src/hypergraph/runners/__init__.py
+++ b/src/hypergraph/runners/__init__.py
@@ -1,6 +1,7 @@
 """Execution runners for hypergraph."""
 
 from hypergraph.runners._shared.types import (
+    ErrorHandling,
     GraphState,
     NodeExecution,
     PauseExecution,
@@ -15,6 +16,7 @@ from hypergraph.runners.sync import SyncRunner
 
 __all__ = [
     # Core types
+    "ErrorHandling",
     "RunStatus",
     "PauseExecution",
     "PauseInfo",

--- a/src/hypergraph/runners/_shared/helpers.py
+++ b/src/hypergraph/runners/_shared/helpers.py
@@ -632,6 +632,20 @@ def _validate_on_missing(on_missing: str) -> None:
         raise ValueError(f"Invalid on_missing={on_missing!r}. Expected one of: {', '.join(_VALID_ON_MISSING)}")
 
 
+_VALID_ERROR_HANDLING = ("raise", "continue")
+
+
+def _validate_error_handling(error_handling: str) -> None:
+    """Validate error_handling parameter eagerly (before execution)."""
+    if error_handling not in _VALID_ERROR_HANDLING:
+        valid = ", ".join(repr(v) for v in _VALID_ERROR_HANDLING)
+        raise ValueError(
+            f"Invalid error_handling={error_handling!r}.\n\n"
+            f"Valid options: {valid}\n\n"
+            f"How to fix: Pass error_handling='raise' or error_handling='continue'."
+        )
+
+
 def _handle_missing_outputs(
     missing: list[str],
     state: GraphState,

--- a/src/hypergraph/runners/async_/executors/graph_node.py
+++ b/src/hypergraph/runners/async_/executors/graph_node.py
@@ -98,6 +98,4 @@ class AsyncGraphNodeExecutor:
                 values=result.pause.values,
             )
             raise PauseExecution(nested_pause)
-        if result.status == RunStatus.FAILED:
-            raise result.error  # type: ignore[misc]
         return node.map_outputs_from_original(result.values)

--- a/src/hypergraph/runners/base.py
+++ b/src/hypergraph/runners/base.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Literal
 
 from hypergraph.runners._shared.helpers import _UNSET_SELECT
-from hypergraph.runners._shared.types import RunnerCapabilities, RunResult
+from hypergraph.runners._shared.types import ErrorHandling, RunnerCapabilities, RunResult
 
 if TYPE_CHECKING:
     from hypergraph.events.processor import EventProcessor
@@ -45,6 +45,7 @@ class BaseRunner(ABC):
         on_missing: Literal["ignore", "warn", "error"] = "ignore",
         entrypoint: str | None = None,
         max_iterations: int | None = None,
+        error_handling: ErrorHandling = "raise",
         event_processors: list[EventProcessor] | None = None,
         **input_values: Any,
     ) -> RunResult:
@@ -57,6 +58,9 @@ class BaseRunner(ABC):
             on_missing: How to handle missing selected outputs.
             entrypoint: Optional explicit cycle entry point node name.
             max_iterations: Max iterations for cyclic graphs (None = default)
+            error_handling: How to handle node execution errors.
+                "raise" (default) re-raises the original exception.
+                "continue" returns RunResult with status=FAILED and partial values.
             event_processors: Optional list of event processors to receive execution events
             **input_values: Input values shorthand (merged with values)
 

--- a/src/hypergraph/runners/sync/executors/graph_node.py
+++ b/src/hypergraph/runners/sync/executors/graph_node.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from hypergraph.runners._shared.helpers import collect_as_lists, map_inputs_to_func_params
-from hypergraph.runners._shared.types import RunStatus
 
 if TYPE_CHECKING:
     from hypergraph.events.processor import EventProcessor
@@ -77,6 +76,4 @@ class SyncGraphNodeExecutor:
             event_processors=event_processors,
             _parent_span_id=parent_span_id,
         )
-        if result.status == RunStatus.FAILED:
-            raise result.error  # type: ignore[misc]
         return node.map_outputs_from_original(result.values)

--- a/tests/events/test_async_events.py
+++ b/tests/events/test_async_events.py
@@ -186,7 +186,7 @@ class TestErrorEvents:
         runner = AsyncRunner()
         lp = ListProcessor()
 
-        result = await runner.run(graph, {"x": 1}, event_processors=[lp])
+        result = await runner.run(graph, {"x": 1}, error_handling="continue", event_processors=[lp])
 
         assert result.status.value == "failed"
         errors = lp.of_type(NodeErrorEvent)
@@ -205,7 +205,7 @@ class TestErrorEvents:
         runner = AsyncRunner()
         lp = ListProcessor()
 
-        await runner.run(graph, {"x": 1}, event_processors=[lp])
+        await runner.run(graph, {"x": 1}, error_handling="continue", event_processors=[lp])
 
         run_end = lp.of_type(RunEndEvent)[0]
         assert run_end.status == RunStatus.FAILED

--- a/tests/events/test_sync_events.py
+++ b/tests/events/test_sync_events.py
@@ -161,7 +161,7 @@ class TestErrorEvents:
         runner = SyncRunner()
         lp = ListProcessor()
 
-        result = runner.run(graph, {"x": 1}, event_processors=[lp])
+        result = runner.run(graph, {"x": 1}, error_handling="continue", event_processors=[lp])
 
         assert result.status.value == "failed"
         errors = lp.of_type(NodeErrorEvent)
@@ -179,7 +179,7 @@ class TestErrorEvents:
         runner = SyncRunner()
         lp = ListProcessor()
 
-        runner.run(graph, {"x": 1}, event_processors=[lp])
+        runner.run(graph, {"x": 1}, error_handling="continue", event_processors=[lp])
 
         run_end = lp.of_type(RunEndEvent)[0]
         assert run_end.status == RunStatus.FAILED

--- a/tests/test_cache_edge_cases.py
+++ b/tests/test_cache_edge_cases.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import asyncio
 import threading
 
+import pytest
+
 from hypergraph import AsyncRunner, Graph, InMemoryCache, SyncRunner, node
 from hypergraph.cache import compute_cache_key
 from hypergraph.events import EventProcessor
@@ -165,8 +167,8 @@ class TestExceptionSafety:
         graph = Graph([flaky])
         runner = SyncRunner(cache=InMemoryCache())
 
-        r1 = runner.run(graph, {"x": 1})
-        assert r1.status == RunStatus.FAILED
+        with pytest.raises(ValueError, match="boom"):
+            runner.run(graph, {"x": 1})
 
         # Second run should execute (not serve cached error)
         result = runner.run(graph, {"x": 1})

--- a/tests/test_error_handling_edge_cases.py
+++ b/tests/test_error_handling_edge_cases.py
@@ -282,8 +282,8 @@ class TestMapOverSingleItem:
         gn = inner.as_node().map_over("x")
         outer = Graph([gn, passthrough])
         runner = SyncRunner()
-        result = runner.run(outer, {"x": [1]})
-        assert result.status == RunStatus.FAILED
+        with pytest.raises(FailError):
+            runner.run(outer, {"x": [1]})
 
 
 class TestMapOverWithRenamedOutputs:
@@ -321,11 +321,10 @@ class TestMapOverRaisePartialValues:
     """When map_over raise mode fails, outer run() returns FAILED status."""
 
     def test_sync_raise_outer_run_fails(self):
-        """Outer run() returns FAILED when inner map_over raises."""
+        """Outer run() raises when inner map_over raises."""
         inner = Graph([always_fail], name="inner")
         gn = inner.as_node().map_over("x")
         outer = Graph([gn, passthrough])
         runner = SyncRunner()
-        result = runner.run(outer, {"x": [1, 2]})
-        assert result.status == RunStatus.FAILED
-        assert isinstance(result.error, FailError)
+        with pytest.raises(FailError):
+            runner.run(outer, {"x": [1, 2]})

--- a/tests/test_error_handling_edge_cases.py
+++ b/tests/test_error_handling_edge_cases.py
@@ -318,7 +318,7 @@ class TestMapOverEmptyInput:
 
 
 class TestMapOverRaisePartialValues:
-    """When map_over raise mode fails, outer run() returns FAILED status."""
+    """When map_over raise mode fails, outer run() raises the error."""
 
     def test_sync_raise_outer_run_fails(self):
         """Outer run() raises when inner map_over raises."""

--- a/tests/test_interrupt_node.py
+++ b/tests/test_interrupt_node.py
@@ -647,10 +647,8 @@ class TestHandlerFailure:
         graph = Graph([make_draft, approval, finalize])
         runner = AsyncRunner()
 
-        result = await runner.run(graph, {"query": "hello"})
-        assert result.status == RunStatus.FAILED
-        assert isinstance(result.error, RuntimeError)
-        assert "handler broke" in str(result.error)
+        with pytest.raises(RuntimeError, match="handler broke"):
+            await runner.run(graph, {"query": "hello"})
 
 
 class TestNestedInterruptPropagation:

--- a/tests/test_map_over_error_handling.py
+++ b/tests/test_map_over_error_handling.py
@@ -34,13 +34,12 @@ class TestSyncMapOverErrorHandling:
     """SyncRunner with GraphNode.map_over() error_handling."""
 
     def test_raise_mode_is_default(self):
-        """Default error_handling='raise' fails the outer run on first inner failure."""
+        """Default error_handling='raise' raises on first inner failure."""
         inner = Graph([double_or_fail], name="inner")
         outer = Graph([inner.as_node().map_over("x"), passthrough])
         runner = SyncRunner()
-        result = runner.run(outer, {"x": [1, 2, 3, 4, 5]})
-        assert result.status == RunStatus.FAILED
-        assert isinstance(result.error, CustomMapError)
+        with pytest.raises(CustomMapError):
+            runner.run(outer, {"x": [1, 2, 3, 4, 5]})
 
     def test_continue_mode_returns_none_placeholders(self):
         """error_handling='continue' uses None for failed items, preserving list length."""
@@ -88,9 +87,8 @@ class TestAsyncMapOverErrorHandling:
         inner = Graph([async_double_or_fail], name="inner")
         outer = Graph([inner.as_node().map_over("x"), passthrough])
         runner = AsyncRunner()
-        result = await runner.run(outer, {"x": [1, 2, 3, 4, 5]})
-        assert result.status == RunStatus.FAILED
-        assert isinstance(result.error, CustomMapError)
+        with pytest.raises(CustomMapError):
+            await runner.run(outer, {"x": [1, 2, 3, 4, 5]})
 
     @pytest.mark.asyncio
     async def test_continue_mode_returns_none_placeholders(self):

--- a/tests/test_pr32_review_bugs.py
+++ b/tests/test_pr32_review_bugs.py
@@ -152,7 +152,7 @@ class TestPartialStateFromSuperstep:
         """
         graph = Graph([first_node, second_node_fails])
         runner = SyncRunner()
-        result = runner.run(graph, {"x": 1})
+        result = runner.run(graph, {"x": 1}, error_handling="continue")
         assert result.status == RunStatus.FAILED
         # The key test: first_node ran before second_node_fails in the superstep.
         # Its output should be in partial_values.
@@ -172,7 +172,7 @@ class TestPartialStateFromSuperstep:
 
         graph = Graph([step1, step2_fails])
         runner = SyncRunner()
-        result = runner.run(graph, {"x": 5})
+        result = runner.run(graph, {"x": 5}, error_handling="continue")
         assert result.status == RunStatus.FAILED
         # step1 ran in a prior superstep, so its output must be preserved
         assert "step1_out" in result.values
@@ -196,7 +196,7 @@ class TestPartialStateFromSuperstep:
 
         graph = Graph([node_a, node_b, node_c])
         runner = SyncRunner()
-        result = runner.run(graph, {"x": 5})
+        result = runner.run(graph, {"x": 5}, error_handling="continue")
         assert result.status == RunStatus.FAILED
         assert result.values.get("a_out") == 6
         assert result.values.get("b_out") == 12
@@ -215,7 +215,7 @@ class TestPartialStateFromSuperstep:
 
         graph = Graph([async_first, async_second_fails])
         runner = AsyncRunner()
-        result = await runner.run(graph, {"x": 1})
+        result = await runner.run(graph, {"x": 1}, error_handling="continue")
         assert result.status == RunStatus.FAILED
         assert "first_out" in result.values, (
             "Async partial state should include outputs from nodes that completed before the failure in the same superstep"

--- a/tests/test_red_team_fixes.py
+++ b/tests/test_red_team_fixes.py
@@ -52,7 +52,6 @@ class TestMutableDefaults:
         import threading
 
         from hypergraph.graph.validation import GraphConfigError
-        from hypergraph.runners._shared.types import RunStatus
 
         lock = threading.Lock()
 
@@ -66,11 +65,8 @@ class TestMutableDefaults:
         runner = SyncRunner()
 
         # Should fail with GraphConfigError (not warn and continue)
-        result = runner.run(graph, {"x": 5})
-        assert result.status == RunStatus.FAILED
-        assert isinstance(result.error, GraphConfigError)
-        assert "cannot be safely copied" in str(result.error)
-        assert ".bind()" in str(result.error)
+        with pytest.raises(GraphConfigError, match="cannot be safely copied"):
+            runner.run(graph, {"x": 5})
 
 
 # === Fix #2: Cycle termination off-by-one ===

--- a/tests/test_run_error_handling.py
+++ b/tests/test_run_error_handling.py
@@ -1,0 +1,196 @@
+"""Tests for error_handling parameter on runner.run()."""
+
+import pytest
+
+from hypergraph import Graph, node
+from hypergraph.runners import AsyncRunner, RunStatus, SyncRunner
+
+
+class CustomRunError(Exception):
+    """Custom exception for testing."""
+
+    pass
+
+
+@node(output_name="result")
+def succeeding_node(x: int) -> int:
+    return x * 2
+
+
+@node(output_name="result")
+def failing_node(x: int) -> int:
+    raise CustomRunError("intentional failure")
+
+
+@node(output_name="step_a")
+def step_a(x: int) -> int:
+    return x + 100
+
+
+@node(output_name="step_b")
+def step_b(step_a: int) -> int:
+    raise CustomRunError("step_b failed")
+
+
+# === Sync Tests ===
+
+
+class TestSyncRunRaiseMode:
+    """Test error_handling='raise' (new default) for SyncRunner."""
+
+    def test_run_raises_on_failure_by_default(self):
+        graph = Graph([failing_node])
+        runner = SyncRunner()
+        with pytest.raises(CustomRunError, match="intentional failure"):
+            runner.run(graph, {"x": 5})
+
+    def test_run_raises_original_exception_type(self):
+        graph = Graph([failing_node])
+        runner = SyncRunner()
+        with pytest.raises(CustomRunError):
+            runner.run(graph, {"x": 5})
+
+    def test_run_raises_with_clean_str(self):
+        """str(e) should be the original message, no wrapper noise."""
+        graph = Graph([failing_node])
+        runner = SyncRunner()
+        with pytest.raises(CustomRunError) as exc_info:
+            runner.run(graph, {"x": 5})
+        assert str(exc_info.value) == "intentional failure"
+
+    def test_run_success_returns_result(self):
+        """Successful runs still return RunResult."""
+        graph = Graph([succeeding_node])
+        runner = SyncRunner()
+        result = runner.run(graph, {"x": 5})
+        assert result.status == RunStatus.COMPLETED
+        assert result["result"] == 10
+
+    def test_run_explicit_raise_same_as_default(self):
+        graph = Graph([failing_node])
+        runner = SyncRunner()
+        with pytest.raises(CustomRunError, match="intentional failure"):
+            runner.run(graph, {"x": 5}, error_handling="raise")
+
+
+class TestSyncRunContinueMode:
+    """Test error_handling='continue' for SyncRunner."""
+
+    def test_continue_returns_failed_result(self):
+        graph = Graph([failing_node])
+        runner = SyncRunner()
+        result = runner.run(graph, {"x": 5}, error_handling="continue")
+        assert result.status == RunStatus.FAILED
+        assert isinstance(result.error, CustomRunError)
+
+    def test_continue_has_partial_values(self):
+        """Partial values from nodes that succeeded before the failure."""
+        graph = Graph([step_a, step_b])
+        runner = SyncRunner()
+        result = runner.run(graph, {"x": 5}, error_handling="continue")
+        assert result.status == RunStatus.FAILED
+        assert "step_a" in result.values
+        assert result.values["step_a"] == 105
+
+    def test_continue_preserves_error(self):
+        graph = Graph([failing_node])
+        runner = SyncRunner()
+        result = runner.run(graph, {"x": 5}, error_handling="continue")
+        assert isinstance(result.error, CustomRunError)
+        assert str(result.error) == "intentional failure"
+
+
+class TestSyncRunValidation:
+    """Test error_handling parameter validation."""
+
+    def test_invalid_error_handling_raises_value_error(self):
+        graph = Graph([succeeding_node])
+        runner = SyncRunner()
+        with pytest.raises(ValueError, match="Invalid error_handling"):
+            runner.run(graph, {"x": 5}, error_handling="invalid")
+
+    def test_invalid_error_handling_includes_how_to_fix(self):
+        graph = Graph([succeeding_node])
+        runner = SyncRunner()
+        with pytest.raises(ValueError, match="How to fix"):
+            runner.run(graph, {"x": 5}, error_handling="invalid")
+
+
+# === Async Tests ===
+
+
+class TestAsyncRunRaiseMode:
+    """Test error_handling='raise' (new default) for AsyncRunner."""
+
+    @pytest.mark.asyncio
+    async def test_run_raises_on_failure_by_default(self):
+        graph = Graph([failing_node])
+        runner = AsyncRunner()
+        with pytest.raises(CustomRunError, match="intentional failure"):
+            await runner.run(graph, {"x": 5})
+
+    @pytest.mark.asyncio
+    async def test_run_raises_original_exception_type(self):
+        graph = Graph([failing_node])
+        runner = AsyncRunner()
+        with pytest.raises(CustomRunError):
+            await runner.run(graph, {"x": 5})
+
+    @pytest.mark.asyncio
+    async def test_run_raises_with_clean_str(self):
+        graph = Graph([failing_node])
+        runner = AsyncRunner()
+        with pytest.raises(CustomRunError) as exc_info:
+            await runner.run(graph, {"x": 5})
+        assert str(exc_info.value) == "intentional failure"
+
+    @pytest.mark.asyncio
+    async def test_run_success_returns_result(self):
+        graph = Graph([succeeding_node])
+        runner = AsyncRunner()
+        result = await runner.run(graph, {"x": 5})
+        assert result.status == RunStatus.COMPLETED
+        assert result["result"] == 10
+
+
+class TestAsyncRunContinueMode:
+    """Test error_handling='continue' for AsyncRunner."""
+
+    @pytest.mark.asyncio
+    async def test_continue_returns_failed_result(self):
+        graph = Graph([failing_node])
+        runner = AsyncRunner()
+        result = await runner.run(graph, {"x": 5}, error_handling="continue")
+        assert result.status == RunStatus.FAILED
+        assert isinstance(result.error, CustomRunError)
+
+    @pytest.mark.asyncio
+    async def test_continue_has_partial_values(self):
+        graph = Graph([step_a, step_b])
+        runner = AsyncRunner()
+        result = await runner.run(graph, {"x": 5}, error_handling="continue")
+        assert result.status == RunStatus.FAILED
+        assert "step_a" in result.values
+        assert result.values["step_a"] == 105
+
+
+class TestMapStillWorks:
+    """Verify map() is unaffected by run() default change."""
+
+    def test_map_raise_mode_still_works(self):
+        graph = Graph([failing_node])
+        runner = SyncRunner()
+        with pytest.raises(CustomRunError):
+            runner.map(graph, values={"x": [1, 2, 3]}, map_over="x")
+
+    def test_map_continue_mode_still_works(self):
+        graph = Graph([failing_node])
+        runner = SyncRunner()
+        results = runner.map(
+            graph,
+            values={"x": [1, 2, 3]},
+            map_over="x",
+            error_handling="continue",
+        )
+        assert len(results) == 3
+        assert all(r.status == RunStatus.FAILED for r in results)

--- a/tests/test_runners/test_async_runner.py
+++ b/tests/test_runners/test_async_runner.py
@@ -414,10 +414,8 @@ class TestAsyncRunnerRun:
         graph = Graph([failing])
         runner = AsyncRunner()
 
-        result = await runner.run(graph, {"x": 5})
-
-        assert result.status == RunStatus.FAILED
-        assert isinstance(result.error, ValueError)
+        with pytest.raises(ValueError, match="intentional error"):
+            await runner.run(graph, {"x": 5})
 
 
 class TestAsyncRunnerMap:

--- a/tests/test_runners/test_async_runner.py
+++ b/tests/test_runners/test_async_runner.py
@@ -405,7 +405,7 @@ class TestAsyncRunnerRun:
             await runner.run(graph, {})
 
     async def test_node_exception_propagates(self):
-        """Node exceptions result in FAILED status."""
+        """Node exceptions propagate by default (error_handling='raise')."""
 
         @node(output_name="result")
         async def failing(x: int) -> int:

--- a/tests/test_runners/test_routing.py
+++ b/tests/test_runners/test_routing.py
@@ -393,11 +393,8 @@ class TestRoutingEdgeCases:
             return x
 
         graph = Graph([decide, a, b])
-        result = SyncRunner().run(graph, {"x": 5})
-
-        assert result.status == RunStatus.FAILED
-        assert isinstance(result.error, ValueError)
-        assert "invalid target" in str(result.error)
+        with pytest.raises(ValueError, match="invalid target"):
+            SyncRunner().run(graph, {"x": 5})
 
     def test_return_end_not_in_targets_raises(self):
         """Returning END when END isn't in targets should error."""
@@ -415,10 +412,8 @@ class TestRoutingEdgeCases:
             return x
 
         graph = Graph([decide, a, b])
-        result = SyncRunner().run(graph, {"x": 5})
-
-        assert result.status == RunStatus.FAILED
-        assert isinstance(result.error, ValueError)
+        with pytest.raises(ValueError):
+            SyncRunner().run(graph, {"x": 5})
 
     def test_single_target_returns_list_raises(self):
         """multi_target=False returning list should error."""
@@ -436,11 +431,8 @@ class TestRoutingEdgeCases:
             return x
 
         graph = Graph([decide, a, b])
-        result = SyncRunner().run(graph, {"x": 5})
-
-        assert result.status == RunStatus.FAILED
-        assert isinstance(result.error, TypeError)
-        assert "multi_target=False but returned a list" in str(result.error)
+        with pytest.raises(TypeError, match="multi_target=False but returned a list"):
+            SyncRunner().run(graph, {"x": 5})
 
     def test_multi_target_returns_string_raises(self):
         """multi_target=True returning string should error."""
@@ -458,11 +450,8 @@ class TestRoutingEdgeCases:
             return x
 
         graph = Graph([decide, a, b])
-        result = SyncRunner().run(graph, {"x": 5})
-
-        assert result.status == RunStatus.FAILED
-        assert isinstance(result.error, TypeError)
-        assert "multi_target=True but returned str" in str(result.error)
+        with pytest.raises(TypeError, match="multi_target=True but returned str"):
+            SyncRunner().run(graph, {"x": 5})
 
     # NOTE: test_chained_gates was removed because it exposes a known bug where
     # routing decisions don't block nodes that only depend on graph inputs.

--- a/tests/test_runners/test_sync_runner.py
+++ b/tests/test_runners/test_sync_runner.py
@@ -344,11 +344,8 @@ class TestSyncRunnerRun:
         graph = Graph([counter, always_continue])
         runner = SyncRunner()
 
-        result = runner.run(graph, {"count": 0}, max_iterations=5)
-
-        # Should fail due to infinite loop
-        assert result.status == RunStatus.FAILED
-        assert isinstance(result.error, InfiniteLoopError)
+        with pytest.raises(InfiniteLoopError):
+            runner.run(graph, {"count": 0}, max_iterations=5)
 
     def test_cycle_raises_on_infinite_loop(self):
         """Infinite loop detected and reported."""
@@ -360,10 +357,8 @@ class TestSyncRunnerRun:
         graph = Graph([counter, always_continue])
         runner = SyncRunner()
 
-        result = runner.run(graph, {"count": 0}, max_iterations=10)
-
-        assert result.status == RunStatus.FAILED
-        assert "10" in str(result.error)  # Max iterations in message
+        with pytest.raises(InfiniteLoopError, match="10"):
+            runner.run(graph, {"count": 0}, max_iterations=10)
 
     # Nested graphs
 
@@ -432,10 +427,8 @@ class TestSyncRunnerRun:
         graph = Graph([failing])
         runner = SyncRunner()
 
-        result = runner.run(graph, {"x": 5})
-
-        assert result.status == RunStatus.FAILED
-        assert isinstance(result.error, ValueError)
+        with pytest.raises(ValueError, match="intentional error"):
+            runner.run(graph, {"x": 5})
 
     def test_node_exception_sets_failed_status(self):
         """Exception sets status to FAILED."""
@@ -447,9 +440,8 @@ class TestSyncRunnerRun:
         graph = Graph([failing])
         runner = SyncRunner()
 
-        result = runner.run(graph, {"x": 5})
-
-        assert result.status == RunStatus.FAILED
+        with pytest.raises(RuntimeError, match="test"):
+            runner.run(graph, {"x": 5})
 
 
 class TestSyncRunnerRunGenerators:

--- a/tests/test_runners/test_sync_runner.py
+++ b/tests/test_runners/test_sync_runner.py
@@ -401,7 +401,7 @@ class TestSyncRunnerRun:
     # Errors
 
     def test_missing_input_raises(self):
-        """Missing required input causes FAILED status."""
+        """Missing required input raises MissingInputError."""
         graph = Graph([double])
         runner = SyncRunner()
 
@@ -418,7 +418,7 @@ class TestSyncRunnerRun:
             runner.run(graph, {"x": 5})
 
     def test_node_exception_propagates(self):
-        """Node exceptions result in FAILED status."""
+        """Node exceptions propagate by default (error_handling='raise')."""
 
         @node(output_name="result")
         def failing(x: int) -> int:

--- a/tests/test_runners/test_value_resolution.py
+++ b/tests/test_runners/test_value_resolution.py
@@ -2,6 +2,8 @@
 
 import threading
 
+import pytest
+
 from hypergraph import Graph, SyncRunner, node
 from hypergraph.graph.validation import GraphConfigError
 
@@ -148,18 +150,11 @@ class TestNonCopyableBoundValues:
         graph = Graph([produce, bad_default])
         runner = SyncRunner()
 
-        # Should fail with GraphConfigError in RunResult
-        result = runner.run(graph, {})
-
-        # Check that execution failed
-        from hypergraph.runners._shared.types import RunStatus
-
-        assert result.status == RunStatus.FAILED
-        assert result.error is not None
-        assert isinstance(result.error, GraphConfigError)
+        # Should fail with GraphConfigError
+        with pytest.raises(GraphConfigError, match="cannot be safely copied") as exc_info:
+            runner.run(graph, {})
 
         # Check error message content
-        error_msg = str(result.error)
-        assert "cannot be safely copied" in error_msg
+        error_msg = str(exc_info.value)
         assert ".bind()" in error_msg  # Suggests solution
         assert "Why copying is needed" in error_msg  # Explains problem


### PR DESCRIPTION
### **User description**
## Summary

- **`runner.run()` now raises on node failure by default** instead of returning `RunResult(status=FAILED)`. This aligns with Python conventions and every comparable library (Hamilton, PipeFunc, Prefect, LangGraph, Dask, pydantic-graph), as well as hypergraph's own `map()` behavior.
- New `error_handling` parameter: `"raise"` (default) re-raises the original exception with a clean traceback; `"continue"` returns `RunResult(status=FAILED, error=e, values=partial_outputs)` for programmatic error handling.
- `ErrorHandling` type exported from `hypergraph` and `hypergraph.runners`.

## Test plan

- [x] 18 new TDD tests in `test_run_error_handling.py` covering sync/async raise mode, continue mode, and validation
- [x] 51 existing tests updated (pytest.raises for default raise, error_handling="continue" for partial value inspection)
- [x] All 1404 non-viz tests pass (`uv run pytest`)
- [x] `_validate_error_handling()` rejects invalid values with actionable error message
- [x] `map()` behavior unchanged (already had error_handling)
- [x] Nested graphs (GraphNode) propagate errors correctly
- [x] Async pause/interrupt still returns `RunResult(status=PAUSED)`
- [x] Docs updated: `docs/06-api-reference/runners.md` — signatures, args, raises, examples, partial values section

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- `runner.run()` now raises on node failure by default instead of returning `RunResult(status=FAILED)`, aligning with Python conventions and industry standards

- New `error_handling` parameter: `"raise"` (default) re-raises original exception; `"continue"` returns `RunResult` with partial outputs

- `ErrorHandling` type exported from `hypergraph` and `hypergraph.runners` modules

- 51 existing tests updated to use `pytest.raises()` for raise mode or `error_handling="continue"` for partial value inspection

- 18 new TDD tests added covering sync/async raise/continue modes and validation

- Nested graphs (GraphNode) now propagate errors correctly without redundant checks


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["run() called"] --> B{"error_handling param"}
  B -->|"raise" default| C["Node fails"]
  C --> D["Re-raise original exception"]
  B -->|"continue"| E["Node fails"]
  E --> F["Return RunResult<br/>status=FAILED<br/>with partial values"]
  G["Validation"] --> H["_validate_error_handling()"]
  H --> I["Reject invalid values"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>__init__.py</strong><dd><code>Export ErrorHandling type from top-level module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/55/files#diff-e7d6c6e1cf38352ffe203d28e95fa696fbd3cbc49742c0b8c312f7395ec94300">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong><dd><code>Export ErrorHandling type from runners module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/55/files#diff-88837d3b2dc709d88ff8a5a6dbb610b804b076972a43bd97a4d316a04f65746d">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>helpers.py</strong><dd><code>Add error_handling parameter validation function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/55/files#diff-527974079a4ec295ee9c51c980e1d75db64c7f4e23f68f63e4b8530363665d8b">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>template_async.py</strong><dd><code>Add error_handling parameter to async run() and map()</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/55/files#diff-ff91f27bd8e68e8dd4fc3f5d28d6901eadcac60d593a7a436077382b62822bfc">+12/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>template_sync.py</strong><dd><code>Add error_handling parameter to sync run() and map()</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/55/files#diff-2c1d33c530c559cb6cddd7b491c379e45ca778404c2ff1c2f61aa4b3bda65afb">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>base.py</strong><dd><code>Add error_handling parameter to base runner abstract class</code></dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/55/files#diff-59f26995a12fb85035a7326a292b5283709387419b10d53b492716d90009af13">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>graph_node.py</strong><dd><code>Remove redundant FAILED status check in async executor</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/55/files#diff-611f8742b9625319f6c8f5d635a07639f91ec3fffb1bfe0e5e5e6ab549b14b16">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>graph_node.py</strong><dd><code>Remove redundant FAILED status check in sync executor</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/55/files#diff-5152d8110dfb744c449b61cea44198e49ff15aa93241bcb6ef60b964bae1b62f">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>15 files</summary><table>
<tr>
  <td><strong>test_async_events.py</strong><dd><code>Update async event tests to use error_handling="continue"</code></dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/55/files#diff-a4a39b42a3cd817e968035a6b42f4b982c024fe04acf2a8470928c84a3ad6c34">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_sync_events.py</strong><dd><code>Update sync event tests to use error_handling="continue"</code>&nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/55/files#diff-0aeaa72cda417076ec0ba0252e5ad0069d5b69045a8559025e1a4e19dadaa097">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_cache_edge_cases.py</strong><dd><code>Update cache tests to expect exceptions with pytest.raises()</code></dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/55/files#diff-7e52324ed57c41085ef5be31dbcec7a54d93d58448e8126139a804464aa0ecef">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_error_handling_edge_cases.py</strong><dd><code>Update error handling tests to expect exceptions by default</code></dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/55/files#diff-aea7f988687fe2c76850edd878565a5e61fb0be60651beb049dfef0e85db15e9">+5/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_exception_propagation.py</strong><dd><code>Update exception propagation tests to use pytest.raises()</code></dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/55/files#diff-74a059b7d25e8f04389a0a754def45ed1793224d3297347d057792a0d641d9d2">+44/-83</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_interrupt_node.py</strong><dd><code>Update interrupt node tests to expect exceptions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/55/files#diff-68e097f9278db08fbe2f26c993951dab019d2f87b0329fd4a65134299fb8d428">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_map_over_error_handling.py</strong><dd><code>Update map_over tests to expect exceptions by default</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/55/files#diff-e3f2554370006cbb114698e1f9a8e0a89095bd2d3ac0150a0908edad9f7cc084">+5/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_pr32_review_bugs.py</strong><dd><code>Update partial values tests to use error_handling="continue"</code></dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/55/files#diff-abfedba9879f7ac8b6d9d9c879fd36ee7e9b9df706c036e254d6d24ab0c07419">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_red_team_fixes.py</strong><dd><code>Update red team tests to expect exceptions with pytest.raises()</code></dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/55/files#diff-a1275d48ffeefe914d35a226b0ea74603217d1260129c4fda375db023a185e8e">+2/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_run_error_handling.py</strong><dd><code>Add comprehensive tests for error_handling parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/55/files#diff-e61835335baed51156ea14c17b790a13135440d7741c8a88c72d7408dac666fc">+196/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_async_runner.py</strong><dd><code>Update async runner tests to expect exceptions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/55/files#diff-7f57b1618fa0e453a41d06b2cae0c7cb46c8dcb43b4640386b0969c0e058ae5d">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_graphnode_map_over.py</strong><dd><code>Update GraphNode map_over tests for new error behavior</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/55/files#diff-3629e6556deee6d328acfb157a97a6ed5f6ff18ba070482abd1814b56f788bd4">+13/-16</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_routing.py</strong><dd><code>Update routing tests to expect exceptions by default</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/55/files#diff-b2d58eba9176372e55a3a28dcddde03d2ca9aac53ea96d89e125d9c55fd8f8b9">+8/-19</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_sync_runner.py</strong><dd><code>Update sync runner tests to expect exceptions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/55/files#diff-820ec982ecfbd0bfaa3ef8d2ada54f526eb57c208dc6ac028b5e9c966048fd66">+8/-16</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_value_resolution.py</strong><dd><code>Update value resolution tests to expect exceptions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/55/files#diff-7bfcc6658454f4bfb15e4b53082948d13614b93ca08b9d8c5c34aac47ec6960f">+6/-11</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>runners.md</strong><dd><code>Document error_handling parameter and partial values behavior</code></dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/55/files#diff-56c9ed459757844ea23c5ca70f3a761fb9225f0592b12a873a0c34a55c261860">+25/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public error_handling option to runners and map: "raise" (default) or "continue"; controls whether exceptions are re-raised or returned as partial results.
  * Exported ErrorHandling type to the public API.

* **Documentation**
  * Updated API reference and examples to document error_handling behavior and how to obtain partial results.

* **Tests**
  * Updated tests to cover raise vs continue semantics and to expect exception propagation where appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->