### PR TITLE
feat(graph): add partial input semantics (with_entrypoint, select-aware InputSpec, on_internal_override)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ src/hypergraph/
     _rename.py         #   Internal rename/copy machinery
 
   graph/               # Graph construction and validation
-    core.py            #   Graph class (build pipeline, bind/select/unbind)
+    core.py            #   Graph class (build pipeline, bind/select/unbind/with_entrypoint)
     input_spec.py      #   InputSpec (required/optional/entrypoint classification)
     validation.py      #   Build-time validation checks
     _conflict.py       #   Name conflict resolution

--- a/README.md
+++ b/README.md
@@ -187,14 +187,17 @@ See the docs for more patterns: [multi-agent orchestration](https://gilad-rubin.
 
 ```python
 # What does a graph need?
-print(graph.input_spec)
-# InputSpec(required={'text', 'query'}, optional={'config'}, seed={'messages'})
+print(graph.inputs)
+# InputSpec(required=('text', 'query'), optional=('config',), ...)
 
 # Pre-fill inputs for reuse
 configured = graph.bind(model="gpt-4", temperature=0.7)
 
 # Return only specific outputs
 focused = graph.select("answer", "confidence")
+
+# Start execution from a specific node (skip upstream)
+partial = graph.with_entrypoint("retriever")
 
 # Enable build-time type checking across node boundaries
 graph = Graph(nodes=[...], strict_types=True)

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ configured = graph.bind(model="gpt-4", temperature=0.7)
 focused = graph.select("answer", "confidence")
 
 # Start execution from a specific node (skip upstream)
-partial = graph.with_entrypoint("retriever")
+partial = graph.with_entrypoint("retrieve")
 
 # Enable build-time type checking across node boundaries
 graph = Graph(nodes=[...], strict_types=True)

--- a/docs/06-api-reference/inputspec.md
+++ b/docs/06-api-reference/inputspec.md
@@ -364,12 +364,12 @@ Emit-only outputs (ordering signals from `emit=`) cannot be bound — they are i
 
 When multiple sources provide the same value, the runner uses: **EDGE > PROVIDED > BOUND > DEFAULT**
 
-- A node that CAN run WILL run, and its output overwrites any provided/bound value
+- A node that CAN run WILL run (absent a compute/inject conflict), and its output overwrites any provided/bound value
+- Hard conflict rule: **either compute or inject, never both for the same node**
+  - Injecting a node's outputs while also making that node runnable raises `ValueError` unconditionally
+  - Partial injection of a multi-output producer is rejected when downstream still needs missing outputs
 - For non-conflicting internal overrides, `run(..., on_internal_override="ignore"|"warn"|"error")` controls policy (default: `"warn"`)
   - `map(...)` inherits the same policy and applies it per iteration
-- Hard conflict rule: **either compute or inject, never both for the same node**
-  - Injecting a node's outputs while also making that node runnable is rejected with `ValueError`
-  - Partial injection of a multi-output producer is rejected when downstream still needs missing outputs
 - Bound values bootstrap cycles: on the first iteration the bound value is used, then the cycle produces subsequent values
 
 ### Cycle entrypoints exclude certain parameters

--- a/docs/06-api-reference/inputspec.md
+++ b/docs/06-api-reference/inputspec.md
@@ -365,7 +365,11 @@ Emit-only outputs (ordering signals from `emit=`) cannot be bound — they are i
 When multiple sources provide the same value, the runner uses: **EDGE > PROVIDED > BOUND > DEFAULT**
 
 - A node that CAN run WILL run, and its output overwrites any provided/bound value
-- Providing an output AND its producer's inputs triggers a warning (the producer will overwrite your value)
+- For non-conflicting internal overrides, `run(..., on_internal_override="ignore"|"warn"|"error")` controls policy (default: `"warn"`)
+  - `map(...)` inherits the same policy and applies it per iteration
+- Hard conflict rule: **either compute or inject, never both for the same node**
+  - Injecting a node's outputs while also making that node runnable is rejected with `ValueError`
+  - Partial injection of a multi-output producer is rejected when downstream still needs missing outputs
 - Bound values bootstrap cycles: on the first iteration the bound value is used, then the cycle produces subsequent values
 
 ### Cycle entrypoints exclude certain parameters

--- a/docs/06-api-reference/runners.md
+++ b/docs/06-api-reference/runners.md
@@ -52,6 +52,7 @@ def run(
     *,
     select: str | list[str] = "**",
     on_missing: Literal["ignore", "warn", "error"] = "ignore",
+    on_internal_override: Literal["ignore", "warn", "error"] = "warn",
     entrypoint: str | None = None,
     max_iterations: int | None = None,
     event_processors: list[EventProcessor] | None = None,
@@ -69,6 +70,11 @@ Execute a graph once.
   - `"ignore"` (default): silently omit missing outputs
   - `"warn"`: warn about missing outputs, return what's available
   - `"error"`: raise error if any selected output is missing
+- `on_internal_override` - How to handle non-conflicting internal/unknown override-style inputs:
+  - `"warn"` (default): emit warning
+  - `"ignore"`: allow silently
+  - `"error"`: fail fast
+  - Note: contradictory compute+inject inputs for the same node always fail
 - `entrypoint` - Optional explicit cycle entrypoint node name. Disambiguates when multiple entrypoints match.
 - `max_iterations` - Max supersteps for cyclic graphs (default: 1000)
 - `event_processors` - Optional list of [event processors](events.md) to observe execution
@@ -119,6 +125,7 @@ def map(
     map_mode: Literal["zip", "product"] = "zip",
     select: str | list[str] = "**",
     on_missing: Literal["ignore", "warn", "error"] = "ignore",
+    on_internal_override: Literal["ignore", "warn", "error"] = "warn",
     entrypoint: str | None = None,
     error_handling: Literal["raise", "continue"] = "raise",
     event_processors: list[EventProcessor] | None = None,
@@ -135,6 +142,7 @@ Execute a graph multiple times with different inputs.
 - `map_mode` - `"zip"` for parallel iteration, `"product"` for cartesian product
 - `select` - Which outputs to return. `"**"` (default) returns all outputs.
 - `on_missing` - How to handle missing selected outputs (`"ignore"`, `"warn"`, or `"error"`)
+- `on_internal_override` - How to handle non-conflicting internal/unknown overrides (`"ignore"`, `"warn"`, or `"error"`)
 - `entrypoint` - Optional explicit cycle entrypoint (passed to each `run()` call)
 - `error_handling` - How to handle failures:
   - `"raise"` (default): Stop on first failure and raise the exception
@@ -241,6 +249,7 @@ async def run(
     *,
     select: str | list[str] = "**",
     on_missing: Literal["ignore", "warn", "error"] = "ignore",
+    on_internal_override: Literal["ignore", "warn", "error"] = "warn",
     entrypoint: str | None = None,
     max_iterations: int | None = None,
     max_concurrency: int | None = None,
@@ -256,6 +265,7 @@ Execute a graph asynchronously.
 - `values` - Optional input values
 - `select` - Which outputs to return. `"**"` (default) returns all outputs. Also narrows input validation to only what's needed for the selected outputs.
 - `on_missing` - How to handle missing selected outputs (`"ignore"`, `"warn"`, or `"error"`)
+- `on_internal_override` - How to handle non-conflicting internal/unknown overrides (`"ignore"`, `"warn"`, or `"error"`). Contradictory compute+inject inputs always fail.
 - `entrypoint` - Optional explicit cycle entrypoint node name
 - `max_iterations` - Max supersteps for cyclic graphs (default: 1000)
 - `max_concurrency` - Max parallel node executions (default: unlimited)
@@ -314,6 +324,7 @@ async def map(
     map_mode: Literal["zip", "product"] = "zip",
     select: str | list[str] = "**",
     on_missing: Literal["ignore", "warn", "error"] = "ignore",
+    on_internal_override: Literal["ignore", "warn", "error"] = "warn",
     entrypoint: str | None = None,
     max_concurrency: int | None = None,
     error_handling: Literal["raise", "continue"] = "raise",
@@ -331,6 +342,7 @@ Execute graph multiple times concurrently.
 - `map_mode` - `"zip"` or `"product"`
 - `select` - Which outputs to return. `"**"` (default) returns all outputs.
 - `on_missing` - How to handle missing selected outputs (`"ignore"`, `"warn"`, or `"error"`)
+- `on_internal_override` - How to handle non-conflicting internal/unknown overrides (`"ignore"`, `"warn"`, or `"error"`)
 - `entrypoint` - Optional explicit cycle entrypoint (passed to each `run()` call)
 - `max_concurrency` - Shared limit across all executions
 - `error_handling` - How to handle failures:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@
 - **Select-aware InputSpec** — `graph.select("a").inputs.required` now shows only what's needed to produce output "a", not the full graph. Previously `select()` only filtered returned outputs.
 - **Runtime select narrowing** — `runner.run(graph, values, select="a")` validates only the inputs needed for output "a". Passing `select` at runtime recomputes InputSpec scoped to the selected outputs.
 - **`entrypoints_config` property** — `graph.entrypoints_config` returns the configured entry point node names, or `None` if all nodes are active.
+- **`on_internal_override` parameter** — `run()` and `map()` accept `on_internal_override="ignore"|"warn"|"error"` (default: `"warn"`) to control how non-conflicting internal parameter overrides are handled. Contradictory compute+inject inputs always raise `ValueError` regardless of policy.
 
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ Issues = "https://github.com/gilad-rubin/hypergraph/issues"
 [dependency-groups]
 dev = [
     "allpairspy>=2.5.1",
+    "diskcache>=5.6.3",
     "nbstripout>=0.9.0",
     "playwright>=1.56.0",
     "pre-commit>=4.0.0",

--- a/src/hypergraph/graph/input_spec.py
+++ b/src/hypergraph/graph/input_spec.py
@@ -54,6 +54,7 @@ def compute_input_spec(
     *,
     entrypoints: tuple[str, ...] | None = None,
     selected: tuple[str, ...] | None = None,
+    _active_scope: tuple[dict[str, HyperNode], nx.DiGraph] | None = None,
 ) -> InputSpec:
     """Compute input specification for a graph.
 
@@ -69,16 +70,21 @@ def compute_input_spec(
         bound: Currently bound values
         entrypoints: Optional entry point node names (narrows to forward-reachable)
         selected: Optional output names to produce (narrows to backward-reachable)
+        _active_scope: Pre-computed (active_nodes, active_subgraph) to skip
+            redundant graph traversal. Internal optimization detail.
 
     Returns:
         InputSpec with categorized parameters scoped to the active subgraph
     """
-    active_nodes, active_subgraph = _compute_active_scope(
-        nodes,
-        nx_graph,
-        entrypoints=entrypoints,
-        selected=selected,
-    )
+    if _active_scope is not None:
+        active_nodes, active_subgraph = _active_scope
+    else:
+        active_nodes, active_subgraph = _compute_active_scope(
+            nodes,
+            nx_graph,
+            entrypoints=entrypoints,
+            selected=selected,
+        )
 
     edge_produced = get_edge_produced_values(active_subgraph)
     cycle_entrypoints = _compute_entrypoints(active_nodes, active_subgraph, edge_produced, bound)

--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -143,6 +143,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
         *,
         select: str | list[str] = _UNSET_SELECT,
         on_missing: Literal["ignore", "warn", "error"] = "ignore",
+        on_internal_override: Literal["ignore", "warn", "error"] = "warn",
         entrypoint: str | None = None,
         max_iterations: int | None = None,
         max_concurrency: int | None = None,
@@ -165,6 +166,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
             normalized_values,
             entrypoint=entrypoint,
             selected=effective_selected,
+            on_internal_override=on_internal_override,
         )
         _validate_on_missing(on_missing)
 
@@ -248,6 +250,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
         map_mode: Literal["zip", "product"] = "zip",
         select: str | list[str] = _UNSET_SELECT,
         on_missing: Literal["ignore", "warn", "error"] = "ignore",
+        on_internal_override: Literal["ignore", "warn", "error"] = "warn",
         entrypoint: str | None = None,
         max_concurrency: int | None = None,
         error_handling: ErrorHandling = "raise",
@@ -297,6 +300,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                     variation_inputs,
                     select=select,
                     on_missing=on_missing,
+                    on_internal_override=on_internal_override,
                     entrypoint=entrypoint,
                     max_concurrency=max_concurrency,
                     event_processors=event_processors,

--- a/src/hypergraph/runners/_shared/template_sync.py
+++ b/src/hypergraph/runners/_shared/template_sync.py
@@ -116,6 +116,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
         *,
         select: str | list[str] = _UNSET_SELECT,
         on_missing: Literal["ignore", "warn", "error"] = "ignore",
+        on_internal_override: Literal["ignore", "warn", "error"] = "warn",
         entrypoint: str | None = None,
         max_iterations: int | None = None,
         event_processors: list[EventProcessor] | None = None,
@@ -137,6 +138,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
             normalized_values,
             entrypoint=entrypoint,
             selected=effective_selected,
+            on_internal_override=on_internal_override,
         )
         _validate_on_missing(on_missing)
 
@@ -206,6 +208,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
         map_mode: Literal["zip", "product"] = "zip",
         select: str | list[str] = _UNSET_SELECT,
         on_missing: Literal["ignore", "warn", "error"] = "ignore",
+        on_internal_override: Literal["ignore", "warn", "error"] = "warn",
         entrypoint: str | None = None,
         error_handling: ErrorHandling = "raise",
         event_processors: list[EventProcessor] | None = None,
@@ -246,6 +249,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
                     variation_inputs,
                     select=select,
                     on_missing=on_missing,
+                    on_internal_override=on_internal_override,
                     entrypoint=entrypoint,
                     event_processors=event_processors,
                     _parent_span_id=map_span_id,

--- a/src/hypergraph/runners/base.py
+++ b/src/hypergraph/runners/base.py
@@ -43,6 +43,7 @@ class BaseRunner(ABC):
         *,
         select: str | list[str] = _UNSET_SELECT,
         on_missing: Literal["ignore", "warn", "error"] = "ignore",
+        on_internal_override: Literal["ignore", "warn", "error"] = "warn",
         entrypoint: str | None = None,
         max_iterations: int | None = None,
         event_processors: list[EventProcessor] | None = None,
@@ -55,6 +56,7 @@ class BaseRunner(ABC):
             values: Optional input values dict
             select: Which outputs to return. "**" (default) = all outputs.
             on_missing: How to handle missing selected outputs.
+            on_internal_override: How to handle non-conflicting internal input overrides.
             entrypoint: Optional explicit cycle entry point node name.
             max_iterations: Max iterations for cyclic graphs (None = default)
             event_processors: Optional list of event processors to receive execution events
@@ -75,6 +77,7 @@ class BaseRunner(ABC):
         map_mode: Literal["zip", "product"] = "zip",
         select: str | list[str] = _UNSET_SELECT,
         on_missing: Literal["ignore", "warn", "error"] = "ignore",
+        on_internal_override: Literal["ignore", "warn", "error"] = "warn",
         event_processors: list[EventProcessor] | None = None,
         **input_values: Any,
     ) -> list[RunResult]:
@@ -87,6 +90,7 @@ class BaseRunner(ABC):
             map_mode: "zip" for parallel iteration, "product" for cartesian
             select: Which outputs to return. "**" (default) = all outputs.
             on_missing: How to handle missing selected outputs.
+            on_internal_override: How to handle non-conflicting internal input overrides.
             event_processors: Optional list of event processors to receive execution events
             **input_values: Input values shorthand (merged with values)
 

--- a/src/hypergraph/viz/debug.py
+++ b/src/hypergraph/viz/debug.py
@@ -735,7 +735,7 @@ def _run_async_extract_in_thread(
     import threading
 
     result: RenderedDebugData | None = None
-    error: BaseException | None = None
+    error: Exception | None = None
 
     def _worker() -> None:
         nonlocal result, error
@@ -750,7 +750,7 @@ def _run_async_extract_in_thread(
                     timeout=timeout,
                 )
             )
-        except BaseException as exc:  # pragma: no cover - re-raised in caller
+        except Exception as exc:  # pragma: no cover - re-raised in caller
             error = exc
 
     # daemon=True: if the caller times out, the process can still exit cleanly.

--- a/src/hypergraph/viz/debug.py
+++ b/src/hypergraph/viz/debug.py
@@ -753,7 +753,10 @@ def _run_async_extract_in_thread(
         except BaseException as exc:  # pragma: no cover - re-raised in caller
             error = exc
 
-    thread = threading.Thread(target=_worker, name="hypergraph-viz-debug-extract")
+    # daemon=True: if the caller times out, the process can still exit cleanly.
+    # The thread continues running in the background until Playwright's own
+    # timeout fires, at which point it terminates naturally.
+    thread = threading.Thread(target=_worker, name="hypergraph-viz-debug-extract", daemon=True)
     thread.start()
     # Playwright has its own timeout; add margin for setup/teardown
     join_timeout = timeout / 1000 + 30

--- a/tests/test_red_team_fixes.py
+++ b/tests/test_red_team_fixes.py
@@ -152,13 +152,11 @@ class TestIntermediateInjection:
         assert result["end"] == "hello_mid_end"
 
     def test_multi_output_partial_injection_still_requires_upstream_inputs(self):
-        """Partial injection of multi-output node must still require its inputs.
+        """Partial injection of multi-output node is rejected early.
 
         If a node produces (left, right) and user only provides "left" but NOT "x",
-        validation should STILL require "x" because "right" is needed downstream.
-        The bug: current code marks split as bypassed if ANY output is provided.
+        validation rejects this contradictory configuration before execution.
         """
-        from hypergraph.exceptions import MissingInputError
 
         @node(output_name=("left", "right"))
         def split(x: int) -> tuple[int, int]:
@@ -175,9 +173,9 @@ class TestIntermediateInjection:
         graph = Graph(nodes=[split, use_left, use_right])
         runner = SyncRunner()
 
-        # Provide only "left" - but "right" is still needed from split!
-        # Should raise MissingInputError for "x"
-        with pytest.raises(MissingInputError, match="x"):
+        # Provide only "left" - but "right" is still needed from split.
+        # Reject as invalid internal override config.
+        with pytest.raises(ValueError, match="partial inject outputs"):
             runner.run(graph, {"left": 100})
 
     def test_multi_output_full_injection_skips_node(self):

--- a/tests/test_runners/test_async_runner.py
+++ b/tests/test_runners/test_async_runner.py
@@ -336,6 +336,46 @@ class TestAsyncRunnerRun:
         assert "sum" in result
         assert "doubled" not in result
 
+    async def test_on_internal_override_policy_is_enforced(self):
+        """run() forwards on_internal_override policy into validation."""
+
+        @node(output_name=("left", "right"))
+        def split(x: int) -> tuple[int, int]:
+            return x, x + 1
+
+        @node(output_name="double_left")
+        def use_left(left: int) -> int:
+            return left * 2
+
+        @node(output_name="double_right")
+        def use_right(right: int) -> int:
+            return right * 2
+
+        graph = Graph([split, use_left, use_right])
+        runner = AsyncRunner()
+
+        with pytest.raises(ValueError, match="internal parameters"):
+            await runner.run(
+                graph,
+                {"left": 100, "right": 200},
+                on_internal_override="error",
+            )
+
+        result = await runner.run(
+            graph,
+            {"left": 100, "right": 200},
+            on_internal_override="ignore",
+        )
+        assert result["double_left"] == 200
+        assert result["double_right"] == 400
+
+        with pytest.warns(UserWarning, match="left <- split"):
+            await runner.run(
+                graph,
+                {"left": 100, "right": 200},
+                on_internal_override="warn",
+            )
+
     # Cycles
 
     async def test_cycle_executes_until_stable(self):
@@ -483,6 +523,50 @@ class TestAsyncRunnerMap:
         )
 
         assert [r["sum"] for r in results] == [11, 12]
+
+    async def test_map_forwards_on_internal_override_policy(self):
+        """map() forwards on_internal_override to per-item run() validation."""
+
+        @node(output_name=("left", "right"))
+        def split(x: int) -> tuple[int, int]:
+            return x, x + 1
+
+        @node(output_name="double_left")
+        def use_left(left: int) -> int:
+            return left * 2
+
+        @node(output_name="double_right")
+        def use_right(right: int) -> int:
+            return right * 2
+
+        graph = Graph([split, use_left, use_right])
+        runner = AsyncRunner()
+
+        with pytest.raises(ValueError, match="internal parameters"):
+            await runner.map(
+                graph,
+                {"left": [100], "right": 200},
+                map_over="left",
+                on_internal_override="error",
+            )
+
+        results = await runner.map(
+            graph,
+            {"left": [100], "right": 200},
+            map_over="left",
+            on_internal_override="ignore",
+        )
+        assert len(results) == 1
+        assert results[0]["double_left"] == 200
+        assert results[0]["double_right"] == 400
+
+        with pytest.warns(UserWarning, match="left <- split"):
+            await runner.map(
+                graph,
+                {"left": [100], "right": 200},
+                map_over="left",
+                on_internal_override="warn",
+            )
 
     async def test_map_runs_concurrently(self):
         """Map executions run concurrently."""

--- a/tests/test_runners/test_validation.py
+++ b/tests/test_runners/test_validation.py
@@ -186,6 +186,17 @@ class TestInternalOverrideValidation:
         with pytest.raises(ValueError, match="Invalid on_internal_override"):
             validate_inputs(graph, {"x": 1}, on_internal_override="raise")  # type: ignore[arg-type]
 
+    def test_cycle_entrypoint_param_not_flagged_as_internal_override(self):
+        """Cycle entry point params are excluded from compute+inject conflict checks.
+
+        'count' is both produced by an edge (self-loop) and needed as a seed
+        value to bootstrap the cycle. Providing it should NOT be treated as an
+        internal override conflict.
+        """
+        graph = Graph([counter])
+        # 'count' is a cycle entrypoint param — should pass cleanly
+        validate_inputs(graph, {"count": 0}, on_internal_override="error")
+
     def test_entrypoint_scope_treats_excluded_branch_output_as_root_input(self):
         """Active-scope required roots are not treated as internal overrides."""
 

--- a/tests/test_runners/test_validation.py
+++ b/tests/test_runners/test_validation.py
@@ -122,6 +122,97 @@ class TestValidateInputs:
         assert set(exc_info.value.missing) == {"a", "b"}
 
 
+class TestInternalOverrideValidation:
+    """Tests for internal override policy and conflict checks."""
+
+    @staticmethod
+    def _make_split_graph() -> Graph:
+        @node(output_name=("left", "right"))
+        def split(x: int) -> tuple[int, int]:
+            return x, x + 1
+
+        @node(output_name="double_left")
+        def use_left(left: int) -> int:
+            return left * 2
+
+        @node(output_name="double_right")
+        def use_right(right: int) -> int:
+            return right * 2
+
+        return Graph([split, use_left, use_right])
+
+    def test_mixed_compute_and_inject_for_same_node_errors(self):
+        """Providing producer inputs + produced outputs is a hard conflict."""
+        graph = self._make_split_graph()
+        with pytest.raises(ValueError, match="Cannot mix compute and inject"):
+            validate_inputs(
+                graph,
+                {"left": 100, "x": 5},
+                on_internal_override="ignore",
+            )
+
+    def test_full_internal_injection_allowed_with_ignore(self):
+        """Non-conflicting internal injection is allowed with ignore policy."""
+        graph = self._make_split_graph()
+        validate_inputs(
+            graph,
+            {"left": 100, "right": 200},
+            on_internal_override="ignore",
+        )
+
+    def test_full_internal_injection_rejected_with_error_policy(self):
+        """Non-conflicting internal injection can be rejected via policy."""
+        graph = self._make_split_graph()
+        with pytest.raises(ValueError, match="internal parameters"):
+            validate_inputs(
+                graph,
+                {"left": 100, "right": 200},
+                on_internal_override="error",
+            )
+
+    def test_internal_override_warning_includes_producer_mapping(self):
+        """Warning text should identify which node produces each internal key."""
+        graph = self._make_split_graph()
+        with pytest.warns(UserWarning, match="left <- split"):
+            validate_inputs(
+                graph,
+                {"left": 100, "right": 200},
+                on_internal_override="warn",
+            )
+
+    def test_invalid_internal_override_policy_raises(self):
+        """Reject unknown policy values."""
+        graph = Graph([double])
+        with pytest.raises(ValueError, match="Invalid on_internal_override"):
+            validate_inputs(graph, {"x": 1}, on_internal_override="raise")  # type: ignore[arg-type]
+
+    def test_entrypoint_scope_treats_excluded_branch_output_as_root_input(self):
+        """Active-scope required roots are not treated as internal overrides."""
+
+        @node(output_name="x")
+        def a(seed: int) -> int:
+            return seed + 1
+
+        @node(output_name="b_out")
+        def b(x: int) -> int:
+            return x * 2
+
+        @node(output_name="c_out")
+        def c(x: int) -> int:
+            return x * 3
+
+        @node(output_name="e")
+        def e(b_out: int, c_out: int) -> int:
+            return b_out + c_out
+
+        graph = Graph([a, b, c, e]).with_entrypoint("b").select("e")
+        validate_inputs(
+            graph,
+            {"x": 10, "c_out": 99},
+            on_internal_override="error",
+        )
+
+
 class TestNormalizeInputs:
     """Tests for values + kwargs input normalization."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -1406,6 +1406,7 @@ viz = [
 [package.dev-dependencies]
 dev = [
     { name = "allpairspy" },
+    { name = "diskcache" },
     { name = "nbstripout" },
     { name = "playwright" },
     { name = "pre-commit" },
@@ -1458,6 +1459,7 @@ provides-extras = ["batch", "daft", "viz", "notebook", "cache", "progress", "tel
 [package.metadata.requires-dev]
 dev = [
     { name = "allpairspy", specifier = ">=2.5.1" },
+    { name = "diskcache", specifier = ">=5.6.3" },
     { name = "nbstripout", specifier = ">=0.9.0" },
     { name = "playwright", specifier = ">=1.56.0" },
     { name = "pre-commit", specifier = ">=4.0.0" },


### PR DESCRIPTION
### **User description**
## Summary

- **`with_entrypoint(*node_names)`** — narrows execution to start at specific nodes, skipping upstream. Works for DAGs and cycles. Returns new Graph (immutable, chainable).
- **Select-aware InputSpec** — `graph.select("a").inputs.required` now shows only what's needed to produce output "a". Runtime `select=` in `run()`/`map()` recomputes validation scope.
- **`on_internal_override` parameter** — `run()` and `map()` accept `on_internal_override="ignore"|"warn"|"error"` (default: `"warn"`) to control how non-conflicting internal parameter overrides are handled. Contradictory compute+inject inputs always raise `ValueError`.
- **Active-set enforcement** — nodes outside the active scope (excluded by entrypoint/selection) are never scheduled, even if their inputs are satisfied.

## Test plan

- [x] `test_partial_inputs.py` — 626 lines covering `with_entrypoint`, `select`, composition, cycles, immutability, runtime select, async
- [x] `test_validation.py::TestInternalOverrideValidation` — compute+inject conflicts, partial inject, policy enforcement, cycle EP exclusion, entrypoint scope
- [x] `test_sync_runner.py` / `test_async_runner.py` — `on_internal_override` for both `run()` and `map()`
- [x] `test_code_review_fixes.py::TestInputValidationOverrides` — sync + async conflict detection
- [x] `test_red_team_fixes.py::TestIntermediateInjection` — partial/full injection, multi-output nodes
- [x] All 1603+ non-matrix tests pass, full suite (1661) passes with only flaky xdist race conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add `on_internal_override` parameter to control non-conflicting internal input override policies
  - Three modes: `"ignore"`, `"warn"` (default), `"error"`
  - Applies to both `run()` and `map()` methods

- Implement hard conflict detection for compute+inject contradictions
  - Reject when node inputs are provided while also injecting its outputs
  - Reject partial injection when downstream needs missing outputs

- Optimize InputSpec computation by reusing pre-computed active scope
  - Eliminates redundant graph traversal via `_active_scope` parameter

- Fix async debug extraction to use dedicated thread instead of nest_asyncio
  - Prevents nested event loop errors in async contexts


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User calls run/map"] --> B["validate_inputs"]
  B --> C["Compute active scope"]
  C --> D["Check hard conflicts"]
  D --> E{Conflict found?}
  E -->|Yes| F["Raise ValueError"]
  E -->|No| G["Apply policy"]
  G --> H{Policy check}
  H -->|ignore| I["Allow silently"]
  H -->|warn| J["Warn and allow"]
  H -->|error| K["Raise ValueError"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>input_spec.py</strong><dd><code>Add optional active_scope parameter for optimization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/57/files#diff-9bacc96380e98dfe15699ebe6ea2640693ef29e6e980e52b44261bf89c3b65b7">+12/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>validation.py</strong><dd><code>Implement on_internal_override policy and conflict detection</code></dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/57/files#diff-77c351d52fa45973c2d3654d426b8d3e25c4ee418bbe9a2ec86af9513c369771">+183/-25</a></td>

</tr>

<tr>
  <td><strong>template_sync.py</strong><dd><code>Add on_internal_override parameter to run and map</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/57/files#diff-2c1d33c530c559cb6cddd7b491c379e45ca778404c2ff1c2f61aa4b3bda65afb">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>template_async.py</strong><dd><code>Add on_internal_override parameter to async run and map</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/57/files#diff-ff91f27bd8e68e8dd4fc3f5d28d6901eadcac60d593a7a436077382b62822bfc">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>base.py</strong><dd><code>Add on_internal_override to base runner interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/57/files#diff-59f26995a12fb85035a7326a292b5283709387419b10d53b492716d90009af13">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>debug.py</strong><dd><code>Fix async extraction using dedicated thread instead of nest_asyncio</code></dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/57/files#diff-60a4252b85752d2c6a2db08843f4ea6729698f47b35ac90bed30d21558660030">+60/-25</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>test_code_review_fixes.py</strong><dd><code>Update tests to expect ValueError for compute+inject conflicts</code></dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/57/files#diff-375d0a40e4653c27e5b90a49b1b7d4b5fea05705b15c1d6c147ca65ddec0fc18">+23/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_red_team_fixes.py</strong><dd><code>Update partial injection tests to expect conflict rejection</code></dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/57/files#diff-a1275d48ffeefe914d35a226b0ea74603217d1260129c4fda375db023a185e8e">+5/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_sync_runner.py</strong><dd><code>Add tests for on_internal_override policy enforcement</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/57/files#diff-820ec982ecfbd0bfaa3ef8d2ada54f526eb57c208dc6ac028b5e9c966048fd66">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_async_runner.py</strong><dd><code>Add async tests for on_internal_override policy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/57/files#diff-7f57b1618fa0e453a41d06b2cae0c7cb46c8dcb43b4640386b0969c0e058ae5d">+84/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_validation.py</strong><dd><code>Add comprehensive internal override validation tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/57/files#diff-88cac1e9f2274f40020adcdf9dfcd4cbd5ecde9ee65d4db935de62b3b78c60ca">+102/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>inputspec.md</strong><dd><code>Document on_internal_override policy and conflict rules</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/57/files#diff-e0051d9ef5cc6141c393406381568a0b88202d106e788c924af7f194d401c41a">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>runners.md</strong><dd><code>Document on_internal_override parameter in runner APIs</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/57/files#diff-56c9ed459757844ea23c5ca70f3a761fb9225f0592b12a873a0c34a55c261860">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>changelog.md</strong><dd><code>Add on_internal_override to changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/57/files#diff-77f023b99d3d58008351d3e82fc06e6d06ba1bc2da9e41be6329b7fa4f419f05">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong><dd><code>Add with_entrypoint example and fix stale references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/57/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AGENTS.md</strong><dd><code>Update module map to include with_entrypoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/57/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>pyproject.toml</strong><dd><code>Add diskcache dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/57/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Start execution from a specific node via a new Graph entrypoint capability.
  * New on_internal_override option for run/map to control handling of internal overrides: "ignore", "warn", or "error" (default "warn").

* **API Changes**
  * Graph.input_spec renamed to Graph.inputs.

* **Bug Fixes**
  * Conflicting compute vs. inject inputs are now rejected (ValueError) with clearer messages.
* **Tests & Docs**
  * Updated examples, docs, and tests demonstrating entrypoint usage and internal-override policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->