### PR TITLE
chore: add PR template and remove Entire session tracking

### DIFF
--- a/.claude/skills/feature/SKILL.md
+++ b/.claude/skills/feature/SKILL.md
@@ -217,34 +217,11 @@ Task tool:
 
 ## Phase 4: PR
 
-Create a pull request using the repo's PR template structure:
+Create a pull request following the template in `.github/PULL_REQUEST_TEMPLATE.md`. Fill in each section:
 
-```bash
-gh pr create --title "<concise title>" --body "$(cat <<'EOF'
-## Problem / Bug / Challenge
-<What was broken, missing, or hard — 1-3 sentences>
-
-## Before / After
-<Show the change with code snippets, API examples, or screenshots.
- For viz changes, include before/after visualizations.>
-
-**Before:**
-```python
-<old behavior or code>
-```
-
-**After:**
-```python
-<new behavior or code>
-```
-
-## Test Plan
-<checklist from TDD spec>
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-EOF
-)"
-```
+- **Problem / Bug / Challenge** — from the plan's requirements/scope
+- **Before / After** — code snippets, API examples, or screenshots (especially for viz changes)
+- **Test Plan** — from the TDD spec
 
 Mark the PR task as `completed`.
 

--- a/.claude/skills/feature/SKILL.md
+++ b/.claude/skills/feature/SKILL.md
@@ -217,14 +217,28 @@ Task tool:
 
 ## Phase 4: PR
 
-Create a pull request using project conventions:
+Create a pull request using the repo's PR template structure:
 
 ```bash
 gh pr create --title "<concise title>" --body "$(cat <<'EOF'
-## Summary
-<1-3 bullet points from the plan>
+## Problem / Bug / Challenge
+<What was broken, missing, or hard — 1-3 sentences>
 
-## Test plan
+## Before / After
+<Show the change with code snippets, API examples, or screenshots.
+ For viz changes, include before/after visualizations.>
+
+**Before:**
+```python
+<old behavior or code>
+```
+
+**After:**
+```python
+<new behavior or code>
+```
+
+## Test Plan
 <checklist from TDD spec>
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -11,7 +11,7 @@ Fetch PR review comments from ALL sources, triage by severity, fix issues, and i
 ### 1. SETUP
 - Run `git branch --show-current` to confirm the current branch. **Never commit to main/master directly.**
 - If a PR number is provided, use it. Otherwise, detect via `gh pr view --json number -q .number`.
-- If no PR exists yet: run the conflict check (below), then `gh pr create` and post the URL.
+- If no PR exists yet: run the conflict check (below), then `gh pr create` following `.github/PULL_REQUEST_TEMPLATE.md` and post the URL.
 - Determine repo owner/name: `gh repo view --json nameWithOwner -q .nameWithOwner`
 
 #### Conflict Check (run before creating OR pushing to a PR)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Problem / Bug / Challenge
+
+<!-- What's broken, missing, or hard? Link issues if applicable. -->
+
+## Before / After
+
+<!-- Show the change. Pick what fits:
+     - Code snippets (before → after)
+     - Screenshots or visualizations (especially for viz/ changes)
+     - API usage examples
+     - Error messages before → expected behavior after
+-->
+
+**Before:**
+
+```python
+```
+
+**After:**
+
+```python
+```
+
+## Test Plan
+
+- [ ] <!-- How did you verify this works? -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,12 +13,12 @@
 
 **Before:**
 
-```python
+```
 ```
 
 **After:**
 
-```python
+```
 ```
 
 ## Test Plan

--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,3 @@ logs/security/
 
 # Dev scratch directories
 viz-dev/
-.entire/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,27 +106,8 @@ These run without agent intervention via `.claude/settings.json`:
 | Event | What It Does |
 |-------|--------------|
 | **PostToolUse (Write\|Edit)** | Auto-runs `ruff check --fix` + `ruff format` on any `.py` file after edits |
-| **SessionStart** | Entire: begins session tracking, captures agent type and start time |
-| **UserPromptSubmit** | Entire: records each prompt for the session transcript |
-| **PreToolUse (Task)** | Entire: tracks subagent spawn (nested session hierarchy) |
-| **PostToolUse (Task)** | Entire: captures subagent results and token usage |
-| **PostToolUse (TodoWrite)** | Entire: records task list changes |
-| **SessionEnd / Stop** | Entire: finalizes session, stores transcript + token metrics + line attribution |
 
 The auto-format hook means agents never need to manually run ruff — code is always formatted after every edit.
-
-### Entire (Session Tracking)
-
-[Entire](https://docs.entire.io) captures agent sessions as Git-native checkpoints. On every commit, it stores the full transcript, files touched, token usage, and agent-vs-human line attribution. Strategy: `manual-commit` (checkpoints only on explicit commits, no extra commits on your branch).
-
-```bash
-entire status                    # Show active sessions
-entire explain                   # Browse checkpoints on current branch
-entire explain --commit HEAD     # See AI reasoning behind a specific commit
-entire rewind                    # Interactive rewind to any checkpoint
-```
-
-**Note**: If `uv run pre-commit install` overwrites git hooks, re-run `entire enable` to restore.
 
 ## Skills
 

--- a/dev/CONTRIBUTING.md
+++ b/dev/CONTRIBUTING.md
@@ -19,9 +19,6 @@ uv sync --group dev
 uv run pre-commit install
 uv run pre-commit install --hook-type pre-push
 
-# Enable session tracking (captures agent transcripts as Git checkpoints)
-entire enable
-
 # Playwright (only needed for viz tests)
 uv run playwright install chromium
 ```
@@ -43,12 +40,6 @@ uv run pre-commit run --all-files          # all hooks
 
 # Viz tests
 uv run pytest tests/viz/                   # requires Playwright
-
-# Session tracking (entire)
-entire status                              # active sessions
-entire explain                             # browse checkpoints
-entire explain --commit HEAD               # reasoning behind a commit
-entire rewind                              # interactive rewind
 ```
 
 ## Workflow
@@ -57,9 +48,7 @@ entire rewind                              # interactive rewind
 2. Implement with TDD: write failing test first, then make it pass
 3. Run `uv run pytest` after each logical step
 4. Commit with conventional commits: `feat(graph): add X`, `fix(runners): handle Y`
-   - Each commit automatically creates an Entire checkpoint with session context
 5. Push and create PR
-6. After pre-commit reinstalls hooks: `entire enable` to restore session tracking
 
 ## PR Expectations
 


### PR DESCRIPTION
### **User description**
## Problem / Bug / Challenge

PRs had no consistent structure — each one was formatted differently depending on which skill or manual process created it. Additionally, Entire (session tracking tool) was no longer in use but its hooks, docs references, and config were still scattered across the project, causing commit failures in worktrees.

## Before / After

**Before:**
PRs created by `/feature` used an inlined "Summary + Test plan" format hardcoded in the skill. Other skills had no PR format guidance at all.

```markdown
## Summary
<1-3 bullet points from the plan>

## Test plan
<checklist from TDD spec>
```

**After:**
Single source of truth in `.github/PULL_REQUEST_TEMPLATE.md`. All skills reference it instead of inlining templates.

```markdown
## Problem / Bug / Challenge
<!-- What's broken, missing, or hard? -->

## Before / After
<!-- Code snippets, screenshots, or visualizations -->

## Test Plan
- [ ] <!-- verification steps -->
```

Also removes all Entire references: AGENTS.md hooks table, CONTRIBUTING.md setup/commands, .gitignore entry, git hooks, and system installation.

## Test Plan

- [x] Verified git hooks restored (pre-push runs pre-commit checks, commit-msg/prepare-commit-msg removed)
- [x] Confirmed `entire` uninstalled (`which entire` → not found)
- [x] Pushed branch successfully with lint checks passing
- [x] This PR itself uses the new template as validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Add standardized PR template with Problem/Before-After/Test Plan structure

- Remove all Entire session tracking references from docs and configuration

- Update skills to reference centralized PR template instead of inlined format

- Simplify contributor setup and workflow documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PR Template<br/>Creation"] -->|"Centralized<br/>Format"| B["Skills Reference<br/>Template File"]
  C["Entire<br/>References"] -->|"Removed from"| D["AGENTS.md<br/>CONTRIBUTING.md<br/>.gitignore"]
  B --> E["Consistent<br/>PR Structure"]
  D --> F["Simplified<br/>Documentation"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PULL_REQUEST_TEMPLATE.md</strong><dd><code>Create standardized PR template file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/PULL_REQUEST_TEMPLATE.md

<ul><li>New file created with standardized PR template structure<br> <li> Includes three main sections: Problem/Bug/Challenge, Before/After, and <br>Test Plan<br> <li> Provides helpful comments and code block examples for contributors<br> <li> Serves as single source of truth for PR formatting across all skills</ul>


</details>


  </td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/58/files#diff-18813c86948efc57e661623d7ba48ff94325c9b5421ec9177f724922dd553a35">+26/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AGENTS.md</strong><dd><code>Remove Entire session tracking documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

AGENTS.md

<ul><li>Removed all Entire session tracking hooks from the hooks table <br>(SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, SessionEnd)<br> <li> Deleted entire "Entire (Session Tracking)" section with documentation <br>and commands<br> <li> Kept PostToolUse hook for auto-formatting with ruff<br> <li> Removed note about re-enabling Entire after pre-commit installation</ul>


</details>


  </td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/58/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+0/-19</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CONTRIBUTING.md</strong><dd><code>Remove Entire references from contributor guide</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dev/CONTRIBUTING.md

<ul><li>Removed <code>entire enable</code> command from setup instructions<br> <li> Deleted entire session tracking commands section (status, explain, <br>rewind)<br> <li> Removed note about re-enabling Entire after pre-commit hook <br>installation<br> <li> Simplified workflow documentation by removing Entire checkpoint <br>references</ul>


</details>


  </td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/58/files#diff-406d602a2bb5c2c3c8510113af3a04c39ad606a58015cac8785ae9ee48108944">+0/-11</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Refactor</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SKILL.md</strong><dd><code>Point feature skill to PR template</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.claude/skills/feature/SKILL.md

<ul><li>Replaced inlined PR body template with reference to <br><code>.github/PULL_REQUEST_TEMPLATE.md</code><br> <li> Removed hardcoded Summary and Test plan sections from Phase 4<br> <li> Added guidance on filling each template section from plan requirements<br> <li> Simplified PR creation instructions for clarity</ul>


</details>


  </td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/58/files#diff-90f7cd3e1550aba95263690d2a4206c5871469cb3773ed34033954a302955cd1">+4/-13</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SKILL.md</strong><dd><code>Update review-pr to use PR template</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.claude/skills/review-pr/SKILL.md

<ul><li>Updated PR creation fallback path to reference <br><code>.github/PULL_REQUEST_TEMPLATE.md</code><br> <li> Changed from implicit format to explicit template guidance<br> <li> Maintains existing conflict check and branch validation logic</ul>


</details>


  </td>
  <td><a href="https://github.com/gilad-rubin/hypergraph/pull/58/files#diff-d3868df87b01c11da861242ea30e7eb2b576b64a3b4cc4c0ad6afbfb7c2088c6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a structured pull-request template with sections for Problem/Bug/Challenge, Before/After, and a Test Plan to improve PR clarity.
  * Updated PR creation/review guidance to reference and use the new template.
  * Removed several session-tracking and automatic-hook entries from project docs to simplify developer-facing documentation.

* **Chores**
  * Adjusted repository ignore settings to stop excluding a previously ignored development scratch directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->