### PR TITLE
feat(checkpointers): unify explorer and persist paused runs

### DIFF
--- a/docs/03-patterns/07-human-in-the-loop.md
+++ b/docs/03-patterns/07-human-in-the-loop.md
@@ -272,7 +272,7 @@ checkpointer = SqliteCheckpointer("chat.db")
 
 # Sync reads — no await needed
 run = checkpointer.get_run("conv-1")
-print(run.status)  # "active" (paused) or "completed"
+print(run.status)  # "paused" or "completed"
 
 steps = checkpointer.steps("conv-1")
 for s in steps:

--- a/docs/05-how-to/batch-processing.md
+++ b/docs/05-how-to/batch-processing.md
@@ -385,7 +385,7 @@ await runner.run(Graph([double, triple]), {"x": 5}, workflow_id="job-1")
 # await runner.run(Graph([double, triple]), workflow_id="job-1")
 ```
 
-Resume is intended for ACTIVE/FAILED workflows (e.g., retry after failure), not for appending new work to completed lineages.
+Resume is intended for ACTIVE/PAUSED/FAILED workflows (for example: still-running work, interrupt-paused workflows, or retry after failure), not for appending new work to completed lineages.
 
 #### Fork (new workflow_id, optional overrides)
 

--- a/docs/05-how-to/debug-workflows.md
+++ b/docs/05-how-to/debug-workflows.md
@@ -274,8 +274,8 @@ result = await runner.run(graph, {"x": 5}, workflow_id="my-run-1")
 
 Paused interrupt-driven workflows are now persisted as **`PAUSED`** runs rather than overloading `ACTIVE`. In the CLI and notebook explorer, that means:
 
-- `active` means currently running / non-terminal work
-- `paused` means resumable and waiting for an interrupt response
+- `active` means currently executing and non-terminal
+- `paused` means waiting for interrupt input, resumable, and also non-terminal
 - `completed` and `failed` remain terminal
 
 `runner.map()` still requires an explicit `workflow_id` to persist parent/child batch runs.

--- a/docs/05-how-to/debug-workflows.md
+++ b/docs/05-how-to/debug-workflows.md
@@ -272,6 +272,12 @@ print(result.workflow_id)  # e.g. run-20260302-a7b3c2
 result = await runner.run(graph, {"x": 5}, workflow_id="my-run-1")
 ```
 
+Paused interrupt-driven workflows are now persisted as **`PAUSED`** runs rather than overloading `ACTIVE`. In the CLI and notebook explorer, that means:
+
+- `active` means currently running / non-terminal work
+- `paused` means resumable and waiting for an interrupt response
+- `completed` and `failed` remain terminal
+
 `runner.map()` still requires an explicit `workflow_id` to persist parent/child batch runs.
 
 ### Hierarchical Checkpointing
@@ -703,6 +709,7 @@ hypergraph runs ls --db /path/to/runs.db
 | "What happened in yesterday's run?" | Checkpointer + CLI |
 | "What values were produced at step 3?" | CLI (`runs values --superstep 3`) |
 | "What failed runs exist?" | CLI (`runs ls --status failed`) |
+| "What paused runs can I resume?" | CLI (`runs ls --status paused`) |
 | "What did the nested graph produce?" | CLI (`runs show <id>` + `runs ls --parent <id>`) |
 | "What happened in batch item 5?" | CLI (`runs show <batch-id>/5`) |
 | "Find all steps that hit a specific error" | CLI (`runs search "error message"`) |

--- a/docs/06-api-reference/runners.md
+++ b/docs/06-api-reference/runners.md
@@ -91,7 +91,7 @@ Execute a graph once.
 - `checkpoint` - Optional low-level checkpoint snapshot (`values + steps`) for explicit fork restores.
 - `workflow_id` - Optional workflow identifier for lineage tracking. With a checkpointer:
   - omitted: auto-generated for `run()`
-  - existing: strict resume only (no runtime values; same graph structure)
+  - existing: strict resume only (no runtime values; same graph structure). Existing persisted workflows may be `active`, `paused`, or `failed`; completed workflows are terminal.
   - new + `checkpoint`: explicit fork
 - `override_workflow` - Convenience shortcut for existing `workflow_id`s. When `True` and the `workflow_id` already exists, `run()` auto-forks from that workflow (generates a new workflow ID and uses its checkpoint) instead of raising strict resume errors.
 - `fork_from` - Workflow ID to fork from directly (no manual checkpoint plumbing). Requires a checkpointer.
@@ -327,7 +327,7 @@ Execute a graph asynchronously.
 - `checkpoint` - Optional low-level checkpoint snapshot (`values + steps`) for explicit fork restores.
 - `workflow_id` - Optional workflow identifier for lineage tracking. With a checkpointer:
   - omitted: auto-generated for `run()`
-  - existing: strict resume only (no runtime values; same graph structure)
+  - existing: strict resume only (no runtime values; same graph structure). Existing persisted workflows may be `active`, `paused`, or `failed`; completed workflows are terminal.
   - new + `checkpoint`: explicit fork
 - `override_workflow` - Convenience shortcut for existing `workflow_id`s. When `True` and the `workflow_id` already exists, `run()` auto-forks from that workflow (generates a new workflow ID and uses its checkpoint) instead of raising strict resume errors.
 - `fork_from` - Workflow ID to fork from directly (no manual checkpoint plumbing). Requires a checkpointer.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,7 @@
 - **`override_workflow` on `run()`** — convenience auto-fork mode: when a `workflow_id` already exists, pass `override_workflow=True` to branch to a fresh lineage instead of raising strict resume errors.
 - **Workflow-id based forking/retrying on `run()`** — `fork_from=` and `retry_from=` remove manual checkpoint plumbing for common branch/retry flows.
 - **Checkpointer naming convention updated** — sync helpers are now `fork_workflow()` / `retry_workflow()`, async helpers are `fork_workflow_async()` / `retry_workflow_async()`.
+- **Persisted paused workflows** — checkpointers now store interrupt-paused runs as `PAUSED` instead of overloading `ACTIVE`, and CLI/dashboard views expose paused runs distinctly.
 
 ### Changed
 

--- a/notebooks/checkpointer-explorer-showcase.ipynb
+++ b/notebooks/checkpointer-explorer-showcase.ipynb
@@ -1,0 +1,295 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Tutorial: Checkpointer Explorer Showcase\n",
+    "\n",
+    "Audience:\n",
+    "- Hypergraph users who want one place to inspect persisted workflow state, nested runs, steps, checkpoints, and lineage.\n",
+    "\n",
+    "Prerequisites:\n",
+    "- Basic familiarity with `Graph`, `AsyncRunner`, and `SqliteCheckpointer`.\n",
+    "- `aiosqlite` installed in the active environment.\n",
+    "\n",
+    "Learning goals:\n",
+    "- Build a small run history with completed, failed, retried, forked, and nested workflows.\n",
+    "- Use the new checkpointer explorer as the top-level drill-through UI.\n",
+    "- Jump from checkpointer to runs, steps, checkpoints, and lineage from one notebook.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "## Outline\n",
+    "\n",
+    "1. Setup a fresh demo database\n",
+    "2. Create a small but varied workflow history\n",
+    "3. Open the unified checkpointer explorer\n",
+    "4. Inspect runs, steps, checkpoints, and lineage directly\n",
+    "5. Clean up the database connection\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from __future__ import annotations\n",
+    "\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from hypergraph import AsyncRunner, Graph, interrupt, node\n",
+    "from hypergraph.checkpointers import SqliteCheckpointer\n",
+    "\n",
+    "NOTEBOOK_DIR = Path(\"output/jupyter-notebook\")\n",
+    "NOTEBOOK_DIR.mkdir(parents=True, exist_ok=True)\n",
+    "DB_PATH = NOTEBOOK_DIR / \"checkpointer-explorer-showcase.db\"\n",
+    "if DB_PATH.exists():\n",
+    "    DB_PATH.unlink()\n",
+    "\n",
+    "DB_PATH"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "## Step 1 - Build a mixed run history\n",
+    "\n",
+    "The next cell creates:\n",
+    "- a normal completed workflow\n",
+    "- a forked workflow\n",
+    "- a failed workflow plus retry lineage\n",
+    "- a nested interrupt workflow that is resumed through a fork\n",
+    "\n",
+    "This gives the explorer enough interesting structure to drill through."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@node(output_name=\"doubled\")\n",
+    "def double(x: int) -> int:\n",
+    "    return x * 2\n",
+    "\n",
+    "\n",
+    "@node(output_name=\"tripled\")\n",
+    "def triple(doubled: int) -> int:\n",
+    "    return doubled * 3\n",
+    "\n",
+    "\n",
+    "@node(output_name=\"draft\")\n",
+    "def make_draft(query: str) -> str:\n",
+    "    return f\"Draft for: {query}\"\n",
+    "\n",
+    "\n",
+    "@interrupt(output_name=\"decision\")\n",
+    "def approval(draft: str) -> str: ...\n",
+    "\n",
+    "\n",
+    "@node(output_name=\"final\")\n",
+    "def finalize(decision: str) -> str:\n",
+    "    return f\"Final: {decision}\"\n",
+    "\n",
+    "\n",
+    "basic_graph = Graph([double, triple], name=\"basic\")\n",
+    "review_graph = Graph([approval], name=\"review\")\n",
+    "nested_graph = Graph([make_draft, review_graph.as_node(name=\"review\"), finalize], name=\"nested-review\")\n",
+    "\n",
+    "\n",
+    "async def build_demo() -> dict[str, object]:\n",
+    "    checkpointer = SqliteCheckpointer(str(DB_PATH), durability=\"sync\")\n",
+    "    runner = AsyncRunner(checkpointer=checkpointer)\n",
+    "\n",
+    "    base = await runner.run(basic_graph, {\"x\": 5}, workflow_id=\"demo-basic\")\n",
+    "    base_checkpoint = checkpointer.checkpoint(\"demo-basic\")\n",
+    "    forked = await runner.run(basic_graph, {\"x\": 7}, checkpoint=base_checkpoint, workflow_id=\"demo-basic-fork\")\n",
+    "\n",
+    "    fail_once = {\"value\": True}\n",
+    "\n",
+    "    @node(output_name=\"seed\")\n",
+    "    def seed(x: int) -> int:\n",
+    "        return x\n",
+    "\n",
+    "    @node(output_name=\"out\")\n",
+    "    def flaky(seed: int) -> int:\n",
+    "        if fail_once[\"value\"]:\n",
+    "            fail_once[\"value\"] = False\n",
+    "            raise RuntimeError(\"transient failure\")\n",
+    "        return seed * 10\n",
+    "\n",
+    "    flaky_graph = Graph([seed, flaky], name=\"flaky\")\n",
+    "    failed = await runner.run(flaky_graph, {\"x\": 3}, workflow_id=\"demo-retry-root\", error_handling=\"continue\")\n",
+    "    retried = await runner.run(flaky_graph.with_entrypoint(\"flaky\"), retry_from=\"demo-retry-root\", workflow_id=\"demo-retry-root-1\")\n",
+    "\n",
+    "    paused = await runner.run(nested_graph, {\"query\": \"hello reviewer\"}, workflow_id=\"demo-nested\")\n",
+    "    resumed_fork = await runner.run(\n",
+    "        nested_graph,\n",
+    "        {paused.pause.response_key: \"approved\"},\n",
+    "        fork_from=\"demo-nested\",\n",
+    "        workflow_id=\"demo-nested-fork\",\n",
+    "    )\n",
+    "\n",
+    "    return {\n",
+    "        \"checkpointer\": checkpointer,\n",
+    "        \"base\": base,\n",
+    "        \"forked\": forked,\n",
+    "        \"failed\": failed,\n",
+    "        \"retried\": retried,\n",
+    "        \"paused\": paused,\n",
+    "        \"resumed_fork\": resumed_fork,\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "demo = await build_demo()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sorted(demo.keys())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7",
+   "metadata": {},
+   "source": [
+    "## Step 2 - Open the unified explorer\n",
+    "\n",
+    "This is the new top-level notebook UI.\n",
+    "\n",
+    "Start here, then click through runs, child runs, source lineage, and steps from a single surface."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cp = demo[\"checkpointer\"]\n",
+    "cp"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9",
+   "metadata": {},
+   "source": [
+    "## Step 3 - The lower-level views still work\n",
+    "\n",
+    "The explorer is the new entry point, but the individual views remain useful when you want a focused object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cp.runs(limit=20)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cp.steps(\"demo-nested-fork/review\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cp.checkpoint(\"demo-basic\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cp.lineage(\"demo-nested-fork\", include_steps=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14",
+   "metadata": {},
+   "source": [
+    "## Step 4 - A few direct lookups\n",
+    "\n",
+    "These are handy when you already know the run ID and want a precise answer rather than browsing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "{\n",
+    "    \"resumed_nested_final\": demo[\"resumed_fork\"][\"final\"],\n",
+    "    \"retry_run_status\": demo[\"retried\"].status.value,\n",
+    "    \"known_child_runs\": [run.id for run in cp.runs(limit=20) if run.parent_run_id],\n",
+    "}"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/hypergraph/checkpointers/__init__.py
+++ b/src/hypergraph/checkpointers/__init__.py
@@ -5,6 +5,8 @@ and supporting types for durable workflow execution.
 """
 
 from hypergraph.checkpointers.base import Checkpointer, CheckpointPolicy
+from hypergraph.checkpointers.inspection import RunInspector, SqliteRunInspector
+from hypergraph.checkpointers.memory import MemoryCheckpointer
 from hypergraph.checkpointers.protocols import SyncCheckpointerProtocol
 from hypergraph.checkpointers.serializers import JsonSerializer, PickleSerializer, Serializer
 from hypergraph.checkpointers.sqlite import SqliteCheckpointer
@@ -27,11 +29,14 @@ __all__ = [
     "JsonSerializer",
     "LineageRow",
     "LineageView",
+    "MemoryCheckpointer",
     "PickleSerializer",
     "Run",
+    "RunInspector",
     "RunTable",
     "Serializer",
     "SqliteCheckpointer",
+    "SqliteRunInspector",
     "StepRecord",
     "StepStatus",
     "StepTable",

--- a/src/hypergraph/checkpointers/base.py
+++ b/src/hypergraph/checkpointers/base.py
@@ -154,8 +154,11 @@ class Checkpointer(ABC):
         superstep: int | None = None,
     ) -> tuple[str, Checkpoint]:
         """Prepare a retry fork with retry lineage metadata."""
+        source = await self.get_run_async(source_run_id)
+        if source is None:
+            raise ValueError(f"Unknown source workflow_id: {source_run_id!r}")
         checkpoint = await self.get_checkpoint(source_run_id, superstep=superstep)
-        siblings = await self.list_runs(limit=10_000)
+        siblings = await self.list_runs(limit=None)
         retry_count = sum(1 for run in siblings if run.retry_of == source_run_id)
         retry_index = retry_count + 1
         new_workflow_id = workflow_id or f"{source_run_id}-retry-{retry_index}"
@@ -174,14 +177,14 @@ class Checkpointer(ABC):
         *,
         status: WorkflowStatus | None = None,
         parent_run_id: str | None = None,
-        limit: int = 100,
+        limit: int | None = 100,
     ) -> list[Run]:
         """List runs, optionally filtered by status and/or parent.
 
         Args:
             status: Filter to runs with this status (None = all).
             parent_run_id: Filter to children of this run (None = no filter).
-            limit: Max results to return.
+            limit: Max results to return. ``None`` returns all matches.
         """
         ...
 

--- a/src/hypergraph/checkpointers/base.py
+++ b/src/hypergraph/checkpointers/base.py
@@ -158,8 +158,7 @@ class Checkpointer(ABC):
         if source is None:
             raise ValueError(f"Unknown source workflow_id: {source_run_id!r}")
         checkpoint = await self.get_checkpoint(source_run_id, superstep=superstep)
-        siblings = await self.list_runs(limit=None)
-        retry_count = sum(1 for run in siblings if run.retry_of == source_run_id)
+        retry_count = await self.count_runs(retry_of=source_run_id)
         retry_index = retry_count + 1
         new_workflow_id = workflow_id or f"{source_run_id}-retry-{retry_index}"
         checkpoint.retry_of = source_run_id
@@ -187,6 +186,23 @@ class Checkpointer(ABC):
             limit: Max results to return. ``None`` returns all matches.
         """
         ...
+
+    async def count_runs(
+        self,
+        *,
+        status: WorkflowStatus | None = None,
+        parent_run_id: str | None = None,
+        retry_of: str | None = None,
+    ) -> int:
+        """Count runs matching a small set of backend-neutral filters.
+
+        Backends with efficient query support should override this to avoid
+        materializing full run objects for simple counting operations.
+        """
+        runs = await self.list_runs(status=status, parent_run_id=parent_run_id, limit=None)
+        if retry_of is not None:
+            runs = [run for run in runs if run.retry_of == retry_of]
+        return len(runs)
 
     async def search_async(self, query: str, *, field: str | None = None, limit: int = 20) -> list[StepRecord]:
         """Search steps using FTS. Returns empty list if not supported."""

--- a/src/hypergraph/checkpointers/inspection.py
+++ b/src/hypergraph/checkpointers/inspection.py
@@ -57,7 +57,7 @@ class SqliteRunInspector:
 
     @property
     def db_path(self) -> str:
-        return self.checkpointer._path
+        return self.checkpointer.path
 
     def get_run(self, run_id: str) -> Run | None:
         return self.checkpointer.get_run(run_id)

--- a/src/hypergraph/checkpointers/inspection.py
+++ b/src/hypergraph/checkpointers/inspection.py
@@ -1,0 +1,100 @@
+"""Inspection adapters for querying persisted runs.
+
+The core ``Checkpointer`` contract is intentionally small and runner-focused.
+Inspection surfaces such as the CLI should depend on a dedicated adapter
+instead of reaching into a concrete backend's convenience API directly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from hypergraph.checkpointers.sqlite import SqliteCheckpointer
+    from hypergraph.checkpointers.types import Checkpoint, LineageView, Run, StepRecord, WorkflowStatus
+
+_UNSET = object()
+
+
+class RunInspector(Protocol):
+    """Backend-neutral sync inspection interface for persisted workflow runs."""
+
+    @property
+    def db_path(self) -> str: ...
+
+    def get_run(self, run_id: str) -> Run | None: ...
+
+    def runs(
+        self,
+        *,
+        status: WorkflowStatus | None = None,
+        graph_name: str | None = None,
+        since: datetime | None = None,
+        parent_run_id: str | None | object = _UNSET,
+        limit: int | None = 100,
+    ) -> list[Run]: ...
+
+    def steps(self, run_id: str, *, superstep: int | None = None) -> list[StepRecord]: ...
+
+    def state(self, run_id: str, *, superstep: int | None = None) -> dict[str, Any]: ...
+
+    def search(self, query: str, *, field: str | None = None, limit: int = 20) -> list[StepRecord]: ...
+
+    def stats(self, run_id: str) -> dict[str, Any]: ...
+
+    def checkpoint(self, run_id: str, *, superstep: int | None = None) -> Checkpoint: ...
+
+    def lineage(self, workflow_id: str, *, include_steps: bool = True, max_runs: int = 200) -> LineageView: ...
+
+
+@dataclass(frozen=True)
+class SqliteRunInspector:
+    """Inspection adapter over ``SqliteCheckpointer`` sync query helpers."""
+
+    checkpointer: SqliteCheckpointer
+
+    @property
+    def db_path(self) -> str:
+        return self.checkpointer._path
+
+    def get_run(self, run_id: str) -> Run | None:
+        return self.checkpointer.get_run(run_id)
+
+    def runs(
+        self,
+        *,
+        status: WorkflowStatus | None = None,
+        graph_name: str | None = None,
+        since: datetime | None = None,
+        parent_run_id: str | None | object = _UNSET,
+        limit: int | None = 100,
+    ) -> list[Run]:
+        kwargs: dict[str, Any] = {
+            "status": status,
+            "graph_name": graph_name,
+            "since": since,
+            "limit": limit,
+        }
+        if parent_run_id is not _UNSET:
+            kwargs["parent_run_id"] = parent_run_id
+        return self.checkpointer.runs(**kwargs)
+
+    def steps(self, run_id: str, *, superstep: int | None = None) -> list[StepRecord]:
+        return self.checkpointer.steps(run_id, superstep=superstep)
+
+    def state(self, run_id: str, *, superstep: int | None = None) -> dict[str, Any]:
+        return self.checkpointer.state(run_id, superstep=superstep)
+
+    def search(self, query: str, *, field: str | None = None, limit: int = 20) -> list[StepRecord]:
+        return self.checkpointer.search(query, field=field, limit=limit)
+
+    def stats(self, run_id: str) -> dict[str, Any]:
+        return self.checkpointer.stats(run_id)
+
+    def checkpoint(self, run_id: str, *, superstep: int | None = None) -> Checkpoint:
+        return self.checkpointer.checkpoint(run_id, superstep=superstep)
+
+    def lineage(self, workflow_id: str, *, include_steps: bool = True, max_runs: int = 200) -> LineageView:
+        return self.checkpointer.lineage(workflow_id, include_steps=include_steps, max_runs=max_runs)

--- a/src/hypergraph/checkpointers/memory.py
+++ b/src/hypergraph/checkpointers/memory.py
@@ -7,7 +7,9 @@ from datetime import datetime, timezone
 from typing import Any
 
 from hypergraph.checkpointers.base import Checkpointer
-from hypergraph.checkpointers.types import Run, StepRecord, WorkflowStatus
+from hypergraph.checkpointers.types import Run, StepRecord, StepStatus, WorkflowStatus
+
+_BASELINE_NODE_NAME = "__retained_state__"
 
 
 def _step_sort_key(record: StepRecord) -> tuple[datetime, datetime, int, str]:
@@ -118,6 +120,22 @@ class MemoryCheckpointer(Checkpointer):
             runs = runs[:limit]
         return runs
 
+    async def count_runs(
+        self,
+        *,
+        status: WorkflowStatus | None = None,
+        parent_run_id: str | None = None,
+        retry_of: str | None = None,
+    ) -> int:
+        runs = self._runs.values()
+        return sum(
+            1
+            for run in runs
+            if (status is None or run.status == status)
+            and (parent_run_id is None or run.parent_run_id == parent_run_id)
+            and (retry_of is None or run.retry_of == retry_of)
+        )
+
     def _apply_retention_policy(self, run_id: str) -> None:
         retention = self.policy.retention
         if retention == "full":
@@ -128,15 +146,67 @@ class MemoryCheckpointer(Checkpointer):
             return
 
         if retention == "latest":
+            ordered = sorted(run_steps.values(), key=_step_sort_key)
             latest_by_node: dict[str, StepRecord] = {}
-            for record in sorted(run_steps.values(), key=_step_sort_key):
+            for record in ordered:
+                if record.node_name == _BASELINE_NODE_NAME:
+                    continue
                 latest_by_node[record.node_name] = record
-            self._steps[run_id] = {(record.superstep, record.node_name): record for record in latest_by_node.values()}
+            kept = list(latest_by_node.values())
+            dropped = [record for record in ordered if record.node_name != _BASELINE_NODE_NAME and record not in kept]
+            baseline = _make_baseline_record(
+                run_id,
+                dropped,
+                baseline_superstep=(min((record.superstep for record in kept), default=0) - 1),
+            )
+            retained = [*([baseline] if baseline is not None else []), *kept]
+            self._steps[run_id] = {(record.superstep, record.node_name): record for record in retained}
             return
 
         if retention == "windowed" and self.policy.window is not None:
-            max_superstep = max(record.superstep for record in run_steps.values())
+            ordered = sorted(run_steps.values(), key=_step_sort_key)
+            max_superstep = max(record.superstep for record in ordered)
             cutoff = max_superstep - self.policy.window + 1
             if cutoff <= 0:
                 return
-            self._steps[run_id] = {key: record for key, record in run_steps.items() if record.superstep >= cutoff}
+            kept = [record for record in ordered if record.superstep >= cutoff and record.node_name != _BASELINE_NODE_NAME]
+            dropped = [record for record in ordered if record.superstep < cutoff and record.node_name != _BASELINE_NODE_NAME]
+            baseline = _make_baseline_record(run_id, dropped, baseline_superstep=cutoff - 1)
+            retained = [*([baseline] if baseline is not None else []), *kept]
+            self._steps[run_id] = {(record.superstep, record.node_name): record for record in retained}
+
+
+def _merge_state(records: list[StepRecord]) -> dict[str, Any]:
+    state: dict[str, Any] = {}
+    for record in sorted(records, key=_step_sort_key):
+        if record.values:
+            state.update(record.values)
+    return state
+
+
+def _make_baseline_record(
+    run_id: str,
+    records: list[StepRecord],
+    *,
+    baseline_superstep: int,
+) -> StepRecord | None:
+    if not records:
+        return None
+    values = _merge_state(records)
+    if not values:
+        return None
+    created_at = min(record.created_at for record in records)
+    completed_candidates = [record.completed_at for record in records if record.completed_at is not None]
+    completed_at = max(completed_candidates) if completed_candidates else created_at
+    return StepRecord(
+        run_id=run_id,
+        superstep=baseline_superstep,
+        node_name=_BASELINE_NODE_NAME,
+        index=min(record.index for record in records),
+        status=StepStatus.COMPLETED,
+        input_versions={},
+        values=values,
+        created_at=created_at,
+        completed_at=completed_at,
+        node_type="RetentionBaseline",
+    )

--- a/src/hypergraph/checkpointers/memory.py
+++ b/src/hypergraph/checkpointers/memory.py
@@ -1,0 +1,142 @@
+"""In-memory checkpointer for tests and lightweight experimentation."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timezone
+from typing import Any
+
+from hypergraph.checkpointers.base import Checkpointer
+from hypergraph.checkpointers.types import Run, StepRecord, WorkflowStatus
+
+
+def _step_sort_key(record: StepRecord) -> tuple[datetime, datetime, int, str]:
+    completed_or_created = record.completed_at or record.created_at
+    return (completed_or_created, record.created_at, record.index, record.node_name)
+
+
+class MemoryCheckpointer(Checkpointer):
+    """Simple async-only checkpointer backed by in-process memory."""
+
+    def __init__(self):
+        super().__init__()
+        self._runs: dict[str, Run] = {}
+        self._steps: dict[str, dict[tuple[int, str], StepRecord]] = {}
+
+    async def save_step(self, record: StepRecord) -> None:
+        run_steps = self._steps.setdefault(record.run_id, {})
+        run_steps[(record.superstep, record.node_name)] = record
+        self._apply_retention_policy(record.run_id)
+
+    async def create_run(
+        self,
+        run_id: str,
+        *,
+        graph_name: str | None = None,
+        parent_run_id: str | None = None,
+        forked_from: str | None = None,
+        fork_superstep: int | None = None,
+        retry_of: str | None = None,
+        retry_index: int | None = None,
+        config: dict[str, Any] | None = None,
+    ) -> Run:
+        existing = self._runs.get(run_id)
+        created_at = existing.created_at if existing is not None else datetime.now(timezone.utc)
+        run = Run(
+            id=run_id,
+            status=WorkflowStatus.ACTIVE,
+            graph_name=graph_name,
+            duration_ms=None,
+            node_count=0,
+            error_count=0,
+            parent_run_id=parent_run_id,
+            forked_from=forked_from,
+            fork_superstep=fork_superstep,
+            retry_of=retry_of,
+            retry_index=retry_index,
+            config=config,
+            created_at=created_at,
+            completed_at=None,
+        )
+        self._runs[run_id] = run
+        return run
+
+    async def update_run_status(
+        self,
+        run_id: str,
+        status: WorkflowStatus,
+        *,
+        duration_ms: float | None = None,
+        node_count: int | None = None,
+        error_count: int | None = None,
+    ) -> None:
+        existing = self._runs.get(run_id)
+        if existing is None:
+            raise ValueError(f"Unknown run_id: {run_id!r}")
+
+        self._runs[run_id] = replace(
+            existing,
+            status=status,
+            duration_ms=duration_ms if duration_ms is not None else existing.duration_ms,
+            node_count=node_count if node_count is not None else existing.node_count,
+            error_count=error_count if error_count is not None else existing.error_count,
+            completed_at=datetime.now(timezone.utc) if status in {WorkflowStatus.COMPLETED, WorkflowStatus.FAILED} else None,
+        )
+
+    async def get_state(self, run_id: str, *, superstep: int | None = None) -> dict[str, Any]:
+        state: dict[str, Any] = {}
+        for step in await self.get_steps(run_id, superstep=superstep):
+            if step.values:
+                state.update(step.values)
+        return state
+
+    async def get_steps(self, run_id: str, *, superstep: int | None = None) -> list[StepRecord]:
+        run_steps = self._steps.get(run_id, {})
+        records = list(run_steps.values())
+        if superstep is not None:
+            records = [record for record in records if record.superstep <= superstep]
+        return sorted(records, key=_step_sort_key)
+
+    async def get_run_async(self, run_id: str) -> Run | None:
+        return self._runs.get(run_id)
+
+    async def list_runs(
+        self,
+        *,
+        status: WorkflowStatus | None = None,
+        parent_run_id: str | None = None,
+        limit: int | None = 100,
+    ) -> list[Run]:
+        runs = list(self._runs.values())
+        if status is not None:
+            runs = [run for run in runs if run.status == status]
+        if parent_run_id is not None:
+            runs = [run for run in runs if run.parent_run_id == parent_run_id]
+
+        runs.sort(key=lambda run: run.created_at, reverse=True)
+        if limit is not None:
+            runs = runs[:limit]
+        return runs
+
+    def _apply_retention_policy(self, run_id: str) -> None:
+        retention = self.policy.retention
+        if retention == "full":
+            return
+
+        run_steps = self._steps.get(run_id)
+        if not run_steps:
+            return
+
+        if retention == "latest":
+            latest_by_node: dict[str, StepRecord] = {}
+            for record in sorted(run_steps.values(), key=_step_sort_key):
+                latest_by_node[record.node_name] = record
+            self._steps[run_id] = {(record.superstep, record.node_name): record for record in latest_by_node.values()}
+            return
+
+        if retention == "windowed" and self.policy.window is not None:
+            max_superstep = max(record.superstep for record in run_steps.values())
+            cutoff = max_superstep - self.policy.window + 1
+            if cutoff <= 0:
+                return
+            self._steps[run_id] = {key: record for key, record in run_steps.items() if record.superstep >= cutoff}

--- a/src/hypergraph/checkpointers/presenters.py
+++ b/src/hypergraph/checkpointers/presenters.py
@@ -527,7 +527,7 @@ def render_run_table_html(table: Any) -> str:
             id=group_id,
             status=status,
             graph_name=members[0].graph_name if members else None,
-            duration_ms=max((r.duration_ms or 0.0 for r in members), default=None),
+            duration_ms=max((r.duration_ms or 0.0 for r in members), default=0.0) if members else None,
             node_count=sum(r.node_count for r in members),
             error_count=sum(r.error_count for r in members),
             created_at=created,

--- a/src/hypergraph/checkpointers/presenters.py
+++ b/src/hypergraph/checkpointers/presenters.py
@@ -9,6 +9,11 @@ if TYPE_CHECKING:
     from hypergraph.checkpointers.types import Run, StepRecord
 
 
+def _safe_json_payload(payload: dict[str, Any]) -> str:
+    """Serialize JSON safely for embedding inside a script tag."""
+    return json.dumps(payload).replace("<", "\\u003c").replace(">", "\\u003e").replace("&", "\\u0026")
+
+
 def render_checkpointer_explorer_html(
     *,
     title: str,
@@ -92,7 +97,7 @@ def render_checkpointer_explorer_html(
         f'<div id="{panel_body_id}" style="{panel_style}"></div>'
         f"</section>"
         f"</div>"
-        f'<script type="application/json" id="{data_id}">{json.dumps(payload)}</script>'
+        f'<script type="application/json" id="{data_id}">{_safe_json_payload(payload)}</script>'
         f"<script>{_explorer_script(explorer_id, data_id, header_id, run_list_id, empty_id, summary_id, panel_nav_id, panel_body_id)}</script>"
         f"</div>"
     )

--- a/src/hypergraph/checkpointers/presenters.py
+++ b/src/hypergraph/checkpointers/presenters.py
@@ -1,0 +1,761 @@
+"""Presentation helpers for checkpointer notebook/HTML displays."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from hypergraph.checkpointers.types import Run, StepRecord
+
+
+def render_checkpointer_explorer_html(
+    *,
+    title: str,
+    path: str,
+    state_key: str,
+    run_count: int | None = None,
+    step_count: int | None = None,
+    size_bytes: int | None = None,
+    runs: list[Run] | None = None,
+    steps_by_run: dict[str, list[StepRecord]] | None = None,
+    run_limit: int | None = None,
+) -> str:
+    """Render a drill-through explorer for a checkpointer."""
+    from hypergraph._repr import (
+        BORDER_COLOR,
+        FONT_MONO_STYLE,
+        MUTED_COLOR,
+        PANEL_COLOR,
+        TEXT_STRONG_COLOR,
+        _code,
+        html_kv,
+        html_panel,
+        theme_wrap,
+        unique_dom_id,
+    )
+
+    runs = runs or []
+    steps_by_run = steps_by_run or {}
+
+    kvs = [html_kv("Path", _code(path))]
+    if size_bytes is not None:
+        size_mb = size_bytes / (1024 * 1024)
+        kvs.append(html_kv("Size", f"{size_mb:.1f} MB" if size_mb >= 1 else f"{size_bytes / 1024:.0f} KB"))
+    if run_count is not None:
+        kvs.append(html_kv("Runs", str(run_count)))
+    if step_count is not None:
+        kvs.append(html_kv("Steps", str(step_count)))
+    summary = " &nbsp;|&nbsp; ".join(kvs)
+
+    payload = {
+        "runs": [run.to_dict() for run in runs],
+        "steps_by_run": {run_id: [step.to_dict() for step in run_steps] for run_id, run_steps in steps_by_run.items()},
+        "initial_run_id": runs[0].id if runs else None,
+        "run_limit": run_limit,
+    }
+
+    explorer_id = unique_dom_id("checkpointer-explorer", path)
+    data_id = f"{explorer_id}-data"
+    header_id = f"{explorer_id}-header"
+    run_list_id = f"{explorer_id}-runs"
+    empty_id = f"{explorer_id}-empty"
+    summary_id = f"{explorer_id}-summary"
+    panel_nav_id = f"{explorer_id}-nav"
+    panel_body_id = f"{explorer_id}-body"
+
+    panel_style = f"border:1px solid {BORDER_COLOR}; border-radius:10px; background:{PANEL_COLOR}; padding:12px; min-height:120px"
+    mono = FONT_MONO_STYLE
+
+    controls_note = "Select a run on the left, then drill into overview, steps, and lineage from one place."
+    if run_limit is not None and run_count is not None and run_count > run_limit:
+        controls_note += f" Showing the newest {run_limit} runs in the explorer."
+
+    container = (
+        f'<div id="{explorer_id}" data-hg-explorer="checkpointer" '
+        f'style="display:flex; flex-direction:column; gap:12px">'
+        f"{html_panel(title, summary)}"
+        f'<div style="color:{MUTED_COLOR}; font-size:0.9em">{controls_note}</div>'
+        f'<div style="display:grid; grid-template-columns:minmax(240px, 300px) minmax(420px, 1fr); gap:12px; align-items:start">'
+        f'<section style="{panel_style}">'
+        f'<div style="display:flex; justify-content:space-between; gap:8px; align-items:center; margin-bottom:8px">'
+        f'<div data-hg-panel-title="Run Explorer" style="{mono}; font-weight:700; color:{TEXT_STRONG_COLOR}">Run Explorer</div>'
+        f'<div style="color:{MUTED_COLOR}; font-size:0.85em">Explore: {_code(".runs()")} {_code(".steps(run_id)")} {_code(".search(query)")} {_code(".stats(run_id)")}</div>'
+        f"</div>"
+        f'<div id="{run_list_id}" style="display:flex; flex-direction:column; gap:8px"></div>'
+        f'<div id="{empty_id}" style="display:none; color:{MUTED_COLOR}; {mono}">No runs available.</div>'
+        f"</section>"
+        f'<section style="display:flex; flex-direction:column; gap:12px">'
+        f'<div id="{header_id}" style="{panel_style}"></div>'
+        f'<div id="{summary_id}" style="display:grid; grid-template-columns:repeat(auto-fit, minmax(180px, 1fr)); gap:8px"></div>'
+        f'<div id="{panel_nav_id}" style="display:flex; gap:8px; flex-wrap:wrap"></div>'
+        f'<div id="{panel_body_id}" style="{panel_style}"></div>'
+        f"</section>"
+        f"</div>"
+        f'<script type="application/json" id="{data_id}">{json.dumps(payload)}</script>'
+        f"<script>{_explorer_script(explorer_id, data_id, header_id, run_list_id, empty_id, summary_id, panel_nav_id, panel_body_id)}</script>"
+        f"</div>"
+    )
+    return theme_wrap(container, state_key=state_key)
+
+
+def _explorer_script(
+    explorer_id: str,
+    data_id: str,
+    header_id: str,
+    run_list_id: str,
+    empty_id: str,
+    summary_id: str,
+    panel_nav_id: str,
+    panel_body_id: str,
+) -> str:
+    """Inline JS for the checkpointer explorer."""
+    status_colors = {
+        "completed": ("#059669", "#ecfdf5"),
+        "failed": ("#dc2626", "#fef2f2"),
+        "active": ("#d97706", "#fffbeb"),
+        "paused": ("#7c3aed", "#f5f3ff"),
+        "partial": ("#d97706", "#fffbeb"),
+        "cached": ("#2563eb", "#eff6ff"),
+    }
+    return f"""
+(function(){{
+  var root=document.getElementById({json.dumps(explorer_id)});
+  var dataEl=document.getElementById({json.dumps(data_id)});
+  if(!root||!dataEl||root.__hgExplorerBound) return;
+  root.__hgExplorerBound=true;
+  var headerEl=document.getElementById({json.dumps(header_id)});
+  var runListEl=document.getElementById({json.dumps(run_list_id)});
+  var emptyEl=document.getElementById({json.dumps(empty_id)});
+  var summaryEl=document.getElementById({json.dumps(summary_id)});
+  var navEl=document.getElementById({json.dumps(panel_nav_id)});
+  var bodyEl=document.getElementById({json.dumps(panel_body_id)});
+  var data=JSON.parse(dataEl.textContent||"{{}}");
+  var runs=(data.runs||[]);
+  var stepsByRun=(data.steps_by_run||{{}});
+  var statusColors={json.dumps(status_colors)};
+  var runsById={{}};
+  var childrenByParent={{}};
+  for(var i=0;i<runs.length;i++) {{
+    var run=runs[i];
+    runsById[run.id]=run;
+    if(run.parent_run_id) {{
+      if(!childrenByParent[run.parent_run_id]) childrenByParent[run.parent_run_id]=[];
+      childrenByParent[run.parent_run_id].push(run.id);
+    }}
+  }}
+  var state={{runId:data.initial_run_id||null, panel:"overview", stepIndex:null}};
+  var esc=function(value){{
+    return String(value===undefined||value===null?"":value)
+      .replace(/&/g,"&amp;")
+      .replace(/</g,"&lt;")
+      .replace(/>/g,"&gt;")
+      .replace(/"/g,"&quot;")
+      .replace(/'/g,"&#39;");
+  }};
+  var fmtDuration=function(ms){{
+    if(ms===null||ms===undefined||ms==="") return "—";
+    var n=Number(ms);
+    if(!isFinite(n)||n<=0) return "0ms";
+    if(n<1000) return n.toFixed(n<10?2:(n<100?1:0))+"ms";
+    return (n/1000).toFixed((n/1000)<10?2:1)+"s";
+  }};
+  var fmtDate=function(value){{
+    if(!value) return "—";
+    var d=new Date(value);
+    if(isNaN(d.getTime())) return esc(value);
+    return esc(d.toISOString().replace("T"," ").replace("Z"," UTC"));
+  }};
+  var badge=function(status){{
+    var colors=statusColors[status]||["#6b7280","#f3f4f6"];
+    return '<span style="display:inline-block; padding:2px 8px; border-radius:999px; font-size:0.85em; font-weight:600; color:'+colors[0]+'; background:'+colors[1]+'">'+esc(status)+'</span>';
+  }};
+  var runButton=function(run){{
+    var active=state.runId===run.id;
+    var stepCount=(stepsByRun[run.id]||[]).length;
+    var childCount=(childrenByParent[run.id]||[]).length;
+    return (
+      '<button type="button" data-run-target="'+esc(run.id)+'" style="text-align:left; padding:10px 12px; border-radius:10px; border:1px solid '+(active?'#2563eb':'#e5e7eb')+'; background:'+(active?'#eff6ff':'#ffffff')+'; cursor:pointer">' +
+      '<div style="display:flex; justify-content:space-between; gap:8px; align-items:center">' +
+      '<span style="font-weight:700; font-family:ui-monospace, monospace; color:#111827">'+esc(run.id)+'</span>' +
+      badge(run.status) +
+      '</div>' +
+      '<div style="margin-top:6px; color:#6b7280; font-size:0.88em">' +
+      esc(run.graph_name||'unnamed') + ' | ' + stepCount + ' step' + (stepCount===1?'':'s') +
+      (childCount?(' | '+childCount+' child run'+(childCount===1?'':'s')):'') +
+      '</div>' +
+      '</button>'
+    );
+  }};
+  var relatedLineage=function(run){{
+    var ids=[];
+    var seen={{}};
+    var current=run;
+    while(current){{
+      if(seen[current.id]) break;
+      seen[current.id]=true;
+      ids.unshift(current.id);
+      var parentId=current.forked_from||current.retry_of;
+      current=parentId ? runsById[parentId] : null;
+    }}
+    var descendants=[];
+    for(var i=0;i<runs.length;i++) {{
+      var candidate=runs[i];
+      var p=candidate.forked_from||candidate.retry_of;
+      if(p===run.id) descendants.push(candidate.id);
+    }}
+    return {{ancestors:ids, descendants:descendants}};
+  }};
+  var summaryCard=function(label, value){{
+    return '<div style="border:1px solid #e5e7eb; border-radius:10px; background:#ffffff; padding:10px 12px">' +
+      '<div style="color:#6b7280; font-size:0.82em">'+esc(label)+'</div>' +
+      '<div style="margin-top:4px; color:#111827; font-weight:700">'+value+'</div></div>';
+  }};
+  var renderRunList=function(){{
+    if(!runs.length){{
+      runListEl.innerHTML='';
+      emptyEl.style.display='block';
+      return;
+    }}
+    emptyEl.style.display='none';
+    runListEl.innerHTML=runs.map(runButton).join('');
+  }};
+  var renderHeader=function(run){{
+    if(!run){{
+      headerEl.innerHTML='<div style="color:#6b7280">No run selected.</div>';
+      summaryEl.innerHTML='';
+      navEl.innerHTML='';
+      bodyEl.innerHTML='<div style="color:#6b7280">Select a run to inspect it.</div>';
+      return;
+    }}
+    var lineageParent=run.forked_from||run.retry_of;
+    headerEl.innerHTML =
+      '<div style="display:flex; justify-content:space-between; gap:12px; flex-wrap:wrap; align-items:flex-start">' +
+      '<div>' +
+      '<div style="font-family:ui-monospace, monospace; font-size:1.05em; font-weight:700; color:#111827">'+esc(run.id)+'</div>' +
+      '<div style="margin-top:6px; color:#6b7280">'+esc(run.graph_name||'unnamed graph')+'</div>' +
+      '</div>' +
+      '<div style="display:flex; gap:8px; flex-wrap:wrap; align-items:center">' +
+      badge(run.status) +
+      (lineageParent?'<button type="button" data-run-target="'+esc(lineageParent)+'" style="padding:6px 10px; border-radius:8px; border:1px solid #e5e7eb; background:#ffffff; cursor:pointer">Open source</button>':'') +
+      '</div></div>';
+    var steps=(stepsByRun[run.id]||[]);
+    var children=(childrenByParent[run.id]||[]);
+    summaryEl.innerHTML = [
+      summaryCard('Duration', esc(fmtDuration(run.duration_ms))),
+      summaryCard('Steps', esc(String(steps.length||run.node_count||0))),
+      summaryCard('Errors', esc(String(run.error_count||0))),
+      summaryCard('Children', esc(String(children.length)))
+    ].join('');
+    var panels=[['overview','Overview'],['steps','Steps'],['lineage','Lineage']];
+    navEl.innerHTML=panels.map(function(pair){{
+      var active=state.panel===pair[0];
+      return '<button type="button" data-panel="'+pair[0]+'" style="padding:6px 10px; border-radius:8px; border:1px solid '+(active?'#2563eb':'#e5e7eb')+'; background:'+(active?'#eff6ff':'#ffffff')+'; cursor:pointer">'+pair[1]+'</button>';
+    }}).join('');
+  }};
+  var renderOverview=function(run){{
+    var steps=(stepsByRun[run.id]||[]);
+    var children=(childrenByParent[run.id]||[]);
+    var items=[
+      ['Created', fmtDate(run.created_at)],
+      ['Completed', fmtDate(run.completed_at)],
+      ['Parent Run', run.parent_run_id?'<button type="button" data-run-target="'+esc(run.parent_run_id)+'" style="padding:0; border:none; background:none; color:#2563eb; cursor:pointer; font-family:ui-monospace, monospace">'+esc(run.parent_run_id)+'</button>':'—'],
+      ['Forked From', run.forked_from?'<button type="button" data-run-target="'+esc(run.forked_from)+'" style="padding:0; border:none; background:none; color:#2563eb; cursor:pointer; font-family:ui-monospace, monospace">'+esc(run.forked_from)+(run.fork_superstep!==null&&run.fork_superstep!==undefined?('@'+esc(run.fork_superstep)):'')+'</button>':'—'],
+      ['Retry Of', run.retry_of?'<button type="button" data-run-target="'+esc(run.retry_of)+'" style="padding:0; border:none; background:none; color:#2563eb; cursor:pointer; font-family:ui-monospace, monospace">'+esc(run.retry_of)+'</button>':'—']
+    ];
+    var meta='<div style="display:grid; grid-template-columns:minmax(140px, 180px) 1fr; gap:8px 12px">';
+    for(var i=0;i<items.length;i++) {{
+      meta += '<div style="color:#6b7280">'+items[i][0]+'</div><div style="color:#111827">'+items[i][1]+'</div>';
+    }}
+    meta += '</div>';
+    var childHtml = children.length
+      ? '<div style="margin-top:12px"><div style="font-weight:700; margin-bottom:6px">Child Runs</div>' +
+        children.map(function(id){{ var child=runsById[id]; return child?'<div style="margin:4px 0"><button type="button" data-run-target="'+esc(id)+'" style="padding:0; border:none; background:none; color:#2563eb; cursor:pointer; font-family:ui-monospace, monospace">'+esc(id)+'</button> '+badge(child.status)+'</div>':''; }}).join('') +
+        '</div>'
+      : '';
+    var stepSummary = steps.length
+      ? '<div style="margin-top:12px"><div style="font-weight:700; margin-bottom:6px">Recent Steps</div>' +
+        steps.slice(0,5).map(function(step){{ return '<div style="margin:4px 0"><button type="button" data-panel="steps" data-step-index="'+esc(step.index)+'" style="padding:0; border:none; background:none; color:#2563eb; cursor:pointer">['+esc(step.index)+'] '+esc(step.node_name)+'</button> '+badge(step.cached?'cached':step.status)+'</div>'; }}).join('') +
+        (steps.length>5?'<div style="color:#6b7280; margin-top:4px">+'+(steps.length-5)+' more steps</div>':'') + '</div>'
+      : '<div style="margin-top:12px; color:#6b7280">No steps loaded for this run.</div>';
+    return meta + childHtml + stepSummary;
+  }};
+  var renderSteps=function(run){{
+    var steps=(stepsByRun[run.id]||[]);
+    if(!steps.length) return '<div style="color:#6b7280">No steps loaded for this run.</div>';
+    if(state.stepIndex===null) state.stepIndex=steps[0].index;
+    var selected=null;
+    for(var i=0;i<steps.length;i++) if(steps[i].index===state.stepIndex) selected=steps[i];
+    if(!selected) selected=steps[0];
+    var rows = steps.map(function(step){{
+      var active=selected&&selected.index===step.index;
+      return '<tr data-step-index="'+esc(step.index)+'" style="cursor:pointer; background:'+(active?'#eff6ff':'transparent')+'">' +
+        '<td style="padding:6px 8px; border-bottom:1px solid #f3f4f6">'+esc(step.index)+'</td>' +
+        '<td style="padding:6px 8px; border-bottom:1px solid #f3f4f6">'+esc(step.node_name)+'</td>' +
+        '<td style="padding:6px 8px; border-bottom:1px solid #f3f4f6">'+badge(step.cached?'cached':step.status)+'</td>' +
+        '<td style="padding:6px 8px; border-bottom:1px solid #f3f4f6">'+esc(fmtDuration(step.duration_ms))+'</td>' +
+        '<td style="padding:6px 8px; border-bottom:1px solid #f3f4f6">'+esc(step.superstep)+'</td>' +
+        '</tr>';
+    }}).join('');
+    var pretty=function(value){{ return esc(JSON.stringify(value, null, 2)); }};
+    return '<div style="display:grid; grid-template-columns:minmax(280px, 1fr) minmax(260px, 1fr); gap:12px">' +
+      '<div><table style="width:100%; border-collapse:collapse; font-size:0.92em"><thead><tr>' +
+      '<th style="text-align:left; padding:6px 8px; border-bottom:2px solid #e5e7eb">#</th>' +
+      '<th style="text-align:left; padding:6px 8px; border-bottom:2px solid #e5e7eb">Node</th>' +
+      '<th style="text-align:left; padding:6px 8px; border-bottom:2px solid #e5e7eb">Status</th>' +
+      '<th style="text-align:left; padding:6px 8px; border-bottom:2px solid #e5e7eb">Duration</th>' +
+      '<th style="text-align:left; padding:6px 8px; border-bottom:2px solid #e5e7eb">Superstep</th>' +
+      '</tr></thead><tbody>'+rows+'</tbody></table></div>' +
+      '<div style="border:1px solid #e5e7eb; border-radius:10px; background:#ffffff; padding:10px 12px">' +
+      '<div style="font-weight:700; margin-bottom:8px">Step Detail</div>' +
+      '<div style="display:grid; grid-template-columns:110px 1fr; gap:6px 10px">' +
+      '<div style="color:#6b7280">Node</div><div>'+esc(selected.node_name)+'</div>' +
+      '<div style="color:#6b7280">Status</div><div>'+badge(selected.cached?'cached':selected.status)+'</div>' +
+      '<div style="color:#6b7280">Superstep</div><div>'+esc(selected.superstep)+'</div>' +
+      '<div style="color:#6b7280">Duration</div><div>'+esc(fmtDuration(selected.duration_ms))+'</div>' +
+      '<div style="color:#6b7280">Decision</div><div>'+esc(selected.decision===null||selected.decision===undefined?'—':JSON.stringify(selected.decision))+'</div>' +
+      '<div style="color:#6b7280">Child Run</div><div>'+(selected.child_run_id?'<button type="button" data-run-target="'+esc(selected.child_run_id)+'" style="padding:0; border:none; background:none; color:#2563eb; cursor:pointer; font-family:ui-monospace, monospace">'+esc(selected.child_run_id)+'</button>':'—')+'</div>' +
+      '</div>' +
+      '<div style="margin-top:10px">' +
+      '<div style="font-weight:700; margin-bottom:4px">Input Versions</div>' +
+      '<pre style="margin:0; padding:8px; border-radius:8px; background:#f8fafc; overflow:auto">'+pretty(selected.input_versions||{{}})+'</pre>' +
+      '</div>' +
+      '<div style="margin-top:10px">' +
+      '<div style="font-weight:700; margin-bottom:4px">Values</div>' +
+      '<pre style="margin:0; padding:8px; border-radius:8px; background:#f8fafc; overflow:auto">'+pretty(selected.values||{{}})+'</pre>' +
+      '</div>' +
+      '<div style="margin-top:10px">' +
+      '<div style="font-weight:700; margin-bottom:4px">Error</div>' +
+      '<pre style="margin:0; padding:8px; border-radius:8px; background:#f8fafc; overflow:auto">'+esc(selected.error||'')+'</pre>' +
+      '</div></div></div>';
+  }};
+  var renderLineage=function(run){{
+    var rel=relatedLineage(run);
+    var ancestorHtml=rel.ancestors.length
+      ? rel.ancestors.map(function(id){{
+          var item=runsById[id];
+          if(!item) return '';
+          var selected=(id===run.id);
+          return '<div style="margin:4px 0">'+(selected?'&rarr; ':'')+'<button type="button" data-run-target="'+esc(id)+'" style="padding:0; border:none; background:none; color:#2563eb; cursor:pointer; font-family:ui-monospace, monospace">'+esc(id)+'</button> '+badge(item.status)+'</div>';
+        }}).join('')
+      : '<div style="color:#6b7280">No lineage in loaded data.</div>';
+    var descendantHtml=rel.descendants.length
+      ? rel.descendants.map(function(id){{
+          var item=runsById[id];
+          return item?'<div style="margin:4px 0"><button type="button" data-run-target="'+esc(id)+'" style="padding:0; border:none; background:none; color:#2563eb; cursor:pointer; font-family:ui-monospace, monospace">'+esc(id)+'</button> '+badge(item.status)+'</div>':'';
+        }}).join('')
+      : '<div style="color:#6b7280">No direct fork/retry descendants in loaded data.</div>';
+    return '<div style="display:grid; grid-template-columns:minmax(220px, 1fr) minmax(220px, 1fr); gap:12px">' +
+      '<div style="border:1px solid #e5e7eb; border-radius:10px; background:#ffffff; padding:10px 12px"><div style="font-weight:700; margin-bottom:8px">Ancestry</div>'+ancestorHtml+'</div>' +
+      '<div style="border:1px solid #e5e7eb; border-radius:10px; background:#ffffff; padding:10px 12px"><div style="font-weight:700; margin-bottom:8px">Descendants</div>'+descendantHtml+'</div>' +
+      '</div>';
+  }};
+  var renderBody=function(run){{
+    if(!run) {{
+      bodyEl.innerHTML='<div style="color:#6b7280">Select a run to inspect it.</div>';
+      return;
+    }}
+    if(state.panel==='steps') {{
+      bodyEl.innerHTML=renderSteps(run);
+      return;
+    }}
+    if(state.panel==='lineage') {{
+      bodyEl.innerHTML=renderLineage(run);
+      return;
+    }}
+    bodyEl.innerHTML=renderOverview(run);
+  }};
+  var render=function(){{
+    renderRunList();
+    var run=state.runId ? runsById[state.runId] : null;
+    renderHeader(run);
+    renderBody(run);
+  }};
+  root.addEventListener('click', function(event){{
+    var runTarget=event.target.closest('[data-run-target]');
+    if(runTarget){{
+      state.runId=runTarget.getAttribute('data-run-target');
+      state.stepIndex=null;
+      render();
+      return;
+    }}
+    var panelTarget=event.target.closest('[data-panel]');
+    if(panelTarget){{
+      state.panel=panelTarget.getAttribute('data-panel');
+      var stepIndex=panelTarget.getAttribute('data-step-index');
+      state.stepIndex=stepIndex!==null?Number(stepIndex):state.stepIndex;
+      render();
+      return;
+    }}
+    var stepTarget=event.target.closest('[data-step-index]');
+    if(stepTarget){{
+      state.panel='steps';
+      state.stepIndex=Number(stepTarget.getAttribute('data-step-index'));
+      render();
+    }}
+  }});
+  render();
+}})();
+"""
+
+
+def render_step_record_html(step: Any) -> str:
+    """Render notebook HTML for a single StepRecord."""
+    from hypergraph._repr import ERROR_COLOR, FONT_SANS_STYLE, MUTED_COLOR, duration_html, status_badge, theme_wrap, widget_state_key
+
+    status = "cached" if step.cached else step.status.value
+    dur = duration_html(step.duration_ms) if step.duration_ms > 0 else ""
+    error = f' <span style="color:{ERROR_COLOR}; font-size:0.85em">{step.error[:80]}</span>' if step.error else ""
+    return theme_wrap(
+        f'<span style="{FONT_SANS_STYLE}; font-size:0.9em">'
+        f"<b>[{step.index}] {step.node_name}</b> {status_badge(status)} {dur}"
+        f' <span style="color:{MUTED_COLOR}">superstep {step.superstep}</span>'
+        f"{error}</span>",
+        state_key=widget_state_key("step-record", step.run_id, step.index, step.node_name, step.superstep),
+    )
+
+
+def render_run_html(run: Any) -> str:
+    """Render notebook HTML for a single Run."""
+    from hypergraph._repr import (
+        ERROR_COLOR,
+        MUTED_COLOR,
+        _code,
+        datetime_html,
+        duration_html,
+        html_kv,
+        html_panel,
+        status_badge,
+        theme_wrap,
+        widget_state_key,
+    )
+
+    kvs = [
+        html_kv("Status", status_badge(run.status.value)),
+        html_kv("Duration", duration_html(run.duration_ms)),
+    ]
+    if run.node_count:
+        kvs.append(html_kv("Steps", str(run.node_count)))
+    if run.error_count:
+        kvs.append(html_kv("Errors", f'<span style="color:{ERROR_COLOR}; font-weight:600">{run.error_count}</span>'))
+    if run.parent_run_id:
+        kvs.append(html_kv("Parent", _code(run.parent_run_id)))
+    if run.forked_from:
+        label = run.forked_from if run.fork_superstep is None else f"{run.forked_from}@{run.fork_superstep}"
+        kvs.append(html_kv("Forked From", _code(label)))
+    if run.retry_of:
+        label = run.retry_of if run.retry_index is None else f"{run.retry_of} (#{run.retry_index})"
+        kvs.append(html_kv("Retry Of", _code(label)))
+    kvs.append(html_kv("Created", datetime_html(run.created_at)))
+    title = f"Run: {run.id}"
+    if run.graph_name:
+        title += f' <span style="color:{MUTED_COLOR}; font-weight:400">({run.graph_name})</span>'
+    body = " &nbsp;|&nbsp; ".join(kvs)
+    return theme_wrap(html_panel(title, body), state_key=widget_state_key("run", run.id))
+
+
+def render_checkpoint_html(checkpoint: Any) -> str:
+    """Render notebook HTML for a Checkpoint."""
+    from hypergraph._repr import _code, html_panel, theme_wrap, widget_state_key
+
+    keys = ", ".join(_code(k) for k in sorted(checkpoint.values.keys())[:10])
+    if len(checkpoint.values) > 10:
+        keys += f" ... (+{len(checkpoint.values) - 10} more)"
+    body = f"<b>{len(checkpoint.values)}</b> values: {keys}<br><b>{len(checkpoint.steps)}</b> steps"
+    return theme_wrap(
+        html_panel("Checkpoint", body),
+        state_key=widget_state_key("checkpoint", checkpoint.source_run_id or "ad-hoc", checkpoint.source_superstep),
+    )
+
+
+def render_run_table_html(table: Any) -> str:
+    """Render notebook HTML for a RunTable."""
+    from datetime import datetime, timezone
+
+    from hypergraph._repr import (
+        ERROR_COLOR,
+        FONT_SANS_STYLE,
+        MUTED_COLOR,
+        _code,
+        duration_html,
+        html_detail,
+        html_table,
+        html_table_controls,
+        html_table_controls_script,
+        html_table_with_row_attrs,
+        status_badge,
+        theme_wrap,
+        unique_dom_id,
+        widget_state_key,
+    )
+
+    if not table:
+        return theme_wrap(
+            f'<div style="color:{MUTED_COLOR}; {FONT_SANS_STYLE}">RunTable: (empty)</div>',
+            state_key=widget_state_key("run-table", "empty"),
+        )
+
+    def _utcnow():
+        return datetime.now(timezone.utc)
+
+    headers = ["ID", "Graph", "Status", "Duration", "Steps", "Errors"]
+
+    def _group_key(run: Any) -> str:
+        if run.parent_run_id:
+            return run.parent_run_id
+        if "/" in run.id:
+            return run.id.split("/", 1)[0]
+        return run.id
+
+    def _synth_parent(group_id: str, members: list[Any]) -> Any:
+        from hypergraph.checkpointers.types import Run, WorkflowStatus
+
+        status = WorkflowStatus.COMPLETED
+        if any(r.status == WorkflowStatus.ACTIVE for r in members):
+            status = WorkflowStatus.ACTIVE
+        elif any(r.status == WorkflowStatus.PAUSED for r in members):
+            status = WorkflowStatus.PAUSED
+        elif any(r.status == WorkflowStatus.FAILED for r in members):
+            status = WorkflowStatus.FAILED
+        created = max((r.created_at for r in members), default=_utcnow())
+        return Run(
+            id=group_id,
+            status=status,
+            graph_name=members[0].graph_name if members else None,
+            duration_ms=max((r.duration_ms or 0.0 for r in members), default=None),
+            node_count=sum(r.node_count for r in members),
+            error_count=sum(r.error_count for r in members),
+            created_at=created,
+        )
+
+    by_id = {run.id: run for run in table}
+    groups: dict[str, list[Any]] = {}
+    for run in table:
+        groups.setdefault(_group_key(run), []).append(run)
+
+    row_items: list[tuple[Any, bool, str]] = []
+    for group_id, members in groups.items():
+        parent = by_id.get(group_id)
+        children = sorted([r for r in members if r.id != group_id], key=lambda r: r.created_at, reverse=True)
+        if parent is None:
+            parent = _synth_parent(group_id, members)
+        row_items.append((parent, False, group_id))
+        for child in children:
+            row_items.append((child, True, group_id))
+
+    rows: list[list[str]] = []
+    row_attrs: list[dict[str, str]] = []
+    for run, is_child, _group_id in row_items:
+        rows.append(
+            [
+                _code(run.id),
+                run.graph_name or "—",
+                status_badge(run.status.value),
+                duration_html(run.duration_ms),
+                str(run.node_count) if run.node_count else "—",
+                f'<span style="color:{ERROR_COLOR}">{run.error_count}</span>' if run.error_count else "0",
+            ]
+        )
+        row_attrs.append(
+            {
+                "data-id": run.id,
+                "data-status": run.status.value,
+                "data-parent": "1" if is_child else "0",
+                "data-created-ts": str(run.created_at.timestamp()),
+                "data-duration-ms": str(run.duration_ms or 0.0),
+                "data-errors": str(run.error_count),
+            }
+        )
+
+    detail_sections: list[str] = []
+    for group_id, members in groups.items():
+        parent = by_id.get(group_id)
+        children = sorted([r for r in members if r.id != group_id], key=lambda r: r.created_at, reverse=True)
+        if parent is None:
+            parent = _synth_parent(group_id, members)
+
+        summary = f"{_code(group_id)} — {status_badge(parent.status.value)}"
+        if children:
+            summary += f' <span style="color:{MUTED_COLOR}">({len(children)} child run{"s" if len(children) != 1 else ""})</span>'
+
+        detail_parts = [render_run_html(parent)]
+        if children:
+            child_rows = [
+                [
+                    _code(c.id),
+                    c.graph_name or "—",
+                    status_badge(c.status.value),
+                    duration_html(c.duration_ms),
+                    str(c.node_count) if c.node_count else "—",
+                    f'<span style="color:{ERROR_COLOR}">{c.error_count}</span>' if c.error_count else "0",
+                ]
+                for c in children
+            ]
+            detail_parts.append(html_table(["ID", "Graph", "Status", "Duration", "Steps", "Errors"], child_rows))
+
+        run_steps = getattr(table, "_steps_by_run", {}).get(group_id)
+        if run_steps:
+            detail_parts.append(
+                html_detail(
+                    f"Steps ({len(run_steps)} step{'s' if len(run_steps) != 1 else ''})",
+                    render_step_table_html(run_steps),
+                    state_key=f"run-steps-{group_id}",
+                )
+            )
+
+        detail_sections.append(html_detail(summary, "<br>".join(detail_parts), state_key=f"run-{group_id}"))
+
+    run_ids = ",".join(run.id for run in table)
+    table_id = unique_dom_id("run-table-ui", run_ids, len(row_items))
+    view_id = f"{table_id}-view"
+    status_id = f"{table_id}-status"
+    sort_id = f"{table_id}-sort"
+    show_id = f"{table_id}-show"
+
+    controls = html_table_controls(
+        view_id=view_id,
+        status_id=status_id,
+        sort_id=sort_id,
+        show_id=show_id,
+        show_options=[20, 50, 100],
+        total_rows=len(row_items),
+    )
+    table_html = html_table_with_row_attrs(
+        headers, rows, row_attrs=row_attrs, title=f"{len(table)} run{'s' if len(table) != 1 else ''}", table_id=table_id
+    )
+    script = html_table_controls_script(table_id=table_id, view_id=view_id, status_id=status_id, sort_id=sort_id, show_id=show_id)
+    traces = html_detail("Run Traces", "".join(detail_sections), state_key="run-traces")
+    body = controls + table_html + traces + script
+    return theme_wrap(body, state_key=widget_state_key("run-table", run_ids))
+
+
+def render_step_table_html(table: Any) -> str:
+    """Render notebook HTML for a StepTable."""
+    from hypergraph._repr import (
+        FONT_SANS_STYLE,
+        MUTED_COLOR,
+        _code,
+        datetime_html,
+        duration_html,
+        html_detail,
+        html_kv,
+        html_table,
+        status_badge,
+        theme_wrap,
+        values_html,
+        widget_state_key,
+    )
+
+    if not table:
+        return theme_wrap(
+            f'<div style="color:{MUTED_COLOR}; {FONT_SANS_STYLE}">StepTable: (empty)</div>',
+            state_key=widget_state_key("step-table", "empty"),
+        )
+    headers = ["#", "Node", "Status", "Duration", "At", "Superstep"]
+    rows = []
+    for step in table:
+        status = "cached" if step.cached else step.status.value
+        rows.append(
+            [
+                str(step.index),
+                _code(step.node_name),
+                status_badge(status),
+                duration_html(step.duration_ms) if step.duration_ms > 0 else "—",
+                datetime_html(step.completed_at or step.created_at),
+                str(step.superstep),
+            ]
+        )
+    step_fingerprint = ",".join(f"{step.run_id}:{step.superstep}:{step.node_name}" for step in table)
+    body = html_table(headers, rows, title=f"{len(table)} step{'s' if len(table) != 1 else ''}")
+    for i, step in enumerate(table):
+        status = "cached" if step.cached else step.status.value
+        meta = " &nbsp;|&nbsp; ".join(
+            [
+                html_kv("Node", _code(step.node_name)),
+                html_kv("Superstep", str(step.superstep)),
+                html_kv("Status", status_badge(status)),
+                html_kv("Duration", duration_html(step.duration_ms) if step.duration_ms > 0 else "—"),
+            ]
+        )
+        content = meta
+        if step.decision is not None:
+            content += "<br>" + html_kv("Decision", _code(str(step.decision)))
+        if step.error:
+            content += "<br>" + html_kv("Error", _code(step.error))
+        if step.values:
+            content += "<br><br>" + html_detail("Values", values_html(step.values), state_key=f"values-{i}")
+        body += html_detail(f"[{step.index}] {step.node_name}", content, state_key=f"step-{i}")
+    return theme_wrap(body, state_key=widget_state_key("step-table", step_fingerprint))
+
+
+def render_lineage_view_html(view: Any) -> str:
+    """Render notebook HTML for a LineageView."""
+    from hypergraph._repr import (
+        _code,
+        datetime_html,
+        html_detail,
+        html_kv,
+        html_panel,
+        html_table,
+        status_badge,
+        theme_wrap,
+        widget_state_key,
+    )
+
+    if not view:
+        return theme_wrap("<div>LineageView: (empty)</div>", state_key=widget_state_key("lineage", "empty"))
+
+    headers = ["Lane", "Workflow", "Kind", "Status", "Fork Point", "Created", "Steps", "Cached", "Failed"]
+    rows: list[list[str]] = []
+    for row in view:
+        run = row.run
+        lane = _code(row.lane.rstrip() or "●")
+        workflow = _code(run.id) + (" &nbsp;<b>(selected)</b>" if row.is_selected else "")
+        fork_point = "root"
+        if run.forked_from:
+            at = f"@{run.fork_superstep}" if run.fork_superstep is not None else ""
+            fork_point = _code(f"{run.forked_from}{at}")
+        kind = "retry" if run.retry_of else ("fork" if run.forked_from else "root")
+        n_steps = len(view.steps_by_run.get(run.id, [])) if view.steps_by_run else run.node_count
+        cached = 0
+        failed = 0
+        if view.steps_by_run and run.id in view.steps_by_run:
+            cached = sum(1 for s in view.steps_by_run[run.id] if s.cached)
+            failed = sum(1 for s in view.steps_by_run[run.id] if s.status.value == "failed")
+        rows.append(
+            [
+                lane,
+                workflow,
+                kind,
+                status_badge(run.status.value),
+                fork_point,
+                datetime_html(run.created_at),
+                str(n_steps) if n_steps else "0",
+                str(cached),
+                str(failed),
+            ]
+        )
+
+    body = html_table(headers, rows, title=f"Lineage from root {view.root_run_id}")
+    if view.steps_by_run:
+        for row in view:
+            run = row.run
+            steps = view.steps_by_run.get(run.id)
+            if steps is None:
+                continue
+            cached = sum(1 for s in steps if s.cached)
+            failed = sum(1 for s in steps if s.status.value == "failed")
+            kind = "retry" if run.retry_of else ("fork" if run.forked_from else "root")
+            meta = " &nbsp;|&nbsp; ".join(
+                [
+                    html_kv("Kind", kind),
+                    html_kv("Steps", str(len(steps))),
+                    html_kv("Cached", str(cached)),
+                    html_kv("Failed", str(failed)),
+                ]
+            )
+            summary = f"{row.lane}{run.id} — {len(steps)} step{'s' if len(steps) != 1 else ''}, {cached} cached, {failed} failed"
+            body += html_detail(summary, f"{meta}<br><br>{render_step_table_html(steps)}", state_key=f"steps-{run.id}")
+    return theme_wrap(
+        html_panel(f"Workflow Lineage: {view.selected_run_id}", body), state_key=widget_state_key("lineage", view.root_run_id, view.selected_run_id)
+    )

--- a/src/hypergraph/checkpointers/sqlite.py
+++ b/src/hypergraph/checkpointers/sqlite.py
@@ -154,6 +154,11 @@ class SqliteCheckpointer(Checkpointer):
         except Exception:
             return f"SqliteCheckpointer: {self._path}"
 
+    @property
+    def path(self) -> str:
+        """Database path."""
+        return self._path
+
     def _repr_html_(self) -> str:
         from hypergraph._repr import _code, theme_wrap, widget_state_key
 
@@ -492,6 +497,33 @@ class SqliteCheckpointer(Checkpointer):
         cursor = await self._db.execute(query, params)
         rows = await cursor.fetchall()
         return RunTable(self._row_to_run(row) for row in rows)
+
+    async def count_runs(
+        self,
+        *,
+        status: WorkflowStatus | None = None,
+        parent_run_id: str | None = None,
+        retry_of: str | None = None,
+    ) -> int:
+        """Count runs without materializing full run records."""
+        await self._ensure_db()
+
+        conditions: list[str] = []
+        params: list[Any] = []
+        if status is not None:
+            conditions.append("status = ?")
+            params.append(status.value)
+        if parent_run_id is not None:
+            conditions.append("parent_run_id = ?")
+            params.append(parent_run_id)
+        if retry_of is not None:
+            conditions.append("retry_of = ?")
+            params.append(retry_of)
+
+        where = f" WHERE {' AND '.join(conditions)}" if conditions else ""
+        cursor = await self._db.execute(f"SELECT COUNT(*) FROM runs{where}", params)
+        (count,) = await cursor.fetchone()
+        return int(count or 0)
 
     _FTS_FIELDS = frozenset({"node_name", "error"})
 

--- a/src/hypergraph/checkpointers/sqlite.py
+++ b/src/hypergraph/checkpointers/sqlite.py
@@ -12,6 +12,7 @@ from typing import Any, Literal
 
 from hypergraph.checkpointers._migrate import ensure_schema
 from hypergraph.checkpointers.base import Checkpointer, CheckpointPolicy
+from hypergraph.checkpointers.presenters import render_checkpointer_explorer_html
 from hypergraph.checkpointers.serializers import JsonSerializer, Serializer
 from hypergraph.checkpointers.types import (
     Checkpoint,
@@ -50,6 +51,11 @@ def _parse_dt(value: str | None) -> datetime | None:
     if value.endswith("Z"):
         value = value[:-1] + "+00:00"
     return datetime.fromisoformat(value)
+
+
+def _lineage_parent_id(run: Run) -> str | None:
+    """Return the workflow-lineage parent for fork/retry traversal."""
+    return run.forked_from or run.retry_of
 
 
 def _require_aiosqlite() -> Any:
@@ -149,8 +155,7 @@ class SqliteCheckpointer(Checkpointer):
             return f"SqliteCheckpointer: {self._path}"
 
     def _repr_html_(self) -> str:
-        from hypergraph._repr import MUTED_COLOR, _code, html_detail, html_kv, html_panel, theme_wrap, widget_state_key
-        from hypergraph._utils import plural
+        from hypergraph._repr import _code, theme_wrap, widget_state_key
 
         state_key = widget_state_key("checkpointer", self._path)
         try:
@@ -158,40 +163,29 @@ class SqliteCheckpointer(Checkpointer):
         except Exception:
             return theme_wrap(_code(f"SqliteCheckpointer: {self._path}"), state_key=state_key)
 
-        kvs = [html_kv("Path", _code(str(stats["path"])))]
-        if stats["size_bytes"] is not None:
-            size_mb = stats["size_bytes"] / (1024 * 1024)
-            kvs.append(html_kv("Size", f"{size_mb:.1f} MB" if size_mb >= 1 else f"{stats['size_bytes'] / 1024:.0f} KB"))
-        if stats["run_count"] is not None:
-            kvs.append(html_kv("Runs", str(stats["run_count"])))
-            kvs.append(html_kv("Steps", str(stats["step_count"])))
-        body = " &nbsp;|&nbsp; ".join(kvs)
-
-        # Collapsible recent runs with inline steps
+        explorer_runs: list[Run] = []
+        steps_by_run: dict[str, list[StepRecord]] = {}
+        explorer_limit = 30
         try:
-            recent = self.runs(limit=5)
-            if recent:
-                steps_by_run = {}
-                for run in recent:
+            explorer_runs = list(self.runs(limit=explorer_limit))
+            if explorer_runs:
+                for run in explorer_runs:
                     with contextlib.suppress(Exception):
-                        steps_by_run[run.id] = self.steps(run.id)
-                recent._steps_by_run = steps_by_run
-                body += html_detail(
-                    f"Recent runs ({plural(len(recent), 'shown')})",
-                    recent._repr_html_(),
-                    state_key="recent-runs",
-                )
+                        steps_by_run[run.id] = list(self.steps(run.id))
         except Exception:
             pass
 
-        # API hints
-        body += (
-            f'<div style="color:{MUTED_COLOR}; font-size:0.85em; margin-top:8px">'
-            f"Explore: {_code('.runs()')} {_code('.steps(run_id)')} "
-            f"{_code('.search(query)')} {_code('.stats(run_id)')}"
-            "</div>"
+        return render_checkpointer_explorer_html(
+            title="SqliteCheckpointer",
+            path=str(stats["path"]),
+            state_key=state_key,
+            run_count=stats["run_count"],
+            step_count=stats["step_count"],
+            size_bytes=stats["size_bytes"],
+            runs=explorer_runs,
+            steps_by_run=steps_by_run,
+            run_limit=explorer_limit,
         )
-        return theme_wrap(html_panel("SqliteCheckpointer", body), state_key=state_key)
 
     async def initialize(self) -> None:
         """Create database and tables if they don't exist."""
@@ -305,8 +299,9 @@ class SqliteCheckpointer(Checkpointer):
         await self._db.execute(
             "INSERT INTO runs (id, status, graph_name, created_at, parent_run_id, forked_from, fork_superstep, retry_of, retry_index, config) "
             "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
-            " ON CONFLICT(id) DO UPDATE SET status = ?, graph_name = ?, parent_run_id = ?, "
-            "forked_from = ?, fork_superstep = ?, retry_of = ?, retry_index = ?, config = ?",
+            " ON CONFLICT(id) DO UPDATE SET status = ?, graph_name = ?, duration_ms = NULL, node_count = 0, "
+            "error_count = 0, completed_at = NULL, parent_run_id = ?, forked_from = ?, "
+            "fork_superstep = ?, retry_of = ?, retry_index = ?, config = ?",
             (
                 run_id,
                 WorkflowStatus.ACTIVE.value,
@@ -353,7 +348,7 @@ class SqliteCheckpointer(Checkpointer):
     ) -> None:
         """Update run status with optional stats."""
         await self._ensure_db()
-        completed_at = datetime.now(timezone.utc).isoformat() if status != WorkflowStatus.ACTIVE else None
+        completed_at = datetime.now(timezone.utc).isoformat() if status in {WorkflowStatus.COMPLETED, WorkflowStatus.FAILED} else None
 
         # Build SET clause dynamically based on what's provided
         sets = ["status = ?", "completed_at = ?"]
@@ -473,7 +468,7 @@ class SqliteCheckpointer(Checkpointer):
         *,
         status: WorkflowStatus | None = None,
         parent_run_id: str | None = None,
-        limit: int = 100,
+        limit: int | None = 100,
     ) -> list[Run]:
         """List runs, optionally filtered by status and/or parent."""
         await self._ensure_db()
@@ -489,12 +484,12 @@ class SqliteCheckpointer(Checkpointer):
             params.append(parent_run_id)
 
         where = f" WHERE {' AND '.join(conditions)}" if conditions else ""
-        params.append(limit)
+        query = f"SELECT {_RUNS_COLS} FROM runs{where} ORDER BY created_at DESC"
+        if limit is not None:
+            query += " LIMIT ?"
+            params.append(limit)
 
-        cursor = await self._db.execute(
-            f"SELECT {_RUNS_COLS} FROM runs{where} ORDER BY created_at DESC LIMIT ?",
-            params,
-        )
+        cursor = await self._db.execute(query, params)
         rows = await cursor.fetchall()
         return RunTable(self._row_to_run(row) for row in rows)
 
@@ -652,7 +647,7 @@ class SqliteCheckpointer(Checkpointer):
         graph_name: str | None = None,
         since: datetime | None = None,
         parent_run_id: str | None | object = _UNSET,
-        limit: int = 100,
+        limit: int | None = 100,
     ) -> list[Run]:
         """List runs synchronously with optional filters.
 
@@ -683,12 +678,12 @@ class SqliteCheckpointer(Checkpointer):
                 params.append(parent_run_id)
 
         where = f" WHERE {' AND '.join(conditions)}" if conditions else ""
-        params.append(limit)
+        query = f"SELECT {_RUNS_COLS} FROM runs{where} ORDER BY created_at DESC"
+        if limit is not None:
+            query += " LIMIT ?"
+            params.append(limit)
 
-        cursor = db.execute(
-            f"SELECT {_RUNS_COLS} FROM runs{where} ORDER BY created_at DESC LIMIT ?",
-            params,
-        )
+        cursor = db.execute(query, params)
         return RunTable(self._row_to_run(row) for row in cursor.fetchall())
 
     def lineage(
@@ -709,8 +704,11 @@ class SqliteCheckpointer(Checkpointer):
 
         root = selected
         seen_ancestors = {root.id}
-        while root.forked_from:
-            parent = self.get_run(root.forked_from)
+        while _lineage_parent_id(root):
+            parent_id = _lineage_parent_id(root)
+            if parent_id is None:
+                break
+            parent = self.get_run(parent_id)
             if parent is None or parent.id in seen_ancestors:
                 break
             root = parent
@@ -891,8 +889,9 @@ class SqliteCheckpointer(Checkpointer):
         db.execute(
             "INSERT INTO runs (id, status, graph_name, created_at, parent_run_id, forked_from, fork_superstep, retry_of, retry_index, config) "
             "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
-            " ON CONFLICT(id) DO UPDATE SET status = ?, graph_name = ?, parent_run_id = ?, "
-            "forked_from = ?, fork_superstep = ?, retry_of = ?, retry_index = ?, config = ?",
+            " ON CONFLICT(id) DO UPDATE SET status = ?, graph_name = ?, duration_ms = NULL, node_count = 0, "
+            "error_count = 0, completed_at = NULL, parent_run_id = ?, forked_from = ?, "
+            "fork_superstep = ?, retry_of = ?, retry_index = ?, config = ?",
             (
                 run_id,
                 WorkflowStatus.ACTIVE.value,
@@ -1068,7 +1067,7 @@ class SqliteCheckpointer(Checkpointer):
     ) -> None:
         """Update run status with optional stats synchronously."""
         db = self._sync_db()
-        completed_at = datetime.now(timezone.utc).isoformat() if status != WorkflowStatus.ACTIVE else None
+        completed_at = datetime.now(timezone.utc).isoformat() if status in {WorkflowStatus.COMPLETED, WorkflowStatus.FAILED} else None
 
         sets = ["status = ?", "completed_at = ?"]
         params: list[Any] = [status.value, completed_at]

--- a/src/hypergraph/checkpointers/types.py
+++ b/src/hypergraph/checkpointers/types.py
@@ -27,6 +27,7 @@ class WorkflowStatus(Enum):
     """Status of a run (kept as WorkflowStatus to avoid collision with runners.RunStatus)."""
 
     ACTIVE = "active"
+    PAUSED = "paused"
     COMPLETED = "completed"
     FAILED = "failed"
 
@@ -67,18 +68,9 @@ class StepRecord:
         return " | ".join(parts)
 
     def _repr_html_(self) -> str:
-        from hypergraph._repr import ERROR_COLOR, FONT_SANS_STYLE, MUTED_COLOR, duration_html, status_badge, theme_wrap, widget_state_key
+        from hypergraph.checkpointers.presenters import render_step_record_html
 
-        status = "cached" if self.cached else self.status.value
-        dur = duration_html(self.duration_ms) if self.duration_ms > 0 else ""
-        error = f' <span style="color:{ERROR_COLOR}; font-size:0.85em">{self.error[:80]}</span>' if self.error else ""
-        return theme_wrap(
-            f'<span style="{FONT_SANS_STYLE}; font-size:0.9em">'
-            f"<b>[{self.index}] {self.node_name}</b> {status_badge(status)} {dur}"
-            f' <span style="color:{MUTED_COLOR}">superstep {self.superstep}</span>'
-            f"{error}</span>",
-            state_key=widget_state_key("step-record", self.run_id, self.index, self.node_name, self.superstep),
-        )
+        return render_step_record_html(self)
 
     def to_dict(self) -> dict[str, Any]:
         """JSON-serializable dict with only primitive types."""
@@ -143,41 +135,9 @@ class Run:
         return " | ".join(parts)
 
     def _repr_html_(self) -> str:
-        from hypergraph._repr import (
-            ERROR_COLOR,
-            MUTED_COLOR,
-            _code,
-            datetime_html,
-            duration_html,
-            html_kv,
-            html_panel,
-            status_badge,
-            theme_wrap,
-            widget_state_key,
-        )
+        from hypergraph.checkpointers.presenters import render_run_html
 
-        kvs = [
-            html_kv("Status", status_badge(self.status.value)),
-            html_kv("Duration", duration_html(self.duration_ms)),
-        ]
-        if self.node_count:
-            kvs.append(html_kv("Steps", str(self.node_count)))
-        if self.error_count:
-            kvs.append(html_kv("Errors", f'<span style="color:{ERROR_COLOR}; font-weight:600">{self.error_count}</span>'))
-        if self.parent_run_id:
-            kvs.append(html_kv("Parent", _code(self.parent_run_id)))
-        if self.forked_from:
-            label = self.forked_from if self.fork_superstep is None else f"{self.forked_from}@{self.fork_superstep}"
-            kvs.append(html_kv("Forked From", _code(label)))
-        if self.retry_of:
-            label = self.retry_of if self.retry_index is None else f"{self.retry_of} (#{self.retry_index})"
-            kvs.append(html_kv("Retry Of", _code(label)))
-        kvs.append(html_kv("Created", datetime_html(self.created_at)))
-        title = f"Run: {self.id}"
-        if self.graph_name:
-            title += f' <span style="color:{MUTED_COLOR}; font-weight:400">({self.graph_name})</span>'
-        body = " &nbsp;|&nbsp; ".join(kvs)
-        return theme_wrap(html_panel(title, body), state_key=widget_state_key("run", self.id))
+        return render_run_html(self)
 
     def to_dict(self) -> dict[str, Any]:
         """JSON-serializable dict."""
@@ -221,16 +181,9 @@ class Checkpoint:
         return f"Checkpoint{origin}: {plural(len(self.values), 'value')}, {plural(len(self.steps), 'step')}"
 
     def _repr_html_(self) -> str:
-        from hypergraph._repr import _code, html_panel, theme_wrap, widget_state_key
+        from hypergraph.checkpointers.presenters import render_checkpoint_html
 
-        keys = ", ".join(_code(k) for k in sorted(self.values.keys())[:10])
-        if len(self.values) > 10:
-            keys += f" ... (+{len(self.values) - 10} more)"
-        body = f"<b>{len(self.values)}</b> values: {keys}<br><b>{len(self.steps)}</b> steps"
-        return theme_wrap(
-            html_panel("Checkpoint", body),
-            state_key=widget_state_key("checkpoint", self.source_run_id or "ad-hoc", self.source_superstep),
-        )
+        return render_checkpoint_html(self)
 
 
 class RunTable(list):
@@ -258,173 +211,9 @@ class RunTable(list):
         return "\n".join(lines)
 
     def _repr_html_(self) -> str:
-        from hypergraph._repr import (
-            ERROR_COLOR,
-            FONT_SANS_STYLE,
-            MUTED_COLOR,
-            _code,
-            duration_html,
-            html_detail,
-            html_table,
-            html_table_controls,
-            html_table_controls_script,
-            html_table_with_row_attrs,
-            status_badge,
-            theme_wrap,
-            unique_dom_id,
-            widget_state_key,
-        )
+        from hypergraph.checkpointers.presenters import render_run_table_html
 
-        if not self:
-            return theme_wrap(
-                f'<div style="color:{MUTED_COLOR}; {FONT_SANS_STYLE}">RunTable: (empty)</div>',
-                state_key=widget_state_key("run-table", "empty"),
-            )
-        headers = ["ID", "Graph", "Status", "Duration", "Steps", "Errors"]
-
-        def _group_key(run: Run) -> str:
-            if run.parent_run_id:
-                return run.parent_run_id
-            if "/" in run.id:
-                return run.id.split("/", 1)[0]
-            return run.id
-
-        def _synth_parent(group_id: str, members: list[Run]) -> Run:
-            # Synthesize a parent summary when only child rows are present.
-            status = WorkflowStatus.COMPLETED
-            if any(r.status == WorkflowStatus.ACTIVE for r in members):
-                status = WorkflowStatus.ACTIVE
-            elif any(r.status == WorkflowStatus.FAILED for r in members):
-                status = WorkflowStatus.FAILED
-            created = max((r.created_at for r in members), default=_utcnow())
-            return Run(
-                id=group_id,
-                status=status,
-                graph_name=members[0].graph_name if members else None,
-                duration_ms=max((r.duration_ms or 0.0 for r in members), default=None),
-                node_count=sum(r.node_count for r in members),
-                error_count=sum(r.error_count for r in members),
-                created_at=created,
-            )
-
-        by_id = {run.id: run for run in self}
-        groups: dict[str, list[Run]] = {}
-        for run in self:
-            groups.setdefault(_group_key(run), []).append(run)
-
-        row_items: list[tuple[Run, bool, str]] = []
-        for group_id, members in groups.items():
-            parent = by_id.get(group_id)
-            children = sorted(
-                [r for r in members if r.id != group_id],
-                key=lambda r: r.created_at,
-                reverse=True,
-            )
-            if parent is None:
-                parent = _synth_parent(group_id, members)
-            row_items.append((parent, False, group_id))
-            for child in children:
-                row_items.append((child, True, group_id))
-
-        rows: list[list[str]] = []
-        row_attrs: list[dict[str, str]] = []
-        for run, is_child, _group_id in row_items:
-            rows.append(
-                [
-                    _code(run.id),
-                    run.graph_name or "—",
-                    status_badge(run.status.value),
-                    duration_html(run.duration_ms),
-                    str(run.node_count) if run.node_count else "—",
-                    f'<span style="color:{ERROR_COLOR}">{run.error_count}</span>' if run.error_count else "0",
-                ]
-            )
-            row_attrs.append(
-                {
-                    "data-id": run.id,
-                    "data-status": run.status.value,
-                    "data-parent": "1" if is_child else "0",
-                    "data-created-ts": str(run.created_at.timestamp()),
-                    "data-duration-ms": str(run.duration_ms or 0.0),
-                    "data-errors": str(run.error_count),
-                }
-            )
-
-        detail_sections: list[str] = []
-        for group_id, members in groups.items():
-            parent = by_id.get(group_id)
-            children = sorted(
-                [r for r in members if r.id != group_id],
-                key=lambda r: r.created_at,
-                reverse=True,
-            )
-            if parent is None:
-                parent = _synth_parent(group_id, members)
-
-            summary = f"{_code(group_id)} — {status_badge(parent.status.value)}"
-            if children:
-                summary += f' <span style="color:{MUTED_COLOR}">({plural(len(children), "child run")})</span>'
-
-            detail_parts = [parent._repr_html_()]
-            if children:
-                child_rows = [
-                    [
-                        _code(c.id),
-                        c.graph_name or "—",
-                        status_badge(c.status.value),
-                        duration_html(c.duration_ms),
-                        str(c.node_count) if c.node_count else "—",
-                        f'<span style="color:{ERROR_COLOR}">{c.error_count}</span>' if c.error_count else "0",
-                    ]
-                    for c in children
-                ]
-                detail_parts.append(html_table(["ID", "Graph", "Status", "Duration", "Steps", "Errors"], child_rows))
-
-            # Inline step history when available
-            run_steps = getattr(self, "_steps_by_run", {}).get(group_id)
-            if run_steps:
-                detail_parts.append(
-                    html_detail(
-                        f"Steps ({plural(len(run_steps), 'step')})",
-                        run_steps._repr_html_(),
-                        state_key=f"run-steps-{group_id}",
-                    )
-                )
-
-            detail_sections.append(html_detail(summary, "<br>".join(detail_parts), state_key=f"run-{group_id}"))
-
-        run_ids = ",".join(run.id for run in self)
-        table_id = unique_dom_id("run-table-ui", run_ids, len(row_items))
-        view_id = f"{table_id}-view"
-        status_id = f"{table_id}-status"
-        sort_id = f"{table_id}-sort"
-        show_id = f"{table_id}-show"
-
-        controls = html_table_controls(
-            view_id=view_id,
-            status_id=status_id,
-            sort_id=sort_id,
-            show_id=show_id,
-            show_options=[20, 50, 100],
-            total_rows=len(row_items),
-        )
-        table_html = html_table_with_row_attrs(
-            headers,
-            rows,
-            row_attrs=row_attrs,
-            title=plural(len(self), "run"),
-            table_id=table_id,
-        )
-        script = html_table_controls_script(
-            table_id=table_id,
-            view_id=view_id,
-            status_id=status_id,
-            sort_id=sort_id,
-            show_id=show_id,
-        )
-        traces = html_detail("Run Traces", "".join(detail_sections), state_key="run-traces")
-        body = controls + table_html + traces + script
-        return theme_wrap(body, state_key=widget_state_key("run-table", run_ids))
+        return render_run_table_html(self)
 
 
 class StepTable(list):
@@ -442,61 +231,9 @@ class StepTable(list):
         return "\n".join(lines)
 
     def _repr_html_(self) -> str:
-        from hypergraph._repr import (
-            FONT_SANS_STYLE,
-            MUTED_COLOR,
-            _code,
-            datetime_html,
-            duration_html,
-            html_detail,
-            html_kv,
-            html_table,
-            status_badge,
-            theme_wrap,
-            values_html,
-            widget_state_key,
-        )
+        from hypergraph.checkpointers.presenters import render_step_table_html
 
-        if not self:
-            return theme_wrap(
-                f'<div style="color:{MUTED_COLOR}; {FONT_SANS_STYLE}">StepTable: (empty)</div>',
-                state_key=widget_state_key("step-table", "empty"),
-            )
-        headers = ["#", "Node", "Status", "Duration", "At", "Superstep"]
-        rows = []
-        for step in self:
-            status = "cached" if step.cached else step.status.value
-            rows.append(
-                [
-                    str(step.index),
-                    _code(step.node_name),
-                    status_badge(status),
-                    duration_html(step.duration_ms) if step.duration_ms > 0 else "—",
-                    datetime_html(step.completed_at or step.created_at),
-                    str(step.superstep),
-                ]
-            )
-        step_fingerprint = ",".join(f"{step.run_id}:{step.superstep}:{step.node_name}" for step in self)
-        body = html_table(headers, rows, title=plural(len(self), "step"))
-        for i, step in enumerate(self):
-            status = "cached" if step.cached else step.status.value
-            meta = " &nbsp;|&nbsp; ".join(
-                [
-                    html_kv("Node", _code(step.node_name)),
-                    html_kv("Superstep", str(step.superstep)),
-                    html_kv("Status", status_badge(status)),
-                    html_kv("Duration", duration_html(step.duration_ms) if step.duration_ms > 0 else "—"),
-                ]
-            )
-            content = meta
-            if step.decision is not None:
-                content += "<br>" + html_kv("Decision", _code(str(step.decision)))
-            if step.error:
-                content += "<br>" + html_kv("Error", _code(step.error))
-            if step.values:
-                content += "<br><br>" + html_detail("Values", values_html(step.values), state_key=f"values-{i}")
-            body += html_detail(f"[{step.index}] {step.node_name}", content, state_key=f"step-{i}")
-        return theme_wrap(body, state_key=widget_state_key("step-table", step_fingerprint))
+        return render_step_table_html(self)
 
 
 @dataclass(frozen=True)
@@ -553,75 +290,6 @@ class LineageView(list):
         return "\n".join(lines)
 
     def _repr_html_(self) -> str:
-        from hypergraph._repr import (
-            _code,
-            datetime_html,
-            html_detail,
-            html_kv,
-            html_panel,
-            html_table,
-            status_badge,
-            theme_wrap,
-            widget_state_key,
-        )
+        from hypergraph.checkpointers.presenters import render_lineage_view_html
 
-        if not self:
-            return theme_wrap("<div>LineageView: (empty)</div>", state_key=widget_state_key("lineage", "empty"))
-
-        headers = ["Lane", "Workflow", "Kind", "Status", "Fork Point", "Created", "Steps", "Cached", "Failed"]
-        rows: list[list[str]] = []
-        for row in self:
-            run = row.run
-            lane = _code(row.lane.rstrip() or "●")
-            workflow = _code(run.id) + (" &nbsp;<b>(selected)</b>" if row.is_selected else "")
-            fork_point = "root"
-            if run.forked_from:
-                at = f"@{run.fork_superstep}" if run.fork_superstep is not None else ""
-                fork_point = _code(f"{run.forked_from}{at}")
-            kind = "retry" if run.retry_of else ("fork" if run.forked_from else "root")
-            n_steps = len(self.steps_by_run.get(run.id, [])) if self.steps_by_run else run.node_count
-            cached = 0
-            failed = 0
-            if self.steps_by_run and run.id in self.steps_by_run:
-                cached = sum(1 for s in self.steps_by_run[run.id] if s.cached)
-                failed = sum(1 for s in self.steps_by_run[run.id] if s.status == StepStatus.FAILED)
-            rows.append(
-                [
-                    lane,
-                    workflow,
-                    kind,
-                    status_badge(run.status.value),
-                    fork_point,
-                    datetime_html(run.created_at),
-                    str(n_steps) if n_steps else "0",
-                    str(cached),
-                    str(failed),
-                ]
-            )
-
-        body = html_table(headers, rows, title=f"Lineage from root {self.root_run_id}")
-
-        if self.steps_by_run:
-            for row in self:
-                run = row.run
-                steps = self.steps_by_run.get(run.id)
-                if steps is None:
-                    continue
-                cached = sum(1 for s in steps if s.cached)
-                failed = sum(1 for s in steps if s.status == StepStatus.FAILED)
-                kind = "retry" if run.retry_of else ("fork" if run.forked_from else "root")
-                meta = " &nbsp;|&nbsp; ".join(
-                    [
-                        html_kv("Kind", kind),
-                        html_kv("Steps", str(len(steps))),
-                        html_kv("Cached", str(cached)),
-                        html_kv("Failed", str(failed)),
-                    ]
-                )
-                summary = f"{row.lane}{run.id} — {plural(len(steps), 'step')}, {cached} cached, {failed} failed"
-                body += html_detail(summary, f"{meta}<br><br>{steps._repr_html_()}", state_key=f"steps-{run.id}")
-
-        return theme_wrap(
-            html_panel(f"Workflow Lineage: {self.selected_run_id}", body),
-            state_key=widget_state_key("lineage", self.root_run_id, self.selected_run_id),
-        )
+        return render_lineage_view_html(self)

--- a/src/hypergraph/cli/_db.py
+++ b/src/hypergraph/cli/_db.py
@@ -12,3 +12,10 @@ def open_checkpointer(db: str | None = None):
     from hypergraph.cli._config import resolve_db_path
 
     return SqliteCheckpointer(resolve_db_path(db))
+
+
+def open_run_inspector(db: str | None = None):
+    """Open the default run inspection adapter for CLI queries."""
+    from hypergraph.checkpointers import SqliteRunInspector
+
+    return SqliteRunInspector(open_checkpointer(db))

--- a/src/hypergraph/cli/runs.py
+++ b/src/hypergraph/cli/runs.py
@@ -7,7 +7,7 @@ from typing import Annotated
 
 import typer
 
-from hypergraph.cli._db import open_checkpointer
+from hypergraph.cli._db import open_run_inspector
 from hypergraph.cli._format import (
     DEFAULT_LIMIT,
     describe_value,
@@ -79,6 +79,7 @@ def _print_run_traces(run_list: list) -> None:
                 members,
                 key=lambda r: (
                     r.status.value == "active",
+                    r.status.value == "paused",
                     r.status.value == "failed",
                     r.created_at is not None,
                     r.created_at,
@@ -110,24 +111,26 @@ def runs_dashboard(
     if ctx.invoked_subcommand is not None:
         return
 
-    cp = open_checkpointer(db)
-    all_runs = cp.runs(parent_run_id=None)
+    inspector = open_run_inspector(db)
+    all_runs = inspector.runs(parent_run_id=None)
 
     if not all_runs:
         if as_json:
             print_json("runs", {"active": [], "recent": []}, output)
         else:
             print("No runs found.")
-            print(f"\n  Database: {cp._path}")
+            print(f"\n  Database: {inspector.db_path}")
             print("  To create runs, use: runner.run(graph, inputs, workflow_id='my-run')")
         return
 
     active = [r for r in all_runs if r.status.value == "active"]
-    recent = [r for r in all_runs if r.status.value != "active"][:5]
+    paused = [r for r in all_runs if r.status.value == "paused"]
+    recent = [r for r in all_runs if r.status.value not in {"active", "paused"}][:5]
 
     if as_json:
         data = {
             "active": [r.to_dict() for r in active],
+            "paused": [r.to_dict() for r in paused],
             "recent": [r.to_dict() for r in recent],
         }
         print_json("runs", data, output)
@@ -135,10 +138,13 @@ def runs_dashboard(
 
     if active:
         print(f"\nActive ({len(active)} running)\n")
-        _print_run_table(active, cp)
+        _print_run_table(active, inspector)
+    if paused:
+        print(f"\nPaused ({len(paused)} resumable)\n")
+        _print_run_table(paused, inspector)
     if recent:
         print(f"\nRecent (last {len(recent)})\n")
-        _print_run_table(recent, cp)
+        _print_run_table(recent, inspector)
 
     print_ctas(
         [
@@ -149,9 +155,9 @@ def runs_dashboard(
     )
 
 
-def _print_run_table(run_list, cp) -> None:
+def _print_run_table(run_list, inspector) -> None:
     """Print a table of runs with step count info."""
-    step_counts = {r.id: len(cp.steps(r.id)) for r in run_list}
+    step_counts = {r.id: len(inspector.steps(r.id)) for r in run_list}
 
     headers = ["ID", "Graph", "Status", "Steps", "Duration", "Created"]
     rows = [
@@ -190,7 +196,7 @@ def runs_ls(
     output: OutputOption = None,
 ):
     """List runs with filters. Shows top-level runs by default."""
-    cp = open_checkpointer(db)
+    inspector = open_run_inspector(db)
     from hypergraph.checkpointers import WorkflowStatus
 
     view = view.lower()
@@ -223,13 +229,13 @@ def runs_ls(
             try:
                 ws = WorkflowStatus(s.lower())
             except ValueError as e:
-                print(f"Error: Unknown status '{s}'. Use: active, completed, failed")
+                print(f"Error: Unknown status '{s}'. Use: active, paused, completed, failed")
                 raise typer.Exit(1) from e
-            run_list.extend(cp.runs(status=ws, **filter_kwargs))
+            run_list.extend(inspector.runs(status=ws, **filter_kwargs))
         # Deduplicate by ID before sorting/limiting.
         run_list = list({r.id: r for r in run_list}.values())
     else:
-        run_list = cp.runs(**filter_kwargs)
+        run_list = inspector.runs(**filter_kwargs)
 
     run_list = _sort_runs(run_list, sort)[:limit]
 
@@ -285,13 +291,13 @@ def runs_show(
     output: OutputOption = None,
 ):
     """Show run trace for a run."""
-    cp = open_checkpointer(db)
-    r = cp.get_run(run_id)
+    inspector = open_run_inspector(db)
+    r = inspector.get_run(run_id)
     if r is None:
         print(f"Error: Run '{run_id}' not found.")
         raise typer.Exit(1)
 
-    step_list = cp.steps(run_id)
+    step_list = inspector.steps(run_id)
 
     # Single step mode
     if step is not None:
@@ -342,7 +348,7 @@ def runs_show(
         print()
 
     # Check for child runs (batch parent or nested graph parent)
-    children = cp.runs(parent_run_id=run_id)
+    children = inspector.runs(parent_run_id=run_id)
 
     if not step_list:
         print("  No steps recorded.")
@@ -395,6 +401,8 @@ def runs_show(
         ctas.insert(0, f"hypergraph runs show {run_id} --errors   for failures only")
     if r.status.value == "active":
         ctas.insert(0, "Run is still active. Re-run to see new steps.")
+    if r.status.value == "paused":
+        ctas.insert(0, "Run is paused and resumable.")
     print_ctas(ctas)
 
 
@@ -440,14 +448,14 @@ def runs_values(
     output: OutputOption = None,
 ):
     """Show accumulated output values for a run."""
-    cp = open_checkpointer(db)
-    r = cp.get_run(run_id)
+    inspector = open_run_inspector(db)
+    r = inspector.get_run(run_id)
     if r is None:
         print(f"Error: Run '{run_id}' not found.")
         raise typer.Exit(1)
 
-    current_state = cp.state(run_id, superstep=superstep)
-    step_list = cp.steps(run_id, superstep=superstep)
+    current_state = inspector.state(run_id, superstep=superstep)
+    step_list = inspector.steps(run_id, superstep=superstep)
 
     # Single key mode
     if key is not None:
@@ -474,7 +482,7 @@ def runs_values(
 
     # Status header
     step_label = f"through superstep {superstep}" if superstep is not None else f"through step {len(step_list) - 1}" if step_list else "no steps"
-    status_note = f", {format_status(r.status.value)}" if r.status.value == "active" else ""
+    status_note = f", {format_status(r.status.value)}" if r.status.value in {"active", "paused"} else ""
     print(f"\nValues: {run_id} ({step_label}{status_note})\n")
 
     if not current_state:
@@ -526,13 +534,13 @@ def runs_steps(
     output: OutputOption = None,
 ):
     """Show detailed step records."""
-    cp = open_checkpointer(db)
-    r = cp.get_run(run_id)
+    inspector = open_run_inspector(db)
+    r = inspector.get_run(run_id)
     if r is None:
         print(f"Error: Run '{run_id}' not found.")
         raise typer.Exit(1)
 
-    step_list = cp.steps(run_id)
+    step_list = inspector.steps(run_id)
 
     if node:
         step_list = [s for s in step_list if s.node_name == node]
@@ -580,8 +588,8 @@ def runs_search(
     output: OutputOption = None,
 ):
     """Search step records using full-text search."""
-    cp = open_checkpointer(db)
-    results = cp.search(query, field=field, limit=limit)
+    inspector = open_run_inspector(db)
+    results = inspector.search(query, field=field, limit=limit)
 
     if as_json:
         print_json("runs.search", [s.to_dict() for s in results], output)
@@ -624,13 +632,13 @@ def runs_stats(
     output: OutputOption = None,
 ):
     """Show per-node performance statistics for a run."""
-    cp = open_checkpointer(db)
-    r = cp.get_run(run_id)
+    inspector = open_run_inspector(db)
+    r = inspector.get_run(run_id)
     if r is None:
         print(f"Error: Run '{run_id}' not found.")
         raise typer.Exit(1)
 
-    node_stats = cp.stats(run_id)
+    node_stats = inspector.stats(run_id)
 
     if as_json:
         print_json("runs.stats", {"run_id": run_id, "nodes": node_stats}, output)
@@ -679,13 +687,13 @@ def runs_checkpoint(
     output: OutputOption = None,
 ):
     """Inspect a checkpoint snapshot for a run."""
-    cp = open_checkpointer(db)
-    run = cp.get_run(run_id)
+    inspector = open_run_inspector(db)
+    run = inspector.get_run(run_id)
     if run is None:
         print(f"Error: Run '{run_id}' not found.")
         raise typer.Exit(1)
 
-    checkpoint = cp.checkpoint(run_id, superstep=superstep)
+    checkpoint = inspector.checkpoint(run_id, superstep=superstep)
     values = checkpoint.values
     steps = checkpoint.steps
 
@@ -736,9 +744,9 @@ def runs_lineage(
     output: OutputOption = None,
 ):
     """Show git-like fork lineage for a workflow."""
-    cp = open_checkpointer(db)
+    inspector = open_run_inspector(db)
     try:
-        lineage = cp.lineage(run_id, include_steps=deep, max_runs=max_runs)
+        lineage = inspector.lineage(run_id, include_steps=deep, max_runs=max_runs)
     except ValueError as e:
         print(f"Error: {e}")
         raise typer.Exit(1) from e

--- a/src/hypergraph/cli/runs.py
+++ b/src/hypergraph/cli/runs.py
@@ -157,7 +157,7 @@ def runs_dashboard(
 
 def _print_run_table(run_list, inspector) -> None:
     """Print a table of runs with step count info."""
-    step_counts = {r.id: len(inspector.steps(r.id)) for r in run_list}
+    step_counts = {r.id: (r.node_count or len(inspector.steps(r.id))) for r in run_list}
 
     headers = ["ID", "Graph", "Status", "Steps", "Duration", "Created"]
     rows = [

--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -700,7 +700,9 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
 
                 error_count = sum(1 for r in results if r.status == RunStatus.FAILED)
                 paused_count = sum(1 for r in results if r.status == RunStatus.PAUSED)
-                persisted_status = WorkflowStatus.PAUSED if paused_count and error_count == 0 else WorkflowStatus.COMPLETED
+                persisted_status = (
+                    WorkflowStatus.FAILED if error_count > 0 else WorkflowStatus.PAUSED if paused_count > 0 else WorkflowStatus.COMPLETED
+                )
                 await checkpointer.update_run_status(
                     workflow_id,
                     persisted_status,

--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -428,7 +428,18 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
             if has_checkpointer:
                 for record in step_buffer:
                     await checkpointer.save_step(record)
-            # Workflow stays ACTIVE when paused (can be resumed)
+                from hypergraph.checkpointers.types import WorkflowStatus
+                from hypergraph.runners._shared.checkpoint_helpers import checkpoint_offsets
+
+                _, step_offset = checkpoint_offsets(resume_checkpoint)
+                step_count = step_offset + len(collector._records)
+                await checkpointer.update_run_status(
+                    workflow_id,
+                    WorkflowStatus.PAUSED,
+                    duration_ms=total_duration_ms,
+                    node_count=step_count,
+                    error_count=0,
+                )
             return RunResult(
                 values=partial_values,
                 status=RunStatus.PAUSED,
@@ -682,14 +693,16 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
             )
             total_duration_ms = (time.time() - start_time) * 1000
 
-            # Complete parent batch run
+            # Persist parent batch run status
             if has_checkpointer:
                 from hypergraph.checkpointers.types import WorkflowStatus
 
                 error_count = sum(1 for r in results if r.status == RunStatus.FAILED)
+                paused_count = sum(1 for r in results if r.status == RunStatus.PAUSED)
+                persisted_status = WorkflowStatus.PAUSED if paused_count and error_count == 0 else WorkflowStatus.COMPLETED
                 await checkpointer.update_run_status(
                     workflow_id,
-                    WorkflowStatus.COMPLETED,
+                    persisted_status,
                     duration_ms=total_duration_ms,
                     node_count=len(results),
                     error_count=error_count,

--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -433,12 +433,13 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
 
                 _, step_offset = checkpoint_offsets(resume_checkpoint)
                 step_count = step_offset + len(collector._records)
+                error_count = sum(1 for r in collector._records if r.status == "failed")
                 await checkpointer.update_run_status(
                     workflow_id,
                     WorkflowStatus.PAUSED,
                     duration_ms=total_duration_ms,
                     node_count=step_count,
-                    error_count=0,
+                    error_count=error_count,
                 )
             return RunResult(
                 values=partial_values,

--- a/src/hypergraph/runners/_shared/template_sync.py
+++ b/src/hypergraph/runners/_shared/template_sync.py
@@ -383,12 +383,13 @@ class SyncRunnerTemplate(BaseRunner, ABC):
                     sync_cp.save_step_sync(record)
                 _, step_offset = checkpoint_offsets(resume_checkpoint)
                 step_count = step_offset + len(collector._records)
+                error_count = sum(1 for r in collector._records if r.status == "failed")
                 sync_cp.update_run_status_sync(
                     workflow_id,
                     WorkflowStatus.PAUSED,
                     duration_ms=total_duration_ms,
                     node_count=step_count,
-                    error_count=0,
+                    error_count=error_count,
                 )
             return RunResult(
                 values=partial_values,

--- a/src/hypergraph/runners/_shared/template_sync.py
+++ b/src/hypergraph/runners/_shared/template_sync.py
@@ -375,6 +375,32 @@ class SyncRunnerTemplate(BaseRunner, ABC):
             partial_state = getattr(pause, "_partial_state", None)
             partial_values = filter_outputs(partial_state, graph, select) if partial_state is not None else {}
             total_duration_ms = (time.time() - start_time) * 1000
+            if dispatcher.active:
+                from hypergraph.events.types import InterruptEvent, RunEndEvent
+                from hypergraph.events.types import RunStatus as EventRunStatus
+
+                dispatcher.emit(
+                    InterruptEvent(
+                        run_id=run_id,
+                        span_id=pause.span_id or run_span_id,
+                        parent_span_id=run_span_id,
+                        node_name=pause.pause_info.node_name,
+                        graph_name=graph.name,
+                        workflow_id=workflow_id,
+                        value=pause.pause_info.value,
+                        response_param=pause.pause_info.output_param,
+                    )
+                )
+                dispatcher.emit(
+                    RunEndEvent(
+                        run_id=run_id,
+                        span_id=run_span_id,
+                        parent_span_id=_parent_span_id,
+                        graph_name=graph.name,
+                        status=EventRunStatus.PAUSED,
+                        duration_ms=total_duration_ms,
+                    )
+                )
             if sync_cp is not None:
                 from hypergraph.checkpointers.types import WorkflowStatus
                 from hypergraph.runners._shared.checkpoint_helpers import checkpoint_offsets
@@ -575,7 +601,9 @@ class SyncRunnerTemplate(BaseRunner, ABC):
 
                 error_count = sum(1 for r in results if r.status == RunStatus.FAILED)
                 paused_count = sum(1 for r in results if r.status == RunStatus.PAUSED)
-                persisted_status = WorkflowStatus.PAUSED if paused_count and error_count == 0 else WorkflowStatus.COMPLETED
+                persisted_status = (
+                    WorkflowStatus.FAILED if error_count > 0 else WorkflowStatus.PAUSED if paused_count > 0 else WorkflowStatus.COMPLETED
+                )
                 sync_cp.update_run_status_sync(
                     workflow_id,
                     persisted_status,

--- a/src/hypergraph/runners/_shared/template_sync.py
+++ b/src/hypergraph/runners/_shared/template_sync.py
@@ -37,7 +37,7 @@ from hypergraph.runners._shared.input_normalization import (
     normalize_inputs,
 )
 from hypergraph.runners._shared.run_log import RunLogCollector
-from hypergraph.runners._shared.types import ErrorHandling, GraphState, MapResult, RunResult, RunStatus
+from hypergraph.runners._shared.types import ErrorHandling, GraphState, MapResult, PauseExecution, RunResult, RunStatus
 from hypergraph.runners._shared.validation import (
     precompute_input_validation,
     resolve_runtime_selected,
@@ -371,6 +371,33 @@ class SyncRunnerTemplate(BaseRunner, ABC):
                 _, _step_offset = checkpoint_offsets(resume_checkpoint)
                 _flush_and_complete(sync_cp, workflow_id, step_buffer, collector, total_duration_ms, step_offset=_step_offset)
             return result
+        except PauseExecution as pause:
+            partial_state = getattr(pause, "_partial_state", None)
+            partial_values = filter_outputs(partial_state, graph, select) if partial_state is not None else {}
+            total_duration_ms = (time.time() - start_time) * 1000
+            if sync_cp is not None:
+                from hypergraph.checkpointers.types import WorkflowStatus
+                from hypergraph.runners._shared.checkpoint_helpers import checkpoint_offsets
+
+                for record in step_buffer:
+                    sync_cp.save_step_sync(record)
+                _, step_offset = checkpoint_offsets(resume_checkpoint)
+                step_count = step_offset + len(collector._records)
+                sync_cp.update_run_status_sync(
+                    workflow_id,
+                    WorkflowStatus.PAUSED,
+                    duration_ms=total_duration_ms,
+                    node_count=step_count,
+                    error_count=0,
+                )
+            return RunResult(
+                values=partial_values,
+                status=RunStatus.PAUSED,
+                run_id=run_id,
+                workflow_id=workflow_id,
+                pause=pause.pause_info,
+                log=collector.build(graph.name, run_id, total_duration_ms),
+            )
         except Exception as e:
             error = e
             partial_state = getattr(e, "_partial_state", None)
@@ -541,14 +568,16 @@ class SyncRunnerTemplate(BaseRunner, ABC):
             )
             total_duration_ms = (time.time() - start_time) * 1000
 
-            # Complete parent batch run
+            # Persist parent batch run status
             if sync_cp is not None:
                 from hypergraph.checkpointers.types import WorkflowStatus
 
                 error_count = sum(1 for r in results if r.status == RunStatus.FAILED)
+                paused_count = sum(1 for r in results if r.status == RunStatus.PAUSED)
+                persisted_status = WorkflowStatus.PAUSED if paused_count and error_count == 0 else WorkflowStatus.COMPLETED
                 sync_cp.update_run_status_sync(
                     workflow_id,
-                    WorkflowStatus.COMPLETED,
+                    persisted_status,
                     duration_ms=total_duration_ms,
                     node_count=len(results),
                     error_count=error_count,

--- a/src/hypergraph/runners/async_/executors/graph_node.py
+++ b/src/hypergraph/runners/async_/executors/graph_node.py
@@ -108,8 +108,10 @@ class AsyncGraphNodeExecutor:
                     if current_parent_run is not None:
                         source_parent_run_id = current_parent_run.retry_of or current_parent_run.forked_from
                     if source_parent_run_id is not None:
-                        source_child_run_id = f"{source_parent_run_id}/{node.name}"
-                        source_child_run = await self.runner._checkpointer.get_run_async(source_child_run_id)
+                        source_child_run_id = graphnode_child_workflow_id(source_parent_run_id, node.name, state)
+                        source_child_run = (
+                            await self.runner._checkpointer.get_run_async(source_child_run_id) if source_child_run_id is not None else None
+                        )
                         if source_child_run is not None:
                             inner_inputs = {}
                             if current_parent_run is not None and current_parent_run.retry_of is not None:

--- a/src/hypergraph/runners/async_/executors/graph_node.py
+++ b/src/hypergraph/runners/async_/executors/graph_node.py
@@ -95,9 +95,7 @@ class AsyncGraphNodeExecutor:
             child_retry_from: str | None = None
             prefix = f"{node.name}."
             resume_values = {
-                node.resolve_original_output_name(key[len(prefix) :]): value
-                for key, value in state.values.items()
-                if key.startswith(prefix)
+                node.resolve_original_output_name(key[len(prefix) :]): value for key, value in state.values.items() if key.startswith(prefix)
             }
 
             if map_config is None and child_workflow_id is not None and self.runner._checkpointer is not None:

--- a/src/hypergraph/runners/async_/executors/graph_node.py
+++ b/src/hypergraph/runners/async_/executors/graph_node.py
@@ -91,15 +91,38 @@ class AsyncGraphNodeExecutor:
         # Only inject on first execution: on cycle loop-back the node has already
         # executed so the inner interrupt should fire again, not skip.
         if node.name not in state.node_executions:
+            child_fork_from: str | None = None
+            child_retry_from: str | None = None
+            prefix = f"{node.name}."
+            resume_values = {
+                node.resolve_original_output_name(key[len(prefix) :]): value
+                for key, value in state.values.items()
+                if key.startswith(prefix)
+            }
+
             if map_config is None and child_workflow_id is not None and self.runner._checkpointer is not None:
                 existing_child_run = await self.runner._checkpointer.get_run_async(child_workflow_id)
                 if existing_child_run is not None:
                     inner_inputs = {}
-            prefix = f"{node.name}."
-            for key in state.values:
-                if key.startswith(prefix):
-                    inner_key = node.resolve_original_output_name(key[len(prefix) :])
-                    inner_inputs[inner_key] = state.values[key]
+                elif resume_values:
+                    current_parent_run = await self.runner._checkpointer.get_run_async(workflow_id) if workflow_id else None
+                    source_parent_run_id = None
+                    if current_parent_run is not None:
+                        source_parent_run_id = current_parent_run.retry_of or current_parent_run.forked_from
+                    if source_parent_run_id is not None:
+                        source_child_run_id = f"{source_parent_run_id}/{node.name}"
+                        source_child_run = await self.runner._checkpointer.get_run_async(source_child_run_id)
+                        if source_child_run is not None:
+                            inner_inputs = {}
+                            if current_parent_run is not None and current_parent_run.retry_of is not None:
+                                child_retry_from = source_child_run_id
+                            else:
+                                child_fork_from = source_child_run_id
+
+            inner_inputs.update(resume_values)
+        else:
+            child_fork_from = None
+            child_retry_from = None
 
         if map_config:
             _, mode, error_handling = map_config
@@ -125,6 +148,8 @@ class AsyncGraphNodeExecutor:
             inner_inputs,
             event_processors=event_processors,
             workflow_id=child_workflow_id,
+            fork_from=child_fork_from,
+            retry_from=child_retry_from,
             _parent_span_id=parent_span_id,
             _parent_run_id=workflow_id,
         )

--- a/tests/test_checkpointer/test_lineage_semantics.py
+++ b/tests/test_checkpointer/test_lineage_semantics.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import pytest
 
 from hypergraph import END, AsyncRunner, Graph, RunStatus, ifelse, interrupt, node
-from hypergraph.checkpointers import SqliteCheckpointer
+from hypergraph.checkpointers import SqliteCheckpointer, WorkflowStatus
 from hypergraph.exceptions import (
     GraphChangedError,
     InputOverrideRequiresForkError,
@@ -168,6 +168,9 @@ class TestLineageSemantics:
         paused = await runner.run(graph, workflow_id="wf-paused")
         assert paused.status == RunStatus.PAUSED
         assert paused.pause is not None
+        stored = checkpointer.get_run("wf-paused")
+        assert stored is not None
+        assert stored.status == WorkflowStatus.PAUSED
 
         resumed = await runner.run(
             graph,
@@ -198,6 +201,10 @@ class TestLineageSemantics:
         assert paused.status == RunStatus.PAUSED
         assert paused.pause is not None
         assert paused.pause.response_key == "inner.decision"
+        stored_parent = checkpointer.get_run("wf-nested-paused")
+        stored_child = checkpointer.get_run("wf-nested-paused/inner")
+        assert stored_parent is not None and stored_parent.status == WorkflowStatus.PAUSED
+        assert stored_child is not None and stored_child.status == WorkflowStatus.PAUSED
 
         resumed = await runner.run(
             graph,

--- a/tests/test_checkpointer/test_memory.py
+++ b/tests/test_checkpointer/test_memory.py
@@ -3,7 +3,7 @@
 import pytest
 
 from hypergraph import AsyncRunner, Graph, RunStatus, interrupt, node
-from hypergraph.checkpointers import MemoryCheckpointer, WorkflowStatus
+from hypergraph.checkpointers import CheckpointPolicy, MemoryCheckpointer, StepRecord, StepStatus, WorkflowStatus
 
 
 @node(output_name="doubled")
@@ -140,3 +140,43 @@ class TestMemoryCheckpointer:
         assert child is not None
         assert child.parent_run_id == "wf-nested-pause-retry-1"
         assert child.retry_of == "wf-nested-pause-retry/inner"
+
+    async def test_latest_retention_preserves_reconstructible_state(self, checkpointer):
+        checkpointer.policy = CheckpointPolicy(retention="latest")
+        await checkpointer.create_run("wf-retained")
+        await checkpointer.save_step(
+            StepRecord(
+                run_id="wf-retained",
+                superstep=0,
+                node_name="a",
+                index=0,
+                status=StepStatus.COMPLETED,
+                input_versions={},
+                values={"x": 1},
+            )
+        )
+        await checkpointer.save_step(
+            StepRecord(
+                run_id="wf-retained",
+                superstep=1,
+                node_name="b",
+                index=1,
+                status=StepStatus.COMPLETED,
+                input_versions={},
+                values={"y": 2},
+            )
+        )
+        await checkpointer.save_step(
+            StepRecord(
+                run_id="wf-retained",
+                superstep=2,
+                node_name="a",
+                index=2,
+                status=StepStatus.COMPLETED,
+                input_versions={},
+                values={"x": 3},
+            )
+        )
+
+        state = await checkpointer.get_state("wf-retained")
+        assert state == {"x": 3, "y": 2}

--- a/tests/test_checkpointer/test_memory.py
+++ b/tests/test_checkpointer/test_memory.py
@@ -1,0 +1,142 @@
+"""Tests for the backend-neutral in-memory checkpointer."""
+
+import pytest
+
+from hypergraph import AsyncRunner, Graph, RunStatus, interrupt, node
+from hypergraph.checkpointers import MemoryCheckpointer, WorkflowStatus
+
+
+@node(output_name="doubled")
+def double(x: int) -> int:
+    return x * 2
+
+
+@node(output_name="tripled")
+def triple(doubled: int) -> int:
+    return doubled * 3
+
+
+@pytest.fixture
+def checkpointer():
+    return MemoryCheckpointer()
+
+
+class TestMemoryCheckpointer:
+    async def test_retry_workflow_requires_existing_source(self, checkpointer):
+        with pytest.raises(ValueError, match="Unknown source workflow_id"):
+            await checkpointer.retry_workflow_async("missing-run")
+
+    async def test_retry_workflow_counts_all_matching_retries(self, checkpointer):
+        await checkpointer.create_run("wf-root")
+        for idx in range(1, 4):
+            await checkpointer.create_run(
+                f"wf-root-retry-{idx}",
+                forked_from="wf-root",
+                retry_of="wf-root",
+                retry_index=idx,
+            )
+
+        retry_id, checkpoint = await checkpointer.retry_workflow_async("wf-root")
+
+        assert retry_id == "wf-root-retry-4"
+        assert checkpoint.retry_of == "wf-root"
+        assert checkpoint.retry_index == 4
+
+    async def test_async_runner_nested_graph_works_with_memory_checkpointer(self, checkpointer):
+        runner = AsyncRunner(checkpointer=checkpointer)
+        inner = Graph([double], name="inner")
+        outer = Graph([inner.as_node(name="embed"), triple], name="outer")
+
+        result = await runner.run(outer, {"x": 5}, workflow_id="nested-memory")
+
+        assert result["tripled"] == 30
+
+        root = await checkpointer.get_run_async("nested-memory")
+        child = await checkpointer.get_run_async("nested-memory/embed")
+        steps = await checkpointer.get_steps("nested-memory")
+
+        assert root is not None
+        assert root.status == WorkflowStatus.COMPLETED
+        assert child is not None
+        assert child.parent_run_id == "nested-memory"
+        assert any(step.node_name == "embed" and step.child_run_id == "nested-memory/embed" for step in steps)
+
+    async def test_list_runs_none_limit_returns_full_result_set(self, checkpointer):
+        for run_id in ("wf-1", "wf-2", "wf-3"):
+            await checkpointer.create_run(run_id)
+
+        runs = await checkpointer.list_runs(limit=None)
+
+        assert {run.id for run in runs} == {"wf-1", "wf-2", "wf-3"}
+
+    async def test_forked_nested_pause_resumes_child_from_source_lineage(self, checkpointer):
+        @interrupt(output_name="decision")
+        def approval(draft: str) -> str: ...
+
+        inner = Graph([approval], name="inner")
+
+        @node(output_name="draft")
+        def make_draft(query: str) -> str:
+            return f"Draft for: {query}"
+
+        @node(output_name="result")
+        def finalize(decision: str) -> str:
+            return f"Final: {decision}"
+
+        runner = AsyncRunner(checkpointer=checkpointer)
+        graph = Graph([make_draft, inner.as_node(), finalize])
+
+        paused = await runner.run(graph, {"query": "hello"}, workflow_id="wf-nested-paused")
+        assert paused.status == RunStatus.PAUSED
+        assert paused.pause is not None
+
+        resumed = await runner.run(
+            graph,
+            {paused.pause.response_key: "approved"},
+            fork_from="wf-nested-paused",
+            workflow_id="wf-nested-paused-fork",
+        )
+
+        assert resumed.status == RunStatus.COMPLETED
+        assert resumed["result"] == "Final: approved"
+
+        child = await checkpointer.get_run_async("wf-nested-paused-fork/inner")
+        assert child is not None
+        assert child.parent_run_id == "wf-nested-paused-fork"
+        assert child.forked_from == "wf-nested-paused/inner"
+
+    async def test_retried_nested_pause_resumes_child_from_source_lineage(self, checkpointer):
+        @interrupt(output_name="decision")
+        def approval(draft: str) -> str: ...
+
+        inner = Graph([approval], name="inner")
+
+        @node(output_name="draft")
+        def make_draft(query: str) -> str:
+            return f"Draft for: {query}"
+
+        @node(output_name="result")
+        def finalize(decision: str) -> str:
+            return f"Final: {decision}"
+
+        runner = AsyncRunner(checkpointer=checkpointer)
+        graph = Graph([make_draft, inner.as_node(), finalize])
+
+        paused = await runner.run(graph, {"query": "hello"}, workflow_id="wf-nested-pause-retry")
+        assert paused.status == RunStatus.PAUSED
+        assert paused.pause is not None
+
+        resumed = await runner.run(
+            graph,
+            {paused.pause.response_key: "approved"},
+            retry_from="wf-nested-pause-retry",
+            workflow_id="wf-nested-pause-retry-1",
+        )
+
+        assert resumed.status == RunStatus.COMPLETED
+        assert resumed["result"] == "Final: approved"
+
+        child = await checkpointer.get_run_async("wf-nested-pause-retry-1/inner")
+        assert child is not None
+        assert child.parent_run_id == "wf-nested-pause-retry-1"
+        assert child.retry_of == "wf-nested-pause-retry/inner"

--- a/tests/test_checkpointer/test_sqlite.py
+++ b/tests/test_checkpointer/test_sqlite.py
@@ -65,6 +65,14 @@ class TestRunLifecycle:
         assert r.status == WorkflowStatus.COMPLETED
         assert r.completed_at is not None
 
+    async def test_update_status_paused_keeps_run_resumable(self, checkpointer):
+        await checkpointer.create_run("wf-1")
+        await checkpointer.update_run_status("wf-1", WorkflowStatus.PAUSED, duration_ms=10.0, node_count=1)
+        r = checkpointer.get_run("wf-1")
+        assert r.status == WorkflowStatus.PAUSED
+        assert r.completed_at is None
+        assert r.node_count == 1
+
     async def test_update_status_with_stats(self, checkpointer):
         await checkpointer.create_run("wf-1")
         await checkpointer.update_run_status(
@@ -94,6 +102,15 @@ class TestRunLifecycle:
         active = checkpointer.runs(status=WorkflowStatus.ACTIVE)
         assert len(active) == 1
         assert active[0].id == "wf-2"
+
+    async def test_list_runs_paused(self, checkpointer):
+        await checkpointer.create_run("wf-active")
+        await checkpointer.create_run("wf-paused")
+        await checkpointer.update_run_status("wf-paused", WorkflowStatus.PAUSED)
+
+        paused = checkpointer.runs(status=WorkflowStatus.PAUSED)
+        assert len(paused) == 1
+        assert paused[0].id == "wf-paused"
 
     async def test_create_run_with_lineage_fields(self, checkpointer):
         run = await checkpointer.create_run(
@@ -129,6 +146,28 @@ class TestRunLifecycle:
         assert retry_cp.source_run_id == "wf-root"
         assert retry_cp.retry_of == "wf-root"
         assert retry_cp.retry_index == 1
+
+    async def test_create_run_resets_stale_completion_metadata(self, checkpointer):
+        await checkpointer.create_run("wf-reused", graph_name="before")
+        await checkpointer.update_run_status(
+            "wf-reused",
+            WorkflowStatus.FAILED,
+            duration_ms=123.0,
+            node_count=4,
+            error_count=2,
+        )
+
+        reset = await checkpointer.create_run("wf-reused", graph_name="after")
+        fetched = checkpointer.get_run("wf-reused")
+
+        assert reset.status == WorkflowStatus.ACTIVE
+        assert fetched is not None
+        assert fetched.status == WorkflowStatus.ACTIVE
+        assert fetched.graph_name == "after"
+        assert fetched.duration_ms is None
+        assert fetched.node_count == 0
+        assert fetched.error_count == 0
+        assert fetched.completed_at is None
 
 
 class TestStepPersistence:
@@ -542,6 +581,16 @@ class TestSyncReads:
         html = lineage._repr_html_()
         assert "retry" in html
         assert "Cached" in html
+
+    async def test_lineage_uses_retry_parent_when_fork_parent_missing(self, checkpointer):
+        """Retry-only lineage metadata still resolves the root ancestor."""
+        await checkpointer.create_run("wf-root")
+        await checkpointer.create_run("wf-root-retry-1", retry_of="wf-root", retry_index=1)
+
+        lineage = checkpointer.lineage("wf-root-retry-1", include_steps=False)
+
+        assert lineage.root_run_id == "wf-root"
+        assert [row.run.id for row in lineage] == ["wf-root", "wf-root-retry-1"]
 
 
 class TestRetentionPolicyBehavior:

--- a/tests/test_checkpointer/test_sqlite.py
+++ b/tests/test_checkpointer/test_sqlite.py
@@ -592,6 +592,16 @@ class TestSyncReads:
         assert lineage.root_run_id == "wf-root"
         assert [row.run.id for row in lineage] == ["wf-root", "wf-root-retry-1"]
 
+    async def test_count_runs_can_filter_retry_of(self, checkpointer):
+        await checkpointer.create_run("wf-root")
+        await checkpointer.create_run("wf-root-retry-1", retry_of="wf-root", retry_index=1)
+        await checkpointer.create_run("wf-root-retry-2", retry_of="wf-root", retry_index=2)
+        await checkpointer.create_run("wf-other")
+
+        count = await checkpointer.count_runs(retry_of="wf-root")
+
+        assert count == 2
+
 
 class TestRetentionPolicyBehavior:
     async def test_latest_retention_keeps_latest_per_node(self, checkpointer):

--- a/tests/test_checkpointer/test_types.py
+++ b/tests/test_checkpointer/test_types.py
@@ -126,6 +126,11 @@ class TestRun:
         assert d["status"] == "active"
         assert d["graph_name"] == "my_graph"
 
+    def test_paused_to_dict(self):
+        r = Run(id="wf-paused", status=WorkflowStatus.PAUSED)
+        d = r.to_dict()
+        assert d["status"] == "paused"
+
     def test_new_fields(self):
         r = Run(
             id="wf-1",

--- a/tests/test_cli/test_runs_cli.py
+++ b/tests/test_cli/test_runs_cli.py
@@ -13,7 +13,7 @@ aiosqlite = pytest.importorskip("aiosqlite")
 
 from typer.testing import CliRunner  # noqa: E402
 
-from hypergraph import AsyncRunner, Graph, node  # noqa: E402
+from hypergraph import AsyncRunner, Graph, interrupt, node  # noqa: E402
 from hypergraph.checkpointers import CheckpointPolicy, SqliteCheckpointer, WorkflowStatus  # noqa: E402
 from hypergraph.cli import create_app  # noqa: E402
 
@@ -77,6 +77,25 @@ async def hierarchy_db(db_path):
     await cp.create_run("batch-1/1", graph_name="g", parent_run_id="batch-1")
     await cp.update_run_status("batch-1/1", WorkflowStatus.FAILED, duration_ms=5400.0, node_count=2, error_count=1)
 
+    return db_path
+
+
+@pytest.fixture
+async def paused_db(db_path):
+    """Create a DB with a paused workflow."""
+    cp = SqliteCheckpointer(db_path)
+    cp.policy = CheckpointPolicy(durability="sync", retention="full")
+
+    @interrupt(output_name="decision")
+    def approval() -> str: ...
+
+    @node(output_name="result")
+    def finalize(decision: str) -> str:
+        return decision
+
+    graph = Graph([approval, finalize])
+    runner = AsyncRunner(checkpointer=cp)
+    await runner.run(graph, workflow_id="run-paused")
     return db_path
 
 
@@ -236,6 +255,22 @@ class TestRunsLs:
         assert "Run Traces" in result.output
         assert "batch-1" in result.output
         assert "Child" in result.output
+
+    def test_ls_filter_paused(self, paused_db):
+        """CLI: --status paused filters paused workflows."""
+        app = create_app()
+        result = runner_cli.invoke(app, ["runs", "ls", "--status", "paused", "--db", paused_db])
+        assert result.exit_code == 0
+        assert "run-paused" in result.output
+
+
+class TestRunsDashboard:
+    def test_dashboard_shows_paused_section(self, paused_db):
+        app = create_app()
+        result = runner_cli.invoke(app, ["runs", "--db", paused_db])
+        assert result.exit_code == 0
+        assert "Paused (1 resumable)" in result.output
+        assert "run-paused" in result.output
 
 
 class TestRunsSteps:

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -780,3 +780,26 @@ class TestSqliteCheckpointerRepr:
         assert "data-hg-state-key" in html
         assert 'data-hg-explorer="checkpointer"' in html
         assert "Run Explorer" in html
+
+    def test_repr_html_escapes_explorer_payload(self):
+        pytest.importorskip("aiosqlite")
+        from hypergraph.checkpointers import StepRecord, StepStatus
+        from hypergraph.checkpointers.sqlite import SqliteCheckpointer
+
+        cp = SqliteCheckpointer(":memory:")
+        cp.create_run_sync("xss-run")
+        cp.save_step_sync(
+            StepRecord(
+                run_id="xss-run",
+                superstep=0,
+                node_name="emit",
+                index=0,
+                status=StepStatus.COMPLETED,
+                input_versions={},
+                values={"payload": "</script><script>alert('xss')</script>"},
+            )
+        )
+
+        html = cp._repr_html_()
+        assert "</script><script>alert('xss')</script>" not in html
+        assert "\\u003c/script\\u003e\\u003cscript\\u003ealert('xss')\\u003c/script\\u003e" in html

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -118,6 +118,12 @@ class TestRunRepr:
         assert "(pipeline)" in r
         assert "active" in r
 
+    def test_paused_repr(self):
+        run = Run(id="my-run", status=WorkflowStatus.PAUSED, graph_name="pipeline")
+        r = repr(run)
+        assert "(pipeline)" in r
+        assert "paused" in r
+
     def test_no_enum_repr(self):
         """Enum should show .value, not <WorkflowStatus.COMPLETED: 'completed'>."""
         run = Run(id="x", status=WorkflowStatus.COMPLETED)
@@ -772,3 +778,5 @@ class TestSqliteCheckpointerRepr:
         assert "Runs" in html
         assert ".runs()" in html
         assert "data-hg-state-key" in html
+        assert 'data-hg-explorer="checkpointer"' in html
+        assert "Run Explorer" in html

--- a/tests/test_runners/test_validation.py
+++ b/tests/test_runners/test_validation.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from hypergraph import Graph, node
+from hypergraph import Graph, interrupt, node
 from hypergraph.exceptions import IncompatibleRunnerError, MissingInputError
 from hypergraph.graph.validation import GraphConfigError
 from hypergraph.runners import RunnerCapabilities
@@ -295,8 +295,16 @@ class TestValidateMapCompatible:
     def test_cyclic_graph_passes(self):
         """Cyclic graphs are currently map-compatible."""
         graph = Graph([counter], entrypoint="counter")
-        # Should not raise (Phase 2 will add interrupt checks)
         validate_map_compatible(graph)
+
+    def test_graphnode_map_over_rejects_interrupts(self):
+        @interrupt(output_name="decision")
+        def approval(draft: str) -> str: ...
+
+        inner = Graph([approval], name="inner")
+
+        with pytest.raises(GraphConfigError, match="InterruptNode\\(s\\).*incompatible with map execution"):
+            Graph([inner.as_node().map_over("draft")])
 
 
 class TestRuntimeOverrideRejection:


### PR DESCRIPTION
## Problem statement

Checkpointer inspection had become fragmented across SQLite-specific helpers and notebook-specific HTML, and paused interrupt workflows were persisted as `active`, which made the explorer and CLI misleading. There was also no single notebook surface for drilling from the checkpointer into runs, steps, checkpoints, and lineage.

## Before

- `SqliteCheckpointer` mixed storage, inspection, and notebook rendering directly.
- The top-level notebook view was a summary panel plus a few disconnected subviews.
- Paused workflows were stored as `ACTIVE`, so users could not distinguish running work from resumable paused work.
- CLI dashboards treated paused runs as active/running.

## After

- Added a backend-neutral inspection seam (`RunInspector` / `SqliteRunInspector`).
- Added a unified notebook explorer app for `SqliteCheckpointer` with drillthrough from checkpointer -> run -> overview/steps/lineage.
- Moved checkpointer/type HTML rendering into presenter helpers instead of keeping it inline on storage objects.
- Added `MemoryCheckpointer` to exercise non-SQLite checkpoint behavior.
- Persisted interrupt-paused workflows as `WorkflowStatus.PAUSED` and updated async/sync runner lifecycle handling.
- Updated CLI, reprs, docs, and notebook examples to reflect paused as a first-class persisted state.

## Test plan

- `uv run --with aiosqlite --with typer pytest tests/test_checkpointer/test_types.py tests/test_checkpointer/test_sqlite.py tests/test_checkpointer/test_lineage_semantics.py tests/test_cli/test_runs_cli.py tests/test_repr.py tests/test_checkpointer/test_memory.py -q`
- `uv run ruff check src/hypergraph/checkpointers/types.py src/hypergraph/checkpointers/sqlite.py src/hypergraph/checkpointers/memory.py src/hypergraph/runners/_shared/template_async.py src/hypergraph/runners/_shared/template_sync.py src/hypergraph/cli/runs.py tests/test_checkpointer/test_types.py tests/test_checkpointer/test_sqlite.py tests/test_checkpointer/test_lineage_semantics.py tests/test_cli/test_runs_cli.py tests/test_repr.py`
- Validated the showcase notebook demo logic via a standalone `uv run --with aiosqlite python ...` execution.

## Notes

- Focused test runs still show the existing `aiosqlite` event-loop teardown warning in some async pytest runs; that warning predates this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persisted PAUSED workflow status with CLI/dashboard listing and resume support.
  * Interactive Run Explorer UI for notebooks and a new tutorial notebook.
  * In-memory checkpointer and inspection API for lightweight exploration and querying persisted runs.

* **Documentation**
  * Expanded how-to, patterns, and FAQ entries clarifying active vs paused semantics and resumption examples.

* **Improvements**
  * More accurate run/step counts, lineage resolution, retention behaviors, and richer run representations.

* **Tests**
  * Added coverage for paused state, lineage, counting/filtering, retention, and the in-memory checkpointer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->