### PR TITLE
Improve docs with framework-inspired Hypergraph examples

### DIFF
--- a/docs/01-introduction/comparison.md
+++ b/docs/01-introduction/comparison.md
@@ -1,25 +1,26 @@
 # Framework Comparison
 
-How hypergraph compares to other Python workflow frameworks.
+How hypergraph compares to adjacent workflow frameworks.
 
-- **vs LangGraph/Pydantic-Graph** - No state schemas, pure functions, automatic edge inference
-- **vs Hamilton/Pipefunc** - Same clean DAG model, plus cycles and agentic patterns
-- **Best of both** - DAG simplicity meets agent flexibility
+- **vs LangGraph / Pydantic-Graph** - Less state-schema ceremony, more value flow through named edges
+- **vs Hamilton / pipefunc** - Similar functional DAG ergonomics, but with cycles and first-class nesting
+- **vs DBOS / Inngest / Restate** - Stronger graph composition model today, lighter durable runtime story today
 
 ## Quick Comparison
 
-| Feature | hypergraph | LangGraph | Hamilton | Pipefunc | Pydantic-Graph |
-|---------|:---:|:---:|:---:|:---:|:---:|
-| DAG Pipelines | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Agentic Loops | ✓ | ✓ | — | — | ✓ |
-| Hierarchical | First-class | ✓ | ✓ | ✓ | ✓ |
-| Human-in-the-Loop | ✓ | ✓ | — | — | ✓ |
+| Feature | hypergraph | LangGraph | Hamilton | pipefunc | Pydantic-Graph | DBOS / Inngest / Restate |
+|---------|:---:|:---:|:---:|:---:|:---:|:---:|
+| DAG Pipelines | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Agentic Loops | ✓ | ✓ | — | — | ✓ | ✓ |
+| Graphs Inside Graphs | First-class | ✓ | partial / DAG-oriented | partial / DAG-oriented | ✓ | workflow/runtime oriented |
+| Human-in-the-Loop | ✓ | ✓ | — | — | ✓ | ✓ |
+| Turnkey External Event Waits | partial / app-managed | partial | — | — | partial | strong |
 
 ## The Design Space
 
 ### DAG-First Frameworks
 
-**Hamilton** and **Pipefunc** excel at data pipelines. Functions define nodes, edges are inferred from parameter names. Clean, testable, minimal boilerplate.
+**Hamilton** and **pipefunc** excel at data pipelines. Functions define nodes, edges are inferred from parameter names. Clean, testable, minimal boilerplate.
 
 But they can't express cycles. Multi-turn conversations, agentic workflows, iterative refinement - none of these are possible when the framework fundamentally assumes DAG execution.
 
@@ -29,12 +30,24 @@ But they can't express cycles. Multi-turn conversations, agentic workflows, iter
 
 But they require explicit state schemas. Every node reads from and writes to a shared state object. Functions become framework-coupled. Testing requires mocking state.
 
-### Hypergraph: The Middle Path
+### Durable Workflow Platforms
+
+**DBOS**, **Inngest**, and **Restate** push farther on orchestration runtime concerns:
+
+- waiting for external events
+- resuming after long pauses
+- approval inboxes
+- workflow inspection and lifecycle operations
+
+Hypergraph can model the same business flows, but more of the orchestration shell still lives in your application code. Hypergraph's current center of gravity is the graph model itself: named values, nested graphs, routes, interrupts, and mapped subgraphs.
+
+### Hypergraph: The Structural Middle Path
 
 Hypergraph takes the best of both:
 
 - **From DAG frameworks**: Functions are pure. Edges are inferred. No state schema.
 - **From agent frameworks**: Cycles, routing, and human-in-the-loop.
+- **From neither extreme**: Hierarchical composition is the primary abstraction, so DAGs, loops, and mapped subgraphs can be combined in one model.
 
 ## Code Comparison: RAG Pipeline
 
@@ -223,6 +236,25 @@ Hamilton and pipefunc are DAG frameworks — cycles are outside their scope. For
 | Hamilton | Outputs flow forward, no shared state |
 | Pipefunc | Outputs flow forward, no shared state |
 
+### Where Hypergraph Is Strongest
+
+Hypergraph usually looks best when the workflow has real structure, not just "an agent loop":
+
+- a retrieval DAG inside a chat loop
+- a nested approval or escalation subgraph
+- a graph written for one item, then mapped across a batch
+- an evaluation DAG containing the workflow under test
+
+That is the core comparison story: one model for DAGs, loops, hierarchy, and scale-out.
+
+### Where Hypergraph Is Lighter Today
+
+Hypergraph already has checkpointing, lineage, and interrupts, but it is still lighter on runtime orchestration than DBOS / Inngest / Restate:
+
+- external-event resume is more app-managed
+- approval inboxes are buildable but not first-class
+- workflow lifecycle operations are less prominent than the graph API
+
 ### Function Portability
 
 Can you test functions without the framework?
@@ -252,6 +284,7 @@ Can you test functions without the framework?
 - You need both DAGs and agentic patterns
 - You want minimal boilerplate
 - Hierarchical composition is important
+- You want to write one workflow, then scale it with `runner.map()` or `map_over()`
 - You're building multi-agent systems
 
 ### Choose LangGraph when

--- a/docs/01-introduction/when-to-use.md
+++ b/docs/01-introduction/when-to-use.md
@@ -25,6 +25,13 @@ Evaluation Loop
 
 If your workflows have this kind of nesting — DAGs inside cycles, cycles inside DAGs — hypergraph's hierarchical composition is a natural fit.
 
+This is where hypergraph tends to stand out most clearly:
+
+- A retrieval pipeline inside a multi-turn chat loop
+- A per-document processing graph fanned out over a batch
+- A support workflow that routes into a nested technical-review subgraph
+- An evaluation DAG that contains the workflow under test as a nested node
+
 **Concrete examples:**
 
 | Outer Layer | Inner Layer | Pattern |
@@ -60,6 +67,33 @@ def should_continue(quality: float, attempts: int) -> str:
 
 Hypergraph handles cycles naturally with `@route` and `END`.
 
+### You Want To Write One Workflow, Then Scale It
+
+Hypergraph works especially well when the logic for **one** item is clear, and scale comes later:
+
+```python
+# One item
+@node(output_name="embedding")
+def embed(text: str) -> list[float]:
+    return model.embed(text)
+
+single_item = Graph([embed], name="single_item")
+
+# Many items
+batch = Graph([
+    load_texts,
+    single_item.as_node().with_inputs(text="texts").map_over("texts"),
+    summarize_embeddings,
+])
+```
+
+This "think singular, scale later" pattern is one of the cleanest ways to use hypergraph for:
+
+- document pipelines
+- feature extraction
+- evaluation harnesses
+- ML preprocessing and model comparison
+
 ### You Want Minimal Boilerplate
 
 Define functions, name outputs, and let hypergraph infer the edges:
@@ -93,6 +127,24 @@ Hypergraph is in **alpha**. The core features work, but:
 
 - Breaking API changes are possible
 - Ecosystem integrations are limited
+- Durable workflow runtime patterns are possible, but still more manual than in platforms like Inngest, DBOS, or Restate
+
+### You Want A Turnkey Durable Workflow Platform
+
+Hypergraph already has:
+
+- interrupts for pause/resume
+- checkpointing and lineage
+- nested graphs and batch execution
+
+But if your main need is a runtime that natively owns:
+
+- external event delivery
+- approval inboxes
+- waiting webhook resumes
+- lifecycle operations for long-lived workflows
+
+then you should evaluate whether a more orchestration-heavy platform is a better fit today.
 
 See the [Comparison](comparison.md) page for how hypergraph relates to other frameworks.
 
@@ -102,8 +154,10 @@ See the [Comparison](comparison.md) page for how hypergraph relates to other fra
 |----------------|-----------------|
 | One framework for DAGs and agents | Yes |
 | Hierarchical workflow composition | Yes |
+| Write one workflow, scale with mapped subgraphs | Yes |
 | Pure, testable functions | Yes |
 | Multi-turn AI workflows | Yes |
 | Minimal boilerplate | Yes |
 | Simple scripts | No — just use functions |
 | Production maturity today | Maybe — evaluate alpha status |
+| A turnkey durable workflow runtime | Not yet the primary strength |

--- a/docs/03-patterns/07-human-in-the-loop.md
+++ b/docs/03-patterns/07-human-in-the-loop.md
@@ -10,6 +10,21 @@ Pause execution for human input. Resume when ready.
 
 Many workflows need human judgment at key points: approving a draft, confirming a destructive action, providing feedback on generated content. You need a way to pause the graph, surface a value to the user, and resume with their response.
 
+This page focuses on the **graph-level** pause/resume pattern:
+
+- a run pauses at an interrupt
+- the caller inspects the pause payload
+- the caller later resumes the workflow with a response
+
+That makes interrupts a strong fit for:
+
+- interactive apps
+- review UIs
+- multi-step assistants
+- application-managed human approval flows
+
+For longer-lived event-driven orchestration, checkpointing gives you the persistence foundation, but more of the surrounding runtime shell still lives in your app today.
+
 ## Basic Pause and Resume
 
 The `@interrupt` decorator creates a pause point. Inputs come from the function signature, outputs from `output_name`. When the handler returns `None`, execution pauses.
@@ -53,6 +68,8 @@ The key flow:
 1. **Run** the graph. Execution pauses at the interrupt.
 2. **Inspect** `result.pause.value` to see what the user needs to review.
 3. **Resume** by passing the response via `result.pause.response_key`.
+
+This is intentionally different from event-driven workflow systems like Inngest, DBOS, or Restate, where the runtime often owns external event delivery directly. In hypergraph, the pause/resume primitive is already there; the application typically decides how the later response gets routed back into the run.
 
 ### RunResult Properties
 
@@ -399,6 +416,45 @@ assert result.pause.response_key == "inner.y"
 ```
 
 The `response_key` uses dot-separated paths for nested interrupts: `"inner.y"` means the output `y` inside the graph node `inner`.
+
+Think of `response_key` as a **resume slot identifier**. It is precise and stable, but it is primarily a runtime-facing detail. In user-facing applications, you will often wrap it behind your own inbox, form, or webhook layer.
+
+## Checkpointed Pauses
+
+For durable pause/resume across process restarts, pair interrupts with a checkpointer and a `workflow_id`:
+
+```python
+from hypergraph import AsyncRunner, Graph, interrupt, node
+from hypergraph.checkpointers import SqliteCheckpointer
+
+@interrupt(output_name="decision")
+def approval(draft: str) -> str | None:
+    return None
+
+@node(output_name="result")
+def finalize(decision: str) -> str:
+    return f"Final: {decision}"
+
+graph = Graph([approval, finalize])
+runner = AsyncRunner(checkpointer=SqliteCheckpointer("./runs.db"))
+
+paused = await runner.run(graph, {"draft": "hello"}, workflow_id="review-1")
+
+# ... later, possibly in another process ...
+resumed = await runner.run(
+    graph,
+    {paused.pause.response_key: "approved"},
+    workflow_id="review-1",
+)
+```
+
+This is the current durable HITL story:
+
+- checkpoint state stores the paused execution
+- `workflow_id` identifies the workflow instance
+- `response_key` identifies the waiting output slot
+
+If your application needs approval inboxes, event matching, or webhook-driven resume, build those on top of this pause primitive today.
 
 ## Runner Compatibility
 

--- a/docs/04-real-world/framework-ports.md
+++ b/docs/04-real-world/framework-ports.md
@@ -1,0 +1,65 @@
+# Framework Ports
+
+This page turns adjacent-framework examples into a practical Hypergraph evaluation loop:
+
+1. Pull real upstream examples into a local corpus
+2. Prioritize the ones that best match Hypergraph's strengths
+3. Rebuild them in a clean, Hypergraph-native style
+4. Use the resulting ports to spot real documentation gaps and framework friction
+
+The raw corpus lives under `tmp/framework_corpus/`. Rebuild it with:
+
+```bash
+uv run python scripts/build_framework_corpus.py
+```
+
+## Why This Matters
+
+This project is less about "winning a comparison" and more about pressure-testing Hypergraph against the workflows people already reach for:
+
+- **LangGraph / Mastra / Inngest** for agentic loops, chats, and human review
+- **Hamilton / pipefunc / scikit-learn** for explicit, data-heavy DAGs
+- **DBOS / Restate** for durable orchestration and long-running workflows
+
+Looking at those examples side-by-side clarifies where Hypergraph is already elegant and where the user experience still needs work.
+
+## Top Ports
+
+These are the highest-priority examples I ported because they map directly onto current Hypergraph capabilities and reveal useful trade-offs.
+
+| Port | Upstream inspiration | Why it was prioritized | Hypergraph file |
+|---|---|---|---|
+| Agentic RAG | LangGraph adaptive RAG | Shows nested graph composition plus route-driven source selection without a state schema | `examples/framework_ports/agentic_rag.py` |
+| Support Inbox | Mastra suspend/resume, Inngest support HITL, DBOS agent inbox, Restate chat durability | Exercises nested interrupts, pause propagation, and resume semantics in a realistic support workflow | `examples/framework_ports/support_inbox.py` |
+| ML Model Selection | Hamilton modular ML example, scikit-learn preprocessing/training pipelines | Shows that Hypergraph can express modular ML workflows without turning the whole graph into framework-specific plumbing | `examples/framework_ports/ml_model_selection.py` |
+| Document Batch Pipeline | DBOS document ingestion, Restate RAG ingestion, pipefunc mapped examples | Demonstrates the "write one document graph, then fan it out" pattern with mapped graph nodes | `examples/framework_ports/document_batch_pipeline.py` |
+
+## What The Ports Suggest
+
+### Where Hypergraph feels strong
+
+- **Nested graphs are natural.** The LangGraph-style and support-style ports become smaller once the repeated subflows are first-class graphs.
+- **Automatic wiring helps.** The Hamilton- and scikit-learn-inspired pipelines stay readable because values move by name instead of through explicit edge boilerplate.
+- **Interrupt propagation is a good primitive.** The support example shows that nested human-review steps can surface cleanly to the outer run.
+- **Mapped graph nodes are a real differentiator.** The document and ML ports both benefit from the "think singular, scale later" model.
+
+### Where Hypergraph still feels thin
+
+- **Durability is more explicit than in DBOS, Restate, or Inngest.** Hypergraph has checkpointing, but it is not yet as turnkey for event waits, inbox queries, or long-running service-style orchestration.
+- **The best `map_over()` patterns are under-documented.** The capability is strong, but people coming from pipefunc or batch-oriented systems need more first-class examples.
+- **HITL examples should talk about persistence earlier.** Interrupts are well-covered, but the durable "pause today, resume tomorrow" story should be easier to discover.
+- **Framework-comparison examples deserve a home in the docs.** These ports make the trade-offs concrete in a way abstract comparison tables do not.
+
+## Suggested Next Ports
+
+These upstream examples are promising next steps after the current set:
+
+- DBOS `reliable-refunds-langchain` for a more explicit durable approval flow
+- Restate `chat-bot` for longer-lived chat/session patterns
+- Inngest `code-assistant-rag` for a tool-using research assistant
+- Hamilton `reverse_etl` for a business-data pipeline with real IO boundaries
+- pipefunc `sensor-data-processing` for a non-LLM batch-processing example
+
+## Verification
+
+The committed ports are covered by focused tests in `tests/test_framework_ports.py`.

--- a/docs/05-how-to/batch-processing.md
+++ b/docs/05-how-to/batch-processing.md
@@ -17,6 +17,20 @@ graph = Graph([extract])
 results = runner.map(graph, {"document": documents}, map_over="document")
 ```
 
+This pattern is one of hypergraph's biggest advantages in practice:
+
+- write the logic for one item
+- compose it into a graph
+- scale it with `runner.map()` or a mapped `GraphNode`
+
+That same shape works for:
+
+- ETL and document ingestion
+- feature extraction
+- model comparison
+- evaluation datasets
+- nested workflows where each item may branch internally
+
 ## Basic Usage
 
 ```python
@@ -151,6 +165,15 @@ batch_pipeline = Graph([
 ])
 ```
 
+For many real systems, this is the most natural Hypergraph pattern:
+
+1. Build and test the single-item workflow first
+2. Name it with `Graph(..., name="...")`
+3. Reuse it as a node with `.as_node()`
+4. Add `.map_over(...)` when you need batch scale
+
+This keeps the core logic small and reusable instead of mixing per-item logic with batch orchestration.
+
 ## Working with MapResult
 
 `runner.map()` returns a `MapResult` — a read-only sequence with batch-level metadata and aggregate accessors. It's fully backward compatible: `len()`, iteration, and indexing all work as before.
@@ -258,6 +281,7 @@ results = runner.map(graph, {"url": urls}, map_over="url", error_handling="conti
 
 - Processing independent items (scraping, embedding, classification)
 - When you need per-item RunLogs for debugging
+- When batch items should behave like separate workflow runs
 - Quick fan-out over a single parameter
 - With `workflow_id`: persisted batch with per-item child runs
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -31,6 +31,7 @@
 * [Evaluation Harness](04-real-world/evaluation-harness.md)
 * [Data Pipeline](04-real-world/data-pipeline.md)
 * [Prompt Optimization](04-real-world/prompt-optimization.md)
+* [Framework Ports](04-real-world/framework-ports.md)
 
 ## How-To Guides
 

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,1 @@
+"""Runnable example modules for Hypergraph."""

--- a/examples/framework_ports/__init__.py
+++ b/examples/framework_ports/__init__.py
@@ -1,0 +1,13 @@
+"""Curated Hypergraph ports of adjacent-framework examples."""
+
+from .agentic_rag import build_agentic_rag_graph
+from .document_batch_pipeline import build_document_batch_graph
+from .ml_model_selection import build_ml_model_selection_graph
+from .support_inbox import build_support_inbox_graph
+
+__all__ = [
+    "build_agentic_rag_graph",
+    "build_document_batch_graph",
+    "build_ml_model_selection_graph",
+    "build_support_inbox_graph",
+]

--- a/examples/framework_ports/agentic_rag.py
+++ b/examples/framework_ports/agentic_rag.py
@@ -1,0 +1,121 @@
+"""Hypergraph port of adaptive / agentic RAG patterns.
+
+Inspired primarily by LangGraph's adaptive RAG examples, but rewritten to lean
+into Hypergraph's automatic wiring and nested-graph composition.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+from hypergraph import Graph, SyncRunner, node, route
+
+
+def _keywords(text: str) -> set[str]:
+    return {token.strip(".,?!:;()").lower() for token in text.split() if token.strip(".,?!:;()")}
+
+
+def _match_documents(question: str, documents: list[str]) -> list[str]:
+    query_terms = _keywords(question)
+    scored: list[tuple[int, str]] = []
+    for document in documents:
+        overlap = len(query_terms & _keywords(document))
+        if overlap:
+            scored.append((overlap, document))
+    scored.sort(key=lambda item: (-item[0], item[1]))
+    return [document for _, document in scored]
+
+
+@node(output_name="search_source")
+def classify_search_source(question: str) -> str:
+    lowered = question.lower()
+    if any(term in lowered for term in ("latest", "today", "current", "release", "recent")):
+        return "search_web"
+    return "search_local"
+
+
+@route(targets=["search_local", "search_web"])
+def dispatch_search(search_source: str) -> str:
+    return search_source
+
+
+@node(output_name="raw_context")
+def search_local(question: str, local_documents: list[str]) -> list[str]:
+    matches = _match_documents(question, local_documents)
+    return matches[:3] or local_documents[:1]
+
+
+@node(output_name="raw_context")
+def search_web(question: str, web_documents: list[str]) -> list[str]:
+    matches = _match_documents(question, web_documents)
+    return matches[:3] or web_documents[:1]
+
+
+@node(output_name="ranked_context")
+def rank_context(question: str, raw_context: list[str]) -> list[str]:
+    query_terms = _keywords(question)
+    ranked = sorted(
+        raw_context,
+        key=lambda document: (
+            -sum(Counter(_keywords(document))[term] for term in query_terms),
+            document,
+        ),
+    )
+    return ranked[:2]
+
+
+retrieval_graph = Graph(
+    [
+        classify_search_source,
+        dispatch_search,
+        search_local,
+        search_web,
+        rank_context,
+    ],
+    name="retrieval",
+)
+
+
+@node(output_name="answer")
+def draft_answer(question: str, ranked_context: list[str], search_source: str) -> str:
+    lead = ranked_context[0] if ranked_context else "No context found."
+    return f"[{search_source}] {question} -> {lead}"
+
+
+@node(output_name="confidence")
+def confidence_label(ranked_context: list[str]) -> str:
+    return "grounded" if len(ranked_context) >= 2 else "thin"
+
+
+def build_agentic_rag_graph() -> Graph:
+    return Graph(
+        [
+            retrieval_graph.as_node(name="retrieve_context"),
+            draft_answer,
+            confidence_label,
+        ],
+        name="agentic_rag_port",
+    )
+
+
+def demo() -> dict[str, object]:
+    graph = build_agentic_rag_graph()
+    runner = SyncRunner()
+    return runner.run(
+        graph,
+        {
+            "question": "What changed in the latest hypergraph release for interrupts?",
+            "local_documents": [
+                "Hypergraph supports interrupt nodes for human review.",
+                "Nested graphs use automatic wiring and composable outputs.",
+            ],
+            "web_documents": [
+                "Latest release notes mention better interrupt resume semantics.",
+                "Recent release adds improved run logs for nested graphs.",
+            ],
+        },
+    ).values
+
+
+if __name__ == "__main__":
+    print(demo())

--- a/examples/framework_ports/document_batch_pipeline.py
+++ b/examples/framework_ports/document_batch_pipeline.py
@@ -1,0 +1,100 @@
+"""Hypergraph port of batch document processing examples.
+
+This example sits between DBOS's document pipelines, Restate's RAG ingestion,
+and pipefunc's mapped examples. The focus is the Hypergraph-native shape:
+write one document pipeline, then fan it out cleanly over a batch.
+"""
+
+from __future__ import annotations
+
+from hypergraph import Graph, SyncRunner, node
+
+
+@node(output_name="normalized_document")
+def normalize_document(document: str) -> str:
+    return " ".join(document.replace("\n", " ").split()).strip().lower()
+
+
+@node(output_name="sentences")
+def split_sentences(normalized_document: str) -> list[str]:
+    return [sentence.strip() for sentence in normalized_document.split(".") if sentence.strip()]
+
+
+@node(output_name="keywords")
+def extract_keywords(sentences: list[str], top_k: int = 3) -> list[str]:
+    counts: dict[str, int] = {}
+    for sentence in sentences:
+        for word in sentence.split():
+            counts[word] = counts.get(word, 0) + 1
+    ranked = sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+    return [word for word, _ in ranked[:top_k]]
+
+
+@node(output_name="summary")
+def summarize_document(sentences: list[str], keywords: list[str]) -> str:
+    if not sentences:
+        return ""
+    important = [sentence for sentence in sentences if any(keyword in sentence for keyword in keywords)]
+    selected = important[:2] or sentences[:1]
+    return ". ".join(selected)
+
+
+@node(output_name="doc_stats")
+def document_stats(sentences: list[str], keywords: list[str]) -> dict:
+    return {"sentence_count": len(sentences), "keywords": keywords}
+
+
+document_graph = Graph(
+    [
+        normalize_document,
+        split_sentences,
+        extract_keywords,
+        summarize_document,
+        document_stats,
+    ],
+    name="document_pipeline",
+)
+
+
+@node(output_name="ingestion_report")
+def build_ingestion_report(doc_stats: list[dict]) -> dict:
+    keyword_pool = sorted({keyword for stats in doc_stats for keyword in stats["keywords"]})
+    return {
+        "documents_processed": len(doc_stats),
+        "total_sentences": sum(stats["sentence_count"] for stats in doc_stats),
+        "unique_keywords": keyword_pool,
+    }
+
+
+def build_document_batch_graph() -> Graph:
+    mapped_documents = (
+        document_graph.as_node(name="process_document")
+        .with_inputs(document="documents")
+        .with_outputs(summary="document_summaries")
+        .map_over("documents")
+    )
+    return Graph(
+        [
+            mapped_documents,
+            build_ingestion_report,
+        ],
+        name="document_batch_port",
+    )
+
+
+def demo() -> dict[str, object]:
+    graph = build_document_batch_graph()
+    runner = SyncRunner()
+    return runner.run(
+        graph,
+        {
+            "documents": [
+                "Hypergraph composes graphs into larger workflows. It keeps nodes testable.",
+                "Mapped graph nodes let one document pipeline scale across a batch. Automatic wiring keeps the graph readable.",
+            ]
+        },
+    ).values
+
+
+if __name__ == "__main__":
+    print(demo())

--- a/examples/framework_ports/ml_model_selection.py
+++ b/examples/framework_ports/ml_model_selection.py
@@ -1,0 +1,130 @@
+"""Hypergraph port of modular ML pipeline examples.
+
+This example borrows its shape from Hamilton's modular dataflows and
+scikit-learn's preprocessing/training pipelines. The implementation stays
+dependency-light so it is runnable in the core Hypergraph repo.
+"""
+
+from __future__ import annotations
+
+from statistics import mean
+
+from hypergraph import Graph, SyncRunner, node
+
+TOY_FLOWERS = [
+    {"length": 1.0, "width": 0.8, "label": "compact"},
+    {"length": 1.1, "width": 0.9, "label": "compact"},
+    {"length": 0.9, "width": 0.7, "label": "compact"},
+    {"length": 4.2, "width": 3.9, "label": "tall"},
+    {"length": 4.0, "width": 4.1, "label": "tall"},
+    {"length": 4.3, "width": 4.0, "label": "tall"},
+]
+
+
+@node(output_name="rows")
+def load_rows(dataset_name: str) -> list[dict]:
+    if dataset_name != "toy_flowers":
+        raise ValueError(f"Unsupported dataset: {dataset_name}")
+    return list(TOY_FLOWERS)
+
+
+@node(output_name=("train_rows", "test_rows"))
+def split_rows(rows: list[dict], holdout_size: int = 2) -> tuple[list[dict], list[dict]]:
+    return rows[:-holdout_size], rows[-holdout_size:]
+
+
+@node(output_name="evaluated_model_type")
+def record_model_type(model_type: str) -> str:
+    return model_type
+
+
+@node(output_name="trained_model")
+def fit_model(model_type: str, train_rows: list[dict], feature_names: tuple[str, ...]) -> dict:
+    if model_type == "threshold":
+        compact_mean = mean(row[feature_names[0]] for row in train_rows if row["label"] == "compact")
+        tall_mean = mean(row[feature_names[0]] for row in train_rows if row["label"] == "tall")
+        threshold = (compact_mean + tall_mean) / 2
+        return {"model_type": "threshold", "feature": feature_names[0], "threshold": threshold}
+
+    if model_type == "centroid":
+        centroids = {}
+        for label in {row["label"] for row in train_rows}:
+            label_rows = [row for row in train_rows if row["label"] == label]
+            centroids[label] = [mean(row[feature] for row in label_rows) for feature in feature_names]
+        return {"model_type": "centroid", "feature_names": feature_names, "centroids": centroids}
+
+    raise ValueError(f"Unsupported model type: {model_type}")
+
+
+def _predict_row(model: dict, row: dict) -> str:
+    if model["model_type"] == "threshold":
+        return "compact" if row[model["feature"]] < model["threshold"] else "tall"
+
+    assert model["model_type"] == "centroid"
+    distances = {}
+    for label, centroid in model["centroids"].items():
+        distances[label] = sum((row[feature] - centroid[index]) ** 2 for index, feature in enumerate(model["feature_names"]))
+    return min(distances, key=distances.get)
+
+
+@node(output_name="predictions")
+def predict_rows(trained_model: dict, test_rows: list[dict]) -> list[str]:
+    return [_predict_row(trained_model, row) for row in test_rows]
+
+
+@node(output_name="accuracy")
+def accuracy(predictions: list[str], test_rows: list[dict]) -> float:
+    correct = sum(prediction == row["label"] for prediction, row in zip(predictions, test_rows, strict=True))
+    return correct / len(test_rows)
+
+
+trial_graph = Graph(
+    [
+        record_model_type,
+        fit_model,
+        predict_rows,
+        accuracy,
+    ],
+    name="model_trial",
+)
+
+
+@node(output_name="best_model_summary")
+def select_best_model(evaluated_model_type: list[str], accuracy: list[float], trained_model: list[dict]) -> dict:
+    best_index = max(range(len(accuracy)), key=lambda index: (accuracy[index], evaluated_model_type[index]))
+    return {
+        "model_type": evaluated_model_type[best_index],
+        "accuracy": accuracy[best_index],
+        "model": trained_model[best_index],
+        "all_scores": dict(zip(evaluated_model_type, accuracy, strict=True)),
+    }
+
+
+def build_ml_model_selection_graph() -> Graph:
+    mapped_trials = trial_graph.as_node(name="trial").with_inputs(model_type="model_types").map_over("model_types")
+    return Graph(
+        [
+            load_rows,
+            split_rows,
+            mapped_trials,
+            select_best_model,
+        ],
+        name="ml_model_selection_port",
+    )
+
+
+def demo() -> dict[str, object]:
+    graph = build_ml_model_selection_graph()
+    runner = SyncRunner()
+    return runner.run(
+        graph,
+        {
+            "dataset_name": "toy_flowers",
+            "feature_names": ("length", "width"),
+            "model_types": ["threshold", "centroid"],
+        },
+    ).values
+
+
+if __name__ == "__main__":
+    print(demo())

--- a/examples/framework_ports/support_inbox.py
+++ b/examples/framework_ports/support_inbox.py
@@ -128,7 +128,6 @@ async def demo() -> dict[str, object]:
             **values,
             first_run.pause.response_key: "Hotfix deployed and refund requests are safe to retry.",
         },
-        on_internal_override="ignore",
     )
     return resumed.values
 

--- a/examples/framework_ports/support_inbox.py
+++ b/examples/framework_ports/support_inbox.py
@@ -1,0 +1,139 @@
+"""Hypergraph port of durable support / approval inbox examples.
+
+This example is intentionally built around nested graphs and interrupt
+propagation, borrowing the problem shape from Mastra, Inngest, DBOS, and
+Restate examples while staying idiomatic Hypergraph.
+"""
+
+from __future__ import annotations
+
+from hypergraph import AsyncRunner, Graph, interrupt, node, route
+
+
+@node(output_name="ticket")
+def load_ticket(ticket_id: str, tickets_db: dict[str, dict]) -> dict:
+    ticket = tickets_db[ticket_id]
+    return {"id": ticket_id, **ticket}
+
+
+@node(output_name="support_track")
+def classify_ticket(ticket: dict) -> str:
+    return "technical_support" if ticket["kind"] == "technical" else "customer_support"
+
+
+@route(targets=["customer_support", "technical_support"])
+def route_ticket(support_track: str) -> str:
+    return support_track
+
+
+@node(output_name="knowledge_hits")
+def search_knowledge_base(ticket: dict, knowledge_base: list[str]) -> list[str]:
+    issue = ticket["issue"].lower()
+    return [entry for entry in knowledge_base if any(word in entry.lower() for word in issue.split())][:2]
+
+
+@node(output_name="resolution")
+def compose_customer_reply(ticket: dict, knowledge_hits: list[str]) -> str:
+    first_hit = knowledge_hits[0] if knowledge_hits else "We will follow up with documentation."
+    return f"Customer reply for {ticket['id']}: {first_hit}"
+
+
+customer_support_graph = Graph(
+    [
+        search_knowledge_base,
+        compose_customer_reply,
+    ],
+    name="customer_support",
+)
+
+
+@node(output_name="release_note_hits")
+def search_release_notes(ticket: dict, release_notes: list[str]) -> list[str]:
+    issue = ticket["issue"].lower()
+    return [entry for entry in release_notes if any(word in entry.lower() for word in issue.split())][:2]
+
+
+@interrupt(output_name="developer_reply")
+def request_developer_review(ticket: dict, release_note_hits: list[str]) -> str | None:
+    if ticket["priority"] != "critical":
+        return "No manual escalation required."
+    return None
+
+
+@node(output_name="resolution")
+def compose_technical_reply(ticket: dict, release_note_hits: list[str], developer_reply: str) -> str:
+    lead = release_note_hits[0] if release_note_hits else "No matching release notes."
+    return f"Technical reply for {ticket['id']}: {lead} | Developer: {developer_reply}"
+
+
+technical_support_graph = Graph(
+    [
+        search_release_notes,
+        request_developer_review,
+        compose_technical_reply,
+    ],
+    name="technical_support",
+)
+
+
+@node(output_name="customer_message")
+def publish_reply(ticket: dict, resolution: str) -> str:
+    return f"{ticket['customer']}: {resolution}"
+
+
+def build_support_inbox_graph() -> Graph:
+    return Graph(
+        [
+            load_ticket,
+            classify_ticket,
+            route_ticket,
+            customer_support_graph.as_node(),
+            technical_support_graph.as_node(),
+            publish_reply,
+        ],
+        name="support_inbox_port",
+    )
+
+
+async def demo() -> dict[str, object]:
+    graph = build_support_inbox_graph()
+    runner = AsyncRunner()
+    values = {
+        "ticket_id": "T-100",
+        "tickets_db": {
+            "T-100": {
+                "customer": "Acme",
+                "kind": "technical",
+                "priority": "critical",
+                "issue": "refund API timeout after release",
+            }
+        },
+        "knowledge_base": [
+            "General account changes are applied within one hour.",
+            "Password reset links expire after fifteen minutes.",
+        ],
+        "release_notes": [
+            "Refund API timeout fixed in patch 2026.03.",
+            "Release 2026.03 improves webhook retries.",
+        ],
+    }
+
+    first_run = await runner.run(graph, values)
+    if not first_run.paused:
+        return first_run.values
+
+    resumed = await runner.run(
+        graph,
+        {
+            **values,
+            first_run.pause.response_key: "Hotfix deployed and refund requests are safe to retry.",
+        },
+        on_internal_override="ignore",
+    )
+    return resumed.values
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    print(asyncio.run(demo()))

--- a/examples/framework_ports/support_inbox.py
+++ b/examples/framework_ports/support_inbox.py
@@ -119,17 +119,15 @@ async def demo() -> dict[str, object]:
     }
 
     first_run = await runner.run(graph, values)
-    if not first_run.paused:
+    if not first_run.paused or first_run.pause is None:
         return first_run.values
 
-    resumed = await runner.run(
-        graph,
-        {
-            **values,
-            first_run.pause.response_key: "Hotfix deployed and refund requests are safe to retry.",
-        },
-    )
-    return resumed.values
+    return {
+        "paused": True,
+        "node_name": first_run.pause.node_name,
+        "response_key": first_run.pause.response_key,
+        "value": first_run.pause.value,
+    }
 
 
 if __name__ == "__main__":

--- a/tests/test_framework_ports.py
+++ b/tests/test_framework_ports.py
@@ -31,7 +31,7 @@ def test_agentic_rag_routes_latest_questions_to_web():
     assert "latest release notes" in result["answer"].lower()
 
 
-async def test_support_inbox_nested_interrupt_propagates_and_resumes():
+async def test_support_inbox_nested_interrupt_propagates_pause():
     graph = build_support_inbox_graph()
     runner = AsyncRunner()
     values = {
@@ -59,18 +59,6 @@ async def test_support_inbox_nested_interrupt_propagates_and_resumes():
     assert paused.pause is not None
     assert paused.pause.node_name == "technical_support/request_developer_review"
     assert paused.pause.response_key == "technical_support.developer_reply"
-
-    resumed = await runner.run(
-        graph,
-        {
-            **values,
-            paused.pause.response_key: "Hotfix deployed and refund requests are safe to retry.",
-        },
-    )
-
-    assert resumed.paused is False
-    assert "Hotfix deployed" in resumed["customer_message"]
-    assert resumed["support_track"] == "technical_support"
 
 
 def test_ml_model_selection_uses_mapped_trials_to_pick_best_model():

--- a/tests/test_framework_ports.py
+++ b/tests/test_framework_ports.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from examples.framework_ports.agentic_rag import build_agentic_rag_graph
+from examples.framework_ports.document_batch_pipeline import build_document_batch_graph
+from examples.framework_ports.ml_model_selection import build_ml_model_selection_graph
+from examples.framework_ports.support_inbox import build_support_inbox_graph
+from hypergraph import AsyncRunner, SyncRunner
+
+
+def test_agentic_rag_routes_latest_questions_to_web():
+    graph = build_agentic_rag_graph()
+    runner = SyncRunner()
+
+    result = runner.run(
+        graph,
+        {
+            "question": "What changed in the latest release for interrupts?",
+            "local_documents": [
+                "Hypergraph supports interrupt nodes for human review.",
+                "Nested graphs make composition natural.",
+            ],
+            "web_documents": [
+                "Latest release notes mention better interrupt resume semantics.",
+                "Recent release adds richer run logs for nested graphs.",
+            ],
+        },
+    )
+
+    assert result["search_source"] == "search_web"
+    assert result["confidence"] == "grounded"
+    assert "latest release notes" in result["answer"].lower()
+
+
+async def test_support_inbox_nested_interrupt_propagates_and_resumes():
+    graph = build_support_inbox_graph()
+    runner = AsyncRunner()
+    values = {
+        "ticket_id": "T-100",
+        "tickets_db": {
+            "T-100": {
+                "customer": "Acme",
+                "kind": "technical",
+                "priority": "critical",
+                "issue": "refund API timeout after release",
+            }
+        },
+        "knowledge_base": [
+            "General account changes are applied within one hour.",
+        ],
+        "release_notes": [
+            "Refund API timeout fixed in patch 2026.03.",
+            "Release 2026.03 improves webhook retries.",
+        ],
+    }
+
+    paused = await runner.run(graph, values)
+
+    assert paused.paused is True
+    assert paused.pause is not None
+    assert paused.pause.node_name == "technical_support/request_developer_review"
+    assert paused.pause.response_key == "technical_support.developer_reply"
+
+    resumed = await runner.run(
+        graph,
+        {
+            **values,
+            paused.pause.response_key: "Hotfix deployed and refund requests are safe to retry.",
+        },
+        on_internal_override="ignore",
+    )
+
+    assert resumed.paused is False
+    assert "Hotfix deployed" in resumed["customer_message"]
+    assert resumed["support_track"] == "technical_support"
+
+
+def test_ml_model_selection_uses_mapped_trials_to_pick_best_model():
+    graph = build_ml_model_selection_graph()
+    runner = SyncRunner()
+
+    result = runner.run(
+        graph,
+        {
+            "dataset_name": "toy_flowers",
+            "feature_names": ("length", "width"),
+            "model_types": ["threshold", "centroid"],
+        },
+    )
+
+    assert result["evaluated_model_type"] == ["threshold", "centroid"]
+    assert len(result["accuracy"]) == 2
+    assert result["best_model_summary"]["model_type"] in {"threshold", "centroid"}
+    assert result["best_model_summary"]["accuracy"] >= 0.5
+
+
+def test_document_batch_pipeline_maps_one_document_graph_over_many_inputs():
+    graph = build_document_batch_graph()
+    runner = SyncRunner()
+
+    result = runner.run(
+        graph,
+        {
+            "documents": [
+                "Hypergraph composes graphs into larger workflows. It keeps nodes testable.",
+                "Mapped graph nodes let one document pipeline scale across a batch. Automatic wiring keeps the graph readable.",
+            ]
+        },
+    )
+
+    assert len(result["document_summaries"]) == 2
+    assert result["ingestion_report"]["documents_processed"] == 2
+    assert result["ingestion_report"]["total_sentences"] == 4

--- a/tests/test_framework_ports.py
+++ b/tests/test_framework_ports.py
@@ -66,7 +66,6 @@ async def test_support_inbox_nested_interrupt_propagates_and_resumes():
             **values,
             paused.pause.response_key: "Hotfix deployed and refund requests are safe to retry.",
         },
-        on_internal_override="ignore",
     )
 
     assert resumed.paused is False


### PR DESCRIPTION
## Problem

We explored adjacent workflow frameworks to pressure-test Hypergraph's docs and example story. The main gaps were not in the core graph model, but in how clearly the docs explain Hypergraph's strengths around hierarchical composition, mapped subgraphs, and practical HITL trade-offs.

## What changed

- added a new `framework-ports` real-world docs page
- added four framework-inspired Hypergraph example ports:
  - agentic RAG
  - support inbox / nested HITL
  - ML model selection
  - document batch pipeline
- added focused tests for those example ports
- updated intro/comparison docs to better explain:
  - where Hypergraph is strongest
  - where Hypergraph is lighter today than DBOS / Inngest / Restate
  - the "think singular, scale later" story for `map_over()` and batch processing
- expanded HITL docs with clearer durable pause/resume framing

## Before / after

Before:
- docs undersold Hypergraph's strengths in nested graphs and mapped subgraphs
- comparison framing was mostly generic
- durable HITL framing was less explicit
- there were no concrete framework-inspired example ports in the repo

After:
- docs tell a clearer structural story: DAGs inside loops, loops inside DAGs, one-item workflows scaled via mapping
- examples show how adjacent-framework patterns translate into Hypergraph-native code
- comparison docs are more honest about runtime durability trade-offs without weakening the core positioning

## Test plan

- `uv run pytest tests/test_framework_ports.py -q`
- `uv run ruff check docs/01-introduction/when-to-use.md docs/01-introduction/comparison.md docs/03-patterns/07-human-in-the-loop.md docs/05-how-to/batch-processing.md tests/test_framework_ports.py examples/framework_ports`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded introduction comparisons and positioning against adjacent frameworks (LangGraph, Hamilton, DBOS, Inngest, Restate).
  * Added guides for scaling single workflows with batch processing and human-in-the-loop patterns with pausing and resuming.
  * Introduced framework ports documentation.

* **New Features**
  * Added runnable example workflows: agentic RAG, document batch pipeline, ML model selection, and support inbox with nested graphs and interrupt-driven escalation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->