### PR TITLE
fix(runners): support nested checkpoint resumes

### DIFF
--- a/docs/05-how-to/batch-processing.md
+++ b/docs/05-how-to/batch-processing.md
@@ -377,7 +377,6 @@ Retry is symmetrical:
 retried = await runner.run(
     Graph([double, triple]),
     retry_from="job-1",
-    on_internal_override="ignore",   # common for flaky-node recovery
 )
 ```
 

--- a/docs/06-api-reference/inputspec.md
+++ b/docs/06-api-reference/inputspec.md
@@ -354,7 +354,6 @@ Runtime scope switching (`run(..., select=...)`, `run(..., entrypoint=...)`) is 
 When multiple sources provide the same value, the runner uses: **EDGE > PROVIDED > BOUND > DEFAULT**
 
 - Internal edge-produced parameters supplied at runtime are rejected deterministically (`ValueError`).
-- `on_internal_override` is retained for compatibility, but does not allow internal edge-produced injections.
 
 ## Complete Example
 

--- a/docs/06-api-reference/runners.md
+++ b/docs/06-api-reference/runners.md
@@ -57,7 +57,6 @@ def run(
     *,
     select: str | list[str] = "**",
     on_missing: Literal["ignore", "warn", "error"] = "ignore",
-    on_internal_override: Literal["ignore", "warn", "error"] = "warn",
     max_iterations: int | None = None,
     error_handling: Literal["raise", "continue"] = "raise",
     event_processors: list[EventProcessor] | None = None,
@@ -80,7 +79,6 @@ Execute a graph once.
   - `"ignore"` (default): silently omit missing outputs
   - `"warn"`: warn about missing outputs, return what's available
   - `"error"`: raise error if any selected output is missing
-- `on_internal_override` - Reserved for compatibility. Internal produced values are rejected deterministically.
 - `max_iterations` - Max supersteps for cyclic graphs (default: 1000)
 - `error_handling` - How to handle node execution errors:
   - `"raise"` (default): Re-raise the original exception (e.g., `ValueError`). Clean traceback, no wrapper.
@@ -170,7 +168,6 @@ def map(
     clone: bool | list[str] = False,
     select: str | list[str] = "**",
     on_missing: Literal["ignore", "warn", "error"] = "ignore",
-    on_internal_override: Literal["ignore", "warn", "error"] = "warn",
     error_handling: Literal["raise", "continue"] = "raise",
     event_processors: list[EventProcessor] | None = None,
     workflow_id: str | None = None,
@@ -188,7 +185,6 @@ Execute a graph multiple times with different inputs.
 - `clone` - Deep-copy mutable values for each iteration. `True` clones all non-`map_over` values; pass a list of names to clone selectively. Prevents cross-iteration mutation.
 - `select` - Runtime select overrides are not supported. Configure output scope on the graph with `graph.select(...)` before execution.
 - `on_missing` - How to handle missing selected outputs (`"ignore"`, `"warn"`, or `"error"`)
-- `on_internal_override` - Reserved for compatibility. Internal produced values are rejected deterministically.
 - `error_handling` - How to handle failures:
   - `"raise"` (default): Stop on first failure and raise the exception
   - `"continue"`: Collect all results, including failures as `RunResult` with `status=FAILED`
@@ -296,7 +292,6 @@ async def run(
     *,
     select: str | list[str] = "**",
     on_missing: Literal["ignore", "warn", "error"] = "ignore",
-    on_internal_override: Literal["ignore", "warn", "error"] = "warn",
     entrypoint: str | None = None,
     max_iterations: int | None = None,
     max_concurrency: int | None = None,
@@ -318,7 +313,6 @@ Execute a graph asynchronously.
 - `values` - Optional input values
 - `select` - Runtime select overrides are not supported. Configure output scope on the graph with `graph.select(...)` before execution.
 - `on_missing` - How to handle missing selected outputs (`"ignore"`, `"warn"`, or `"error"`)
-- `on_internal_override` - Reserved for compatibility. Internal produced values are rejected deterministically.
 - `entrypoint` - Runtime entrypoint overrides are not supported. Configure entrypoints on the graph via `Graph(..., entrypoint=...)` or `graph.with_entrypoint(...)`.
 - `max_iterations` - Max supersteps for cyclic graphs (default: 1000)
 - `max_concurrency` - Max parallel node executions (default: unlimited)
@@ -390,7 +384,6 @@ async def map(
     clone: bool | list[str] = False,
     select: str | list[str] = "**",
     on_missing: Literal["ignore", "warn", "error"] = "ignore",
-    on_internal_override: Literal["ignore", "warn", "error"] = "warn",
     entrypoint: str | None = None,
     max_concurrency: int | None = None,
     error_handling: Literal["raise", "continue"] = "raise",
@@ -410,7 +403,6 @@ Execute graph multiple times concurrently.
 - `clone` - Deep-copy mutable values for each iteration. `True` clones all non-`map_over` values; pass a list of names to clone selectively.
 - `select` - Runtime select overrides are not supported. Configure output scope on the graph with `graph.select(...)` before execution.
 - `on_missing` - How to handle missing selected outputs (`"ignore"`, `"warn"`, or `"error"`)
-- `on_internal_override` - Reserved for compatibility. Internal produced values are rejected deterministically.
 - `entrypoint` - Runtime entrypoint overrides are not supported.
 - `max_concurrency` - Shared limit across all executions
 - `error_handling` - How to handle failures:

--- a/docs/06-api-reference/runners.md
+++ b/docs/06-api-reference/runners.md
@@ -18,6 +18,10 @@ Runners execute graphs. They handle the execution loop, node scheduling, and con
 
 Sequential execution for synchronous graphs.
 
+`SyncRunner` is not built for interrupts or HITL flows. If a graph contains
+`InterruptNode`s, `SyncRunner` raises `IncompatibleRunnerError`; use
+`AsyncRunner` instead.
+
 ```python
 from hypergraph import Graph, node, SyncRunner
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -67,7 +67,6 @@
 - **Select-aware InputSpec** — `graph.select("a").inputs.required` now shows only what's needed to produce output "a", not the full graph. Previously `select()` only filtered returned outputs.
 - **Runtime select narrowing** — `runner.run(graph, values, select="a")` validates only the inputs needed for output "a". Passing `select` at runtime recomputes InputSpec scoped to the selected outputs.
 - **`entrypoints_config` property** — `graph.entrypoints_config` returns the configured entry point node names, or `None` if all nodes are active.
-- **`on_internal_override` parameter** — `run()` and `map()` accept `on_internal_override="ignore"|"warn"|"error"` (default: `"warn"`) to control how non-conflicting internal parameter overrides are handled. Contradictory compute+inject inputs always raise `ValueError` regardless of policy.
 
 ### Changed
 

--- a/examples/slack_interrupt_auto_resume_demo.py
+++ b/examples/slack_interrupt_auto_resume_demo.py
@@ -64,7 +64,6 @@ async def run_auto_resume_cycle(
         result = await runner.run(
             graph,
             merged,
-            on_internal_override="ignore",
         )
         if not result.paused:
             return result

--- a/notebooks/checkpoint_decision_matrix.ipynb
+++ b/notebooks/checkpoint_decision_matrix.ipynb
@@ -293,7 +293,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "second = runner.run(flaky_graph, workflow_id=\"wf-failed\", on_internal_override=\"ignore\", override_workflow=True)"
+    "second = runner.run(flaky_graph, workflow_id=\"wf-failed\", override_workflow=True)"
    ]
   },
   {
@@ -438,7 +438,7 @@
    "outputs": [],
    "source": [
     "# Resume failed workflow in-place (implicit retry).\n",
-    "retry_resume = runner.run(flaky_graph, workflow_id=\"wf-failed\", on_internal_override=\"ignore\")\n",
+    "retry_resume = runner.run(flaky_graph, workflow_id=\"wf-failed\")\n",
     "print(\"resumed workflow id:\", retry_resume.workflow_id)\n",
     "print(\"resumed out:\", retry_resume[\"out\"])"
    ]

--- a/notebooks/checkpoint_decision_matrix.ipynb
+++ b/notebooks/checkpoint_decision_matrix.ipynb
@@ -293,7 +293,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "second = runner.run(flaky_graph, workflow_id=\"wf-failed\", override_workflow=True)"
+    "forked = runner.run(flaky_graph, workflow_id=\"wf-failed\", override_workflow=True)\n",
+    "print(\"forked workflow id:\", forked.workflow_id)\n",
+    "print(\"forked out:\", forked[\"out\"])"
    ]
   },
   {
@@ -303,7 +305,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\"resumed status:\", second.status.value, \"| out =\", second[\"out\"])"
+    "print(\"forked status:\", forked.status.value, \"| out =\", forked[\"out\"])"
    ]
   },
   {
@@ -313,7 +315,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "second"
+    "forked"
    ]
   },
   {
@@ -437,10 +439,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Resume failed workflow in-place (implicit retry).\n",
-    "retry_resume = runner.run(flaky_graph, workflow_id=\"wf-failed\")\n",
-    "print(\"resumed workflow id:\", retry_resume.workflow_id)\n",
-    "print(\"resumed out:\", retry_resume[\"out\"])"
+    "# Explicit retry lineage.\n",
+    "retry_resume = runner.run(flaky_graph, retry_from=\"wf-failed\")\n",
+    "retry_run = cp.get_run(retry_resume.workflow_id)\n",
+    "print(\"retry workflow id:\", retry_resume.workflow_id)\n",
+    "print(\"retry_of:\", retry_run.retry_of)\n",
+    "print(\"retry_index:\", retry_run.retry_index)\n",
+    "print(\"retry out:\", retry_resume[\"out\"])"
    ]
   },
   {

--- a/notebooks/checkpoint_lineage_walkthrough.ipynb
+++ b/notebooks/checkpoint_lineage_walkthrough.ipynb
@@ -220,7 +220,7 @@
     "\n",
     "# Same-ID resume (no new values)\n",
     "fail_switch[\"on\"] = False\n",
-    "resumed = runner.run(failed_graph, workflow_id=\"wf-failed\", on_internal_override=\"ignore\")\n",
+    "resumed = runner.run(failed_graph, workflow_id=\"wf-failed\")\n",
     "print(\"resumed id:\", resumed.workflow_id)\n",
     "print(\"resumed status:\", resumed.status.value, \"| out =\", resumed[\"out\"])"
    ]

--- a/notebooks/checkpoint_use_case_recipes.ipynb
+++ b/notebooks/checkpoint_use_case_recipes.ipynb
@@ -176,7 +176,7 @@
     "\n",
     "# Fix the transient issue, then resume same workflow_id.\n",
     "fail_switch[\"on\"] = False\n",
-    "resumed = runner.run(flaky_graph, workflow_id=\"job-failed\", on_internal_override=\"ignore\")\n",
+    "resumed = runner.run(flaky_graph, workflow_id=\"job-failed\")\n",
     "print(\"resumed id:\", resumed.workflow_id, \"out=\", resumed[\"out\"])"
    ]
   },

--- a/src/hypergraph/runners/_shared/helpers.py
+++ b/src/hypergraph/runners/_shared/helpers.py
@@ -823,11 +823,34 @@ def is_interrupt_resume_payload(
     if not values:
         return False
 
-    allowed_outputs: set[str] = set()
-    for interrupt_node in graph.interrupt_nodes:
-        allowed_outputs.update(interrupt_node.data_outputs)
+    allowed_outputs = _collect_interrupt_resume_keys(graph)
 
     return bool(allowed_outputs) and set(values).issubset(allowed_outputs)
+
+
+def _collect_interrupt_resume_keys(
+    graph: Graph,
+    *,
+    prefix: str = "",
+) -> set[str]:
+    """Collect valid interrupt resume keys for this graph scope.
+
+    Top-level interrupt outputs are exposed directly (``decision``).
+    Nested graph interrupts are exposed with dotted graph-node prefixes
+    (``inner.decision`` / ``outer.inner.decision``), matching
+    ``PauseInfo.response_key``.
+    """
+    from hypergraph.nodes.graph_node import GraphNode
+
+    allowed_outputs: set[str] = set()
+    for node in graph.iter_nodes():
+        if node.is_interrupt:
+            allowed_outputs.update(f"{prefix}{output}" for output in node.data_outputs)
+            continue
+        if isinstance(node, GraphNode):
+            nested_prefix = f"{prefix}{node.name}."
+            allowed_outputs.update(_collect_interrupt_resume_keys(node.graph, prefix=nested_prefix))
+    return allowed_outputs
 
 
 _UNSET_SELECT: Any = object()

--- a/src/hypergraph/runners/_shared/helpers.py
+++ b/src/hypergraph/runners/_shared/helpers.py
@@ -228,6 +228,54 @@ def get_ready_nodes(
     return ready
 
 
+def find_missing_resume_seed_inputs(
+    graph: Graph,
+    state: GraphState,
+    *,
+    active_nodes: set[str] | None = None,
+    startup_predecessors: dict[str, frozenset[str]] | None = None,
+) -> set[str]:
+    """Return graph inputs that block checkpoint-started execution from resuming.
+
+    This is used after restoring checkpoint state. If no nodes are ready, but an
+    activated node would become runnable once a graph-level seed input existed,
+    returning that input lets callers raise a clear error instead of silently
+    no-op completing the run.
+    """
+    activated_nodes = _get_activated_nodes(graph, state)
+    if startup_predecessors is None:
+        startup_predecessors = _compute_startup_predecessors(graph, active_nodes=active_nodes)
+
+    missing: set[str] = set()
+    graph_inputs = set(graph.inputs.all)
+
+    for node in graph._nodes.values():
+        if active_nodes is not None and node.name not in active_nodes:
+            continue
+        if node.name not in activated_nodes:
+            continue
+        if node.is_interrupt and all(output in state.values for output in node.data_outputs):
+            continue
+        if not _startup_predecessors_satisfied(
+            node,
+            graph,
+            state,
+            activated_nodes=activated_nodes,
+            startup_predecessors=startup_predecessors,
+        ):
+            continue
+        if not _wait_for_satisfied(node, state):
+            continue
+        if not _needs_execution(node, graph, state):
+            continue
+
+        for param in node.inputs:
+            if param in graph_inputs and not _has_input(param, node, graph, state):
+                missing.add(param)
+
+    return missing
+
+
 def _compute_startup_predecessors(
     graph: Graph,
     *,

--- a/src/hypergraph/runners/_shared/input_normalization.py
+++ b/src/hypergraph/runners/_shared/input_normalization.py
@@ -9,6 +9,7 @@ RUN_RESERVED_OPTION_NAMES = frozenset(
         "select",
         "max_iterations",
         "event_processors",
+        "on_internal_override",
         "_parent_span_id",
     }
 )
@@ -29,6 +30,7 @@ MAP_RESERVED_OPTION_NAMES = frozenset(
         "select",
         "error_handling",
         "event_processors",
+        "on_internal_override",
         "_parent_span_id",
     }
 )

--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -170,7 +170,6 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
         *,
         select: str | list[str] = _UNSET_SELECT,
         on_missing: Literal["ignore", "warn", "error"] = "ignore",
-        on_internal_override: Literal["ignore", "warn", "error"] = "warn",
         entrypoint: str | None = None,
         max_iterations: int | None = None,
         max_concurrency: int | None = None,
@@ -206,6 +205,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
         if _validation_ctx is None and (fork_from is not None or retry_from is not None) and checkpointer is None:
             raise ValueError("fork_from/retry_from require a checkpointer and workflow persistence to be enabled.")
         resume_checkpoint = None
+        skip_missing_input_validation = False
         if checkpointer is not None and _validation_ctx is None:
             if workflow_id is None:
                 workflow_id = generate_workflow_id()
@@ -240,6 +240,11 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                     if existing_run.status.value == "completed":
                         raise WorkflowAlreadyCompletedError(workflow_id)
                     resume_checkpoint = await checkpointer.get_checkpoint(workflow_id)
+            if resume_checkpoint is not None:
+                # Runs that start from checkpoint state (resume, fork, retry)
+                # should not re-require original graph inputs that were already
+                # consumed by upstream completed steps.
+                skip_missing_input_validation = True
 
         has_checkpointer = checkpointer is not None and workflow_id is not None
         forked_from: str | None = None
@@ -269,10 +274,10 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                 validation_values,
                 entrypoint=entrypoint,
                 selected=effective_selected,
-                on_internal_override=on_internal_override,
+                skip_missing_required=skip_missing_input_validation,
             )
         else:
-            validate_item_inputs(_validation_ctx, normalized_values, on_internal_override=on_internal_override)
+            validate_item_inputs(_validation_ctx, normalized_values)
 
         max_iter = max_iterations or self.default_max_iterations
         collector = RunLogCollector()
@@ -436,7 +441,6 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
         clone: bool | list[str] = False,
         select: str | list[str] = _UNSET_SELECT,
         on_missing: Literal["ignore", "warn", "error"] = "ignore",
-        on_internal_override: Literal["ignore", "warn", "error"] = "warn",
         entrypoint: str | None = None,
         max_concurrency: int | None = None,
         error_handling: ErrorHandling = "raise",
@@ -540,7 +544,6 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                     variation_inputs,
                     select=select,
                     on_missing=on_missing,
-                    on_internal_override=on_internal_override,
                     entrypoint=entrypoint,
                     max_concurrency=max_concurrency,
                     error_handling="continue",

--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -14,6 +14,7 @@ from hypergraph.exceptions import (
     ExecutionError,
     GraphChangedError,
     InputOverrideRequiresForkError,
+    MissingInputError,
     WorkflowAlreadyCompletedError,
     WorkflowForkError,
 )
@@ -22,9 +23,13 @@ from hypergraph.runners._shared.helpers import (
     _validate_error_handling,
     _validate_on_missing,
     _validate_workflow_id,
+    compute_execution_scope,
     filter_outputs,
+    find_missing_resume_seed_inputs,
     generate_map_inputs,
     generate_workflow_id,
+    get_ready_nodes,
+    initialize_state,
     is_interrupt_resume_payload,
 )
 from hypergraph.runners._shared.input_normalization import (
@@ -278,6 +283,35 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
             )
         else:
             validate_item_inputs(_validation_ctx, normalized_values)
+
+        if resume_checkpoint is not None and skip_missing_input_validation:
+            resume_state = initialize_state(graph, normalized_values, checkpoint=resume_checkpoint)
+            scope = compute_execution_scope(graph)
+            ready_nodes = get_ready_nodes(
+                graph,
+                resume_state,
+                active_nodes=scope.active_nodes,
+                startup_predecessors=scope.startup_predecessors,
+            )
+            if not ready_nodes:
+                missing_seed_inputs = sorted(
+                    find_missing_resume_seed_inputs(
+                        graph,
+                        resume_state,
+                        active_nodes=scope.active_nodes,
+                        startup_predecessors=scope.startup_predecessors,
+                    )
+                )
+                if missing_seed_inputs:
+                    raise MissingInputError(
+                        missing=missing_seed_inputs,
+                        provided=sorted(normalized_values),
+                        message=(
+                            "Checkpoint resume is missing required seed inputs: "
+                            + ", ".join(repr(name) for name in missing_seed_inputs)
+                            + ". The restored checkpoint state does not make any pending nodes runnable."
+                        ),
+                    )
 
         max_iter = max_iterations or self.default_max_iterations
         collector = RunLogCollector()

--- a/src/hypergraph/runners/_shared/template_sync.py
+++ b/src/hypergraph/runners/_shared/template_sync.py
@@ -13,6 +13,7 @@ from hypergraph.exceptions import (
     ExecutionError,
     GraphChangedError,
     InputOverrideRequiresForkError,
+    MissingInputError,
     WorkflowAlreadyCompletedError,
     WorkflowForkError,
 )
@@ -21,9 +22,13 @@ from hypergraph.runners._shared.helpers import (
     _validate_error_handling,
     _validate_on_missing,
     _validate_workflow_id,
+    compute_execution_scope,
     filter_outputs,
+    find_missing_resume_seed_inputs,
     generate_map_inputs,
     generate_workflow_id,
+    get_ready_nodes,
+    initialize_state,
     is_interrupt_resume_payload,
 )
 from hypergraph.runners._shared.input_normalization import (
@@ -271,6 +276,35 @@ class SyncRunnerTemplate(BaseRunner, ABC):
             )
         else:
             validate_item_inputs(_validation_ctx, normalized_values)
+
+        if resume_checkpoint is not None and skip_missing_input_validation:
+            resume_state = initialize_state(graph, normalized_values, checkpoint=resume_checkpoint)
+            scope = compute_execution_scope(graph)
+            ready_nodes = get_ready_nodes(
+                graph,
+                resume_state,
+                active_nodes=scope.active_nodes,
+                startup_predecessors=scope.startup_predecessors,
+            )
+            if not ready_nodes:
+                missing_seed_inputs = sorted(
+                    find_missing_resume_seed_inputs(
+                        graph,
+                        resume_state,
+                        active_nodes=scope.active_nodes,
+                        startup_predecessors=scope.startup_predecessors,
+                    )
+                )
+                if missing_seed_inputs:
+                    raise MissingInputError(
+                        missing=missing_seed_inputs,
+                        provided=sorted(normalized_values),
+                        message=(
+                            "Checkpoint resume is missing required seed inputs: "
+                            + ", ".join(repr(name) for name in missing_seed_inputs)
+                            + ". The restored checkpoint state does not make any pending nodes runnable."
+                        ),
+                    )
 
         max_iter = max_iterations or self.default_max_iterations
         collector = RunLogCollector()

--- a/src/hypergraph/runners/_shared/template_sync.py
+++ b/src/hypergraph/runners/_shared/template_sync.py
@@ -165,7 +165,6 @@ class SyncRunnerTemplate(BaseRunner, ABC):
         *,
         select: str | list[str] = _UNSET_SELECT,
         on_missing: Literal["ignore", "warn", "error"] = "ignore",
-        on_internal_override: Literal["ignore", "warn", "error"] = "warn",
         entrypoint: str | None = None,
         max_iterations: int | None = None,
         error_handling: ErrorHandling = "raise",
@@ -202,6 +201,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
         if _validation_ctx is None and (fork_from is not None or retry_from is not None) and sync_cp is None:
             raise ValueError("fork_from/retry_from require a checkpointer and workflow persistence to be enabled.")
         resume_checkpoint = None
+        skip_missing_input_validation = False
         if sync_cp is not None and _validation_ctx is None:
             if fork_from is not None and retry_from is not None:
                 raise ValueError("Cannot pass both fork_from and retry_from. Choose one lineage source.")
@@ -234,6 +234,11 @@ class SyncRunnerTemplate(BaseRunner, ABC):
                     if existing_run.status.value == "completed":
                         raise WorkflowAlreadyCompletedError(workflow_id)
                     resume_checkpoint = sync_cp.checkpoint(workflow_id)
+            if resume_checkpoint is not None:
+                # Runs that start from checkpoint state (resume, fork, retry)
+                # should not re-require original graph inputs that were already
+                # consumed by upstream completed steps.
+                skip_missing_input_validation = True
 
         forked_from: str | None = None
         fork_superstep: int | None = None
@@ -262,10 +267,10 @@ class SyncRunnerTemplate(BaseRunner, ABC):
                 validation_values,
                 entrypoint=entrypoint,
                 selected=effective_selected,
-                on_internal_override=on_internal_override,
+                skip_missing_required=skip_missing_input_validation,
             )
         else:
-            validate_item_inputs(_validation_ctx, normalized_values, on_internal_override=on_internal_override)
+            validate_item_inputs(_validation_ctx, normalized_values)
 
         max_iter = max_iterations or self.default_max_iterations
         collector = RunLogCollector()
@@ -383,7 +388,6 @@ class SyncRunnerTemplate(BaseRunner, ABC):
         clone: bool | list[str] = False,
         select: str | list[str] = _UNSET_SELECT,
         on_missing: Literal["ignore", "warn", "error"] = "ignore",
-        on_internal_override: Literal["ignore", "warn", "error"] = "warn",
         entrypoint: str | None = None,
         error_handling: ErrorHandling = "raise",
         event_processors: list[EventProcessor] | None = None,
@@ -480,7 +484,6 @@ class SyncRunnerTemplate(BaseRunner, ABC):
                     variation_inputs,
                     select=select,
                     on_missing=on_missing,
-                    on_internal_override=on_internal_override,
                     entrypoint=entrypoint,
                     error_handling="continue",
                     event_processors=event_processors,

--- a/src/hypergraph/runners/_shared/validation.py
+++ b/src/hypergraph/runners/_shared/validation.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from difflib import get_close_matches
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any
 
 from hypergraph.exceptions import IncompatibleRunnerError, MissingInputError
 from hypergraph.runners._shared.types import RunnerCapabilities
@@ -13,8 +13,6 @@ if TYPE_CHECKING:
     from hypergraph.graph import Graph
     from hypergraph.graph.input_spec import InputSpec
     from hypergraph.nodes.base import HyperNode
-
-_VALID_ON_INTERNAL_OVERRIDE = ("ignore", "warn", "error")
 
 
 @dataclass(frozen=True, slots=True)
@@ -74,7 +72,7 @@ def validate_item_inputs(
     ctx: _InputValidationContext,
     values: dict[str, Any],
     *,
-    on_internal_override: Literal["ignore", "warn", "error"] = "warn",
+    skip_missing_required: bool = False,
 ) -> None:
     """Per-item value validation using pre-computed context.
 
@@ -82,7 +80,6 @@ def validate_item_inputs(
     graph context.  Handles bound/provided merge, internal override
     detection, bypass detection, cycle entry, and completeness checks.
     """
-    _validate_on_internal_override(on_internal_override)
     inputs_spec = ctx.input_spec
 
     # Step 1: Merge bound + provided
@@ -117,9 +114,7 @@ def validate_item_inputs(
         )
 
     if unknown:
-        _handle_internal_override_policy(
-            on_internal_override=on_internal_override,
-            internal_edge=set(),
+        _warn_on_unrecognized_inputs(
             unknown=unknown,
             expected_inputs=expected_inputs,
             active_nodes=ctx.active_nodes,
@@ -129,7 +124,7 @@ def validate_item_inputs(
     required = set(inputs_spec.required)
     missing_required = required - provided
 
-    if not missing_required:
+    if skip_missing_required or not missing_required:
         return
 
     all_inputs = set(inputs_spec.all)
@@ -154,7 +149,7 @@ def validate_inputs(
     *,
     entrypoint: str | None = None,
     selected: tuple[str, ...] | None = None,
-    on_internal_override: Literal["ignore", "warn", "error"] = "warn",
+    skip_missing_required: bool = False,
 ) -> None:
     """Validate that all required inputs are provided.
 
@@ -163,7 +158,11 @@ def validate_inputs(
     ``precompute_input_validation`` + ``validate_item_inputs`` directly.
     """
     ctx = precompute_input_validation(graph, entrypoint=entrypoint, selected=selected)
-    validate_item_inputs(ctx, values, on_internal_override=on_internal_override)
+    validate_item_inputs(
+        ctx,
+        values,
+        skip_missing_required=skip_missing_required,
+    )
 
 
 def _get_suggestions(
@@ -282,13 +281,6 @@ def validate_map_compatible(graph: Graph) -> None:
         )
 
 
-def _validate_on_internal_override(policy: str) -> None:
-    """Validate on_internal_override parameter."""
-    if policy not in _VALID_ON_INTERNAL_OVERRIDE:
-        valid = ", ".join(_VALID_ON_INTERNAL_OVERRIDE)
-        raise ValueError(f"Invalid on_internal_override={policy!r}. Expected one of: {valid}")
-
-
 def _resolve_active_scope(
     graph: Graph,
     selected: tuple[str, ...] | None,
@@ -304,9 +296,22 @@ def _resolve_active_scope(
     )
 
 
-def _get_interrupt_outputs(nodes: dict[str, HyperNode]) -> set[str]:
-    """Get output names produced by interrupt nodes in the active scope."""
-    return {output for n in nodes.values() if n.is_interrupt for output in n.outputs}
+def _get_interrupt_outputs(
+    nodes: dict[str, HyperNode],
+    *,
+    prefix: str = "",
+) -> set[str]:
+    """Get interrupt resume keys in the active scope, including nested GraphNodes."""
+    from hypergraph.nodes.graph_node import GraphNode
+
+    outputs: set[str] = set()
+    for node in nodes.values():
+        if node.is_interrupt:
+            outputs.update(f"{prefix}{output}" for output in node.data_outputs)
+            continue
+        if isinstance(node, GraphNode):
+            outputs.update(_get_interrupt_outputs(node.graph._nodes, prefix=f"{prefix}{node.name}."))
+    return outputs
 
 
 def _find_internal_override_conflicts(
@@ -371,33 +376,28 @@ def _node_is_runnable_from_seed_values(node: HyperNode, provided: set[str]) -> b
     return all(param in provided or node.has_default_for(param) for param in node.inputs)
 
 
-def _handle_internal_override_policy(
+def _warn_on_unrecognized_inputs(
     *,
-    on_internal_override: Literal["ignore", "warn", "error"],
-    internal_edge: set[str],
     unknown: set[str],
     expected_inputs: set[str],
     active_nodes: dict[str, HyperNode],
 ) -> None:
-    """Apply policy for non-conflicting internal/unknown parameters."""
-    if not internal_edge and not unknown:
-        return
-    if on_internal_override == "ignore":
+    """Warn when extra provided keys are outside the active graph scope."""
+    if not unknown:
         return
 
-    message = _build_internal_override_message(
-        internal_edge=internal_edge,
-        unknown=unknown,
-        expected_inputs=expected_inputs,
-        active_nodes=active_nodes,
+    import warnings
+
+    warnings.warn(
+        _build_internal_override_message(
+            internal_edge=set(),
+            unknown=unknown,
+            expected_inputs=expected_inputs,
+            active_nodes=active_nodes,
+        ),
+        UserWarning,
+        stacklevel=4,
     )
-
-    if on_internal_override == "warn":
-        import warnings
-
-        warnings.warn(message, UserWarning, stacklevel=4)
-        return
-    raise ValueError(message)
 
 
 def _build_internal_override_message(

--- a/src/hypergraph/runners/async_/executors/graph_node.py
+++ b/src/hypergraph/runners/async_/executors/graph_node.py
@@ -78,6 +78,7 @@ class AsyncGraphNodeExecutor:
         # Translate renamed input keys back to original inner graph names
         inner_inputs = map_inputs_to_func_params(node, inputs)
         child_workflow_id = f"{workflow_id}/{node.name}" if workflow_id else None
+        map_config = node.map_config
 
         # Route interrupt resume values into the inner graph.
         # On pause, _handle_nested_result prefixes the node_name ("ask_user/ask_slack")
@@ -90,7 +91,7 @@ class AsyncGraphNodeExecutor:
         # Only inject on first execution: on cycle loop-back the node has already
         # executed so the inner interrupt should fire again, not skip.
         if node.name not in state.node_executions:
-            if child_workflow_id is not None and self.runner._checkpointer is not None:
+            if map_config is None and child_workflow_id is not None and self.runner._checkpointer is not None:
                 existing_child_run = await self.runner._checkpointer.get_run_async(child_workflow_id)
                 if existing_child_run is not None:
                     inner_inputs = {}
@@ -98,8 +99,6 @@ class AsyncGraphNodeExecutor:
             for key in state.values:
                 if key.startswith(prefix):
                     inner_inputs[key[len(prefix) :]] = state.values[key]
-
-        map_config = node.map_config
 
         if map_config:
             _, mode, error_handling = map_config

--- a/src/hypergraph/runners/async_/executors/graph_node.py
+++ b/src/hypergraph/runners/async_/executors/graph_node.py
@@ -77,21 +77,27 @@ class AsyncGraphNodeExecutor:
         """
         # Translate renamed input keys back to original inner graph names
         inner_inputs = map_inputs_to_func_params(node, inputs)
+        child_workflow_id = f"{workflow_id}/{node.name}" if workflow_id else None
 
         # Route interrupt resume values into the inner graph.
         # On pause, _handle_nested_result prefixes the node_name ("ask_user/ask_slack")
         # and PauseInfo.response_key becomes "ask_user.user_input".  On resume the
         # caller puts that dotted key into the outer state — we strip the prefix here
         # so the inner graph sees the unprefixed key ("user_input").
+        # When resuming a persisted child workflow, do not re-send normal child
+        # inputs like "draft" — those are already captured by the child
+        # checkpoint and would be treated as illegal overrides.
         # Only inject on first execution: on cycle loop-back the node has already
         # executed so the inner interrupt should fire again, not skip.
         if node.name not in state.node_executions:
+            if child_workflow_id is not None and self.runner._checkpointer is not None:
+                existing_child_run = await self.runner._checkpointer.get_run_async(child_workflow_id)
+                if existing_child_run is not None:
+                    inner_inputs = {}
             prefix = f"{node.name}."
             for key in state.values:
                 if key.startswith(prefix):
                     inner_inputs[key[len(prefix) :]] = state.values[key]
-
-        child_workflow_id = f"{workflow_id}/{node.name}" if workflow_id else None
 
         map_config = node.map_config
 

--- a/src/hypergraph/runners/base.py
+++ b/src/hypergraph/runners/base.py
@@ -43,7 +43,6 @@ class BaseRunner(ABC):
         *,
         select: str | list[str] = _UNSET_SELECT,
         on_missing: Literal["ignore", "warn", "error"] = "ignore",
-        on_internal_override: Literal["ignore", "warn", "error"] = "warn",
         entrypoint: str | None = None,
         max_iterations: int | None = None,
         error_handling: ErrorHandling = "raise",
@@ -57,7 +56,6 @@ class BaseRunner(ABC):
             values: Optional input values dict
             select: Which outputs to return. "**" (default) = all outputs.
             on_missing: How to handle missing selected outputs.
-            on_internal_override: How to handle non-conflicting internal input overrides.
             entrypoint: Optional explicit cycle entry point node name.
             max_iterations: Max iterations for cyclic graphs (None = default)
             error_handling: How to handle node execution errors.
@@ -82,7 +80,6 @@ class BaseRunner(ABC):
         clone: bool | list[str] = False,
         select: str | list[str] = _UNSET_SELECT,
         on_missing: Literal["ignore", "warn", "error"] = "ignore",
-        on_internal_override: Literal["ignore", "warn", "error"] = "warn",
         event_processors: list[EventProcessor] | None = None,
         **input_values: Any,
     ) -> MapResult:
@@ -99,7 +96,6 @@ class BaseRunner(ABC):
                 list[str] = deep-copy only named params.
             select: Which outputs to return. "**" (default) = all outputs.
             on_missing: How to handle missing selected outputs.
-            on_internal_override: How to handle non-conflicting internal input overrides.
             event_processors: Optional list of event processors to receive execution events
             **input_values: Input values shorthand (merged with values)
 

--- a/src/hypergraph/runners/sync/executors/graph_node.py
+++ b/src/hypergraph/runners/sync/executors/graph_node.py
@@ -56,6 +56,7 @@ class SyncGraphNodeExecutor:
         # Translate renamed input keys back to original inner graph names
         inner_inputs = map_inputs_to_func_params(node, inputs)
         child_workflow_id = f"{workflow_id}/{node.name}" if workflow_id else None
+        map_config = node.map_config
 
         # Route interrupt resume values into the inner graph.
         # On pause, _handle_nested_result prefixes the node_name ("ask_user/ask_slack")
@@ -69,14 +70,12 @@ class SyncGraphNodeExecutor:
         # executed so the inner interrupt should fire again, not skip.
         if node.name not in state.node_executions:
             sync_cp = self.runner._get_sync_checkpointer(child_workflow_id)
-            if sync_cp is not None and sync_cp.get_run(child_workflow_id) is not None:
+            if map_config is None and sync_cp is not None and sync_cp.get_run(child_workflow_id) is not None:
                 inner_inputs = {}
             prefix = f"{node.name}."
             for key in state.values:
                 if key.startswith(prefix):
                     inner_inputs[key[len(prefix) :]] = state.values[key]
-
-        map_config = node.map_config
 
         if map_config:
             _, mode, error_handling = map_config

--- a/src/hypergraph/runners/sync/executors/graph_node.py
+++ b/src/hypergraph/runners/sync/executors/graph_node.py
@@ -55,21 +55,26 @@ class SyncGraphNodeExecutor:
         """
         # Translate renamed input keys back to original inner graph names
         inner_inputs = map_inputs_to_func_params(node, inputs)
+        child_workflow_id = f"{workflow_id}/{node.name}" if workflow_id else None
 
         # Route interrupt resume values into the inner graph.
         # On pause, _handle_nested_result prefixes the node_name ("ask_user/ask_slack")
         # and PauseInfo.response_key becomes "ask_user.user_input".  On resume the
         # caller puts that dotted key into the outer state — we strip the prefix here
         # so the inner graph sees the unprefixed key ("user_input").
+        # When resuming a persisted child workflow, do not re-send normal child
+        # inputs like "draft" — those are already captured by the child
+        # checkpoint and would be treated as illegal overrides.
         # Only inject on first execution: on cycle loop-back the node has already
         # executed so the inner interrupt should fire again, not skip.
         if node.name not in state.node_executions:
+            sync_cp = self.runner._get_sync_checkpointer(child_workflow_id)
+            if sync_cp is not None and sync_cp.get_run(child_workflow_id) is not None:
+                inner_inputs = {}
             prefix = f"{node.name}."
             for key in state.values:
                 if key.startswith(prefix):
                     inner_inputs[key[len(prefix) :]] = state.values[key]
-
-        child_workflow_id = f"{workflow_id}/{node.name}" if workflow_id else None
 
         map_config = node.map_config
 

--- a/tests/test_checkpointer/test_lineage_semantics.py
+++ b/tests/test_checkpointer/test_lineage_semantics.py
@@ -150,7 +150,7 @@ class TestLineageSemantics:
 
         should_fail = False
         retry_graph = graph.with_entrypoint("maybe_fail")
-        resumed = await runner.run(retry_graph, workflow_id="wf-failed", on_internal_override="ignore")
+        resumed = await runner.run(retry_graph, workflow_id="wf-failed")
         assert resumed.status == RunStatus.COMPLETED
         assert resumed["out"] == 50
 
@@ -173,6 +173,36 @@ class TestLineageSemantics:
             graph,
             {paused.pause.response_key: "approved"},
             workflow_id="wf-paused",
+        )
+        assert resumed.status == RunStatus.COMPLETED
+        assert resumed["result"] == "Final: approved"
+
+    async def test_nested_paused_workflow_accepts_dotted_interrupt_response_on_resume(self, checkpointer):
+        @interrupt(output_name="decision")
+        def approval(draft: str) -> str: ...
+
+        inner = Graph([approval], name="inner")
+
+        @node(output_name="draft")
+        def make_draft(query: str) -> str:
+            return f"Draft for: {query}"
+
+        @node(output_name="result")
+        def finalize(decision: str) -> str:
+            return f"Final: {decision}"
+
+        runner = AsyncRunner(checkpointer=checkpointer)
+        graph = Graph([make_draft, inner.as_node(), finalize])
+
+        paused = await runner.run(graph, {"query": "hello"}, workflow_id="wf-nested-paused")
+        assert paused.status == RunStatus.PAUSED
+        assert paused.pause is not None
+        assert paused.pause.response_key == "inner.decision"
+
+        resumed = await runner.run(
+            graph,
+            {paused.pause.response_key: "approved"},
+            workflow_id="wf-nested-paused",
         )
         assert resumed.status == RunStatus.COMPLETED
         assert resumed["result"] == "Final: approved"
@@ -215,7 +245,7 @@ class TestLineageSemantics:
         should_fail = False
         retry_graph = graph.with_entrypoint("maybe_fail")
         retry_id_1, retry_cp_1 = checkpointer.retry_workflow("wf-retry-root")
-        retried_1 = await runner.run(retry_graph, checkpoint=retry_cp_1, workflow_id=retry_id_1, on_internal_override="ignore")
+        retried_1 = await runner.run(retry_graph, checkpoint=retry_cp_1, workflow_id=retry_id_1)
         assert retried_1["out"] == 10
         run_1 = checkpointer.get_run(retry_id_1)
         assert run_1 is not None
@@ -224,7 +254,7 @@ class TestLineageSemantics:
         assert run_1.forked_from == "wf-retry-root"
 
         retry_id_2, retry_cp_2 = checkpointer.retry_workflow("wf-retry-root")
-        await runner.run(retry_graph, checkpoint=retry_cp_2, workflow_id=retry_id_2, on_internal_override="ignore")
+        await runner.run(retry_graph, checkpoint=retry_cp_2, workflow_id=retry_id_2)
         run_2 = checkpointer.get_run(retry_id_2)
         assert run_2 is not None
         assert run_2.retry_of == "wf-retry-root"

--- a/tests/test_checkpointer/test_resume.py
+++ b/tests/test_checkpointer/test_resume.py
@@ -152,7 +152,7 @@ class TestAsyncRunResume:
         should_fail = False
 
         retry_graph = graph.with_entrypoint("flaky")
-        retried = await runner.run(retry_graph, retry_from="retry-src", on_internal_override="ignore")
+        retried = await runner.run(retry_graph, retry_from="retry-src")
         assert retried.status == RunStatus.COMPLETED
         run = checkpointer.get_run(retried.workflow_id)
         assert run is not None

--- a/tests/test_checkpointer/test_resume.py
+++ b/tests/test_checkpointer/test_resume.py
@@ -7,6 +7,7 @@ from hypergraph.checkpointers import SqliteCheckpointer, WorkflowStatus
 from hypergraph.exceptions import (
     GraphChangedError,
     InputOverrideRequiresForkError,
+    MissingInputError,
     WorkflowAlreadyCompletedError,
 )
 from hypergraph.runners._shared.types import RunStatus
@@ -93,6 +94,24 @@ class TestAsyncRunResume:
         checkpoint = checkpointer.checkpoint("valid-1")
         result = await runner.run(graph_step2, checkpoint=checkpoint, workflow_id="valid-1-fork")
         assert result["tripled"] == 30
+
+    async def test_checkpoint_resume_missing_seed_inputs_raises(self, checkpointer):
+        """Checkpoint-started runs should fail clearly instead of no-op completing."""
+        runner = AsyncRunner(checkpointer=checkpointer)
+
+        @node(output_name="consumed")
+        def consume_x(x: int) -> int:
+            return x + 1
+
+        await runner.run(Graph([double]), {"x": 5}, workflow_id="missing-seed-src")
+        checkpoint = checkpointer.checkpoint("missing-seed-src")
+
+        with pytest.raises(MissingInputError, match="missing required seed inputs"):
+            await runner.run(
+                Graph([consume_x]),
+                checkpoint=checkpoint,
+                workflow_id="missing-seed-fork",
+            )
 
     async def test_override_workflow_auto_forks_existing_id(self, checkpointer):
         """override_workflow=True auto-forks instead of raising strict resume errors."""
@@ -409,6 +428,24 @@ class TestSyncRunResume:
         result = runner.run(graph, {"x": 100}, checkpoint=checkpoint, workflow_id="sync-override-fork")
         assert result["doubled"] == 200
         assert result["tripled"] == 600
+
+    def test_checkpoint_resume_missing_seed_inputs_raises(self, sync_checkpointer):
+        """Sync mirror: checkpoint-started no-op resumes should fail clearly."""
+        runner = SyncRunner(checkpointer=sync_checkpointer)
+
+        @node(output_name="consumed")
+        def consume_x(x: int) -> int:
+            return x + 1
+
+        runner.run(Graph([double]), {"x": 5}, workflow_id="sync-missing-seed-src")
+        checkpoint = sync_checkpointer.checkpoint("sync-missing-seed-src")
+
+        with pytest.raises(MissingInputError, match="missing required seed inputs"):
+            runner.run(
+                Graph([consume_x]),
+                checkpoint=checkpoint,
+                workflow_id="sync-missing-seed-fork",
+            )
 
     def test_override_workflow_auto_forks_existing_id(self, sync_checkpointer):
         """Sync mirror: override_workflow=True auto-forks existing workflow_id."""

--- a/tests/test_interrupt_node.py
+++ b/tests/test_interrupt_node.py
@@ -848,7 +848,6 @@ class TestInterruptNodeInCycle:
         r2 = await runner.run(
             graph,
             {"messages": r1.pause.value, r1.pause.response_key: "What is RAG?"},
-            on_internal_override="ignore",
         )
         assert r2.paused
         assert r2.pause.node_name == "ask/ask_user"
@@ -859,7 +858,6 @@ class TestInterruptNodeInCycle:
         r3 = await runner.run(
             graph,
             {"messages": r2.pause.value, r2.pause.response_key: "What is LLM?"},
-            on_internal_override="ignore",
         )
         assert r3.status == RunStatus.COMPLETED
         assert r3["messages"] == [

--- a/tests/test_interrupt_shared_cycle_bug.py
+++ b/tests/test_interrupt_shared_cycle_bug.py
@@ -206,7 +206,6 @@ class TestInterruptSharedCycleE2E:
         r2 = await runner.run(
             GRAPH,
             {"messages": [], "user_input": "hello"},
-            on_internal_override="ignore",
         )
         assert r2.paused, "Should pause at ask again after pipeline completes"
 

--- a/tests/test_runners/test_async_runner.py
+++ b/tests/test_runners/test_async_runner.py
@@ -336,8 +336,8 @@ class TestAsyncRunnerRun:
         assert "sum" in result
         assert "doubled" not in result
 
-    async def test_on_internal_override_policy_is_enforced(self):
-        """Internal edge-produced overrides are rejected for all policies."""
+    async def test_internal_edge_produced_overrides_are_rejected(self):
+        """Internal edge-produced overrides are rejected."""
 
         @node(output_name=("left", "right"))
         def split(x: int) -> tuple[int, int]:
@@ -354,13 +354,16 @@ class TestAsyncRunnerRun:
         graph = Graph([split, use_left, use_right])
         runner = AsyncRunner()
 
-        for policy in ("error", "ignore", "warn"):
-            with pytest.raises(ValueError, match="internal parameters"):
-                await runner.run(
-                    graph,
-                    {"left": 100, "right": 200},
-                    on_internal_override=policy,
-                )
+        with pytest.raises(ValueError, match="internal parameters"):
+            await runner.run(graph, {"left": 100, "right": 200})
+
+    async def test_removed_internal_override_argument_is_rejected(self):
+        """run() treats on_internal_override as a reserved runner option."""
+        graph = Graph([double])
+        runner = AsyncRunner()
+
+        with pytest.raises(ValueError, match="reserved runner options"):
+            await runner.run(graph, {"x": 1}, on_internal_override="warn")  # type: ignore[call-arg]
 
     # Cycles
 
@@ -508,8 +511,8 @@ class TestAsyncRunnerMap:
 
         assert [r["sum"] for r in results] == [11, 12]
 
-    async def test_map_forwards_on_internal_override_policy(self):
-        """Internal edge-produced overrides are rejected for all policies."""
+    async def test_map_rejects_internal_edge_produced_overrides(self):
+        """Internal edge-produced overrides are rejected in map()."""
 
         @node(output_name=("left", "right"))
         def split(x: int) -> tuple[int, int]:
@@ -526,14 +529,20 @@ class TestAsyncRunnerMap:
         graph = Graph([split, use_left, use_right])
         runner = AsyncRunner()
 
-        for policy in ("error", "ignore", "warn"):
-            with pytest.raises(ValueError, match="internal parameters"):
-                await runner.map(
-                    graph,
-                    {"left": [100], "right": 200},
-                    map_over="left",
-                    on_internal_override=policy,
-                )
+        with pytest.raises(ValueError, match="internal parameters"):
+            await runner.map(
+                graph,
+                {"left": [100], "right": 200},
+                map_over="left",
+            )
+
+    async def test_map_removed_internal_override_argument_is_rejected(self):
+        """map() treats on_internal_override as a reserved runner option."""
+        graph = Graph([double])
+        runner = AsyncRunner()
+
+        with pytest.raises(ValueError, match="reserved runner options"):
+            await runner.map(graph, {"x": [1]}, map_over="x", on_internal_override="warn")  # type: ignore[call-arg]
 
     async def test_map_runs_concurrently(self):
         """Map executions run concurrently."""

--- a/tests/test_runners/test_sync_runner.py
+++ b/tests/test_runners/test_sync_runner.py
@@ -261,8 +261,8 @@ class TestSyncRunnerRun:
 
         assert result["result"] == 15  # 5 + 10 (default)
 
-    def test_on_internal_override_policy_is_enforced(self):
-        """Internal edge-produced overrides are rejected for all policies."""
+    def test_internal_edge_produced_overrides_are_rejected(self):
+        """Internal edge-produced overrides are rejected."""
 
         @node(output_name=("left", "right"))
         def split(x: int) -> tuple[int, int]:
@@ -279,13 +279,16 @@ class TestSyncRunnerRun:
         graph = Graph([split, use_left, use_right])
         runner = SyncRunner()
 
-        for policy in ("error", "ignore", "warn"):
-            with pytest.raises(ValueError, match="internal parameters"):
-                runner.run(
-                    graph,
-                    {"left": 100, "right": 200},
-                    on_internal_override=policy,
-                )
+        with pytest.raises(ValueError, match="internal parameters"):
+            runner.run(graph, {"left": 100, "right": 200})
+
+    def test_removed_internal_override_argument_is_rejected(self):
+        """run() treats on_internal_override as a reserved runner option."""
+        graph = Graph([double])
+        runner = SyncRunner()
+
+        with pytest.raises(ValueError, match="reserved runner options"):
+            runner.run(graph, {"x": 1}, on_internal_override="warn")  # type: ignore[call-arg]
 
     def test_input_overrides_bound(self):
         """Explicit input overrides bound value."""
@@ -565,8 +568,8 @@ class TestSyncRunnerMap:
         with pytest.raises(ValueError, match="reserved runner options"):
             runner.map(graph, map_over="x", x=[1, 2], max_concurrency=1)
 
-    def test_map_forwards_on_internal_override_policy(self):
-        """Internal edge-produced overrides are rejected for all policies."""
+    def test_map_rejects_internal_edge_produced_overrides(self):
+        """Internal edge-produced overrides are rejected in map()."""
 
         @node(output_name=("left", "right"))
         def split(x: int) -> tuple[int, int]:
@@ -583,14 +586,20 @@ class TestSyncRunnerMap:
         graph = Graph([split, use_left, use_right])
         runner = SyncRunner()
 
-        for policy in ("error", "ignore", "warn"):
-            with pytest.raises(ValueError, match="internal parameters"):
-                runner.map(
-                    graph,
-                    {"left": [100], "right": 200},
-                    map_over="left",
-                    on_internal_override=policy,
-                )
+        with pytest.raises(ValueError, match="internal parameters"):
+            runner.map(
+                graph,
+                {"left": [100], "right": 200},
+                map_over="left",
+            )
+
+    def test_map_removed_internal_override_argument_is_rejected(self):
+        """map() treats on_internal_override as a reserved runner option."""
+        graph = Graph([double])
+        runner = SyncRunner()
+
+        with pytest.raises(ValueError, match="reserved runner options"):
+            runner.map(graph, {"x": [1]}, map_over="x", on_internal_override="warn")  # type: ignore[call-arg]
 
     def test_map_over_returns_list_of_results(self):
         """Map returns list of RunResult."""

--- a/tests/test_runners/test_validation.py
+++ b/tests/test_runners/test_validation.py
@@ -139,47 +139,25 @@ class TestInternalOverrideValidation:
         """Providing producer inputs + produced outputs is a hard conflict."""
         graph = self._make_split_graph()
         with pytest.raises(ValueError, match="conflict.*you provided"):
-            validate_inputs(
-                graph,
-                {"left": 100, "x": 5},
-                on_internal_override="ignore",
-            )
+            validate_inputs(graph, {"left": 100, "x": 5})
 
-    def test_full_internal_injection_rejected_with_ignore(self):
-        """Internal output injection is always rejected (deterministic error)."""
+    def test_full_internal_injection_is_rejected(self):
+        """Internal output injection is always rejected."""
         graph = self._make_split_graph()
         with pytest.raises(ValueError, match="internal parameters"):
-            validate_inputs(
-                graph,
-                {"left": 100, "right": 200},
-                on_internal_override="ignore",
-            )
-
-    def test_full_internal_injection_rejected_with_error_policy(self):
-        """Non-conflicting internal injection can be rejected via policy."""
-        graph = self._make_split_graph()
-        with pytest.raises(ValueError, match="internal parameters"):
-            validate_inputs(
-                graph,
-                {"left": 100, "right": 200},
-                on_internal_override="error",
-            )
+            validate_inputs(graph, {"left": 100, "right": 200})
 
     def test_internal_override_warning_includes_producer_mapping(self):
         """Error text should identify which node produces each internal key."""
         graph = self._make_split_graph()
         with pytest.raises(ValueError, match="left <- split"):
-            validate_inputs(
-                graph,
-                {"left": 100, "right": 200},
-                on_internal_override="warn",
-            )
+            validate_inputs(graph, {"left": 100, "right": 200})
 
-    def test_invalid_internal_override_policy_raises(self):
-        """Reject unknown policy values."""
+    def test_removed_internal_override_argument_is_rejected(self):
+        """validate_inputs no longer accepts on_internal_override."""
         graph = Graph([double])
-        with pytest.raises(ValueError, match="Invalid on_internal_override"):
-            validate_inputs(graph, {"x": 1}, on_internal_override="raise")  # type: ignore[arg-type]
+        with pytest.raises(TypeError, match="on_internal_override"):
+            validate_inputs(graph, {"x": 1}, on_internal_override="warn")  # type: ignore[call-arg]
 
     def test_cycle_entrypoint_param_not_flagged_as_internal_override(self):
         """Cycle entry point params are excluded from compute+inject conflict checks.
@@ -190,7 +168,7 @@ class TestInternalOverrideValidation:
         """
         graph = Graph([counter], entrypoint="counter")
         # 'count' is a cycle entrypoint param — should pass cleanly
-        validate_inputs(graph, {"count": 0}, on_internal_override="error")
+        validate_inputs(graph, {"count": 0})
 
     def test_entrypoint_scope_treats_excluded_branch_output_as_root_input(self):
         """Active-scope required roots are not treated as internal overrides."""
@@ -212,11 +190,7 @@ class TestInternalOverrideValidation:
             return b_out + c_out
 
         graph = Graph([a, b, c, e]).with_entrypoint("b").select("e")
-        validate_inputs(
-            graph,
-            {"x": 10, "c_out": 99},
-            on_internal_override="error",
-        )
+        validate_inputs(graph, {"x": 10, "c_out": 99})
 
 
 class TestNormalizeInputs:


### PR DESCRIPTION
## Problem / Bug / Challenge

Checkpointed HITL resume handled top-level interrupts correctly but rejected nested interrupt response keys such as `inner.decision` on an existing `workflow_id`. The runner also still exposed the deprecated `on_internal_override` option even though it should no longer be used.

## Before / After

**Before:**

```python
r1 = await runner.run(outer, {"query": "hello"}, workflow_id="wf-nested")
r2 = await runner.run(outer, {r1.pause.response_key: "approved"}, workflow_id="wf-nested")
# InputOverrideRequiresForkError
```

**After:**

```python
r1 = await runner.run(outer, {"query": "hello"}, workflow_id="wf-nested")
r2 = await runner.run(outer, {r1.pause.response_key: "approved"}, workflow_id="wf-nested")
assert r2["result"] == "Final: approved"
```

This PR:
- allows nested dotted interrupt response keys during checkpointed resume
- keeps strict no-override lineage semantics for normal runtime values
- resumes checkpoint/fork/retry runs without re-requiring original fresh-start inputs
- removes `on_internal_override` from the public runner API and docs

## Test Plan

- [x] `uv run pytest -n 0 tests/test_runners/test_validation.py tests/test_runners/test_async_runner.py tests/test_runners/test_sync_runner.py -q`
- [x] `uv run --extra checkpoint pytest -n 0 tests/test_checkpointer/test_resume.py::TestAsyncRunResume::test_retry_from_allows_retry_without_checkpoint_object tests/test_checkpointer/test_lineage_semantics.py::TestLineageSemantics::test_failed_workflow_can_resume_same_id_without_values tests/test_checkpointer/test_lineage_semantics.py::TestLineageSemantics::test_retry_workflow_api_sets_retry_lineage tests/test_checkpointer/test_lineage_semantics.py::TestLineageSemantics::test_nested_paused_workflow_accepts_dotted_interrupt_response_on_resume -q`
- [x] `uv run pytest -n 0 tests/test_interrupt_node.py::TestInterruptNodeInCycle::test_nested_interrupt_resumes_and_accumulates tests/test_interrupt_shared_cycle_bug.py::TestInterruptSharedCycleE2E::test_resume_completes_full_pipeline -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed the legacy internal-override option from runner APIs; default internal handling is now used.
  * Validation now rejects attempts to override internal/edge-produced inputs.

* **Behavioral Changes**
  * Checkpoint resumption improved to avoid re-sending inputs to resumed child workflows.
  * Nested interrupt outputs are recognized using dotted keys (e.g., inner.decision) during pause/resume.

* **Documentation**
  * Updated docs, examples, notebooks, and changelog to reflect these changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->