### PR TITLE
fix(runners): gate activation scheduling, interrupt resume, sync checkpointer

### DIFF
--- a/dev/ARCHITECTURE.md
+++ b/dev/ARCHITECTURE.md
@@ -74,7 +74,13 @@ Execution engines. Template Method pattern with pluggable `NodeExecutor` per nod
 | `async_/superstep.py` | Superstep loop (async) |
 | `async_/executors/` | Per-node-type executors (function, graph, ifelse, route, interrupt) |
 
-**Execution model**: Superstep-based. Each superstep executes all ready nodes (those with satisfied inputs), then loops until no new nodes are ready or convergence.
+**Execution model**: Superstep-based. Each superstep:
+1. `get_ready_nodes` finds nodes with satisfied inputs, gate activation, and changed state
+2. All ready nodes execute concurrently (async) or sequentially (sync)
+3. Results are applied to state; routing decisions are recorded and consumed
+4. Loop until no nodes are ready or convergence
+
+Gate targets are blocked until their controlling gate fires and routes to them. Routing decisions are consumed after the target executes — the gate must re-fire to re-activate the target. See `src/hypergraph/runners/_shared/AGENTS.md` for scheduling rules.
 
 **`_shared/` contents**:
 - `caching.py` — Cache key computation and lookup

--- a/dev/TESTING-GUIDE.md
+++ b/dev/TESTING-GUIDE.md
@@ -169,7 +169,6 @@ async def test_pause_resume(self, tmp_path):
     from hypergraph.checkpointers import SqliteCheckpointer
 
     cp = SqliteCheckpointer(str(tmp_path / "test.db"))
-    await cp.initialize()
     runner = AsyncRunner(checkpointer=cp)
 
     r1 = await runner.run(graph, workflow_id="w", user_input="hello")
@@ -177,8 +176,6 @@ async def test_pause_resume(self, tmp_path):
 
     r2 = await runner.run(graph, workflow_id="w", user_input="more")
     assert r2.paused  # or not, depending on graph logic
-
-    await cp.close()
 ```
 
 Without a checkpointer, the runner has no state between calls — each run starts fresh.

--- a/dev/TESTING-GUIDE.md
+++ b/dev/TESTING-GUIDE.md
@@ -135,6 +135,54 @@ tests/
 - Fixtures: prefer `conftest.py` for shared fixtures, local for one-file fixtures
 - Marks: `@pytest.mark.slow` for slow tests, `@pytest.mark.full_matrix` for exhaustive
 
+### Scheduling: Test Node Readiness Directly
+
+For subtle scheduling bugs, test `get_ready_nodes` directly against `GraphState`:
+
+```python
+from hypergraph.runners._shared.helpers import compute_execution_scope, get_ready_nodes
+from hypergraph.runners._shared.types import GraphState, NodeExecution
+
+scope = compute_execution_scope(graph)
+state = GraphState()
+state.update_value("x", 42)
+
+ready = get_ready_nodes(
+    graph, state,
+    active_nodes=scope.active_nodes,
+    startup_predecessors=scope.startup_predecessors,
+)
+assert "my_node" in [n.name for n in ready]
+```
+
+Simulate execution by adding `NodeExecution` entries to `state.node_executions` and routing decisions to `state.routing_decisions`. This lets you verify scheduling invariants superstep-by-superstep without running the full engine.
+
+See `tests/test_gate_activation_scheduling.py` and `tests/test_interrupt_shared_cycle_bug.py` for examples.
+
+### Interrupt: Test Pause/Resume with Checkpointer
+
+Multi-turn interrupt tests need a checkpointer — each `.run()` call simulates a separate request:
+
+```python
+@pytest.mark.asyncio
+async def test_pause_resume(self, tmp_path):
+    from hypergraph.checkpointers import SqliteCheckpointer
+
+    cp = SqliteCheckpointer(str(tmp_path / "test.db"))
+    await cp.initialize()
+    runner = AsyncRunner(checkpointer=cp)
+
+    r1 = await runner.run(graph, workflow_id="w", user_input="hello")
+    assert r1.paused
+
+    r2 = await runner.run(graph, workflow_id="w", user_input="more")
+    assert r2.paused  # or not, depending on graph logic
+
+    await cp.close()
+```
+
+Without a checkpointer, the runner has no state between calls — each run starts fresh.
+
 ## Common Gotchas
 
 ### Never Use `asyncio.run()` in Tests

--- a/docs/03-patterns/07-human-in-the-loop.md
+++ b/docs/03-patterns/07-human-in-the-loop.md
@@ -171,6 +171,117 @@ assert result.paused  # pauses again for next turn
 
 No ordering signals needed — the edge list makes execution order unambiguous. Both `add_query` and `add_response` produce `messages`, but the edges declare which runs first.
 
+## Persistent Multi-Turn with Checkpointer
+
+The examples above are stateless — each resume replays from scratch, passing all previous responses. For production multi-turn workflows, use a **checkpointer** to persist state between calls. Each `.run()` only needs the new user input.
+
+```python
+from hypergraph import Graph, AsyncRunner, END, node, route, interrupt
+from hypergraph.checkpointers import SqliteCheckpointer
+
+@interrupt(output_name="user_input")
+def wait_for_user() -> None:
+    return None
+
+@node(output_name="messages")
+def add_user_message(messages: list, user_input: str) -> list:
+    return [*messages, {"role": "user", "content": user_input}]
+
+@node(output_name="response")
+async def llm_reply(messages: list, llm_client) -> str:
+    return await llm_client.chat(messages)
+
+@node(output_name="messages")
+def add_response(messages: list, response: str) -> list:
+    return [*messages, {"role": "assistant", "content": response}]
+
+@route(targets=["wait_for_user", END])
+def should_continue(messages: list, max_turns: int) -> str:
+    turns = sum(1 for m in messages if m["role"] == "assistant")
+    return END if turns >= max_turns else "wait_for_user"
+
+chat = Graph(
+    [wait_for_user, add_user_message, llm_reply, add_response, should_continue],
+    edges=[
+        (add_user_message, llm_reply),
+        (llm_reply, add_response),
+        (add_response, should_continue),
+    ],
+    name="chat",
+    shared=["messages"],
+    entrypoint="add_user_message",
+).bind(messages=[], llm_client=my_llm, max_turns=5)
+
+# Checkpointer persists state between calls
+checkpointer = SqliteCheckpointer("chat.db")
+runner = AsyncRunner(checkpointer=checkpointer)
+
+# Turn 1
+r1 = await runner.run(chat, workflow_id="conv-1", user_input="hello")
+assert r1.paused
+print(r1["messages"][-1])  # {"role": "assistant", "content": "..."}
+
+# Turn 2 — only pass the new input, state is restored from checkpoint
+r2 = await runner.run(chat, workflow_id="conv-1", user_input="tell me more")
+assert r2.paused
+```
+
+Key differences from the stateless pattern:
+
+- **`workflow_id`** identifies the conversation — same ID resumes, different ID starts fresh
+- **`shared=["messages"]`** accumulates the message list across the cycle
+- **`entrypoint="add_user_message"`** skips `wait_for_user` on the first call (no need to pause before the user has spoken)
+- Each `.run()` only needs the new `user_input`, not all previous messages
+
+### When the Conversation Ends
+
+When `should_continue` routes to `END`, the workflow completes. Further `.run()` calls with the same `workflow_id` raise `WorkflowAlreadyCompletedError`:
+
+```python
+from hypergraph.exceptions import WorkflowAlreadyCompletedError
+
+try:
+    await runner.run(chat, workflow_id="conv-1", user_input="one more?")
+except WorkflowAlreadyCompletedError:
+    print("Conversation ended — use a new workflow_id")
+```
+
+### Inspecting Checkpoint History
+
+The checkpointer records every node execution. You can inspect the full step log:
+
+```python
+checkpointer = SqliteCheckpointer("chat.db")
+
+# Sync reads — no await needed
+run = checkpointer.get_run("conv-1")
+print(run.status)  # "active" (paused) or "completed"
+
+steps = checkpointer.steps("conv-1")
+for s in steps:
+    print(f"  ss={s.superstep}  {s.node_name:25s}  {s.status}")
+```
+
+A two-turn conversation produces steps like:
+
+```
+  ss=0   add_user_message           completed
+  ss=1   llm_reply                  completed
+  ss=2   add_response               completed
+  ss=3   should_continue            completed    → wait_for_user
+  ss=4   wait_for_user              paused
+  ss=5   wait_for_user              completed    (user_input resolved)
+  ss=6   add_user_message           completed
+  ss=7   llm_reply                  completed
+  ss=8   add_response               completed
+  ss=9   should_continue            completed    → wait_for_user
+  ss=10  wait_for_user              paused
+```
+
+Notice the interrupt appears twice per turn: first as `paused` (waiting), then as `completed` (resolved with the user's input on the next `.run()` call).
+
+> **Full example**: See [`examples/chat_app.py`](../../examples/chat_app.py) for a complete FastAPI integration with durable multi-turn chat, error handling, and checkpoint inspection endpoint.
+
 ## Auto-Resolve with Handlers
 
 For testing or automation, the handler function resolves the interrupt without human input. Return a value to auto-resolve, return `None` to pause.

--- a/docs/05-how-to/debug-workflows.md
+++ b/docs/05-how-to/debug-workflows.md
@@ -199,6 +199,25 @@ cp.lineage("my-run-1")
 
 The sync read methods (`runs()`, `run()`, `values()`, `steps()`, `search()`, `stats()`, `checkpoint()`) work without async/await, making them ideal for debugging scripts, notebooks, and the CLI. No `initialize()` call needed.
 
+#### Interrupt Steps
+
+For workflows with `@interrupt` nodes, the step log shows the pause/resume cycle. Each interrupt appears twice: first as `paused` (waiting for input), then as `completed` (resolved with the provided value):
+
+```python
+steps = cp.steps("my-chat")
+for s in steps:
+    print(f"  ss={s.superstep}  {s.node_name:20s}  {s.status}")
+
+#   ss=0   add_user_message      completed
+#   ss=1   llm_reply             completed
+#   ss=2   add_response          completed
+#   ss=3   should_continue       completed    (decision: wait_for_user)
+#   ss=4   wait_for_user         paused
+#   ss=5   wait_for_user         completed    (values: {user_input: "..."})
+```
+
+Routing decisions are stored on the step record (`s.decision`), and resolved interrupt values appear in `s.values`. See [Human-in-the-Loop](../03-patterns/07-human-in-the-loop.md#inspecting-checkpoint-history) for the full pattern.
+
 For branching semantics, use explicit checkpoints:
 `checkpoint = cp.checkpoint("workflow-id", superstep=...)` and pass it to
 `runner.run(..., checkpoint=checkpoint, workflow_id="new-id")`.

--- a/examples/chat_app.py
+++ b/examples/chat_app.py
@@ -1,0 +1,141 @@
+"""Minimal durable chat app with FastAPI + Hypergraph.
+
+Run:
+    uv run uvicorn examples.chat_app:app --reload
+
+Test:
+    # Start a chat with first message
+    curl -X POST localhost:8000/chats/my-chat/reply -H 'Content-Type: application/json' -d '{"text":"hello"}'
+
+    # Continue the conversation
+    curl -X POST localhost:8000/chats/my-chat/reply -H 'Content-Type: application/json' -d '{"text":"tell me more"}'
+
+    # Inspect checkpoint history (every node execution, with values)
+    curl localhost:8000/chats/my-chat/history
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from hypergraph import END, AsyncRunner, Graph, interrupt, node, route
+from hypergraph.checkpointers import SqliteCheckpointer
+from hypergraph.exceptions import WorkflowAlreadyCompletedError
+
+# --- Fake LLM (replace with real client) ---
+
+
+class FakeLLM:
+    async def chat(self, messages: list) -> str:
+        last_user = next(
+            (m["content"] for m in reversed(messages) if m["role"] == "user"),
+            "nothing",
+        )
+        return f"You said: {last_user}. What else?"
+
+
+# --- Graph ---
+
+
+@interrupt(output_name="user_input")
+def wait_for_user() -> None:
+    return None
+
+
+@node(output_name="messages")
+def add_user_message(messages: list, user_input: str) -> list:
+    return [*messages, {"role": "user", "content": user_input}]
+
+
+@node(output_name="assistant_text")
+async def llm_reply(messages: list, llm_client) -> str:
+    return await llm_client.chat(messages)
+
+
+@node(output_name="messages")
+def add_assistant_message(messages: list, assistant_text: str) -> list:
+    return [*messages, {"role": "assistant", "content": assistant_text}]
+
+
+@route(targets=["wait_for_user", END])
+def should_continue(messages: list, max_turns: int) -> str:
+    turns = sum(1 for m in messages if m["role"] == "assistant")
+    return END if turns >= max_turns else "wait_for_user"
+
+
+chat_graph = Graph(
+    [wait_for_user, add_user_message, llm_reply, add_assistant_message, should_continue],
+    edges=[
+        (add_user_message, llm_reply),
+        (llm_reply, add_assistant_message),
+        (add_assistant_message, should_continue),
+    ],
+    name="chat",
+    shared=["messages"],
+    entrypoint="add_user_message",
+)
+
+chat = chat_graph.bind(messages=[], llm_client=FakeLLM(), max_turns=5)
+
+
+# --- FastAPI ---
+
+
+checkpointer = SqliteCheckpointer("chat.db")
+runner = AsyncRunner(checkpointer=checkpointer)
+app = FastAPI()
+
+
+class UserMessage(BaseModel):
+    text: str
+
+
+@app.post("/chats/{chat_id}/reply")
+async def user_reply(chat_id: str, body: UserMessage):
+    try:
+        result = await runner.run(chat, workflow_id=chat_id, user_input=body.text)
+    except WorkflowAlreadyCompletedError:
+        return JSONResponse(
+            status_code=410,
+            content={"error": f"Chat '{chat_id}' has ended. Start a new chat with a different ID."},
+        )
+    messages = result["messages"]
+    return {
+        "assistant": messages[-1]["content"],
+        "turn": sum(1 for m in messages if m["role"] == "assistant"),
+        "done": not result.paused,
+    }
+
+
+@app.get("/chats/{chat_id}/history")
+async def chat_history(chat_id: str):
+    run = checkpointer.get_run(chat_id)
+    if not run:
+        return JSONResponse(status_code=404, content={"error": f"Chat '{chat_id}' not found."})
+    steps = checkpointer.steps(chat_id)
+
+    # Extract the conversation from the last messages-producing step
+    messages = []
+    for s in reversed(steps):
+        if s.values and "messages" in s.values:
+            messages = s.values["messages"]
+            break
+
+    # Compact step log: skip redundant message values
+    step_log = []
+    for s in steps:
+        entry = {"superstep": s.superstep, "node": s.node_name, "status": s.status}
+        if s.decision:
+            entry["decision"] = s.decision
+        if s.values and "messages" not in s.values:
+            entry["values"] = s.values
+        step_log.append(entry)
+
+    return {
+        "chat_id": run.id,
+        "status": run.status,
+        "messages": messages,
+        "steps": step_log,
+    }

--- a/examples/generate_playground.py
+++ b/examples/generate_playground.py
@@ -479,7 +479,6 @@ result = await runner.run(outer, {{"x": [5, 10, 15]}}, workflow_id="uc4-multi")
 
     nested_cli = run_cli(["runs", "values", "uc4-multi", "--values", "--db", db_path])
 
-    await cp.close()
     return UseCase(
         id="uc4",
         label="UC4",
@@ -549,7 +548,6 @@ results = runner_sync.map(graph, {{"x": [5, 10, 15]}}, map_over="x")
   {chr(10).join(f"  {w.id}: {w.status.value}" for w in wfs)}"""
 
     nested_cli = run_cli(["runs", "show", "uc4-multi", "--db", db_path])
-    await cp.close()
 
     return UseCase(
         id="uc5",
@@ -575,7 +573,6 @@ async def run_uc6(db_path: str) -> UseCase:
     runner = AsyncRunner(checkpointer=cp)
     graph = Graph([succeed_a, fail_b])
     await runner.run(graph, {"x": 1}, workflow_id="uc6-failed", error_handling="continue")
-    await cp.close()
 
     cp2 = SqliteCheckpointer(db_path)
     all_wfs = cp2.runs()
@@ -639,7 +636,6 @@ results = runner_sync.map(
   {chr(10).join(f"  {w.id}: {w.status.value}" for w in cp2.runs(status=WorkflowStatus.COMPLETED))}"""
 
     nested_cli = run_cli(["runs", "ls", "--status", "completed", "--db", db_path])
-    await cp2.close()
 
     return UseCase(
         id="uc6",
@@ -741,7 +737,6 @@ async def run_uc8(db_path: str) -> UseCase:
     await runner.run(graph, {"x": 5}, workflow_id="uc8-live")
 
     state = cp.values("uc8-live")
-    await cp.close()
 
     single = f"""\
 # durability="sync" — data visible immediately for live queries
@@ -784,7 +779,6 @@ results = runner_sync.map(graph, {{"x": [5, 10]}}, map_over="x")
     outer = Graph([inner.as_node().map_over("x")])
     await runner3.run(outer, {"x": [5, 10]}, workflow_id="uc8-multi")
     state_m = cp3.values("uc8-multi")
-    await cp3.close()
 
     nested = f"""\
 # map_over with durability="sync" — each step visible immediately
@@ -822,7 +816,6 @@ async def run_uc9(db_path: str) -> UseCase:
     await runner.run(graph, {"x": 5}, workflow_id="uc9-fork")
 
     checkpoint = cp.checkpoint("uc9-fork")
-    await cp.close()
 
     single = f"""\
 # checkpoint() returns state + steps — a snapshot for forking
@@ -862,7 +855,6 @@ results = runner_sync.map(graph, {{"x": [5, 10]}}, map_over="x")
     outer = Graph([inner.as_node().map_over("x")])
     await runner2.run(outer, {"x": [5, 10]}, workflow_id="uc9-multi")
     checkpoint_m = cp2.checkpoint("uc9-multi")
-    await cp2.close()
 
     nested = f"""\
 # checkpoint() works for mapped runs too

--- a/examples/tracing_demo.py
+++ b/examples/tracing_demo.py
@@ -131,8 +131,6 @@ async def demo_2_checkpointer(db_path: str) -> None:
     print(f"  values: {checkpoint.values}")
     print(f"  steps: {len(checkpoint.steps)}")
 
-    await cp.close()
-
 
 async def demo_3_error_tracing(db_path: str) -> None:
     """Use case 3: Error tracing — failed nodes get tracked."""
@@ -167,8 +165,6 @@ async def demo_3_error_tracing(db_path: str) -> None:
             status_line += f" → {s.values}"
         print(status_line)
 
-    await cp.close()
-
 
 async def demo_4_cyclic_workflow(db_path: str) -> None:
     """Use case 4: Cyclic workflow — re-executions tracked per superstep."""
@@ -196,8 +192,6 @@ async def demo_4_cyclic_workflow(db_path: str) -> None:
     for s in steps:
         decision = f", decision={s.decision}" if s.decision else ""
         print(f"  [superstep {s.superstep}] {s.node_name}: {s.values}{decision}")
-
-    await cp.close()
 
 
 async def demo_5_cli(db_path: str) -> None:

--- a/src/hypergraph/checkpointers/sqlite.py
+++ b/src/hypergraph/checkpointers/sqlite.py
@@ -114,7 +114,7 @@ class SqliteCheckpointer(Checkpointer):
         self._serializer = serializer or JsonSerializer()
         self._db: Any = None
         self._sync_conn: Any = None
-        self._init_lock = asyncio.Lock()
+        self._init_lock: asyncio.Lock | None = None
         self._aiosqlite = _require_aiosqlite()
 
     def _db_stats(self) -> dict[str, Any]:
@@ -231,6 +231,8 @@ class SqliteCheckpointer(Checkpointer):
         """Lazy-initialize on first use."""
         if self._db is not None:
             return
+        if self._init_lock is None:
+            self._init_lock = asyncio.Lock()
         async with self._init_lock:
             if self._db is None:
                 await self.initialize()

--- a/src/hypergraph/checkpointers/sqlite.py
+++ b/src/hypergraph/checkpointers/sqlite.py
@@ -226,6 +226,7 @@ class SqliteCheckpointer(Checkpointer):
         if self._db is not None:
             await self._db.close()
             self._db = None
+        self._init_lock = None
 
     async def _ensure_db(self) -> None:
         """Lazy-initialize on first use."""

--- a/src/hypergraph/runners/_shared/AGENTS.md
+++ b/src/hypergraph/runners/_shared/AGENTS.md
@@ -1,0 +1,61 @@
+# Runners Shared — Agent Guide
+
+The scheduling and state engine. Read this before modifying `helpers.py`, `types.py`, or `template_*.py`.
+
+## Node Readiness (`get_ready_nodes`)
+
+A node is ready when ALL of these pass (checked in order):
+
+1. **Gate activation** — `_get_activated_nodes`: node has no controlling gate, OR a gate has routed to it
+2. **Startup predecessors** — `_startup_predecessors_satisfied`: all DATA+ORDERING predecessors have executed (CONTROL edges excluded — gate activation is handled separately)
+3. **Inputs available** — `_has_all_inputs`: all input params exist in state, bound values, or defaults
+4. **Wait-for satisfied** — `_wait_for_satisfied`: ordering-only deps exist and are fresh
+5. **Needs execution** — `_needs_execution`: never executed, OR inputs changed (stale), OR a routing decision targets this node
+
+After collecting ready nodes, two filters apply:
+- **Gate blocking**: if a gate is ready, its targets are blocked this superstep (gate fires first)
+- **Wait-for deferral**: on first execution, consumers are deferred if their wait-for producers are also ready
+
+## Gate Activation Rules
+
+`_get_activated_nodes` decides which gated nodes can be scheduled:
+
+| Gate state | Node state | `default_open` | Entrypoints set | Result |
+|-----------|-----------|----------------|-----------------|--------|
+| Never executed | Never executed | True | No | **Activated** (first-pass startup) |
+| Never executed | Never executed | True | Yes, node IS entrypoint | **Activated** |
+| Never executed | Never executed | True | Yes, node NOT entrypoint | **Blocked** (wait for gate) |
+| Never executed | Never executed | False | Any | **Blocked** |
+| Executed, decision=this node | Any | Any | Any | **Activated** |
+| Executed, decision=other | Any | Any | Any | **Blocked** |
+| Executed, decision cleared (stale) | Any | Any | Any | **Blocked** |
+
+**Key insight**: the entrypoint restriction prevents inputless gate targets (like interrupt nodes) from firing before the gate on first pass.
+
+## Staleness (`_is_stale`)
+
+A previously-executed node is stale if any input version changed since last execution.
+
+Two optimization rules skip staleness for non-gated nodes:
+1. **Sole Producer Rule** — skip if this node itself produces the param (prevents self-loop re-trigger)
+2. **Descendant Producer Rule** (DAGs only) — skip if ALL producers are descendants (prevents downstream writes from triggering upstream re-execution)
+
+Both rules are **disabled for gate-controlled nodes** — gates explicitly drive cycle re-execution.
+
+**Routing as re-trigger**: `_has_pending_activation` checks if a routing decision targets this node. This is essential for inputless gate targets that would otherwise never be stale.
+
+## Interrupt Lifecycle
+
+InterruptNode execution has three paths:
+
+1. **Resume path** (`is_resuming=True` + all outputs in `provided_values`): auto-resolve from provided values, pop consumed keys
+2. **Handler path** (function returns non-None): normalize response to output dict
+3. **Pause path** (function returns None): raise `PauseExecution` with `PauseInfo`
+
+The `is_resuming` flag prevents false auto-resolve on fresh runs when provided_values happen to match interrupt output names.
+
+## Common Pitfalls
+
+- **Shared params + cycles**: a node that both consumes and produces `messages` triggers the Sole Producer Rule. Split into separate consume/produce nodes if the node is NOT gate-controlled.
+- **Inputless gate targets**: without `_has_pending_activation`, they never re-fire after first execution because `_is_stale` iterates over zero inputs.
+- **Control edges vs ordering edges**: control edges are excluded from `startup_predecessors`. If you need ordering, use `wait_for` or data edges. Gates handle control flow separately.

--- a/src/hypergraph/runners/_shared/CLAUDE.md
+++ b/src/hypergraph/runners/_shared/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/hypergraph/runners/_shared/helpers.py
+++ b/src/hypergraph/runners/_shared/helpers.py
@@ -287,6 +287,14 @@ def _get_activated_nodes(graph: Graph, state: GraphState) -> set[str]:
                             # it must wait for the gate's actual routing decision
                             # before re-firing (prevents mid-pipeline re-trigger
                             # when shared params cause staleness).
+                            #
+                            # Exception: when entrypoints are configured, non-entrypoint
+                            # gate targets must wait for the gate to actually route to
+                            # them.  Without this, an inputless gate target (e.g. an
+                            # interrupt node) would fire before the gate on the first pass.
+                            entrypoints = graph.entrypoints_config
+                            if entrypoints and node_name not in entrypoints:
+                                continue
                             activated.add(node_name)
                             break
                         continue
@@ -482,9 +490,24 @@ def _needs_execution(node: HyperNode, graph: Graph, state: GraphState) -> bool:
     if node.name not in state.node_executions:
         return True  # Never executed
 
+    # A pending routing decision targeting this node is an explicit re-trigger.
+    # Without this, inputless gate targets (e.g. interrupt nodes) would never
+    # be considered stale and would not re-execute on subsequent cycles.
+    if _has_pending_activation(node, graph, state):
+        return True
+
     # Check if any input has changed since last execution
     last_exec = state.node_executions[node.name]
     return _is_stale(node, graph, state, last_exec)
+
+
+def _has_pending_activation(node: HyperNode, graph: Graph, state: GraphState) -> bool:
+    """Check if a gate routing decision is actively targeting this node."""
+    for gate_name in graph.controlled_by.get(node.name, []):
+        decision = state.routing_decisions.get(gate_name)
+        if decision is not None and _is_node_activated_by_decision(node.name, decision):
+            return True
+    return False
 
 
 def _is_stale(

--- a/src/hypergraph/runners/async_/executors/interrupt_node.py
+++ b/src/hypergraph/runners/async_/executors/interrupt_node.py
@@ -23,6 +23,7 @@ class AsyncInterruptNodeExecutor:
         inputs: dict[str, Any],
         *,
         provided_values: dict[str, Any] | None = None,
+        is_resuming: bool = False,
     ) -> dict[str, Any]:
         data_outputs = node.data_outputs
 
@@ -35,17 +36,20 @@ class AsyncInterruptNodeExecutor:
                 )
             input_values[name] = inputs[name]
 
-        # Resume path: all data outputs were provided by the caller THIS run.
-        # We check provided_values (what the user passed to runner.run()),
-        # not state.values, to distinguish fresh resume values from stale
-        # values left over from a previous cycle iteration in checkpointed state.
-        # After consuming, we remove the keys so a second cycle iteration
-        # through this node will correctly invoke the handler and pause.
-        pv = provided_values or {}
-        all_outputs_provided = all(o in pv for o in data_outputs)
-        if all_outputs_provided:
-            result = {o: pv.pop(o) for o in data_outputs}
-            return _add_emit_sentinels(result, node)
+        # Resume path: only auto-resolve when the runner is actually resuming
+        # a paused workflow AND all data outputs are in provided_values.
+        # Without the is_resuming guard, output names that happen to match
+        # regular graph inputs (e.g. user_input used by both add_user_message
+        # and the interrupt) would cause the interrupt to skip its handler
+        # on a fresh run instead of pausing.
+        # After consuming, we pop the keys so a second cycle iteration
+        # through this node correctly invokes the handler and pauses.
+        if is_resuming:
+            pv = provided_values or {}
+            all_outputs_provided = all(o in pv for o in data_outputs)
+            if all_outputs_provided:
+                result = {o: pv.pop(o) for o in data_outputs}
+                return _add_emit_sentinels(result, node)
 
         # Handler path: invoke the function
         try:

--- a/src/hypergraph/runners/async_/runner.py
+++ b/src/hypergraph/runners/async_/runner.py
@@ -206,7 +206,15 @@ class AsyncRunner(AsyncRunnerTemplate):
                         state,
                         ready_nodes,
                         values,
-                        self._make_execute_node(event_processors, workflow_id=workflow_id),
+                        self._make_execute_node(
+                            event_processors,
+                            workflow_id=workflow_id,
+                            is_resuming=(
+                                checkpoint is not None
+                                if self._checkpointer_instance is not None
+                                else True  # stateless mode: preserve old auto-resolve
+                            ),
+                        ),
                         max_concurrency,
                         cache=self._cache,
                         dispatcher=dispatcher,
@@ -347,6 +355,7 @@ class AsyncRunner(AsyncRunnerTemplate):
         self,
         event_processors: list[EventProcessor] | None,
         workflow_id: str | None = None,
+        is_resuming: bool = False,
     ) -> AsyncNodeExecutor:
         """Create an async node executor closure that carries event context.
 
@@ -359,6 +368,7 @@ class AsyncRunner(AsyncRunnerTemplate):
         """
         current_span_id: list[str | None] = [None]
         provided_values_holder: list[dict[str, Any]] = [{}]
+        is_resuming_holder: list[bool] = [is_resuming]
 
         async def execute_node(
             node: HyperNode,
@@ -384,14 +394,15 @@ class AsyncRunner(AsyncRunnerTemplate):
                 )
                 return result
 
-            # For InterruptNodeExecutor, pass provided_values so it can
-            # distinguish fresh resume values from stale cycle values.
+            # For InterruptNodeExecutor, pass provided_values and resuming
+            # context so it only auto-resolves on actual resume, not fresh runs.
             if isinstance(executor, AsyncInterruptNodeExecutor):
                 return await executor(
                     node,
                     state,
                     inputs,
                     provided_values=provided_values_holder[0],
+                    is_resuming=is_resuming_holder[0],
                 )
 
             return await executor(node, state, inputs)
@@ -404,9 +415,10 @@ class AsyncRunner(AsyncRunnerTemplate):
             return ()
 
         # Expose holders so superstep can set parent span, provided_values,
-        # and read nested logs
+        # resuming context, and read nested logs
         execute_node.current_span_id = current_span_id  # type: ignore[attr-defined]
         execute_node.provided_values = provided_values_holder  # type: ignore[attr-defined]
+        execute_node.is_resuming = is_resuming_holder  # type: ignore[attr-defined]
         execute_node.consume_last_inner_logs = consume_last_inner_logs  # type: ignore[attr-defined]
         return execute_node
 

--- a/tests/test_checkpointer/test_hierarchical_checkpointing.py
+++ b/tests/test_checkpointer/test_hierarchical_checkpointing.py
@@ -25,12 +25,10 @@ def triple(doubled: int) -> int:
 
 
 @pytest.fixture
-async def async_cp(tmp_path):
+def async_cp(tmp_path):
     cp = SqliteCheckpointer(str(tmp_path / "test.db"))
     cp.policy = CheckpointPolicy(durability="sync", retention="full")
-    await cp.initialize()
     yield cp
-    await cp.close()
 
 
 @pytest.fixture
@@ -56,7 +54,7 @@ class TestAsyncMapCheckpointing:
 
         await runner.map(graph, {"x": [1, 2, 3]}, map_over="x", workflow_id="batch")
 
-        runs = await async_cp.list_runs()
+        runs = async_cp.runs()
         run_ids = {r.id for r in runs}
         assert "batch" in run_ids
         assert "batch/0" in run_ids
@@ -75,7 +73,7 @@ class TestAsyncMapCheckpointing:
 
         await runner.map(graph, {"x": [10, 20]}, map_over="x", workflow_id="batch-stats")
 
-        run = await async_cp.get_run_async("batch-stats")
+        run = async_cp.get_run("batch-stats")
         assert run.status.value == "completed"
         assert run.node_count == 2
 
@@ -93,12 +91,12 @@ class TestAsyncMapCheckpointing:
 
         await runner.map(graph, {"x": [1, 2, 3]}, map_over="x", workflow_id="batch-fail", error_handling="continue")
 
-        runs = await async_cp.list_runs()
+        runs = async_cp.runs()
         child_runs = {r.id: r for r in runs if r.parent_run_id == "batch-fail"}
         assert len(child_runs) == 3
 
         # Item 1 failed
-        failed = await async_cp.get_run_async("batch-fail/1")
+        failed = async_cp.get_run("batch-fail/1")
         assert failed.status.value == "failed"
 
     async def test_top_level_only_filter(self, async_cp):
@@ -150,7 +148,7 @@ class TestNestedGraphCheckpointing:
         assert result["tripled"] == 30
 
         # Should have parent and child runs
-        runs = await async_cp.list_runs()
+        runs = async_cp.runs()
         run_map = {r.id: r for r in runs}
         assert "nested" in run_map
         assert "nested/embed" in run_map
@@ -164,7 +162,7 @@ class TestNestedGraphCheckpointing:
 
         await runner.run(outer, {"x": 5}, workflow_id="nested-step")
 
-        steps = await async_cp.get_steps("nested-step")
+        steps = async_cp.steps("nested-step")
         embed_step = next(s for s in steps if s.node_name == "embed")
         assert embed_step.child_run_id == "nested-step/embed"
 
@@ -180,7 +178,7 @@ class TestNestedGraphCheckpointing:
 
         await runner.run(outer, {"x": [1, 2]}, workflow_id="nested-map")
 
-        runs = await async_cp.list_runs()
+        runs = async_cp.runs()
         run_ids = {r.id for r in runs}
 
         # outer → embed (batch) → embed/0, embed/1
@@ -206,7 +204,7 @@ class TestNestedGraphCheckpointing:
         result = await runner.run(outer, {"x": 5}, workflow_id="deep")
         assert result["result"] == 6
 
-        runs = await async_cp.list_runs()
+        runs = async_cp.runs()
         run_ids = {r.id for r in runs}
         assert "deep" in run_ids
         assert "deep/A" in run_ids
@@ -222,7 +220,7 @@ class TestNestedGraphCheckpointing:
         assert result["tripled"] == 30
         assert result.workflow_id is not None
 
-        runs = await async_cp.list_runs()
+        runs = async_cp.runs()
         run_ids = {r.id for r in runs}
         assert result.workflow_id in run_ids
         assert f"{result.workflow_id}/embed" in run_ids
@@ -234,15 +232,15 @@ class TestNestedGraphCheckpointing:
         outer = Graph([inner.as_node(name="embed"), triple], name="outer")
 
         await runner.run(outer, {"x": 5}, workflow_id="nested-root")
-        fork_id, fork_cp = await async_cp.fork_workflow_async("nested-root", workflow_id="nested-root-fork")
+        fork_id, fork_cp = async_cp.fork_workflow("nested-root", workflow_id="nested-root-fork")
         await runner.run(outer, {"x": 10}, checkpoint=fork_cp, workflow_id=fork_id)
 
-        fork_run = await async_cp.get_run_async("nested-root-fork")
+        fork_run = async_cp.get_run("nested-root-fork")
         assert fork_run is not None
         assert fork_run.forked_from == "nested-root"
         assert fork_run.retry_of is None
 
-        child = await async_cp.get_run_async("nested-root-fork/embed")
+        child = async_cp.get_run("nested-root-fork/embed")
         assert child is not None
         assert child.parent_run_id == "nested-root-fork"
 

--- a/tests/test_checkpointer/test_lineage_semantics.py
+++ b/tests/test_checkpointer/test_lineage_semantics.py
@@ -26,11 +26,9 @@ aiosqlite = pytest.importorskip("aiosqlite")
 
 
 @pytest.fixture
-async def checkpointer(tmp_path):
+def checkpointer(tmp_path):
     cp = SqliteCheckpointer(str(tmp_path / "lineage.db"))
-    await cp.initialize()
     yield cp
-    await cp.close()
 
 
 @node(output_name="doubled")
@@ -52,7 +50,7 @@ class TestLineageSemantics:
 
         assert result.workflow_id is not None
         assert result.workflow_id.startswith("run-")
-        run = await checkpointer.get_run_async(result.workflow_id)
+        run = checkpointer.get_run(result.workflow_id)
         assert run is not None
         assert run.config is not None
         assert "graph_struct_hash" in run.config
@@ -91,7 +89,7 @@ class TestLineageSemantics:
         graph = Graph([double, triple])
 
         await runner.run(graph, {"x": 5}, workflow_id="wf-parent")
-        checkpoint = await checkpointer.get_checkpoint("wf-parent")
+        checkpoint = checkpointer.checkpoint("wf-parent")
 
         forked = await runner.run(
             graph,
@@ -108,7 +106,7 @@ class TestLineageSemantics:
 
         await runner.run(graph, {"x": 5}, workflow_id="wf-a")
         await runner.run(graph, {"x": 6}, workflow_id="wf-b")
-        checkpoint = await checkpointer.get_checkpoint("wf-a")
+        checkpoint = checkpointer.checkpoint("wf-a")
 
         with pytest.raises(WorkflowForkError):
             await runner.run(graph, checkpoint=checkpoint, workflow_id="wf-b")
@@ -123,10 +121,10 @@ class TestLineageSemantics:
             return next_count >= 2
 
         runner = AsyncRunner(checkpointer=checkpointer)
-        graph = Graph([increment, done])
+        graph = Graph([increment, done], entrypoint="increment")
         await runner.run(graph, {"count": 2}, workflow_id="wf-gate")
 
-        state = await checkpointer.get_state("wf-gate")
+        state = checkpointer.state("wf-gate")
         assert "_done" in state
         assert state["_done"] is True
 
@@ -151,7 +149,8 @@ class TestLineageSemantics:
         assert first.status == RunStatus.FAILED
 
         should_fail = False
-        resumed = await runner.run(graph, workflow_id="wf-failed", on_internal_override="ignore")
+        retry_graph = graph.with_entrypoint("maybe_fail")
+        resumed = await runner.run(retry_graph, workflow_id="wf-failed", on_internal_override="ignore")
         assert resumed.status == RunStatus.COMPLETED
         assert resumed["out"] == 50
 
@@ -183,10 +182,10 @@ class TestLineageSemantics:
         graph = Graph([double])
 
         await runner.run(graph, {"x": 5}, workflow_id="wf-root")
-        checkpoint = await checkpointer.get_checkpoint("wf-root")
+        checkpoint = checkpointer.checkpoint("wf-root")
         await runner.run(graph, {"x": 7}, checkpoint=checkpoint, workflow_id="wf-root-fork")
 
-        run = await checkpointer.get_run_async("wf-root-fork")
+        run = checkpointer.get_run("wf-root-fork")
         assert run is not None
         assert run.forked_from == "wf-root"
         assert run.fork_superstep is None
@@ -214,18 +213,19 @@ class TestLineageSemantics:
         assert failed.status == RunStatus.FAILED
 
         should_fail = False
-        retry_id_1, retry_cp_1 = await checkpointer.retry_workflow_async("wf-retry-root")
-        retried_1 = await runner.run(graph, checkpoint=retry_cp_1, workflow_id=retry_id_1, on_internal_override="ignore")
+        retry_graph = graph.with_entrypoint("maybe_fail")
+        retry_id_1, retry_cp_1 = checkpointer.retry_workflow("wf-retry-root")
+        retried_1 = await runner.run(retry_graph, checkpoint=retry_cp_1, workflow_id=retry_id_1, on_internal_override="ignore")
         assert retried_1["out"] == 10
-        run_1 = await checkpointer.get_run_async(retry_id_1)
+        run_1 = checkpointer.get_run(retry_id_1)
         assert run_1 is not None
         assert run_1.retry_of == "wf-retry-root"
         assert run_1.retry_index == 1
         assert run_1.forked_from == "wf-retry-root"
 
-        retry_id_2, retry_cp_2 = await checkpointer.retry_workflow_async("wf-retry-root")
-        await runner.run(graph, checkpoint=retry_cp_2, workflow_id=retry_id_2, on_internal_override="ignore")
-        run_2 = await checkpointer.get_run_async(retry_id_2)
+        retry_id_2, retry_cp_2 = checkpointer.retry_workflow("wf-retry-root")
+        await runner.run(retry_graph, checkpoint=retry_cp_2, workflow_id=retry_id_2, on_internal_override="ignore")
+        run_2 = checkpointer.get_run(retry_id_2)
         assert run_2 is not None
         assert run_2.retry_of == "wf-retry-root"
         assert run_2.retry_index == 2

--- a/tests/test_checkpointer/test_resume.py
+++ b/tests/test_checkpointer/test_resume.py
@@ -31,12 +31,10 @@ def triple(doubled: int) -> int:
 
 
 @pytest.fixture
-async def checkpointer(tmp_path):
-    """Async checkpointer for each test."""
+def checkpointer(tmp_path):
+    """Checkpointer for each test."""
     cp = SqliteCheckpointer(str(tmp_path / "test.db"))
-    await cp.initialize()
     yield cp
-    await cp.close()
 
 
 @pytest.fixture
@@ -66,7 +64,7 @@ class TestAsyncRunResume:
         with pytest.raises(GraphChangedError):
             await runner.run(graph_step2, workflow_id="resume-1")
 
-        checkpoint = await checkpointer.get_checkpoint("resume-1")
+        checkpoint = checkpointer.checkpoint("resume-1")
         result = await runner.run(graph_step2, checkpoint=checkpoint, workflow_id="resume-1-fork")
         assert result["tripled"] == 30
 
@@ -80,7 +78,7 @@ class TestAsyncRunResume:
         with pytest.raises(InputOverrideRequiresForkError):
             await runner.run(graph, {"x": 100}, workflow_id="override-1")
 
-        checkpoint = await checkpointer.get_checkpoint("override-1")
+        checkpoint = checkpointer.checkpoint("override-1")
         result = await runner.run(graph, {"x": 100}, checkpoint=checkpoint, workflow_id="override-1-fork")
         assert result["doubled"] == 200
         assert result["tripled"] == 600
@@ -92,7 +90,7 @@ class TestAsyncRunResume:
         graph_step2 = Graph([triple])
 
         await runner.run(graph_step1, {"x": 5}, workflow_id="valid-1")
-        checkpoint = await checkpointer.get_checkpoint("valid-1")
+        checkpoint = checkpointer.checkpoint("valid-1")
         result = await runner.run(graph_step2, checkpoint=checkpoint, workflow_id="valid-1-fork")
         assert result["tripled"] == 30
 
@@ -115,7 +113,7 @@ class TestAsyncRunResume:
         assert result.workflow_id.startswith("override-auto-fork-")
         assert result.workflow_id != "override-auto"
 
-        run = await checkpointer.get_run_async(result.workflow_id)
+        run = checkpointer.get_run(result.workflow_id)
         assert run is not None
         assert run.forked_from == "override-auto"
 
@@ -129,7 +127,7 @@ class TestAsyncRunResume:
         assert result["tripled"] == 600
         assert result.workflow_id is not None
 
-        run = await checkpointer.get_run_async(result.workflow_id)
+        run = checkpointer.get_run(result.workflow_id)
         assert run is not None
         assert run.forked_from == "fork-src"
 
@@ -153,9 +151,10 @@ class TestAsyncRunResume:
         await runner.run(graph, {"x": 5}, workflow_id="retry-src", error_handling="continue")
         should_fail = False
 
-        retried = await runner.run(graph, retry_from="retry-src", on_internal_override="ignore")
+        retry_graph = graph.with_entrypoint("flaky")
+        retried = await runner.run(retry_graph, retry_from="retry-src", on_internal_override="ignore")
         assert retried.status == RunStatus.COMPLETED
-        run = await checkpointer.get_run_async(retried.workflow_id)
+        run = checkpointer.get_run(retried.workflow_id)
         assert run is not None
         assert run.retry_of == "retry-src"
 
@@ -176,7 +175,7 @@ class TestAsyncRunResume:
             return count >= 3
 
         runner = AsyncRunner(checkpointer=checkpointer)
-        graph = Graph([increment, check_done])
+        graph = Graph([increment, check_done], entrypoint="increment")
 
         # First run: count goes 0 → 1 → 2 → 3
         await runner.run(graph, {"count": 0}, workflow_id="cycle-1")
@@ -216,7 +215,7 @@ class TestAsyncRunResume:
         result = await runner.run(graph, {"x": 5})
         assert result["tripled"] == 30
         assert result.workflow_id is not None
-        run = await checkpointer.get_run_async(result.workflow_id)
+        run = checkpointer.get_run(result.workflow_id)
         assert run is not None
 
     async def test_first_run_with_no_prior_state(self, checkpointer):
@@ -358,21 +357,19 @@ class TestAsyncMapResume:
     async def test_map_resume_reapplies_select_filter_when_restoring(self, checkpointer):
         """Restored map items should respect select filtering just like fresh runs."""
         runner = AsyncRunner(checkpointer=checkpointer)
-        graph = Graph([double, triple])
+        graph = Graph([double, triple]).select("tripled")
 
         await runner.map(
             graph,
             {"x": [2, 3]},
             map_over="x",
             workflow_id="select-batch",
-            select=["tripled"],
         )
         resumed = await runner.map(
             graph,
             {"x": [3, 2]},
             map_over="x",
             workflow_id="select-batch",
-            select=["tripled"],
         )
 
         assert [set(r.values.keys()) for r in resumed.results] == [{"tripled"}, {"tripled"}]
@@ -540,21 +537,19 @@ class TestSyncMapResume:
     def test_map_resume_reapplies_select_filter_when_restoring(self, sync_checkpointer):
         """Sync mirror: restored map items should preserve select filtering."""
         runner = SyncRunner(checkpointer=sync_checkpointer)
-        graph = Graph([double, triple])
+        graph = Graph([double, triple]).select("tripled")
 
         runner.map(
             graph,
             {"x": [2, 3]},
             map_over="x",
             workflow_id="sync-select-batch",
-            select=["tripled"],
         )
         resumed = runner.map(
             graph,
             {"x": [3, 2]},
             map_over="x",
             workflow_id="sync-select-batch",
-            select=["tripled"],
         )
 
         assert [set(r.values.keys()) for r in resumed.results] == [{"tripled"}, {"tripled"}]
@@ -579,7 +574,7 @@ class TestListRunsParentFilter:
         await runner.run(graph, {"x": 99}, workflow_id="unrelated")
 
         # Filter by parent
-        children = await checkpointer.list_runs(parent_run_id="parent-1")
+        children = checkpointer.runs(parent_run_id="parent-1")
         child_ids = {r.id for r in children}
         assert child_ids == {"parent-1/0", "parent-1/1", "parent-1/2"}
         assert "unrelated" not in child_ids
@@ -601,6 +596,6 @@ class TestCreateRunUpsert:
         await checkpointer.create_run("upsert-1", graph_name="test-v2")
 
         # Fetch from DB to verify
-        stored = await checkpointer.get_run_async("upsert-1")
+        stored = checkpointer.get_run("upsert-1")
         assert stored.created_at == original_created
         assert stored.status == WorkflowStatus.ACTIVE

--- a/tests/test_checkpointer/test_runner_integration.py
+++ b/tests/test_checkpointer/test_runner_integration.py
@@ -15,12 +15,10 @@ aiosqlite = pytest.importorskip("aiosqlite")
 
 
 @pytest.fixture
-async def checkpointer(tmp_path):
+def checkpointer(tmp_path):
     """Create a fresh SqliteCheckpointer for each test."""
     cp = SqliteCheckpointer(str(tmp_path / "test.db"))
-    await cp.initialize()
     yield cp
-    await cp.close()
 
 
 # --- Simple pipeline nodes ---
@@ -51,12 +49,12 @@ class TestRunnerCheckpointIntegration:
         assert result["tripled"] == 30
 
         # Verify run was created and completed
-        r = await checkpointer.get_run_async("wf-1")
+        r = checkpointer.get_run("wf-1")
         assert r is not None
         assert r.status == WorkflowStatus.COMPLETED
 
         # Verify steps were persisted
-        steps = await checkpointer.get_steps("wf-1")
+        steps = checkpointer.steps("wf-1")
         assert len(steps) == 2
         assert steps[0].node_name == "double"
         assert steps[0].status == StepStatus.COMPLETED
@@ -74,7 +72,7 @@ class TestRunnerCheckpointIntegration:
         assert result["tripled"] == 18
 
         # Steps should be persisted (background tasks gathered in finally block)
-        steps = await checkpointer.get_steps("wf-async")
+        steps = checkpointer.steps("wf-async")
         assert len(steps) == 2
 
     async def test_state_reconstruction(self, checkpointer):
@@ -85,7 +83,7 @@ class TestRunnerCheckpointIntegration:
 
         await runner.run(graph, {"x": 4}, workflow_id="wf-state")
 
-        state = await checkpointer.get_state("wf-state")
+        state = checkpointer.state("wf-state")
         assert state == {"doubled": 8, "tripled": 24}
 
     async def test_no_workflow_id_auto_generates_and_checkpoints(self, checkpointer):
@@ -97,7 +95,7 @@ class TestRunnerCheckpointIntegration:
         assert result["tripled"] == 6
         assert result.workflow_id is not None
 
-        run_list = await checkpointer.list_runs()
+        run_list = checkpointer.runs()
         assert len(run_list) == 1
         assert run_list[0].id == result.workflow_id
 
@@ -117,7 +115,7 @@ class TestRunnerCheckpointIntegration:
 
         await runner.run(graph, {"x": 1}, workflow_id="wf-dur")
 
-        steps = await checkpointer.get_steps("wf-dur")
+        steps = checkpointer.steps("wf-dur")
         for step in steps:
             assert step.duration_ms >= 0
 
@@ -129,7 +127,7 @@ class TestRunnerCheckpointIntegration:
 
         await runner.run(graph, {"x": 7}, workflow_id="wf-cp")
 
-        cp = await checkpointer.get_checkpoint("wf-cp")
+        cp = checkpointer.checkpoint("wf-cp")
         assert cp.values == {"doubled": 14, "tripled": 42}
         assert len(cp.steps) == 2
 
@@ -142,7 +140,7 @@ class TestRunnerCheckpointIntegration:
         await runner.run(graph, {"x": 2}, workflow_id="wf-exit")
 
         # Steps should be flushed after the run completes
-        steps = await checkpointer.get_steps("wf-exit")
+        steps = checkpointer.steps("wf-exit")
         assert len(steps) == 2
 
     async def test_failed_node_persists_step_record(self, checkpointer):
@@ -160,12 +158,12 @@ class TestRunnerCheckpointIntegration:
         assert result.status.value == "failed"
 
         # Run should be marked FAILED
-        r = await checkpointer.get_run_async("wf-fail")
+        r = checkpointer.get_run("wf-fail")
         assert r is not None
         assert r.status == WorkflowStatus.FAILED
 
         # The failed node should have a FAILED step record
-        steps = await checkpointer.get_steps("wf-fail")
+        steps = checkpointer.steps("wf-fail")
         assert len(steps) == 1
         assert steps[0].node_name == "explode"
         assert steps[0].status == StepStatus.FAILED
@@ -189,7 +187,7 @@ class TestRunnerCheckpointIntegration:
         result = await runner.run(graph, {"x": 1}, workflow_id="wf-partial", error_handling="continue")
         assert result.status.value == "failed"
 
-        steps = await checkpointer.get_steps("wf-partial")
+        steps = checkpointer.steps("wf-partial")
         statuses = {s.node_name: s.status for s in steps}
         # succeed_a should be COMPLETED, fail_b should be FAILED
         assert statuses["succeed_a"] == StepStatus.COMPLETED
@@ -210,11 +208,11 @@ class TestRunnerCheckpointIntegration:
             return count >= 3
 
         runner = AsyncRunner(checkpointer=checkpointer)
-        graph = Graph([increment, check_done])
+        graph = Graph([increment, check_done], entrypoint="increment")
 
         await runner.run(graph, {"count": 0}, workflow_id="wf-cycle")
 
-        steps = await checkpointer.get_steps("wf-cycle")
+        steps = checkpointer.steps("wf-cycle")
         # increment runs multiple times (count: 0→1, 1→2, 2→3)
         increment_steps = [s for s in steps if s.node_name == "increment"]
         assert len(increment_steps) >= 2, f"Expected ≥2 increment steps, got {len(increment_steps)}: {steps}"
@@ -230,7 +228,7 @@ class TestRunnerCheckpointIntegration:
 
         await runner.run(graph, {"x": 5}, workflow_id="wf-types")
 
-        steps = await checkpointer.get_steps("wf-types")
+        steps = checkpointer.steps("wf-types")
         for step in steps:
             assert step.node_type == "FunctionNode"
 
@@ -242,7 +240,7 @@ class TestRunnerCheckpointIntegration:
 
         await runner.run(graph, {"x": 5}, workflow_id="wf-stats")
 
-        run = await checkpointer.get_run_async("wf-stats")
+        run = checkpointer.get_run("wf-stats")
         assert run.node_count == 2
         assert run.error_count == 0
         assert run.duration_ms > 0
@@ -259,7 +257,7 @@ class TestRunnerCheckpointIntegration:
         graph = Graph([always_fails])
         await runner.run(graph, {"x": 5}, workflow_id="wf-fail", error_handling="continue")
 
-        steps = await checkpointer.get_steps("wf-fail")
+        steps = checkpointer.steps("wf-fail")
         assert len(steps) == 1
         assert steps[0].node_name == "always_fails"
         assert steps[0].status == StepStatus.FAILED

--- a/tests/test_checkpointer/test_sqlite.py
+++ b/tests/test_checkpointer/test_sqlite.py
@@ -19,12 +19,10 @@ aiosqlite = pytest.importorskip("aiosqlite")
 
 
 @pytest.fixture
-async def checkpointer(tmp_path):
+def checkpointer(tmp_path):
     """Create a fresh SqliteCheckpointer for each test."""
     cp = SqliteCheckpointer(str(tmp_path / "test.db"))
-    await cp.initialize()
     yield cp
-    await cp.close()
 
 
 def _make_step(run_id="wf-1", superstep=0, node_name="embed", index=0, **kwargs):
@@ -52,18 +50,18 @@ class TestRunLifecycle:
         assert r.status == WorkflowStatus.ACTIVE
         assert r.graph_name == "test_graph"
 
-        fetched = await checkpointer.get_run_async("wf-1")
+        fetched = checkpointer.get_run("wf-1")
         assert fetched is not None
         assert fetched.id == "wf-1"
         assert fetched.status == WorkflowStatus.ACTIVE
 
     async def test_get_nonexistent(self, checkpointer):
-        assert await checkpointer.get_run_async("nope") is None
+        assert checkpointer.get_run("nope") is None
 
     async def test_update_status(self, checkpointer):
         await checkpointer.create_run("wf-1")
         await checkpointer.update_run_status("wf-1", WorkflowStatus.COMPLETED)
-        r = await checkpointer.get_run_async("wf-1")
+        r = checkpointer.get_run("wf-1")
         assert r.status == WorkflowStatus.COMPLETED
         assert r.completed_at is not None
 
@@ -76,7 +74,7 @@ class TestRunLifecycle:
             node_count=3,
             error_count=1,
         )
-        r = await checkpointer.get_run_async("wf-1")
+        r = checkpointer.get_run("wf-1")
         assert r.duration_ms == 150.5
         assert r.node_count == 3
         assert r.error_count == 1
@@ -86,14 +84,14 @@ class TestRunLifecycle:
         await checkpointer.create_run("wf-2")
         await checkpointer.update_run_status("wf-1", WorkflowStatus.COMPLETED)
 
-        all_runs = await checkpointer.list_runs()
+        all_runs = checkpointer.runs()
         assert len(all_runs) == 2
 
-        completed = await checkpointer.list_runs(status=WorkflowStatus.COMPLETED)
+        completed = checkpointer.runs(status=WorkflowStatus.COMPLETED)
         assert len(completed) == 1
         assert completed[0].id == "wf-1"
 
-        active = await checkpointer.list_runs(status=WorkflowStatus.ACTIVE)
+        active = checkpointer.runs(status=WorkflowStatus.ACTIVE)
         assert len(active) == 1
         assert active[0].id == "wf-2"
 
@@ -110,7 +108,7 @@ class TestRunLifecycle:
         assert run.retry_of == "wf-root"
         assert run.retry_index == 2
 
-        fetched = await checkpointer.get_run_async("wf-child")
+        fetched = checkpointer.get_run("wf-child")
         assert fetched is not None
         assert fetched.forked_from == "wf-parent"
         assert fetched.fork_superstep == 3
@@ -121,12 +119,12 @@ class TestRunLifecycle:
         await checkpointer.create_run("wf-root")
         await checkpointer.save_step(_make_step(run_id="wf-root", values={"x_seed": 7}))
 
-        fork_id, fork_cp = await checkpointer.fork_workflow_async("wf-root")
+        fork_id, fork_cp = checkpointer.fork_workflow("wf-root")
         assert fork_id.startswith("wf-root-fork-")
         assert fork_cp.source_run_id == "wf-root"
         assert fork_cp.retry_of is None
 
-        retry_id, retry_cp = await checkpointer.retry_workflow_async("wf-root")
+        retry_id, retry_cp = checkpointer.retry_workflow("wf-root")
         assert retry_id == "wf-root-retry-1"
         assert retry_cp.source_run_id == "wf-root"
         assert retry_cp.retry_of == "wf-root"
@@ -139,7 +137,7 @@ class TestStepPersistence:
         await checkpointer.save_step(_make_step(index=0, node_name="embed"))
         await checkpointer.save_step(_make_step(index=1, node_name="retrieve", superstep=1, values={"docs": ["a", "b"]}))
 
-        steps = await checkpointer.get_steps("wf-1")
+        steps = checkpointer.steps("wf-1")
         assert len(steps) == 2
         assert steps[0].node_name == "embed"
         assert steps[1].node_name == "retrieve"
@@ -151,7 +149,7 @@ class TestStepPersistence:
         original_values = {"embedding": [0.1, 0.2, 0.3], "count": 42, "flag": True}
         await checkpointer.save_step(_make_step(values=original_values))
 
-        steps = await checkpointer.get_steps("wf-1")
+        steps = checkpointer.steps("wf-1")
         assert steps[0].values == original_values
 
     async def test_step_metadata_roundtrip(self, checkpointer):
@@ -166,7 +164,7 @@ class TestStepPersistence:
             )
         )
 
-        steps = await checkpointer.get_steps("wf-1")
+        steps = checkpointer.steps("wf-1")
         s = steps[0]
         assert s.duration_ms == 150.5
         assert s.cached is True
@@ -179,7 +177,7 @@ class TestStepPersistence:
         await checkpointer.create_run("wf-1")
         await checkpointer.save_step(_make_step(decision=["route_a", "route_b"]))
 
-        steps = await checkpointer.get_steps("wf-1")
+        steps = checkpointer.steps("wf-1")
         assert steps[0].decision == ["route_a", "route_b"]
 
     async def test_upsert_semantics(self, checkpointer):
@@ -188,7 +186,7 @@ class TestStepPersistence:
         await checkpointer.save_step(_make_step(values={"v": 1}))
         await checkpointer.save_step(_make_step(values={"v": 2}))
 
-        steps = await checkpointer.get_steps("wf-1")
+        steps = checkpointer.steps("wf-1")
         assert len(steps) == 1
         assert steps[0].values == {"v": 2}
 
@@ -198,7 +196,7 @@ class TestStepPersistence:
         await checkpointer.save_step(_make_step(superstep=1, node_name="b", index=1))
         await checkpointer.save_step(_make_step(superstep=2, node_name="c", index=2))
 
-        steps = await checkpointer.get_steps("wf-1", superstep=1)
+        steps = checkpointer.steps("wf-1", superstep=1)
         assert len(steps) == 2
         assert {s.node_name for s in steps} == {"a", "b"}
 
@@ -213,7 +211,7 @@ class TestStepPersistence:
         await checkpointer.save_step(_make_step(node_name="later", index=0, created_at=later, completed_at=later))
         await checkpointer.save_step(_make_step(node_name="earlier", index=0, created_at=earlier, completed_at=earlier))
 
-        async_steps = await checkpointer.get_steps("wf-1")
+        async_steps = checkpointer.steps("wf-1")
         sync_steps = checkpointer.steps("wf-1")
         assert [s.node_name for s in async_steps] == ["earlier", "later"]
         assert [s.node_name for s in sync_steps] == ["earlier", "later"]
@@ -227,7 +225,7 @@ class TestStateComputation:
         await checkpointer.save_step(_make_step(superstep=1, node_name="b", index=1, values={"y": 2}))
         await checkpointer.save_step(_make_step(superstep=2, node_name="c", index=2, values={"z": 3}))
 
-        state = await checkpointer.get_state("wf-1")
+        state = checkpointer.state("wf-1")
         assert state == {"x": 1, "y": 2, "z": 3}
 
     async def test_get_state_through_superstep(self, checkpointer):
@@ -237,7 +235,7 @@ class TestStateComputation:
         await checkpointer.save_step(_make_step(superstep=1, node_name="b", index=1, values={"y": 2}))
         await checkpointer.save_step(_make_step(superstep=2, node_name="c", index=2, values={"z": 3}))
 
-        state = await checkpointer.get_state("wf-1", superstep=1)
+        state = checkpointer.state("wf-1", superstep=1)
         assert state == {"x": 1, "y": 2}
         assert "z" not in state
 
@@ -247,12 +245,12 @@ class TestStateComputation:
         await checkpointer.save_step(_make_step(superstep=0, node_name="a", index=0, values={"x": "old"}))
         await checkpointer.save_step(_make_step(superstep=1, node_name="b", index=1, values={"x": "new"}))
 
-        state = await checkpointer.get_state("wf-1")
+        state = checkpointer.state("wf-1")
         assert state["x"] == "new"
 
     async def test_state_empty_run(self, checkpointer):
         await checkpointer.create_run("wf-1")
-        state = await checkpointer.get_state("wf-1")
+        state = checkpointer.state("wf-1")
         assert state == {}
 
     async def test_state_skips_none_values(self, checkpointer):
@@ -261,7 +259,7 @@ class TestStateComputation:
         await checkpointer.save_step(_make_step(superstep=0, node_name="a", index=0, values={"x": 1}))
         await checkpointer.save_step(_make_step(superstep=1, node_name="b", index=1, values=None))
 
-        state = await checkpointer.get_state("wf-1")
+        state = checkpointer.state("wf-1")
         assert state == {"x": 1}
 
     async def test_state_folds_in_timestamp_order_when_indices_tie(self, checkpointer):
@@ -275,7 +273,7 @@ class TestStateComputation:
         await checkpointer.save_step(_make_step(node_name="newer", index=0, values={"x": "new"}, created_at=later, completed_at=later))
         await checkpointer.save_step(_make_step(node_name="older", index=0, values={"x": "old"}, created_at=earlier, completed_at=earlier))
 
-        assert await checkpointer.get_state("wf-1") == {"x": "new"}
+        assert checkpointer.state("wf-1") == {"x": "new"}
         assert checkpointer.state("wf-1") == {"x": "new"}
 
 
@@ -285,7 +283,7 @@ class TestCheckpoint:
         await checkpointer.save_step(_make_step(superstep=0, node_name="a", index=0, values={"x": 1}))
         await checkpointer.save_step(_make_step(superstep=1, node_name="b", index=1, values={"y": 2}))
 
-        cp = await checkpointer.get_checkpoint("wf-1")
+        cp = checkpointer.checkpoint("wf-1")
         assert cp.values == {"x": 1, "y": 2}
         assert len(cp.steps) == 2
 
@@ -294,7 +292,7 @@ class TestCheckpoint:
         await checkpointer.save_step(_make_step(superstep=0, node_name="a", index=0, values={"x": 1}))
         await checkpointer.save_step(_make_step(superstep=1, node_name="b", index=1, values={"y": 2}))
 
-        cp = await checkpointer.get_checkpoint("wf-1", superstep=0)
+        cp = checkpointer.checkpoint("wf-1", superstep=0)
         assert cp.values == {"x": 1}
         assert len(cp.steps) == 1
 
@@ -305,9 +303,8 @@ class TestLazyInit:
         cp = SqliteCheckpointer(str(tmp_path / "lazy.db"))
         # No explicit initialize() call
         await cp.create_run("wf-1")
-        r = await cp.get_run_async("wf-1")
+        r = cp.get_run("wf-1")
         assert r is not None
-        await cp.close()
 
     async def test_concurrent_lazy_initialize_runs_once(self, tmp_path):
         """Concurrent first-use calls should serialize initialization."""
@@ -330,16 +327,13 @@ class TestLazyInit:
         )
 
         assert init_calls == 1
-        await cp.close()
 
     async def test_memory_db_schema_available_after_initialize(self):
         """In-memory DB initialization creates schema for async operations."""
         cp = SqliteCheckpointer(":memory:")
-        await cp.initialize()
         await cp.create_run("wf-mem")
-        run = await cp.get_run_async("wf-mem")
+        run = cp.get_run("wf-mem")
         assert run is not None
-        await cp.close()
 
 
 class TestPolicyIntegration:
@@ -381,18 +375,16 @@ class TestPolicyIntegration:
         db_path = tmp_path / "path-instance.db"
         cp = SqliteCheckpointer(db_path)
         await cp.create_run("wf-1")
-        run = await cp.get_run_async("wf-1")
+        run = cp.get_run("wf-1")
         assert run is not None
-        await cp.close()
 
     async def test_accepts_relative_path_instance(self, tmp_path, monkeypatch):
         """Constructor accepts relative pathlib.Path values."""
         monkeypatch.chdir(tmp_path)
         cp = SqliteCheckpointer(Path("relative-path.db"))
         await cp.create_run("wf-1")
-        run = await cp.get_run_async("wf-1")
+        run = cp.get_run("wf-1")
         assert run is not None
-        await cp.close()
 
 
 class TestSyncReads:
@@ -532,7 +524,7 @@ class TestSyncReads:
         await checkpointer.create_run("wf-root")
         await checkpointer.save_step(_make_step(run_id="wf-root", node_name="seed", index=0, cached=True))
 
-        retry_id, retry_cp = await checkpointer.retry_workflow_async("wf-root")
+        retry_id, retry_cp = checkpointer.retry_workflow("wf-root")
         await checkpointer.create_run(
             retry_id,
             forked_from=retry_cp.source_run_id,
@@ -561,10 +553,10 @@ class TestRetentionPolicyBehavior:
         await checkpointer.save_step(_make_step(run_id="wf-latest", superstep=0, node_name="b", index=1, values={"y": 2}))
         await checkpointer.save_step(_make_step(run_id="wf-latest", superstep=1, node_name="a", index=2, values={"x": 3}))
 
-        steps = await checkpointer.get_steps("wf-latest")
+        steps = checkpointer.steps("wf-latest")
         assert len(steps) == 2
         assert {(s.node_name, s.superstep) for s in steps} == {("a", 1), ("b", 0)}
-        assert await checkpointer.get_state("wf-latest") == {"x": 3, "y": 2}
+        assert checkpointer.state("wf-latest") == {"x": 3, "y": 2}
 
     async def test_windowed_retention_keeps_recent_supersteps(self, checkpointer):
         """windowed retention should keep only the latest N supersteps."""
@@ -574,9 +566,9 @@ class TestRetentionPolicyBehavior:
         await checkpointer.save_step(_make_step(run_id="wf-windowed", superstep=1, node_name="b", index=1, values={"y": 2}))
         await checkpointer.save_step(_make_step(run_id="wf-windowed", superstep=2, node_name="c", index=2, values={"z": 3}))
 
-        steps = await checkpointer.get_steps("wf-windowed")
+        steps = checkpointer.steps("wf-windowed")
         assert {s.superstep for s in steps} == {1, 2}
-        assert await checkpointer.get_state("wf-windowed") == {"y": 2, "z": 3}
+        assert checkpointer.state("wf-windowed") == {"y": 2, "z": 3}
 
     def test_sync_save_step_applies_retention(self, tmp_path):
         """Sync write path should apply windowed retention as well."""
@@ -621,7 +613,7 @@ class TestSearch:
         await checkpointer.create_run("wf-1")
         await checkpointer.save_step(_make_step(node_name="embed", index=0))
 
-        results = await checkpointer.search_async("embed")
+        results = checkpointer.search("embed")
         assert len(results) == 1
 
     async def test_fts_consistent_after_multiple_saves(self, checkpointer):
@@ -651,7 +643,7 @@ class TestSearch:
         await checkpointer.save_step(_make_step(node_name="embed", index=1, superstep=1, created_at=newer, completed_at=newer))
 
         sync_results = checkpointer.search("embed")
-        async_results = await checkpointer.search_async("embed")
+        async_results = checkpointer.search("embed")
         assert [r.superstep for r in sync_results][:2] == [1, 0]
         assert [r.superstep for r in async_results][:2] == [1, 0]
 

--- a/tests/test_checkpointer/test_sync_runner_checkpointing.py
+++ b/tests/test_checkpointer/test_sync_runner_checkpointing.py
@@ -211,7 +211,7 @@ class TestSyncRunnerCheckpointing:
             return count >= 3
 
         runner = SyncRunner(checkpointer=checkpointer)
-        graph = Graph([increment, check_done])
+        graph = Graph([increment, check_done], entrypoint="increment")
 
         runner.run(graph, {"count": 0}, workflow_id="wf-cycle")
 

--- a/tests/test_cli/test_runs_cli.py
+++ b/tests/test_cli/test_runs_cli.py
@@ -41,12 +41,10 @@ async def populated_db(db_path):
     """Create a DB with a completed run."""
     cp = SqliteCheckpointer(db_path)
     cp.policy = CheckpointPolicy(durability="sync", retention="full")
-    await cp.initialize()
 
     r = AsyncRunner(checkpointer=cp)
     graph = Graph([double, triple])
     await r.run(graph, {"x": 5}, workflow_id="run-test")
-    await cp.close()
 
     return db_path
 
@@ -56,14 +54,12 @@ async def lineage_db(db_path):
     """Create a DB with root + fork lineage."""
     cp = SqliteCheckpointer(db_path)
     cp.policy = CheckpointPolicy(durability="sync", retention="full")
-    await cp.initialize()
 
     r = AsyncRunner(checkpointer=cp)
     graph = Graph([double, triple])
     await r.run(graph, {"x": 5}, workflow_id="run-test")
     checkpoint = cp.checkpoint("run-test")
     await r.run(graph, {"x": 7}, checkpoint=checkpoint, workflow_id="run-test-fork")
-    await cp.close()
 
     return db_path
 
@@ -73,7 +69,6 @@ async def hierarchy_db(db_path):
     """Create DB with one parent run and two child runs."""
     cp = SqliteCheckpointer(db_path)
     cp.policy = CheckpointPolicy(durability="sync", retention="full")
-    await cp.initialize()
 
     await cp.create_run("batch-1", graph_name="g")
     await cp.update_run_status("batch-1", WorkflowStatus.COMPLETED, duration_ms=5300.0, node_count=10, error_count=0)
@@ -81,7 +76,6 @@ async def hierarchy_db(db_path):
     await cp.update_run_status("batch-1/0", WorkflowStatus.COMPLETED, duration_ms=5200.0, node_count=2, error_count=0)
     await cp.create_run("batch-1/1", graph_name="g", parent_run_id="batch-1")
     await cp.update_run_status("batch-1/1", WorkflowStatus.FAILED, duration_ms=5400.0, node_count=2, error_count=1)
-    await cp.close()
 
     return db_path
 

--- a/tests/test_gate_activation_scheduling.py
+++ b/tests/test_gate_activation_scheduling.py
@@ -204,6 +204,9 @@ class TestEntrypointAwareDefaultOpen:
         assert "step_a" in ready_names, f"Entrypoint gate target should fire on first pass. Got: {ready_names}"
 
 
+aiosqlite = pytest.importorskip("aiosqlite")
+
+
 class TestChatAppE2E:
     """End-to-end: multi-turn chat with interrupt pause/resume.
 

--- a/tests/test_gate_activation_scheduling.py
+++ b/tests/test_gate_activation_scheduling.py
@@ -1,0 +1,247 @@
+"""Tests for gate activation and scheduling rules.
+
+Covers two key behaviors:
+1. Pending routing decisions re-trigger gate-controlled nodes (even inputless ones)
+2. Entrypoint-aware default_open prevents premature firing of gate targets
+"""
+
+import pytest
+
+from hypergraph import END, AsyncRunner, Graph, interrupt, node, route
+from hypergraph.runners._shared.helpers import (
+    compute_execution_scope,
+    get_ready_nodes,
+)
+from hypergraph.runners._shared.types import GraphState, NodeExecution
+
+# --- Fixtures ---
+
+
+@interrupt(output_name="user_input")
+def wait_for_user() -> None:
+    return None
+
+
+@node(output_name="messages")
+def add_user_message(messages: list, user_input: str) -> list:
+    return [*messages, {"role": "user", "content": user_input}]
+
+
+@node(output_name="assistant_text")
+def llm_reply(messages: list) -> str:
+    last = messages[-1]["content"] if messages else "nothing"
+    return f"echo: {last}"
+
+
+@node(output_name="messages")
+def add_assistant(messages: list, assistant_text: str) -> list:
+    return [*messages, {"role": "assistant", "content": assistant_text}]
+
+
+@route(targets=["wait_for_user", END])
+def check_done(messages: list, max_turns: int) -> str:
+    turns = sum(1 for m in messages if m["role"] == "assistant")
+    return END if turns >= max_turns else "wait_for_user"
+
+
+CHAT_GRAPH = Graph(
+    [wait_for_user, add_user_message, llm_reply, add_assistant, check_done],
+    edges=[
+        (add_user_message, llm_reply),
+        (llm_reply, add_assistant),
+        (add_assistant, check_done),
+    ],
+    name="chat",
+    shared=["messages"],
+    entrypoint="add_user_message",
+)
+
+
+class TestPendingActivationRetrigger:
+    """A routing decision targeting a node is a re-execution signal.
+
+    Without this, inputless gate targets (like interrupt nodes) that already
+    executed would never be "stale" and would not re-fire on subsequent cycles.
+    """
+
+    def test_inputless_gate_target_refires_after_routing(self):
+        """After check_done routes to wait_for_user, it should become ready."""
+        scope = compute_execution_scope(CHAT_GRAPH)
+        state = GraphState()
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        state.update_value("messages", msgs)
+        state.update_value("user_input", "hi")
+        state.update_value("assistant_text", "hello")
+
+        # Simulate: all nodes have executed once
+        state.node_executions["wait_for_user"] = NodeExecution(
+            node_name="wait_for_user",
+            input_versions={},
+            outputs={"user_input": "hi"},
+            output_versions={"user_input": 1},
+        )
+        state.node_executions["add_user_message"] = NodeExecution(
+            node_name="add_user_message",
+            input_versions={"messages": 1, "user_input": 1},
+            outputs={"messages": msgs},
+            output_versions={"messages": state.get_version("messages")},
+        )
+        state.node_executions["llm_reply"] = NodeExecution(
+            node_name="llm_reply",
+            input_versions={"messages": state.get_version("messages")},
+            outputs={"assistant_text": "hello"},
+            output_versions={"assistant_text": state.get_version("assistant_text")},
+        )
+        state.node_executions["add_assistant"] = NodeExecution(
+            node_name="add_assistant",
+            input_versions={
+                "messages": state.get_version("messages"),
+                "assistant_text": state.get_version("assistant_text"),
+            },
+            outputs={"messages": msgs},
+            output_versions={"messages": state.get_version("messages")},
+        )
+        state.node_executions["check_done"] = NodeExecution(
+            node_name="check_done",
+            input_versions={
+                "messages": state.get_version("messages"),
+                "max_turns": 0,
+            },
+            outputs={},
+            output_versions={},
+        )
+
+        # check_done routes to wait_for_user
+        state.routing_decisions["check_done"] = "wait_for_user"
+
+        ready = get_ready_nodes(
+            CHAT_GRAPH,
+            state,
+            active_nodes=scope.active_nodes,
+            startup_predecessors=scope.startup_predecessors,
+        )
+        ready_names = [n.name for n in ready]
+        assert "wait_for_user" in ready_names, f"wait_for_user should be ready after routing decision. Got: {ready_names}"
+
+    def test_no_routing_decision_no_refire(self):
+        """Without a routing decision, an already-executed gate target stays idle."""
+        scope = compute_execution_scope(CHAT_GRAPH)
+        state = GraphState()
+        state.update_value("messages", [])
+        state.update_value("user_input", "hi")
+
+        # wait_for_user already executed, no routing decision
+        state.node_executions["wait_for_user"] = NodeExecution(
+            node_name="wait_for_user",
+            input_versions={},
+            outputs={"user_input": "hi"},
+            output_versions={"user_input": 1},
+        )
+
+        ready = get_ready_nodes(
+            CHAT_GRAPH,
+            state,
+            active_nodes=scope.active_nodes,
+            startup_predecessors=scope.startup_predecessors,
+        )
+        ready_names = [n.name for n in ready]
+        assert "wait_for_user" not in ready_names
+
+
+class TestEntrypointAwareDefaultOpen:
+    """With entrypoints configured, non-entrypoint gate targets should not
+    fire on first pass via default_open.
+
+    Without this fix, an inputless gate target (e.g. an interrupt) fires
+    before the entrypoint node, because default_open=True allows it through
+    and it has no data predecessors to block it.
+    """
+
+    def test_gate_target_blocked_before_gate_fires(self):
+        """wait_for_user should NOT be ready on first pass (entrypoint is add_user_message)."""
+        scope = compute_execution_scope(CHAT_GRAPH)
+        state = GraphState()
+        state.update_value("messages", [])
+        state.update_value("user_input", "hi")
+
+        ready = get_ready_nodes(
+            CHAT_GRAPH,
+            state,
+            active_nodes=scope.active_nodes,
+            startup_predecessors=scope.startup_predecessors,
+        )
+        ready_names = [n.name for n in ready]
+
+        assert "add_user_message" in ready_names, f"Entrypoint should be ready. Got: {ready_names}"
+        assert "wait_for_user" not in ready_names, f"Gate target should not fire before gate on first pass. Got: {ready_names}"
+
+    def test_entrypoint_node_that_is_gate_target_still_fires(self):
+        """A gate target that IS the entrypoint should fire on first pass."""
+
+        @node(output_name="x")
+        def step_a() -> int:
+            return 1
+
+        @route(targets=["step_a", END])
+        def gate(x: int) -> str:
+            return END
+
+        # step_a is both entrypoint and gate target
+        g = Graph([step_a, gate], entrypoint="step_a")
+        scope = compute_execution_scope(g)
+        state = GraphState()
+
+        ready = get_ready_nodes(
+            g,
+            state,
+            active_nodes=scope.active_nodes,
+            startup_predecessors=scope.startup_predecessors,
+        )
+        ready_names = [n.name for n in ready]
+        assert "step_a" in ready_names, f"Entrypoint gate target should fire on first pass. Got: {ready_names}"
+
+
+class TestChatAppE2E:
+    """End-to-end: multi-turn chat with interrupt pause/resume.
+
+    Uses a checkpointer because multi-turn requires durable state:
+    each .run() call is a separate HTTP-request-like invocation.
+    """
+
+    @pytest.mark.asyncio
+    async def test_multi_turn_pause_resume(self, tmp_path):
+        from hypergraph.checkpointers import SqliteCheckpointer
+
+        cp = SqliteCheckpointer(str(tmp_path / "chat.db"))
+        runner = AsyncRunner(checkpointer=cp)
+        graph = CHAT_GRAPH.bind(messages=[], max_turns=3)
+
+        r1 = await runner.run(graph, workflow_id="t", user_input="hello")
+        assert r1.paused
+        msgs = r1["messages"]
+        assert len(msgs) == 2  # user + assistant
+        assert msgs[0]["role"] == "user"
+        assert msgs[1]["role"] == "assistant"
+
+        r2 = await runner.run(graph, workflow_id="t", user_input="more")
+        assert r2.paused
+        assert len(r2["messages"]) == 4
+
+        r3 = await runner.run(graph, workflow_id="t", user_input="last")
+        assert not r3.paused  # max_turns=3 reached
+        assert len(r3["messages"]) == 6
+
+    @pytest.mark.asyncio
+    async def test_single_turn_terminates(self, tmp_path):
+        from hypergraph.checkpointers import SqliteCheckpointer
+
+        cp = SqliteCheckpointer(str(tmp_path / "chat.db"))
+        runner = AsyncRunner(checkpointer=cp)
+        graph = CHAT_GRAPH.bind(messages=[], max_turns=1)
+
+        r = await runner.run(graph, workflow_id="t", user_input="one shot")
+        assert not r.paused
+        assert len(r["messages"]) == 2


### PR DESCRIPTION
## Problem

Three categories of issues:

### 1. Gate Activation Scheduling Bugs
- **Inputless gate targets never re-fire**: When `@route` routes back to an inputless node (e.g. `@interrupt`), `_is_stale()` iterates zero inputs → always False → node never re-executes
- **Premature first-pass firing**: With `entrypoint` configured, `default_open=True` activates inputless gate targets before the gate fires

### 2. Interrupt Resume Logic
- **False auto-resolve on fresh runs**: `provided_values` matching interrupt output names (e.g. `user_input`) caused the interrupt to skip its handler on fresh runs instead of pausing

### 3. Checkpointer Ergonomics
- **Module-scope `asyncio.Lock` deadlock**: Lock created before event loop exists → deadlock on `asyncio.run()`
- **Async ceremony in tests/examples**: Tests and examples used `await initialize()` / `await close()` when sync methods work fine

## Changes

| Commit | Scope | What |
|--------|-------|------|
| `fix(runners)` | `helpers.py`, `interrupt_node.py`, `runner.py` | `_has_pending_activation` for gate re-trigger; entrypoint-aware `default_open`; `is_resuming` flag |
| `fix(checkpointers)` | `sqlite.py` | Lazy `asyncio.Lock` creation in `_ensure_db` |
| `test(runners)` | `test_gate_activation_scheduling.py` | 6 new tests: gate re-trigger, entrypoint blocking, chat E2E |
| `refactor(tests)` | 7 test files | Convert async checkpointer queries → sync; remove init/close |
| `refactor(examples)` | 3 example files | New `chat_app.py`; remove `await cp.close()` |
| `docs` | 6 doc files | Scheduling rules AGENTS.md, HITL pattern, debug guide |

## Before / After

**Gate scheduling:**
- Before: Multi-turn chat hangs after turn 1 (interrupt never re-fires)
- After: `_has_pending_activation` detects routing decision → node re-executes

**First-pass firing:**
- Before: `wait_for_user` fires before `add_user_message` on first pass
- After: Non-entrypoint gate targets blocked until gate routes to them

**Interrupt resume:**
- Before: Fresh run with `user_input="hello"` auto-resolves interrupt (skips pause)
- After: `is_resuming=False` on fresh runs → interrupt always pauses first

## Test Plan

- [x] `uv run pytest` — 2138 passed, 4 skipped (optional deps), 0 failures
- [x] New `test_gate_activation_scheduling.py` — 6 tests covering scheduling invariants
- [x] Codex static analysis review — APPROVED (1 round)

## Non-blocking Notes (from Codex review)

1. Stateless mode keeps `is_resuming=True` for backward compat — Bug C only fully fixed for checkpointed flows
2. `_init_lock` not reset in `close()` — minor fragility if checkpointer reused across event loops

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Minimal durable FastAPI chat app demonstrating persistent multi-turn workflows with checkpointing

* **Documentation**
  * Expanded execution/scheduling and agent runtime guidance; added interrupt/runlog and testing guidance; Human-in-the-Loop pattern expanded

* **Bug Fixes**
  * More consistent gate routing and entrypoint activation; safer interrupt pause/resume behavior

* **API Changes**
  * Checkpointer APIs converted to synchronous style; Graph supports an explicit entrypoint

* **Tests**
  * New gate-activation and multi-turn integration tests; many checkpointer tests moved to sync APIs

* **Refactor**
  * Lazy initialization of resources and removal of explicit checkpointer close calls in examples/demos
<!-- end of auto-generated comment: release notes by coderabbit.ai -->