### PR TITLE
fix(graph): harden nested graph boundaries

### DIFF
--- a/dev/REVIEW-CHECKLIST.md
+++ b/dev/REVIEW-CHECKLIST.md
@@ -35,6 +35,8 @@ When reviewing code changes:
 - [ ] No unnecessary state mutation?
 - [ ] Composition used instead of configuration flags?
 - [ ] Active-set enforcement: does `with_entrypoint` / `select` properly scope both validation AND execution? (Not just one or the other)
+- [ ] Nested graph boundaries preserve the configured public interface? (`with_inputs`/`with_outputs`, scoped outputs, and bound values don't leak across sibling GraphNodes)
+- [ ] Checkpointed nested execution can re-run safely? (Repeated GraphNode execution, especially inside cycles, must not collide with child workflow IDs)
 
 ### Code Quality
 - [ ] Error messages follow three-part structure? (Problem → Context → How to fix)
@@ -47,6 +49,7 @@ When reviewing code changes:
 - [ ] Validation tests assert specific error messages?
 - [ ] Async tests if async code was changed?
 - [ ] No new dependencies unless justified?
+- [ ] Nested regressions covered when touching GraphNode/interrupt/checkpointing code? Include renamed outputs, pause/resume, and checkpointed re-execution where relevant.
 
 ### Sync/Async Parity
 - [ ] Changes to `sync/` mirrored in `async_/`?

--- a/docs/03-patterns/07-human-in-the-loop.md
+++ b/docs/03-patterns/07-human-in-the-loop.md
@@ -472,6 +472,11 @@ runner.run(graph_with_interrupt, {"query": "hello"})
 
 Similarly, `AsyncRunner.map()` does not support interrupts — a graph with interrupts cannot be used with `map()`.
 
+The same restriction applies to `GraphNode.map_over(...)`: a nested graph that
+contains interrupts cannot be wrapped in `map_over()`. If you need batched
+human-in-the-loop processing, use `AsyncRunner.map()` on the item graph itself
+rather than mapping a nested interrupting graph inside a larger workflow.
+
 ## With emit/wait_for
 
 InterruptNode supports ordering signals like FunctionNode:

--- a/docs/03-patterns/07-human-in-the-loop.md
+++ b/docs/03-patterns/07-human-in-the-loop.md
@@ -474,8 +474,8 @@ Similarly, `AsyncRunner.map()` does not support interrupts — a graph with inte
 
 The same restriction applies to `GraphNode.map_over(...)`: a nested graph that
 contains interrupts cannot be wrapped in `map_over()`. If you need batched
-human-in-the-loop processing, use `AsyncRunner.map()` on the item graph itself
-rather than mapping a nested interrupting graph inside a larger workflow.
+human-in-the-loop processing today, orchestrate the batch at the application
+layer rather than nesting an interrupting graph inside `map_over()`.
 
 ## With emit/wait_for
 

--- a/docs/05-how-to/batch-processing.md
+++ b/docs/05-how-to/batch-processing.md
@@ -256,6 +256,11 @@ result = runner.run(batch, {"path": "data.txt"})
 # None entries correspond to failed items
 ```
 
+`map_over()` does not support nested graphs that contain interrupts. If the
+wrapped graph has an `@interrupt`, graph construction raises a
+`GraphConfigError`. For human-in-the-loop batch workflows, use
+`AsyncRunner.map()` with one item per run instead.
+
 ## runner.map() vs map_over
 
 Two batch patterns, different tradeoffs. Both start from the same idea — **write logic for one item, scale to many** — but they give different guarantees:

--- a/docs/06-api-reference/graph.md
+++ b/docs/06-api-reference/graph.md
@@ -246,13 +246,12 @@ print(g.inputs.required)  # ('x',)
 ```
 
 **Args:**
-- `**values`: Named values to bind
+- `**values`: Named values to bind. Keys must be graph inputs in the current scope.
 
 **Returns:** New Graph with bindings applied
 
 **Raises:**
-- `ValueError` - If binding a name not recognized as a graph input or output
-- `ValueError` - If binding an emit-only output (ordering signal, not data)
+- `ValueError` - If binding a name not recognized as a graph input in the current scope
 
 #### Shared State and Non-Copyable Objects
 
@@ -260,6 +259,15 @@ Bound values are **intentionally shared** across runs, not deep-copied. This mak
 - **Stateful objects** (database connections, vector stores, embedders)
 - **Non-copyable objects** (objects with thread locks, file handles, C extensions)
 - **Dependency injection** (providing shared resources to multiple nodes)
+
+`bind()` is not an override mechanism for active internal graph outputs. If a
+value is still produced by an upstream node in the current graph scope, that
+producer wins at runtime. To provide a formerly-intermediate value yourself,
+first slice the graph so it becomes an input:
+
+```python
+scoped = graph.with_entrypoint("retrieve").bind(embedding=my_embedding)
+```
 
 ```python
 class Embedder:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -65,7 +65,7 @@
 
 - **`with_entrypoint(*node_names)`** — Graph method that narrows execution to start at specific nodes, skipping upstream. Works for DAGs and cycles. Returns a new Graph (immutable, chainable). Upstream nodes are excluded from the active set and never execute at runtime.
 - **Select-aware InputSpec** — `graph.select("a").inputs.required` now shows only what's needed to produce output "a", not the full graph. Previously `select()` only filtered returned outputs.
-- **Runtime select narrowing** — `runner.run(graph, values, select="a")` validates only the inputs needed for output "a". Passing `select` at runtime recomputes InputSpec scoped to the selected outputs.
+- **Runtime select overrides removed** — `runner.run(..., select=...)` is no longer supported. Configure output scope on the graph with `graph.select(...)` instead.
 - **`entrypoints_config` property** — `graph.entrypoints_config` returns the configured entry point node names, or `None` if all nodes are active.
 
 ### Changed

--- a/src/hypergraph/events/rich_progress.py
+++ b/src/hypergraph/events/rich_progress.py
@@ -707,12 +707,16 @@ class RichProgressProcessor(TypedEventProcessor):
             elif self._tty_mode:
                 if event.status == RunStatus.COMPLETED:
                     self._progress.console.print(f"[bold green]✓ {event.graph_name or 'Run'} completed![/bold green]")
+                elif event.status == RunStatus.PAUSED:
+                    self._progress.console.print(f"[bold yellow]‖ {event.graph_name or 'Run'} paused[/bold yellow]")
                 else:
                     self._progress.console.print(f"[bold red]✗ {event.graph_name or 'Run'} failed: {event.error}[/bold red]")
             else:
                 name = event.graph_name or "Run"
                 if event.status == RunStatus.COMPLETED:
                     self._print(f"✓ {name} completed!")
+                elif event.status == RunStatus.PAUSED:
+                    self._print(f"‖ {name} paused")
                 else:
                     error_msg = f": {event.error}" if event.error else ""
                     self._print(f"✗ {name} failed{error_msg}")
@@ -729,6 +733,9 @@ class RichProgressProcessor(TypedEventProcessor):
         if event.status == RunStatus.COMPLETED:
             color = STATUS_COLORS["completed"]
             msg = f"✓ {name} completed!"
+        elif event.status == RunStatus.PAUSED:
+            color = STATUS_COLORS["paused"]
+            msg = f"‖ {name} paused"
         else:
             color = STATUS_COLORS["failed"]
             error_text = f": {event.error}" if event.error else ""

--- a/src/hypergraph/events/rich_progress.py
+++ b/src/hypergraph/events/rich_progress.py
@@ -688,6 +688,8 @@ class RichProgressProcessor(TypedEventProcessor):
 
                     if event.status == RunStatus.FAILED:
                         map_info.failures += 1
+                    elif event.status == RunStatus.PAUSED:
+                        pass
                     else:
                         map_info.succeeded += 1
                     self._update_map_stats(map_info)

--- a/src/hypergraph/events/types.py
+++ b/src/hypergraph/events/types.py
@@ -14,10 +14,12 @@ class RunStatus(Enum):
     Values:
         COMPLETED: Run finished successfully.
         FAILED: Run encountered an error.
+        PAUSED: Run paused at an interrupt.
     """
 
     COMPLETED = "completed"
     FAILED = "failed"
+    PAUSED = "paused"
 
 
 def _generate_span_id() -> str:
@@ -70,7 +72,7 @@ class RunEndEvent(BaseEvent):
 
     Attributes:
         graph_name: Name of the graph that was executed.
-        status: Outcome of the run (RunStatus.COMPLETED or RunStatus.FAILED).
+        status: Outcome of the run (completed, failed, or paused).
         error: Error message if status is FAILED.
         duration_ms: Wall-clock duration in milliseconds.
     """

--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -921,22 +921,30 @@ class Graph:
     def bind(self, **values: Any) -> Graph:
         """Bind default values. Returns new Graph (immutable).
 
-        Accepts any graph input or output name. Bound values act as
-        pre-filled run() values — overridable at run time.
+        Accepts graph input names in the current configured scope.
+        Bound values act as pre-filled run() values — overridable at run time.
+        If you want to bind a value that would normally be produced upstream,
+        first slice the graph with ``with_entrypoint()`` / ``select()`` so that
+        value becomes a true graph input.
 
         Raises:
-            ValueError: If key is not a valid graph input or output
-            ValueError: If key is an emit-only output (ordering signal)
+            ValueError: If key is not a valid graph input in the current scope
         """
-        valid_names = set(self.inputs.all) | set(self.outputs)
-        emit_only = self._get_emit_only_outputs()
-        valid_names -= emit_only
+        valid_names = set(self.inputs.all)
+        output_names = set(self.outputs)
 
         for key in values:
-            if key in emit_only:
-                raise ValueError(f"Cannot bind '{key}': emit-only output (ordering signal, not data)")
             if key not in valid_names:
-                raise ValueError(f"Cannot bind '{key}': not a graph input or output. Valid names: {sorted(valid_names)}")
+                if key in output_names:
+                    raise ValueError(
+                        f"Cannot bind '{key}': bind() only accepts graph inputs in the current scope.\n\n"
+                        f"  -> '{key}' is an output of the active graph, not an input\n\n"
+                        f"How to fix:\n"
+                        f"  Slice the graph first so '{key}' becomes an input, then bind it:\n"
+                        f"    graph = graph.with_entrypoint('<downstream_node>').bind({key}=...)\n"
+                        f"  You can also use Graph(..., entrypoint='<downstream_node>') when constructing the graph."
+                    )
+                raise ValueError(f"Cannot bind '{key}': not a graph input in the current scope. Valid inputs: {sorted(valid_names)}")
 
         new_graph = self._shallow_copy()
         new_graph._bound = {**self._bound, **values}
@@ -1015,8 +1023,7 @@ class Graph:
         )
 
         if self._bound:
-            valid_names = set(new_graph.inputs.all) | set(new_graph.outputs)
-            valid_names -= new_graph._get_emit_only_outputs()
+            valid_names = set(new_graph.inputs.all)
             invalid = [k for k in self._bound if k not in valid_names]
             if invalid:
                 raise ValueError(

--- a/src/hypergraph/graph/input_spec.py
+++ b/src/hypergraph/graph/input_spec.py
@@ -351,15 +351,43 @@ def _collect_bound_values(
 
     # Start with current graph's bound values
     all_bound = dict(bound)
+    nested_candidates: dict[str, list[Any]] = {}
 
     # Merge bound values from nested GraphNodes
     for node in nodes.values():
         if isinstance(node, GraphNode):
             # Get bound values from the inner graph
             inner_bound = node.graph.inputs.bound
-            # Merge into all_bound (current graph's values take precedence)
+            # Merge unique nested bindings only. If sibling nested graphs bind
+            # the same key to different values, that key is ambiguous at the
+            # outer graph level and should stay out of graph.inputs.bound.
             for key, value in inner_bound.items():
-                if key not in all_bound:
-                    all_bound[key] = value
+                if key in all_bound:
+                    continue
+                nested_candidates.setdefault(key, []).append(value)
+
+    for key, candidates in nested_candidates.items():
+        if len(candidates) == 1 or _all_values_equal(candidates):
+            all_bound[key] = candidates[0]
 
     return all_bound
+
+
+def _all_values_equal(values: list[Any]) -> bool:
+    """Best-effort equality check for merged nested bound values."""
+    if len(values) <= 1:
+        return True
+    first = values[0]
+    for value in values[1:]:
+        if first is value:
+            continue
+        try:
+            equal = first == value
+            if hasattr(equal, "__iter__"):
+                if not all(equal):
+                    return False
+            elif not bool(equal):
+                return False
+        except Exception:
+            return False
+    return True

--- a/src/hypergraph/graph/input_spec.py
+++ b/src/hypergraph/graph/input_spec.py
@@ -365,9 +365,10 @@ def _collect_bound_values(
             # the same key to different values, that key is ambiguous at the
             # outer graph level and should stay out of graph.inputs.bound.
             for key, value in inner_bound.items():
-                if key in all_bound:
+                public_key = node.map_input_name_from_original(key)
+                if public_key in all_bound:
                     continue
-                nested_candidates.setdefault(key, []).append(value)
+                nested_candidates.setdefault(public_key, []).append(value)
 
     for key, candidates in nested_candidates.items():
         if len(candidates) == 1 or _all_values_equal(candidates):

--- a/src/hypergraph/graph/input_spec.py
+++ b/src/hypergraph/graph/input_spec.py
@@ -87,11 +87,12 @@ def compute_input_spec(
 
     data_subgraph = _data_only_subgraph(active_subgraph)
     edge_produced = get_edge_produced_values(active_subgraph)
+    all_bound = _collect_bound_values(active_nodes, bound)
     cycle_seed_params = _compute_cycle_seed_params(
         active_nodes,
         data_subgraph,
         edge_produced,
-        bound,
+        all_bound,
         configured_entrypoints=entrypoints or (),
     )
 
@@ -104,13 +105,11 @@ def compute_input_spec(
             else:
                 required.append(param)
             continue
-        category = _categorize_param(param, edge_produced, bound, active_nodes)
+        category = _categorize_param(param, edge_produced, all_bound, active_nodes)
         if category == "required":
             required.append(param)
         elif category == "optional":
             optional.append(param)
-
-    all_bound = _collect_bound_values(active_nodes, bound)
 
     return InputSpec(
         required=tuple(required),

--- a/src/hypergraph/graph/input_spec.py
+++ b/src/hypergraph/graph/input_spec.py
@@ -175,7 +175,7 @@ def _categorize_param(
     if param in edge_produced:
         return None  # Produced by an edge, not a user input
 
-    if param in bound or _any_node_has_default(param, nodes):
+    if param in bound or _all_consumers_have_default(param, nodes):
         return "optional"
 
     return "required"
@@ -186,9 +186,12 @@ def _is_interrupt_produced(param: str, nodes: dict[str, HyperNode]) -> bool:
     return any(n.is_interrupt and param in n.outputs for n in nodes.values())
 
 
-def _any_node_has_default(param: str, nodes: dict[str, HyperNode]) -> bool:
-    """Check if any node consuming this param has a default value."""
-    return any(param in node.inputs and node.has_default_for(param) for node in nodes.values())
+def _all_consumers_have_default(param: str, nodes: dict[str, HyperNode]) -> bool:
+    """Check if every node consuming this param has a fallback value."""
+    consumers = [node for node in nodes.values() if param in node.inputs]
+    if not consumers:
+        return False
+    return all(node.has_default_for(param) for node in consumers)
 
 
 def _get_all_cycle_params(

--- a/src/hypergraph/nodes/graph_node.py
+++ b/src/hypergraph/nodes/graph_node.py
@@ -91,7 +91,7 @@ class GraphNode(HyperNode):
         # Core HyperNode attributes
         self.name = resolved_name
         self.inputs = graph.inputs.all
-        self.outputs = graph.selected if graph.selected is not None else graph.outputs
+        self.outputs = self._derive_outputs(graph)
 
     @property
     def graph(self) -> "Graph":
@@ -315,6 +315,32 @@ class GraphNode(HyperNode):
         # Build forward map (original -> renamed) by inverting reverse map
         forward_map = {v: k for k, v in reverse_map.items()}
         return {forward_map.get(key, key): value for key, value in outputs.items()}
+
+    def map_output_name_from_original(self, output_name: str) -> str:
+        """Map a single inner output name to its external renamed name."""
+        reverse_map = build_reverse_rename_map(self._rename_history, "outputs")
+        if not reverse_map:
+            return output_name
+        forward_map = {v: k for k, v in reverse_map.items()}
+        return forward_map.get(output_name, output_name)
+
+    def resolve_original_output_name(self, output_name: str) -> str:
+        """Resolve an external output name back to the inner graph's name."""
+        reverse_map = build_reverse_rename_map(self._rename_history, "outputs")
+        return reverse_map.get(output_name, output_name)
+
+    def map_resume_key_from_original(self, resume_key: str) -> str:
+        """Map a nested resume key from inner names to external names.
+
+        Only the first path component can be renamed by the GraphNode boundary.
+        For example, ``decision`` may become ``verdict`` while
+        ``review.decision`` remains unchanged because ``review`` is internal.
+        """
+        head, sep, tail = resume_key.partition(".")
+        mapped_head = self.map_output_name_from_original(head)
+        if not sep:
+            return mapped_head
+        return f"{mapped_head}.{tail}"
 
     def has_default_for(self, param: str) -> bool:
         """Check if a parameter has a default or bound value in the inner graph.
@@ -570,6 +596,25 @@ class GraphNode(HyperNode):
             renamed._clone = [combined.get(p, p) for p in renamed._clone]
 
         return renamed
+
+    @staticmethod
+    def _derive_outputs(graph: "Graph") -> tuple[str, ...]:
+        """Resolve the GraphNode's visible outputs for the current graph scope."""
+        if graph.selected is not None:
+            return graph.selected
+
+        if graph.entrypoints_config is None:
+            return graph.outputs
+
+        from hypergraph.graph.input_spec import _compute_active_scope
+
+        active_nodes, _ = _compute_active_scope(
+            graph._nodes,
+            graph._nx_graph,
+            entrypoints=graph.entrypoints_config,
+            selected=None,
+        )
+        return tuple(dict.fromkeys(output for node in active_nodes.values() for output in node.outputs))
 
 
 def _validate_clone(

--- a/src/hypergraph/nodes/graph_node.py
+++ b/src/hypergraph/nodes/graph_node.py
@@ -380,8 +380,8 @@ class GraphNode(HyperNode):
         # Resolve to original name for inner graph lookup
         original_param = self._resolve_original_input_name(param)
 
-        # Check if bound in the immediate inner graph
-        if original_param in self._graph._bound:
+        # Check if bound anywhere in the visible inner graph scope
+        if original_param in self._graph.inputs.bound:
             return True
         # Check if any inner node has a default
         inner_nodes_with_param = [n for n in self._graph.iter_nodes() if original_param in n.inputs]
@@ -408,8 +408,8 @@ class GraphNode(HyperNode):
         original_param = self._resolve_original_input_name(param)
 
         # Check if bound in inner graph first
-        if original_param in self._graph._bound:
-            return self._graph._bound[original_param]
+        if original_param in self._graph.inputs.bound:
+            return self._graph.inputs.bound[original_param]
         # Check inner nodes for defaults
         for inner_node in self._graph.iter_nodes():
             if original_param in inner_node.inputs and inner_node.has_default_for(original_param):
@@ -436,7 +436,7 @@ class GraphNode(HyperNode):
         original_param = self._resolve_original_input_name(param)
 
         # Bound parameters don't have signature defaults (they're configuration)
-        if original_param in self._graph._bound:
+        if original_param in self._graph.inputs.bound:
             return False
 
         # Check if ALL inner nodes using this param have signature defaults
@@ -466,7 +466,7 @@ class GraphNode(HyperNode):
         original_param = self._resolve_original_input_name(param)
 
         # Bound parameters don't have signature defaults
-        if original_param in self._graph._bound:
+        if original_param in self._graph.inputs.bound:
             raise KeyError(f"Parameter '{param}' is bound, not a signature default")
 
         # Get signature default from inner nodes (not bound values)

--- a/src/hypergraph/nodes/graph_node.py
+++ b/src/hypergraph/nodes/graph_node.py
@@ -329,6 +329,14 @@ class GraphNode(HyperNode):
         reverse_map = build_reverse_rename_map(self._rename_history, "outputs")
         return reverse_map.get(output_name, output_name)
 
+    def map_input_name_from_original(self, input_name: str) -> str:
+        """Map a single inner input name to its external renamed name."""
+        reverse_map = build_reverse_rename_map(self._rename_history, "inputs")
+        if not reverse_map:
+            return input_name
+        forward_map = {v: k for k, v in reverse_map.items()}
+        return forward_map.get(input_name, input_name)
+
     def map_resume_key_from_original(self, resume_key: str) -> str:
         """Map a nested resume key from inner names to external names.
 
@@ -341,6 +349,18 @@ class GraphNode(HyperNode):
         if not sep:
             return mapped_head
         return f"{mapped_head}.{tail}"
+
+    def iter_active_inner_nodes(self) -> tuple[HyperNode, ...]:
+        """Return the inner graph nodes visible through this GraphNode boundary."""
+        from hypergraph.graph.input_spec import _compute_active_scope
+
+        active_nodes, _ = _compute_active_scope(
+            self._graph._nodes,
+            self._graph._nx_graph,
+            entrypoints=self._graph.entrypoints_config,
+            selected=self._graph.selected,
+        )
+        return tuple(active_nodes.values())
 
     def has_default_for(self, param: str) -> bool:
         """Check if a parameter has a default or bound value in the inner graph.

--- a/src/hypergraph/nodes/graph_node.py
+++ b/src/hypergraph/nodes/graph_node.py
@@ -360,11 +360,14 @@ class GraphNode(HyperNode):
         # Resolve to original name for inner graph lookup
         original_param = self._resolve_original_input_name(param)
 
-        # Check if bound in inner graph
-        if original_param in self._graph.inputs.bound:
+        # Check if bound in the immediate inner graph
+        if original_param in self._graph._bound:
             return True
         # Check if any inner node has a default
-        return any(original_param in inner_node.inputs and inner_node.has_default_for(original_param) for inner_node in self._graph.iter_nodes())
+        inner_nodes_with_param = [n for n in self._graph.iter_nodes() if original_param in n.inputs]
+        if not inner_nodes_with_param:
+            return False
+        return all(inner_node.has_default_for(original_param) for inner_node in inner_nodes_with_param)
 
     def get_default_for(self, param: str) -> Any:
         """Get the default or bound value for a parameter from the inner graph.
@@ -385,8 +388,8 @@ class GraphNode(HyperNode):
         original_param = self._resolve_original_input_name(param)
 
         # Check if bound in inner graph first
-        if original_param in self._graph.inputs.bound:
-            return self._graph.inputs.bound[original_param]
+        if original_param in self._graph._bound:
+            return self._graph._bound[original_param]
         # Check inner nodes for defaults
         for inner_node in self._graph.iter_nodes():
             if original_param in inner_node.inputs and inner_node.has_default_for(original_param):
@@ -413,7 +416,7 @@ class GraphNode(HyperNode):
         original_param = self._resolve_original_input_name(param)
 
         # Bound parameters don't have signature defaults (they're configuration)
-        if original_param in self._graph.inputs.bound:
+        if original_param in self._graph._bound:
             return False
 
         # Check if ALL inner nodes using this param have signature defaults
@@ -443,7 +446,7 @@ class GraphNode(HyperNode):
         original_param = self._resolve_original_input_name(param)
 
         # Bound parameters don't have signature defaults
-        if original_param in self._graph.inputs.bound:
+        if original_param in self._graph._bound:
             raise KeyError(f"Parameter '{param}' is bound, not a signature default")
 
         # Get signature default from inner nodes (not bound values)

--- a/src/hypergraph/runners/_shared/checkpoint_helpers.py
+++ b/src/hypergraph/runners/_shared/checkpoint_helpers.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from hypergraph.checkpointers.types import StepRecord, StepStatus, _utcnow
+from hypergraph.runners._shared.helpers import graphnode_child_workflow_id
 
 if TYPE_CHECKING:
     from hypergraph.graph import Graph
@@ -43,7 +44,13 @@ def build_superstep_records(
         execution = state.node_executions.get(name)
         now = _utcnow()
         node_type = type(graph._nodes[name]).__name__ if name in graph._nodes else None
-        child_run_id = _compute_child_run_id(workflow_id, name, graph)
+        child_run_id = _compute_child_run_id(
+            workflow_id,
+            name,
+            graph,
+            state,
+            had_previous_execution=name in prev_input_versions,
+        )
 
         if is_pause and (execution is None or not _is_fresh(name, execution, prev_input_versions)):
             # Interrupt node raised PauseExecution before producing outputs.
@@ -120,13 +127,22 @@ def _is_fresh(name: str, execution: Any, prev_input_versions: dict[str, dict[str
     return name not in prev_input_versions or execution.input_versions != prev_input_versions[name]
 
 
-def _compute_child_run_id(workflow_id: str, node_name: str, graph: Graph) -> str | None:
+def _compute_child_run_id(
+    workflow_id: str,
+    node_name: str,
+    graph: Graph,
+    state: GraphState,
+    *,
+    had_previous_execution: bool,
+) -> str | None:
     """Deterministic child_run_id for GraphNode steps."""
     from hypergraph.nodes.graph_node import GraphNode
 
     node = graph._nodes.get(node_name)
     if isinstance(node, GraphNode):
-        return f"{workflow_id}/{node_name}"
+        if not had_previous_execution:
+            return f"{workflow_id}/{node_name}"
+        return graphnode_child_workflow_id(workflow_id, node_name, state)
     return None
 
 

--- a/src/hypergraph/runners/_shared/helpers.py
+++ b/src/hypergraph/runners/_shared/helpers.py
@@ -142,9 +142,12 @@ def get_value_source(
     if param in provided_values:
         return (ValueSource.PROVIDED, provided_values[param])
 
-    # 3. Bound value (from graph.bind()) - check both graph and GraphNode
-    if param in graph.inputs.bound:
-        return (ValueSource.BOUND, graph.inputs.bound[param])
+    # 3. Bound value from this graph instance only (graph.bind()).
+    # graph.inputs.bound also includes nested GraphNode bindings for introspection,
+    # so runtime resolution must use the graph's own bound dict to avoid sibling
+    # nested bindings leaking across GraphNodes.
+    if param in graph._bound:
+        return (ValueSource.BOUND, graph._bound[param])
 
     # 3b. For GraphNode: check if inner graph has it bound
     if isinstance(node, GraphNode):
@@ -897,8 +900,34 @@ def _collect_interrupt_resume_keys(
             continue
         if isinstance(node, GraphNode):
             nested_prefix = f"{prefix}{node.name}."
-            allowed_outputs.update(_collect_interrupt_resume_keys(node.graph, prefix=nested_prefix))
+            nested_keys = _collect_interrupt_resume_keys(node.graph)
+            allowed_outputs.update(f"{nested_prefix}{node.map_resume_key_from_original(key)}" for key in nested_keys)
     return allowed_outputs
+
+
+def graphnode_child_workflow_id(
+    workflow_id: str | None,
+    node_name: str,
+    state: GraphState,
+) -> str | None:
+    """Return a child workflow id for a GraphNode execution.
+
+    The first execution keeps the historical ``parent/node`` form so paused
+    nested workflows can resume with the same id. Re-executions append a stable
+    suffix derived from the previous execution's versions so checkpointed outer
+    cycles don't collide with completed child runs.
+    """
+    if workflow_id is None:
+        return None
+
+    base = f"{workflow_id}/{node_name}"
+    execution = state.node_executions.get(node_name)
+    if execution is None:
+        return base
+
+    previous_versions = tuple(execution.output_versions.values()) or tuple(execution.input_versions.values())
+    iteration = max(previous_versions, default=1)
+    return f"{base}/{iteration}"
 
 
 _UNSET_SELECT: Any = object()

--- a/src/hypergraph/runners/_shared/helpers.py
+++ b/src/hypergraph/runners/_shared/helpers.py
@@ -945,8 +945,11 @@ def graphnode_child_workflow_id(
     if execution is None:
         return base
 
-    previous_versions = tuple(execution.input_versions.values()) or tuple(execution.output_versions.values())
-    iteration = max(previous_versions, default=1)
+    # output_versions are recorded after the previous execution completed, so
+    # they already reflect the suffix we want for the next child run. For nodes
+    # without recorded outputs, input_versions reflect the pre-execution state,
+    # so advance one step beyond the highest seen value.
+    iteration = max(execution.output_versions.values()) if execution.output_versions else max(execution.input_versions.values(), default=0) + 1
     return f"{base}/{iteration}"
 
 

--- a/src/hypergraph/runners/_shared/helpers.py
+++ b/src/hypergraph/runners/_shared/helpers.py
@@ -152,8 +152,8 @@ def get_value_source(
     # 3b. For GraphNode: check if inner graph has it bound
     if isinstance(node, GraphNode):
         original_param = node._resolve_original_input_name(param)
-        if original_param in node._graph.inputs.bound:
-            return (ValueSource.BOUND, node._graph.inputs.bound[original_param])
+        if original_param in node._graph._bound:
+            return (ValueSource.BOUND, node._graph._bound[original_param])
 
     # 4. Function default (from signature)
     if node.has_signature_default_for(param):
@@ -529,7 +529,7 @@ def _has_input(param: str, node: HyperNode, graph: Graph, state: GraphState) -> 
         return True
 
     # Bound value in graph
-    if param in graph.inputs.bound:
+    if param in graph._bound:
         return True
 
     # Node has default for this parameter
@@ -787,7 +787,7 @@ def initialize_state_with_checkpoint(
 
     versions: dict[str, int] = {}
     graph_input_names = set(graph.inputs.all)
-    bound_names = set(graph.inputs.bound)
+    bound_names = set(graph._bound)
     for name in checkpoint_values:
         # Runtime-provided graph inputs start at version 1 (set by update_value
         # during initialize_state). Bound values start at version 0 (resolved
@@ -900,7 +900,27 @@ def _collect_interrupt_resume_keys(
             continue
         if isinstance(node, GraphNode):
             nested_prefix = f"{prefix}{node.name}."
-            nested_keys = _collect_interrupt_resume_keys(node.graph)
+            nested_keys = _collect_interrupt_resume_keys_from_nodes(node.iter_active_inner_nodes())
+            allowed_outputs.update(f"{nested_prefix}{node.map_resume_key_from_original(key)}" for key in nested_keys)
+    return allowed_outputs
+
+
+def _collect_interrupt_resume_keys_from_nodes(
+    nodes: tuple[HyperNode, ...],
+    *,
+    prefix: str = "",
+) -> set[str]:
+    """Collect interrupt resume keys from an explicit active node scope."""
+    from hypergraph.nodes.graph_node import GraphNode
+
+    allowed_outputs: set[str] = set()
+    for node in nodes:
+        if node.is_interrupt:
+            allowed_outputs.update(f"{prefix}{output}" for output in node.data_outputs)
+            continue
+        if isinstance(node, GraphNode):
+            nested_prefix = f"{prefix}{node.name}."
+            nested_keys = _collect_interrupt_resume_keys_from_nodes(node.iter_active_inner_nodes())
             allowed_outputs.update(f"{nested_prefix}{node.map_resume_key_from_original(key)}" for key in nested_keys)
     return allowed_outputs
 

--- a/src/hypergraph/runners/_shared/helpers.py
+++ b/src/hypergraph/runners/_shared/helpers.py
@@ -925,7 +925,7 @@ def graphnode_child_workflow_id(
     if execution is None:
         return base
 
-    previous_versions = tuple(execution.output_versions.values()) or tuple(execution.input_versions.values())
+    previous_versions = tuple(execution.input_versions.values()) or tuple(execution.output_versions.values())
     iteration = max(previous_versions, default=1)
     return f"{base}/{iteration}"
 

--- a/src/hypergraph/runners/_shared/helpers.py
+++ b/src/hypergraph/runners/_shared/helpers.py
@@ -142,18 +142,18 @@ def get_value_source(
     if param in provided_values:
         return (ValueSource.PROVIDED, provided_values[param])
 
-    # 3. Bound value from this graph instance only (graph.bind()).
-    # graph.inputs.bound also includes nested GraphNode bindings for introspection,
-    # so runtime resolution must use the graph's own bound dict to avoid sibling
-    # nested bindings leaking across GraphNodes.
-    if param in graph._bound:
-        return (ValueSource.BOUND, graph._bound[param])
+    # 3. Bound value resolved at this graph boundary.
+    # graph.inputs.bound includes this graph's own bindings plus any unique,
+    # non-ambiguous nested GraphNode bindings that are intentionally exposed as
+    # outer defaults.
+    if param in graph.inputs.bound:
+        return (ValueSource.BOUND, graph.inputs.bound[param])
 
     # 3b. For GraphNode: check if inner graph has it bound
     if isinstance(node, GraphNode):
         original_param = node._resolve_original_input_name(param)
-        if original_param in node._graph._bound:
-            return (ValueSource.BOUND, node._graph._bound[original_param])
+        if original_param in node._graph.inputs.bound:
+            return (ValueSource.BOUND, node._graph.inputs.bound[original_param])
 
     # 4. Function default (from signature)
     if node.has_signature_default_for(param):
@@ -529,7 +529,7 @@ def _has_input(param: str, node: HyperNode, graph: Graph, state: GraphState) -> 
         return True
 
     # Bound value in graph
-    if param in graph._bound:
+    if param in graph.inputs.bound:
         return True
 
     # Node has default for this parameter
@@ -787,7 +787,7 @@ def initialize_state_with_checkpoint(
 
     versions: dict[str, int] = {}
     graph_input_names = set(graph.inputs.all)
-    bound_names = set(graph._bound)
+    bound_names = set(graph.inputs.bound)
     for name in checkpoint_values:
         # Runtime-provided graph inputs start at version 1 (set by update_value
         # during initialize_state). Bound values start at version 0 (resolved

--- a/src/hypergraph/runners/_shared/run_log.py
+++ b/src/hypergraph/runners/_shared/run_log.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from hypergraph.events.processor import TypedEventProcessor
 from hypergraph.events.types import (
+    InterruptEvent,
     NodeEndEvent,
     NodeErrorEvent,
     NodeStartEvent,
@@ -74,6 +75,17 @@ class RunLogCollector(TypedEventProcessor):
                 span_id=event.span_id,
                 error=event.error,
                 decision=decision,
+            )
+        )
+
+    def on_interrupt(self, event: InterruptEvent) -> None:
+        self._records.append(
+            NodeRecord(
+                node_name=event.node_name,
+                superstep=self._current_superstep,
+                duration_ms=0.0,
+                status="paused",
+                span_id=event.span_id,
             )
         )
 

--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -406,6 +406,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                 await dispatcher.emit_async(
                     InterruptEvent(
                         run_id=run_id,
+                        span_id=pause.span_id or run_span_id,
                         parent_span_id=run_span_id,
                         node_name=pause.pause_info.node_name,
                         graph_name=graph.name,

--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -399,6 +399,31 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
             partial_state = getattr(pause, "_partial_state", None)
             partial_values = filter_outputs(partial_state, graph, select) if partial_state is not None else {}
             total_duration_ms = (time.time() - start_time) * 1000
+            if dispatcher.active:
+                from hypergraph.events.types import InterruptEvent, RunEndEvent
+                from hypergraph.events.types import RunStatus as EventRunStatus
+
+                await dispatcher.emit_async(
+                    InterruptEvent(
+                        run_id=run_id,
+                        parent_span_id=run_span_id,
+                        node_name=pause.pause_info.node_name,
+                        graph_name=graph.name,
+                        workflow_id=workflow_id,
+                        value=pause.pause_info.value,
+                        response_param=pause.pause_info.output_param,
+                    )
+                )
+                await dispatcher.emit_async(
+                    RunEndEvent(
+                        run_id=run_id,
+                        span_id=run_span_id,
+                        parent_span_id=_parent_span_id,
+                        graph_name=graph.name,
+                        status=EventRunStatus.PAUSED,
+                        duration_ms=total_duration_ms,
+                    )
+                )
             if has_checkpointer:
                 for record in step_buffer:
                     await checkpointer.save_step(record)

--- a/src/hypergraph/runners/_shared/types.py
+++ b/src/hypergraph/runners/_shared/types.py
@@ -636,6 +636,7 @@ class PauseExecution(BaseException):
 
     def __init__(self, pause_info: PauseInfo):
         self.pause_info = pause_info
+        self.span_id: str | None = None
         super().__init__(f"Paused at {pause_info.node_name}")
 
 

--- a/src/hypergraph/runners/_shared/types.py
+++ b/src/hypergraph/runners/_shared/types.py
@@ -779,7 +779,7 @@ class NodeRecord:
         node_name: Name of the executed node.
         superstep: Parallel execution round (0-indexed).
         duration_ms: Wall-clock execution time in milliseconds.
-        status: "completed" or "failed".
+        status: "completed", "failed", or "paused".
         span_id: Correlates with OTel traces.
         error: Error message if status is "failed".
         cached: Whether this was a cache hit.
@@ -789,7 +789,7 @@ class NodeRecord:
     node_name: str
     superstep: int
     duration_ms: float
-    status: Literal["completed", "failed"]
+    status: Literal["completed", "failed", "paused"]
     span_id: str
     error: str | None = None
     cached: bool = False
@@ -989,7 +989,12 @@ class RunLog:
 
         for i, step in enumerate(self.steps):
             dur = _format_duration(step.duration_ms) if step.status != "failed" or step.duration_ms > 0 else "—"
-            status = "completed" if step.status == "completed" else f"FAILED: {step.error or 'unknown'}"
+            if step.status == "completed":
+                status = "completed"
+            elif step.status == "paused":
+                status = "paused"
+            else:
+                status = f"FAILED: {step.error or 'unknown'}"
             if step.cached:
                 status = "cached"
             if step._inner_logs:

--- a/src/hypergraph/runners/_shared/validation.py
+++ b/src/hypergraph/runners/_shared/validation.py
@@ -310,7 +310,8 @@ def _get_interrupt_outputs(
             outputs.update(f"{prefix}{output}" for output in node.data_outputs)
             continue
         if isinstance(node, GraphNode):
-            outputs.update(_get_interrupt_outputs(node.graph._nodes, prefix=f"{prefix}{node.name}."))
+            nested_outputs = _get_interrupt_outputs(node.graph._nodes)
+            outputs.update(f"{prefix}{node.name}.{node.map_resume_key_from_original(output)}" for output in nested_outputs)
     return outputs
 
 

--- a/src/hypergraph/runners/_shared/validation.py
+++ b/src/hypergraph/runners/_shared/validation.py
@@ -310,7 +310,7 @@ def _get_interrupt_outputs(
             outputs.update(f"{prefix}{output}" for output in node.data_outputs)
             continue
         if isinstance(node, GraphNode):
-            nested_outputs = _get_interrupt_outputs(node.graph._nodes)
+            nested_outputs = _get_interrupt_outputs({inner.name: inner for inner in node.iter_active_inner_nodes()})
             outputs.update(f"{prefix}{node.name}.{node.map_resume_key_from_original(output)}" for output in nested_outputs)
     return outputs
 

--- a/src/hypergraph/runners/_shared/validation.py
+++ b/src/hypergraph/runners/_shared/validation.py
@@ -430,19 +430,12 @@ def _build_internal_override_message(
 
 
 def _find_bypassed_inputs(graph: Graph, provided: set[str], inputs_spec: InputSpec) -> set[str]:
-    """Find inputs that belong to nodes fully bypassed by intermediate injection.
+    """Legacy helper for classifying impossible compute-vs-inject mixes.
 
-    A node is bypassed ONLY if ALL of its outputs that are consumed downstream
-    are provided by the user. If any consumed output is missing, the node must
-    still run to produce it.
-
-    When a node is bypassed, its exclusive inputs (not needed by other nodes)
-    can be removed from the required set.
-
-    Note: This iterates ``graph._nodes`` (the full graph), not just the active
-    subgraph. This is safe because bypassed inputs are subtracted from
-    ``inputs_spec.required``, which is already scoped to active nodes.
-    Extra bypassed inputs from inactive nodes are no-ops.
+    The runtime no longer supports supplying active internal edge-produced
+    values to skip execution. This helper remains as topology analysis for
+    conflict reporting, describing which inputs would become irrelevant if a
+    user tries to provide all outputs of some active producer nodes.
     """
     # Build output -> producer nodes mapping (handle mutex branches)
     output_to_nodes: dict[str, list[str]] = {}
@@ -455,26 +448,27 @@ def _find_bypassed_inputs(graph: Graph, provided: set[str], inputs_spec: InputSp
     for node in graph._nodes.values():
         consumed_outputs.update(node.inputs)
 
-    # Cycle entry point params: providing these means bootstrapping a cycle,
-    # NOT bypassing the producer node. Exclude from bypass check.
+    # Cycle entry point params bootstrap a cycle and do not imply that an
+    # active producer has been replaced.
     cycle_ep_params = {p for params in inputs_spec.entrypoints.values() for p in params}
 
-    # A node is bypassed only if ALL its non-cycle consumed outputs are provided
+    # A node is considered fully replaced only if ALL its non-cycle consumed
+    # outputs are provided by the user.
     bypassed_nodes: set[str] = set()
     for node in graph._nodes.values():
         node_consumed_outputs = (set(node.outputs) & consumed_outputs) - cycle_ep_params
         if node_consumed_outputs and node_consumed_outputs <= provided:
-            # All consumed outputs are provided — node is bypassed
+            # All consumed outputs are provided — treat the node as replaced for
+            # conflict analysis.
             bypassed_nodes.add(node.name)
 
     if not bypassed_nodes:
         return set()
 
-    # Also mark nodes as bypassed if ALL their non-cycle outputs are provided.
+    # Also mark nodes as replaced if ALL their non-cycle outputs are provided.
     # Unlike the first pass (consumed only), this catches nodes whose outputs
-    # aren't consumed downstream but are still fully overridden by user values.
-    # Cycle entry point params are excluded: providing them means bootstrapping
-    # the cycle, NOT bypassing the producer.
+    # are not consumed downstream but are still being fully supplied by the
+    # user in a contradictory request.
     for node in graph._nodes.values():
         non_cycle_outputs = set(node.outputs) - cycle_ep_params
         if non_cycle_outputs and non_cycle_outputs <= provided:

--- a/src/hypergraph/runners/async_/executors/graph_node.py
+++ b/src/hypergraph/runners/async_/executors/graph_node.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any
 
-from hypergraph.runners._shared.helpers import collect_as_lists, map_inputs_to_func_params
+from hypergraph.runners._shared.helpers import collect_as_lists, graphnode_child_workflow_id, map_inputs_to_func_params
 from hypergraph.runners._shared.types import PauseExecution, PauseInfo, RunResult, RunStatus
 
 if TYPE_CHECKING:
@@ -77,7 +77,7 @@ class AsyncGraphNodeExecutor:
         """
         # Translate renamed input keys back to original inner graph names
         inner_inputs = map_inputs_to_func_params(node, inputs)
-        child_workflow_id = f"{workflow_id}/{node.name}" if workflow_id else None
+        child_workflow_id = graphnode_child_workflow_id(workflow_id, node.name, state)
         map_config = node.map_config
 
         # Route interrupt resume values into the inner graph.
@@ -98,7 +98,8 @@ class AsyncGraphNodeExecutor:
             prefix = f"{node.name}."
             for key in state.values:
                 if key.startswith(prefix):
-                    inner_inputs[key[len(prefix) :]] = state.values[key]
+                    inner_key = node.resolve_original_output_name(key[len(prefix) :])
+                    inner_inputs[inner_key] = state.values[key]
 
         if map_config:
             _, mode, error_handling = map_config
@@ -136,10 +137,14 @@ class AsyncGraphNodeExecutor:
             assert result.pause is not None, "PAUSED status requires pause info"
             nested_pause = PauseInfo(
                 node_name=f"{node.name}/{result.pause.node_name}",
-                output_param=result.pause.output_param,
+                output_param=node.map_output_name_from_original(result.pause.output_param),
                 value=result.pause.value,
                 # Propagate multi-output fields (new in PR #40)
-                output_params=result.pause.output_params,
+                output_params=(
+                    tuple(node.map_output_name_from_original(name) for name in result.pause.output_params)
+                    if result.pause.output_params is not None
+                    else None
+                ),
                 values=result.pause.values,
             )
             raise PauseExecution(nested_pause)

--- a/src/hypergraph/runners/async_/superstep.py
+++ b/src/hypergraph/runners/async_/superstep.py
@@ -23,7 +23,7 @@ from hypergraph.runners._shared.event_helpers import (
     build_route_decision_event,
 )
 from hypergraph.runners._shared.helpers import collect_inputs_for_node
-from hypergraph.runners._shared.types import GraphState, NodeExecution
+from hypergraph.runners._shared.types import GraphState, NodeExecution, PauseExecution
 
 
 def _decision_activates(node_name: str, decision: Any) -> bool:
@@ -169,6 +169,9 @@ async def run_superstep_async(
                 await dispatcher.emit_async(build_node_end_event(run_id, node_span_id, run_span_id, node, graph, duration_ms, inner_logs=inner_logs))
 
             return node, outputs, input_versions, wait_for_versions, duration_ms, False
+        except PauseExecution as exc:
+            exc.span_id = node_span_id
+            raise
         except Exception:
             if active:
                 await dispatcher.emit_async(build_node_error_event(run_id, node_span_id, run_span_id, node, graph))

--- a/src/hypergraph/runners/sync/executors/graph_node.py
+++ b/src/hypergraph/runners/sync/executors/graph_node.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from hypergraph.runners._shared.helpers import collect_as_lists, map_inputs_to_func_params
+from hypergraph.runners._shared.helpers import collect_as_lists, graphnode_child_workflow_id, map_inputs_to_func_params
 
 if TYPE_CHECKING:
     from hypergraph.events.processor import EventProcessor
@@ -55,7 +55,7 @@ class SyncGraphNodeExecutor:
         """
         # Translate renamed input keys back to original inner graph names
         inner_inputs = map_inputs_to_func_params(node, inputs)
-        child_workflow_id = f"{workflow_id}/{node.name}" if workflow_id else None
+        child_workflow_id = graphnode_child_workflow_id(workflow_id, node.name, state)
         map_config = node.map_config
 
         # Route interrupt resume values into the inner graph.
@@ -75,7 +75,8 @@ class SyncGraphNodeExecutor:
             prefix = f"{node.name}."
             for key in state.values:
                 if key.startswith(prefix):
-                    inner_inputs[key[len(prefix) :]] = state.values[key]
+                    inner_key = node.resolve_original_output_name(key[len(prefix) :])
+                    inner_inputs[inner_key] = state.values[key]
 
         if map_config:
             _, mode, error_handling = map_config

--- a/tests/events/test_async_events.py
+++ b/tests/events/test_async_events.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import pytest
 
-from hypergraph import END, AsyncRunner, Graph, node, route
+from hypergraph import END, AsyncRunner, Graph, interrupt, node, route
 from hypergraph.events import AsyncEventProcessor, EventProcessor
 from hypergraph.events.types import (
+    InterruptEvent,
     NodeEndEvent,
     NodeErrorEvent,
     NodeStartEvent,
@@ -259,6 +260,57 @@ class TestRoutingEvents:
         assert decisions[0].node_name == "check"
         # Last decision should be END (count >= 1)
         assert decisions[-1].decision == END
+
+
+class TestInterruptEvents:
+    @pytest.mark.asyncio
+    async def test_paused_run_emits_interrupt_and_paused_run_end(self):
+        @interrupt(output_name="decision")
+        def approval(draft: str) -> str:
+            return None
+
+        graph = Graph([approval], name="review")
+        runner = AsyncRunner()
+        lp = ListProcessor()
+
+        result = await runner.run(graph, {"draft": "hello"}, event_processors=[lp])
+
+        assert result.paused
+        interrupts = lp.of_type(InterruptEvent)
+        assert len(interrupts) == 1
+        assert interrupts[0].node_name == "approval"
+        assert interrupts[0].response_param == "decision"
+
+        run_ends = lp.of_type(RunEndEvent)
+        assert len(run_ends) == 1
+        assert run_ends[0].status == RunStatus.PAUSED
+
+    @pytest.mark.asyncio
+    async def test_nested_paused_run_emits_interrupt_for_nested_node(self):
+        @interrupt(output_name="decision")
+        def approval(draft: str) -> str:
+            return None
+
+        inner = Graph([approval], name="inner")
+
+        @node(output_name="draft")
+        def make_draft(query: str) -> str:
+            return query
+
+        outer = Graph([make_draft, inner.as_node()], name="outer")
+        runner = AsyncRunner()
+        lp = ListProcessor()
+
+        result = await runner.run(outer, {"query": "hello"}, event_processors=[lp])
+
+        assert result.paused
+        interrupts = lp.of_type(InterruptEvent)
+        assert len(interrupts) == 2
+        assert {event.node_name for event in interrupts} == {"approval", "inner/approval"}
+
+        run_ends = lp.of_type(RunEndEvent)
+        assert len(run_ends) == 2
+        assert all(event.status == RunStatus.PAUSED for event in run_ends)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/events/test_async_events.py
+++ b/tests/events/test_async_events.py
@@ -266,7 +266,7 @@ class TestInterruptEvents:
     @pytest.mark.asyncio
     async def test_paused_run_emits_interrupt_and_paused_run_end(self):
         @interrupt(output_name="decision")
-        def approval(draft: str) -> str:
+        def approval(draft: str) -> str | None:
             return None
 
         graph = Graph([approval], name="review")
@@ -288,7 +288,7 @@ class TestInterruptEvents:
     @pytest.mark.asyncio
     async def test_nested_paused_run_emits_interrupt_for_nested_node(self):
         @interrupt(output_name="decision")
-        def approval(draft: str) -> str:
+        def approval(draft: str) -> str | None:
             return None
 
         inner = Graph([approval], name="inner")
@@ -315,7 +315,7 @@ class TestInterruptEvents:
     @pytest.mark.asyncio
     async def test_interrupt_event_reuses_paused_node_span_id(self):
         @interrupt(output_name="decision")
-        def approval(draft: str) -> str:
+        def approval(draft: str) -> str | None:
             return None
 
         graph = Graph([approval], name="review")

--- a/tests/events/test_async_events.py
+++ b/tests/events/test_async_events.py
@@ -312,6 +312,23 @@ class TestInterruptEvents:
         assert len(run_ends) == 2
         assert all(event.status == RunStatus.PAUSED for event in run_ends)
 
+    @pytest.mark.asyncio
+    async def test_interrupt_event_reuses_paused_node_span_id(self):
+        @interrupt(output_name="decision")
+        def approval(draft: str) -> str:
+            return None
+
+        graph = Graph([approval], name="review")
+        runner = AsyncRunner()
+        lp = ListProcessor()
+
+        result = await runner.run(graph, {"draft": "hello"}, event_processors=[lp])
+
+        assert result.paused
+        node_start = lp.of_type(NodeStartEvent)[0]
+        interrupt_event = lp.of_type(InterruptEvent)[0]
+        assert interrupt_event.span_id == node_start.span_id
+
 
 # ---------------------------------------------------------------------------
 # Cyclic graph

--- a/tests/events/test_rich_progress.py
+++ b/tests/events/test_rich_progress.py
@@ -402,6 +402,25 @@ class TestMapFailures:
         assert "1✓" in last_stats
         assert "1✗" in last_stats
 
+    def test_paused_map_child_does_not_increment_success_stats(self):
+        proc, mock = _make_processor()
+        proc.on_run_start(_run_start(span_id="map1", is_map=True, map_size=2))
+
+        proc.on_run_start(_run_start(run_id="r2", span_id="item1", parent_span_id="map1"))
+        proc.on_run_end(
+            _run_end(
+                run_id="r2",
+                span_id="item1",
+                parent_span_id="map1",
+                status="paused",
+            )
+        )
+
+        stats_calls = [c for c in mock.update.call_args_list if "stats" in c.kwargs]
+        last_stats = stats_calls[-1].kwargs["stats"]
+        assert "✓" not in last_stats
+        assert "✗" not in last_stats
+
 
 class TestNodeError:
     def test_error_advances_bar_and_tracks_stats(self):

--- a/tests/test_bind_defaults.py
+++ b/tests/test_bind_defaults.py
@@ -323,3 +323,19 @@ def test_nested_bound_value_does_not_make_shared_param_optional_for_other_nodes(
 
     assert "cfg" in outer.inputs.required
     assert "cfg" not in outer.inputs.optional
+
+
+def test_nested_bound_values_use_graphnode_public_input_names():
+    """Outer InputSpec.bound should expose aliased GraphNode input names."""
+
+    @node(output_name="result")
+    def inner_func(x: int, cfg: str) -> str:
+        return f"{x}:{cfg}"
+
+    inner = Graph([inner_func], name="inner").bind(cfg="inner-cfg")
+    nested = inner.as_node().with_inputs(cfg="public_cfg")
+    outer = Graph([nested], name="outer")
+
+    assert "public_cfg" in outer.inputs.bound
+    assert "cfg" not in outer.inputs.bound
+    assert outer.inputs.bound["public_cfg"] == "inner-cfg"

--- a/tests/test_bind_defaults.py
+++ b/tests/test_bind_defaults.py
@@ -305,3 +305,21 @@ def test_sibling_nested_bindings_do_not_leak():
     result = SyncRunner().run(graph, {"x": 1})
     assert result["out_a"] == "A:1:CFG_A"
     assert result["out_b"] == "B:1:CFG_B"
+
+
+def test_nested_bound_value_does_not_make_shared_param_optional_for_other_nodes():
+    """A nested bind should not make a sibling consumer think it has a fallback."""
+
+    @node(output_name="nested_out")
+    def nested_consumer(x: int, cfg: str) -> str:
+        return f"{x}:{cfg}"
+
+    @node(output_name="final")
+    def sibling_consumer(nested_out: str, cfg: str) -> str:
+        return f"{nested_out}:{cfg}"
+
+    inner = Graph([nested_consumer], name="inner").bind(cfg="inner-cfg")
+    outer = Graph([inner.as_node(), sibling_consumer], name="outer")
+
+    assert "cfg" in outer.inputs.required
+    assert "cfg" not in outer.inputs.optional

--- a/tests/test_bind_defaults.py
+++ b/tests/test_bind_defaults.py
@@ -283,3 +283,25 @@ def test_three_level_nested_binding():
     )
 
     assert result["judgment"] == "Judged: Answer: test query"
+
+
+def test_sibling_nested_bindings_do_not_leak():
+    """Sibling GraphNodes should resolve their own bound values independently."""
+
+    @node(output_name="out_a")
+    def use_a(x: int, cfg: str) -> str:
+        return f"A:{x}:{cfg}"
+
+    @node(output_name="out_b")
+    def use_b(x: int, cfg: str) -> str:
+        return f"B:{x}:{cfg}"
+
+    inner_a = Graph([use_a], name="inner_a").bind(cfg="CFG_A")
+    inner_b = Graph([use_b], name="inner_b").bind(cfg="CFG_B")
+    graph = Graph([inner_a.as_node(), inner_b.as_node()], name="outer")
+
+    assert "cfg" not in graph.inputs.bound
+
+    result = SyncRunner().run(graph, {"x": 1})
+    assert result["out_a"] == "A:1:CFG_A"
+    assert result["out_b"] == "B:1:CFG_B"

--- a/tests/test_bind_defaults.py
+++ b/tests/test_bind_defaults.py
@@ -307,24 +307,6 @@ def test_sibling_nested_bindings_do_not_leak():
     assert result["out_b"] == "B:1:CFG_B"
 
 
-def test_nested_bound_value_does_not_make_shared_param_optional_for_other_nodes():
-    """A nested bind should not make a sibling consumer think it has a fallback."""
-
-    @node(output_name="nested_out")
-    def nested_consumer(x: int, cfg: str) -> str:
-        return f"{x}:{cfg}"
-
-    @node(output_name="final")
-    def sibling_consumer(nested_out: str, cfg: str) -> str:
-        return f"{nested_out}:{cfg}"
-
-    inner = Graph([nested_consumer], name="inner").bind(cfg="inner-cfg")
-    outer = Graph([inner.as_node(), sibling_consumer], name="outer")
-
-    assert "cfg" in outer.inputs.required
-    assert "cfg" not in outer.inputs.optional
-
-
 def test_nested_bound_values_use_graphnode_public_input_names():
     """Outer InputSpec.bound should expose aliased GraphNode input names."""
 

--- a/tests/test_bind_edge_cases.py
+++ b/tests/test_bind_edge_cases.py
@@ -1,5 +1,7 @@
 """Tests for bind/unbind edge cases."""
 
+import pytest
+
 from hypergraph.graph import Graph
 from hypergraph.nodes.function import node
 
@@ -178,7 +180,7 @@ class TestBindCycleEntryPoints:
         assert configured.inputs.bound["count"] == 0
 
     def test_bind_multi_node_cycle_param(self):
-        """Multi-node cycle params are bindable."""
+        """Only the configured cycle bootstrap param is bindable."""
 
         @node(output_name="a")
         def node_a(b: int) -> int:
@@ -192,15 +194,15 @@ class TestBindCycleEntryPoints:
 
         assert g.has_cycles
 
-        # Both a and b are cycle params — binding is allowed
-        configured = g.bind(a=0)
-        assert configured.inputs.bound["a"] == 0
+        # Only the active bootstrap input is bindable under the current scope.
+        with pytest.raises(ValueError, match="bind\\(\\) only accepts graph inputs in the current scope"):
+            g.bind(a=0)
 
         configured = g.bind(b=0)
         assert configured.inputs.bound["b"] == 0
 
-    def test_bind_node_output_accepted(self):
-        """Node outputs can be bound (bypass if producer doesn't run)."""
+    def test_bind_node_output_rejected_until_graph_is_sliced(self):
+        """Node outputs cannot be bound until slicing makes them graph inputs."""
 
         @node(output_name="x")
         def producer(input_val: int) -> int:
@@ -214,8 +216,11 @@ class TestBindCycleEntryPoints:
 
         assert "input_val" in g.inputs.required
 
-        # Binding an output is allowed — acts as fallback when producer can't run
-        configured = g.bind(x=10)
+        with pytest.raises(ValueError, match="bind\\(\\) only accepts graph inputs in the current scope"):
+            g.bind(x=10)
+
+        scoped = g.with_entrypoint("consumer")
+        configured = scoped.bind(x=10)
         assert configured.inputs.bound["x"] == 10
 
 

--- a/tests/test_checkpointer/test_hierarchical_checkpointing.py
+++ b/tests/test_checkpointer/test_hierarchical_checkpointing.py
@@ -268,6 +268,35 @@ class TestNestedGraphCheckpointing:
         assert "nested-cycle/inner/2" in run_ids
         assert "nested-cycle/inner/3" in run_ids
 
+    async def test_nested_graph_in_outer_cycle_uses_distinct_child_ids_when_output_repeats(self, async_cp):
+        """Repeated nested executions should still get new child ids if outputs stay equal."""
+
+        @node(output_name="tick")
+        def tick(tick: int) -> int:
+            return tick + 1
+
+        @node(output_name="stable")
+        def constant(_tick: int) -> int:
+            return 1
+
+        inner = Graph([tick, constant], name="inner", entrypoint="tick")
+
+        @route(targets=["inner", END])
+        def decide(tick: int) -> str:
+            return END if tick >= 3 else "inner"
+
+        runner = AsyncRunner(checkpointer=async_cp)
+        outer = Graph([inner.as_node(), decide], entrypoint="inner")
+
+        result = await runner.run(outer, {"tick": 0}, workflow_id="nested-stable")
+        assert result["tick"] == 3
+        assert result["stable"] == 1
+
+        run_ids = {run.id for run in async_cp.runs()}
+        assert "nested-stable/inner" in run_ids
+        assert "nested-stable/inner/2" in run_ids
+        assert "nested-stable/inner/3" in run_ids
+
 
 # --- SyncRunner nested + map ---
 

--- a/tests/test_checkpointer/test_hierarchical_checkpointing.py
+++ b/tests/test_checkpointer/test_hierarchical_checkpointing.py
@@ -1,8 +1,8 @@
-"""Integration tests for hierarchical checkpointing: map() and nested graphs."""
+"""Integration tests for hierarchical checkpointing: map(), nested graphs, and cycles."""
 
 import pytest
 
-from hypergraph import AsyncRunner, Graph, SyncRunner, node
+from hypergraph import END, AsyncRunner, Graph, SyncRunner, node, route
 from hypergraph.checkpointers import CheckpointPolicy, SqliteCheckpointer
 
 aiosqlite = pytest.importorskip("aiosqlite")
@@ -240,9 +240,33 @@ class TestNestedGraphCheckpointing:
         assert fork_run.forked_from == "nested-root"
         assert fork_run.retry_of is None
 
-        child = async_cp.get_run("nested-root-fork/embed")
+        child = next((run for run in async_cp.runs(parent_run_id="nested-root-fork") if run.id.startswith("nested-root-fork/embed")), None)
         assert child is not None
         assert child.parent_run_id == "nested-root-fork"
+
+    async def test_nested_graph_in_outer_cycle_uses_distinct_child_run_ids(self, async_cp):
+        """Checkpointed outer cycles should not collide on repeated nested executions."""
+
+        @node(output_name="count")
+        def increment(count: int, limit: int = 3) -> int:
+            return count + 1
+
+        inner = Graph([increment], name="inner", entrypoint="increment")
+
+        @route(targets=["inner", END])
+        def decide(count: int, limit: int = 3) -> str:
+            return END if count >= limit else "inner"
+
+        runner = AsyncRunner(checkpointer=async_cp)
+        outer = Graph([inner.as_node(), decide], entrypoint="inner")
+
+        result = await runner.run(outer, {"count": 0, "limit": 3}, workflow_id="nested-cycle")
+        assert result["count"] == 3
+
+        run_ids = {run.id for run in async_cp.runs()}
+        assert "nested-cycle/inner" in run_ids
+        assert "nested-cycle/inner/2" in run_ids
+        assert "nested-cycle/inner/3" in run_ids
 
 
 # --- SyncRunner nested + map ---

--- a/tests/test_checkpointer/test_hierarchical_checkpointing.py
+++ b/tests/test_checkpointer/test_hierarchical_checkpointing.py
@@ -264,9 +264,9 @@ class TestNestedGraphCheckpointing:
         assert result["count"] == 3
 
         run_ids = {run.id for run in async_cp.runs()}
-        assert "nested-cycle/inner" in run_ids
-        assert "nested-cycle/inner/2" in run_ids
-        assert "nested-cycle/inner/3" in run_ids
+        inner_run_ids = {run_id for run_id in run_ids if run_id.startswith("nested-cycle/inner")}
+        assert "nested-cycle/inner" in inner_run_ids
+        assert len(inner_run_ids) == 3
 
     async def test_nested_graph_in_outer_cycle_uses_distinct_child_ids_when_output_repeats(self, async_cp):
         """Repeated nested executions should still get new child ids if outputs stay equal."""

--- a/tests/test_checkpointer/test_hierarchical_checkpointing.py
+++ b/tests/test_checkpointer/test_hierarchical_checkpointing.py
@@ -276,7 +276,7 @@ class TestNestedGraphCheckpointing:
             return tick + 1
 
         @node(output_name="stable")
-        def constant(_tick: int) -> int:
+        def constant(tick: int) -> int:
             return 1
 
         inner = Graph([tick, constant], name="inner", entrypoint="tick")
@@ -293,9 +293,9 @@ class TestNestedGraphCheckpointing:
         assert result["stable"] == 1
 
         run_ids = {run.id for run in async_cp.runs()}
-        assert "nested-stable/inner" in run_ids
-        assert "nested-stable/inner/2" in run_ids
-        assert "nested-stable/inner/3" in run_ids
+        inner_run_ids = {run_id for run_id in run_ids if run_id.startswith("nested-stable/inner")}
+        assert "nested-stable/inner" in inner_run_ids
+        assert len(inner_run_ids) == 3
 
 
 # --- SyncRunner nested + map ---

--- a/tests/test_checkpointer/test_hierarchical_checkpointing.py
+++ b/tests/test_checkpointer/test_hierarchical_checkpointing.py
@@ -266,7 +266,7 @@ class TestNestedGraphCheckpointing:
         run_ids = {run.id for run in async_cp.runs()}
         inner_run_ids = {run_id for run_id in run_ids if run_id.startswith("nested-cycle/inner")}
         assert "nested-cycle/inner" in inner_run_ids
-        assert len(inner_run_ids) == 3
+        assert inner_run_ids == {"nested-cycle/inner", "nested-cycle/inner/2", "nested-cycle/inner/3"}
 
     async def test_nested_graph_in_outer_cycle_uses_distinct_child_ids_when_output_repeats(self, async_cp):
         """Repeated nested executions should still get new child ids if outputs stay equal."""
@@ -294,8 +294,7 @@ class TestNestedGraphCheckpointing:
 
         run_ids = {run.id for run in async_cp.runs()}
         inner_run_ids = {run_id for run_id in run_ids if run_id.startswith("nested-stable/inner")}
-        assert "nested-stable/inner" in inner_run_ids
-        assert len(inner_run_ids) == 3
+        assert inner_run_ids == {"nested-stable/inner", "nested-stable/inner/2", "nested-stable/inner/3"}
 
 
 # --- SyncRunner nested + map ---
@@ -350,3 +349,56 @@ class TestSyncNestedCheckpointing:
         assert "sync-map-nest/embed" in run_ids
         assert "sync-map-nest/embed/0" in run_ids
         assert "sync-map-nest/embed/1" in run_ids
+
+    def test_sync_nested_graph_in_outer_cycle_uses_distinct_child_run_ids(self, sync_cp):
+        """SyncRunner uses the same child-run suffixes for repeated nested executions."""
+
+        @node(output_name="count")
+        def increment(count: int, limit: int = 3) -> int:
+            return count + 1
+
+        inner = Graph([increment], name="inner", entrypoint="increment")
+
+        @route(targets=["inner", END])
+        def decide(count: int, limit: int = 3) -> str:
+            return END if count >= limit else "inner"
+
+        runner = SyncRunner(checkpointer=sync_cp)
+        outer = Graph([inner.as_node(), decide], entrypoint="inner")
+
+        result = runner.run(outer, {"count": 0, "limit": 3}, workflow_id="sync-nested-cycle")
+        assert result["count"] == 3
+
+        db = sync_cp._sync_db()
+        runs = db.execute("SELECT id FROM runs ORDER BY id").fetchall()
+        inner_run_ids = {row[0] for row in runs if row[0].startswith("sync-nested-cycle/inner")}
+        assert inner_run_ids == {"sync-nested-cycle/inner", "sync-nested-cycle/inner/2", "sync-nested-cycle/inner/3"}
+
+    def test_sync_nested_graph_in_outer_cycle_uses_distinct_child_ids_when_output_repeats(self, sync_cp):
+        """SyncRunner also handles repeated nested executions with stable outputs."""
+
+        @node(output_name="tick")
+        def tick(tick: int) -> int:
+            return tick + 1
+
+        @node(output_name="stable")
+        def constant(tick: int) -> int:
+            return 1
+
+        inner = Graph([tick, constant], name="inner", entrypoint="tick")
+
+        @route(targets=["inner", END])
+        def decide(tick: int) -> str:
+            return END if tick >= 3 else "inner"
+
+        runner = SyncRunner(checkpointer=sync_cp)
+        outer = Graph([inner.as_node(), decide], entrypoint="inner")
+
+        result = runner.run(outer, {"tick": 0}, workflow_id="sync-nested-stable")
+        assert result["tick"] == 3
+        assert result["stable"] == 1
+
+        db = sync_cp._sync_db()
+        runs = db.execute("SELECT id FROM runs ORDER BY id").fetchall()
+        inner_run_ids = {row[0] for row in runs if row[0].startswith("sync-nested-stable/inner")}
+        assert inner_run_ids == {"sync-nested-stable/inner", "sync-nested-stable/inner/2", "sync-nested-stable/inner/3"}

--- a/tests/test_checkpointer/test_lineage_semantics.py
+++ b/tests/test_checkpointer/test_lineage_semantics.py
@@ -207,6 +207,36 @@ class TestLineageSemantics:
         assert resumed.status == RunStatus.COMPLETED
         assert resumed["result"] == "Final: approved"
 
+    async def test_nested_paused_workflow_accepts_renamed_dotted_interrupt_response_on_resume(self, checkpointer):
+        @interrupt(output_name="decision")
+        def approval(draft: str) -> str: ...
+
+        inner = Graph([approval], name="inner")
+
+        @node(output_name="draft")
+        def make_draft(query: str) -> str:
+            return f"Draft for: {query}"
+
+        @node(output_name="result")
+        def finalize(verdict: str) -> str:
+            return f"Final: {verdict}"
+
+        runner = AsyncRunner(checkpointer=checkpointer)
+        graph = Graph([make_draft, inner.as_node().with_outputs(decision="verdict"), finalize])
+
+        paused = await runner.run(graph, {"query": "hello"}, workflow_id="wf-renamed-nested-paused")
+        assert paused.status == RunStatus.PAUSED
+        assert paused.pause is not None
+        assert paused.pause.response_key == "inner.verdict"
+
+        resumed = await runner.run(
+            graph,
+            {paused.pause.response_key: "approved"},
+            workflow_id="wf-renamed-nested-paused",
+        )
+        assert resumed.status == RunStatus.COMPLETED
+        assert resumed["result"] == "Final: approved"
+
     async def test_fork_metadata_is_persisted(self, checkpointer):
         runner = AsyncRunner(checkpointer=checkpointer)
         graph = Graph([double])

--- a/tests/test_checkpointer/test_lineage_semantics.py
+++ b/tests/test_checkpointer/test_lineage_semantics.py
@@ -237,6 +237,38 @@ class TestLineageSemantics:
         assert resumed.status == RunStatus.COMPLETED
         assert resumed["result"] == "Final: approved"
 
+    async def test_inactive_nested_interrupt_key_does_not_count_as_resume_payload(self, checkpointer):
+        @interrupt(output_name="decision_a")
+        def approval_a(draft: str) -> str: ...
+
+        @interrupt(output_name="decision_b")
+        def approval_b(draft: str) -> str: ...
+
+        inner = Graph([approval_a, approval_b], name="inner").select("decision_a")
+
+        @node(output_name="draft")
+        def make_draft(query: str) -> str:
+            return f"Draft for: {query}"
+
+        @node(output_name="result")
+        def finalize(verdict: str) -> str:
+            return f"Final: {verdict}"
+
+        runner = AsyncRunner(checkpointer=checkpointer)
+        graph = Graph([make_draft, inner.as_node().with_outputs(decision_a="verdict"), finalize])
+
+        paused = await runner.run(graph, {"query": "hello"}, workflow_id="wf-inactive-interrupt")
+        assert paused.status == RunStatus.PAUSED
+        assert paused.pause is not None
+        assert paused.pause.response_key == "inner.verdict"
+
+        with pytest.raises(InputOverrideRequiresForkError):
+            await runner.run(
+                graph,
+                {"inner.decision_b": "wrong"},
+                workflow_id="wf-inactive-interrupt",
+            )
+
     async def test_fork_metadata_is_persisted(self, checkpointer):
         runner = AsyncRunner(checkpointer=checkpointer)
         graph = Graph([double])

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -491,8 +491,8 @@ class TestGraphBind:
 
         assert g2.inputs.bound == {"x": 2}
 
-    def test_bind_edge_produced_accepted(self):
-        """Test binding an edge-produced value is accepted (bypass if producer doesn't run)."""
+    def test_bind_edge_produced_rejected(self):
+        """Binding an active edge-produced value should be rejected."""
 
         @node(output_name="x")
         def source(a):
@@ -504,12 +504,26 @@ class TestGraphBind:
 
         g = Graph([source, destination])
 
-        # 'x' is produced by source node — binding is now allowed
+        with pytest.raises(ValueError, match="bind\\(\\) only accepts graph inputs in the current scope"):
+            g.bind(x=10)
+
+    def test_bind_former_intermediate_allowed_after_entrypoint_slice(self):
+        """A former intermediate can be bound once slicing makes it an input."""
+
+        @node(output_name="x")
+        def source(a):
+            return a * 2
+
+        @node(output_name="result")
+        def destination(x):
+            return x + 1
+
+        g = Graph([source, destination]).with_entrypoint("destination")
         configured = g.bind(x=10)
         assert configured.inputs.bound["x"] == 10
 
     def test_bind_unknown_key_raises(self):
-        """Test binding a key not in graph.inputs.all or graph.outputs raises ValueError."""
+        """Test binding a key not in graph.inputs.all raises ValueError."""
 
         @node(output_name="result")
         def foo(x):
@@ -517,8 +531,8 @@ class TestGraphBind:
 
         g = Graph([foo])
 
-        # 'unknown' is not a graph input or output
-        with pytest.raises(ValueError, match="not a graph input or output"):
+        # 'unknown' is not a graph input
+        with pytest.raises(ValueError, match="not a graph input in the current scope"):
             g.bind(unknown=42)
 
     def test_original_unchanged_after_bind(self):
@@ -2114,8 +2128,8 @@ class TestAddNodes:
         g2 = g.add_nodes(bar)
         assert g2.inputs.bound == {"x": 10}
 
-    def test_bind_edge_produced_still_valid(self):
-        """Bound key that becomes edge-produced stays valid (can override at runtime)."""
+    def test_bind_becomes_edge_produced_after_add_nodes_raises(self):
+        """Bound key that becomes edge-produced after add_nodes must be unbound first."""
 
         @node(output_name="result")
         def consumer(x: int) -> int:
@@ -2127,9 +2141,8 @@ class TestAddNodes:
         def producer(a: int) -> int:
             return a * 2
 
-        # x is still a valid output, so binding is preserved
-        g2 = g.add_nodes(producer)
-        assert g2.inputs.bound == {"x": 10}
+        with pytest.raises(ValueError, match=r"no longer valid.*unbind"):
+            g.add_nodes(producer)
 
     def test_bind_becomes_emit_only_raises(self):
         """Bound key that becomes emit-only after add_nodes raises ValueError."""

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -865,6 +865,25 @@ class TestGraphAsNode:
         assert gnode.outputs == g.outputs
         assert gnode.outputs == ("x", "y")
 
+    def test_graphnode_outputs_follow_active_entrypoint_scope(self):
+        """GraphNode should not expose outputs from inactive upstream nodes."""
+
+        @node(output_name="a")
+        def produce(x: int) -> int:
+            return x + 1
+
+        @node(output_name="b")
+        def consume(a: int) -> int:
+            return a * 2
+
+        scoped = Graph([produce, consume], name="inner").with_entrypoint("consume")
+        gnode = scoped.as_node()
+
+        assert gnode.inputs == ("a",)
+        assert gnode.outputs == ("b",)
+        outer = Graph([gnode])
+        assert outer.has_cycles is False
+
     def test_graphnode_definition_hash(self):
         """Test GraphNode.definition_hash returns graph's hash."""
 

--- a/tests/test_interrupt_node.py
+++ b/tests/test_interrupt_node.py
@@ -1250,6 +1250,57 @@ class TestInterruptDecoratorExecution:
         assert result.pause.node_name == "inner/approval"
         assert result.pause.response_key == "inner.decision"
 
+    @pytest.mark.asyncio
+    async def test_nested_graph_interrupt_respects_graphnode_output_rename(self):
+        """Nested interrupt response keys should use renamed GraphNode outputs."""
+
+        @interrupt(output_name="decision")
+        def approval(x: str) -> str: ...
+
+        inner = Graph([approval], name="inner")
+
+        @node(output_name="x")
+        def produce(query: str) -> str:
+            return query
+
+        @node(output_name="result")
+        def consume(verdict: str) -> str:
+            return f"got: {verdict}"
+
+        outer = Graph([produce, inner.as_node().with_outputs(decision="verdict"), consume])
+        runner = AsyncRunner()
+
+        paused = await runner.run(outer, {"query": "hello"})
+        assert paused.paused
+        assert paused.pause.node_name == "inner/approval"
+        assert paused.pause.response_key == "inner.verdict"
+
+        resumed = await runner.run(outer, {"query": "hello", paused.pause.response_key: "approved"})
+        assert resumed.status == RunStatus.COMPLETED
+        assert resumed["result"] == "got: approved"
+
+    @pytest.mark.asyncio
+    async def test_paused_nested_interrupt_is_visible_in_run_log(self):
+        """Paused nested runs should include the interrupt node in the RunLog."""
+
+        @interrupt(output_name="decision")
+        def approval(x: str) -> str: ...
+
+        inner = Graph([approval], name="inner")
+
+        @node(output_name="x")
+        def produce(query: str) -> str:
+            return query
+
+        outer = Graph([produce, inner.as_node()], name="outer")
+        runner = AsyncRunner()
+
+        paused = await runner.run(outer, {"query": "hello"})
+        assert paused.paused
+        assert paused.log is not None
+        assert [step.node_name for step in paused.log.steps] == ["produce", "inner/approval"]
+        assert paused.log.steps[-1].status == "paused"
+
 
 # ── FunctionNode-like constructor + emit/wait_for ──
 

--- a/tests/test_red_team_fixes.py
+++ b/tests/test_red_team_fixes.py
@@ -112,8 +112,8 @@ class TestCycleTermination:
 
 
 class TestIntermediateInjection:
-    def test_skip_upstream_with_intermediate_value(self):
-        """Providing an intermediate output should skip upstream nodes."""
+    def test_intermediate_value_injection_is_rejected(self):
+        """Providing an active intermediate output is rejected."""
 
         @node(output_name="mid")
         def step1(start: str) -> str:
@@ -130,7 +130,7 @@ class TestIntermediateInjection:
             runner.run(graph, {"mid": "SKIP"})
 
     def test_normal_execution_still_works(self):
-        """Normal execution (no intermediate injection) still works."""
+        """Normal execution without internal overrides still works."""
 
         @node(output_name="mid")
         def step1(start: str) -> str:


### PR DESCRIPTION
## Problem / Bug / Challenge

Nested graph boundaries had a few places where outer and inner behavior drifted apart:

- sibling nested bindings could leak across GraphNodes when param names collided
- checkpointed outer cycles could collide on repeated nested child runs
- nested interrupt resume keys ignored `GraphNode.with_outputs(...)` renames
- `with_entrypoint()` on an inner graph could leak inactive outputs through `as_node()`
- paused async runs had weak observability (`InterruptEvent` / paused `RunEndEvent` / RunLog gap)
- the `map_over()` + interrupt limitation was not clearly surfaced in the user docs

## Before / After

**Before:**

```python
# sibling binds leaked
inner_a = Graph([use_a], name="inner_a").bind(cfg="CFG_A")
inner_b = Graph([use_b], name="inner_b").bind(cfg="CFG_B")
Graph([inner_a.as_node(), inner_b.as_node()])
# out_b could incorrectly use CFG_A

# renamed nested interrupt still paused on the old key
paused.pause.response_key == "inner.decision"
# even if the GraphNode exposed "verdict"

# checkpointed outer cycles reused the same nested child run id
wf/inner
wf/inner   # second execution collided instead of being distinct
```

**After:**

```python
# sibling binds stay scoped to their own GraphNode
result["out_a"] == "A:1:CFG_A"
result["out_b"] == "B:1:CFG_B"

# renamed nested interrupts resume through the renamed outer interface
paused.pause.response_key == "inner.verdict"

# repeated nested executions in checkpointed outer cycles get distinct child ids
wf/inner
wf/inner/2
wf/inner/3
```

## Test Plan

- [x] `uv run --with aiosqlite pytest tests/test_bind_defaults.py tests/test_graph.py tests/test_interrupt_node.py tests/events/test_async_events.py tests/test_checkpointer/test_lineage_semantics.py tests/test_checkpointer/test_hierarchical_checkpointing.py -q`
- [x] `uv run ruff check src/hypergraph/nodes/graph_node.py src/hypergraph/graph/input_spec.py src/hypergraph/runners/_shared/helpers.py src/hypergraph/runners/_shared/checkpoint_helpers.py src/hypergraph/runners/_shared/validation.py src/hypergraph/runners/async_/executors/graph_node.py src/hypergraph/runners/sync/executors/graph_node.py src/hypergraph/events/types.py src/hypergraph/runners/_shared/run_log.py src/hypergraph/runners/_shared/types.py src/hypergraph/runners/_shared/template_async.py src/hypergraph/events/rich_progress.py tests/test_bind_defaults.py tests/test_graph.py tests/test_interrupt_node.py tests/events/test_async_events.py tests/test_checkpointer/test_lineage_semantics.py tests/test_checkpointer/test_hierarchical_checkpointing.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PAUSED run status and interrupt events: paused runs and steps are shown in run outputs and logs; interrupt records emitted and resumable runs accept renamed nested output keys.

* **Bug Fixes**
  * Prevented bound-value leakage between sibling nested graphs.
  * More robust child run/checkpoint IDs for repeated nested executions.
  * bind() now only accepts graph inputs in the current scope.

* **Documentation**
  * Clarified map_over() interrupt limitation and bind() usage/guidance.

* **Tests**
  * Added tests covering paused workflows, nested interrupts, binding rules, and hierarchical checkpointing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->