### PR TITLE
refactor(runners): replace executor side-channels with ExecutionContext

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - run: uv sync --group dev --extra daft
-      - run: uv run pytest -W error --junitxml=pytest.xml
+      - run: uv sync --group dev --extra daft --python ${{ matrix.python-version }}
+      - run: uv run --python ${{ matrix.python-version }} playwright install chromium
+      - run: uv run --python ${{ matrix.python-version }} pytest -W error --junitxml=pytest.xml
       - run: |
           python - <<'PY'
           import sys

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,5 +34,22 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - run: uv sync --group dev
-      - run: uv run pytest
+      - run: uv sync --group dev --extra daft
+      - run: uv run pytest -W error --junitxml=pytest.xml
+      - run: |
+          python - <<'PY'
+          import sys
+          import xml.etree.ElementTree as ET
+
+          root = ET.parse("pytest.xml").getroot()
+          suite = root if root.tag == "testsuite" else root.find("testsuite")
+          if suite is None:
+              raise SystemExit("Could not find testsuite in pytest.xml")
+          skipped = int(suite.attrib.get("skipped", "0"))
+          warnings = int(suite.attrib.get("warnings", "0"))
+          if skipped:
+              raise SystemExit(f"CI requires zero skipped tests, found {skipped}")
+          if warnings:
+              raise SystemExit(f"CI requires zero warnings, found {warnings}")
+          print("Pytest reported zero skips and zero warnings.")
+          PY

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ Change validation expectations:
 - Run focused tests for touched modules first, then broader suites as needed.
 - Before PR, ensure `uv run pytest` passes.
 - Auto-format/lint hook runs after Python edits (`ruff check --fix` + `ruff format`), so avoid redundant manual formatting loops.
+- For async tests that allocate long-lived resources (for example `SqliteCheckpointer` / `aiosqlite`), make teardown explicit. Prefer async fixtures that `await ...close()` rather than relying on event-loop shutdown to clean up worker threads.
 
 ## Working Rules For Agents
 

--- a/dev/ARCHITECTURE-MAP.md
+++ b/dev/ARCHITECTURE-MAP.md
@@ -1,0 +1,667 @@
+# Architecture Map
+
+A maintainer-oriented mental model of the current Hypergraph codebase.
+
+This file is not an exhaustive API reference. It exists to answer higher-level questions:
+
+- Where does a behavior live?
+- Which subsystem owns a concern?
+- What changes are architectural versus local implementation detail?
+- Which surfaces must stay aligned when a core abstraction changes?
+
+## What The Project Is Now
+
+Hypergraph is one framework for Python workflows across DAGs, branches, loops, nested graphs, map-style batch execution, human-in-the-loop interrupts, durable lineage, and multiple inspection surfaces.
+
+The user-facing API is intentionally small:
+
+- Define nodes as plain Python functions
+- Build graphs from nodes
+- Run them with sync or async runners
+- Compose by nesting graphs as nodes
+
+The internal system is broader because Hypergraph treats nested graphs as first-class across:
+
+- execution
+- checkpointing
+- lineage
+- CLI inspection
+- observability
+- visualization
+- notebook/HTML presentation
+
+That is the main source of architectural breadth.
+
+## Five Working Zones
+
+```text
+semantic core
+  nodes + graph construction + input scoping + validation
+
+execution kernel
+  runners + scheduling + supersteps + staleness + gate activation
+
+durability and inspection
+  checkpointers + lineage + snapshots + CLI/query adapters + HTML presenters
+
+observability and UX surfaces
+  events + run logs + widgets + viz + CLI output
+
+optional integrations
+  runner implementations that project the core model into another runtime
+```
+
+These zones are coupled in one direction:
+
+```text
+nodes -> graph -> runners -> events
+                    |
+                    +-> checkpointers
+                    +-> viz
+                    +-> cli
+                    +-> integrations
+```
+
+The key architectural rule is still: the semantic model stays small, while outer surfaces adapt to it without redefining it.
+
+## Zone 1: Semantic Core
+
+This is the "what the workflow means" layer.
+
+### Nodes
+
+Key files:
+
+- `src/hypergraph/nodes/base.py`
+- `src/hypergraph/nodes/function.py`
+- `src/hypergraph/nodes/gate.py`
+- `src/hypergraph/nodes/graph_node.py`
+- `src/hypergraph/nodes/interrupt.py`
+- `src/hypergraph/nodes/_callable.py`
+- `src/hypergraph/nodes/_rename.py`
+
+Current node hierarchy:
+
+```text
+HyperNode
+├── FunctionNode
+│   └── InterruptNode
+├── GateNode
+│   ├── RouteNode
+│   └── IfElseNode
+└── GraphNode
+    ├── map_over(...)
+    └── with_runner(...)
+```
+
+Key ideas:
+
+- Nodes are immutable value objects.
+- `FunctionNode` keeps functions testable outside the framework.
+- `GateNode` owns control-flow decisions, not heavy computation.
+- `InterruptNode` is a specialized function node for pause/resume semantics.
+- `GraphNode` is the hierarchy bridge.
+
+Important recent reality:
+
+- `GraphNode.with_runner()` and `Graph.as_node(runner=...)` let nested graphs delegate execution to a different runner.
+- `GraphNode.map_over()` is now part of the core composition story, not a fringe add-on.
+
+### Graph Construction
+
+Key files:
+
+- `src/hypergraph/graph/core.py`
+- `src/hypergraph/graph/input_spec.py`
+- `src/hypergraph/graph/validation.py`
+- `src/hypergraph/graph/_helpers.py`
+- `src/hypergraph/graph/_conflict.py`
+
+The build pipeline in `Graph` still does the same high-level job:
+
+1. normalize nodes
+2. resolve output producers
+3. infer data edges from matching names
+4. infer control edges from gates
+5. infer ordering edges from `emit` / `wait_for`
+6. validate structure
+
+The important modern nuance is scope computation.
+
+`InputSpec` and active-scope logic are now shaped by multiple graph-level dimensions:
+
+- `bind()`
+- `select()`
+- `with_entrypoint()`
+- `shared=...`
+
+That means the graph layer owns more than "validation". It also owns the definition of which subgraph is active for both validation and execution.
+
+### Shared Vocabulary For The Core
+
+- **active scope**: the nodes and outputs still relevant after entrypoint and select slicing
+- **shared params**: parameters intentionally excluded from auto-wiring
+- **seed**: a value needed to start a cycle
+- **rename history**: the mapping chain created by `with_inputs()` / `with_outputs()`
+- **runner delegation**: using a specific runner for a nested graph node
+
+## Zone 2: Execution Kernel
+
+This is where most hidden complexity lives.
+
+Key files:
+
+- `src/hypergraph/runners/base.py`
+- `src/hypergraph/runners/sync/runner.py`
+- `src/hypergraph/runners/sync/superstep.py`
+- `src/hypergraph/runners/async_/runner.py`
+- `src/hypergraph/runners/async_/superstep.py`
+- `src/hypergraph/runners/_shared/helpers.py`
+- `src/hypergraph/runners/_shared/types.py`
+- `src/hypergraph/runners/_shared/protocols.py`
+- `src/hypergraph/runners/_shared/template_sync.py`
+- `src/hypergraph/runners/_shared/template_async.py`
+- `src/hypergraph/runners/_shared/checkpoint_helpers.py`
+- `src/hypergraph/runners/_shared/validation.py`
+- `src/hypergraph/runners/_shared/input_normalization.py`
+- `src/hypergraph/runners/_shared/run_log.py`
+
+### Execution Model
+
+The runner is no longer best understood as "simple supersteps over ready nodes".
+
+The current model is:
+
+```text
+Graph
+  -> compute execution scope
+  -> collapse active graph into SCC execution components
+  -> build an ExecutionFrontier
+  -> repeatedly ask the frontier for the next ready batch
+  -> execute one local superstep for that batch
+  -> record outputs, logs, routing decisions, checkpoints, and status
+```
+
+Important types:
+
+- `ExecutionScope`: precomputed active subgraph + component graph
+- `ExecutionComponent`: one SCC or DAG fragment in execution order
+- `ExecutionFrontier`: runtime scheduler state for SCC-level progress
+- `ExecutionContext`: per-node execution environment threaded into executors
+- `GraphState`: runtime mutable state
+- `RunResult` / `MapResult`: execution outputs
+- `RunLog` / `MapLog` / `NodeRecord`: always-on trace surfaces
+
+### The Scheduler
+
+The scheduler logic lives primarily in `runners/_shared/helpers.py`.
+
+Core responsibilities:
+
+- active node filtering
+- stale gate-decision clearing
+- readiness detection
+- staleness checks
+- explicit-edge aware producer tracking
+- SCC execution planning
+- checkpoint state restoration
+- input resolution precedence
+
+When discussing bugs in this area, "scheduler" usually means:
+
+- `get_ready_nodes`
+- `_needs_execution`
+- `_is_stale`
+- gate activation / routing consumption
+- SCC planning and frontier advancement
+
+### Sync / Async Structure
+
+The sync and async runners remain parallel implementations built around template base classes.
+
+Current split of responsibilities:
+
+- `template_sync.py` / `template_async.py`
+  - public `run()` / `map()` lifecycle
+  - input normalization and runtime validation
+  - resume/fork/retry semantics
+  - top-level dispatcher and run-status handling
+  - batch persistence behavior
+- concrete runner modules
+  - scheduler loop
+  - frontier stepping
+  - superstep orchestration
+- executor modules
+  - node-type-specific execution
+
+### Executors
+
+Executor directories:
+
+- `src/hypergraph/runners/sync/executors/`
+- `src/hypergraph/runners/async_/executors/`
+
+Current important architectural fact:
+
+- Executors now consume an `ExecutionContext` rather than ad hoc side-channels.
+
+That context is the transport for:
+
+- parent span IDs
+- event processors
+- workflow IDs
+- resume payload visibility
+- nested inner-log propagation
+
+This is now part of the core execution design, not just a local implementation detail.
+
+### Nested Graph Execution
+
+Nested execution is where the execution kernel touches almost every other subsystem.
+
+`GraphNode` execution has to preserve:
+
+- renamed inputs and outputs
+- map-over behavior
+- delegated runner behavior
+- nested checkpoint workflow IDs
+- pause propagation
+- nested run-log propagation
+
+That makes `graph_node.py` executors one of the highest-risk change zones in the repo.
+
+## Zone 3: Durability And Inspection
+
+This zone grew substantially and deserves to be treated as a first-class subsystem.
+
+Key files:
+
+- `src/hypergraph/checkpointers/base.py`
+- `src/hypergraph/checkpointers/sqlite.py`
+- `src/hypergraph/checkpointers/memory.py`
+- `src/hypergraph/checkpointers/types.py`
+- `src/hypergraph/checkpointers/inspection.py`
+- `src/hypergraph/checkpointers/presenters.py`
+- `src/hypergraph/checkpointers/protocols.py`
+- `src/hypergraph/checkpointers/serializers.py`
+- `src/hypergraph/checkpointers/_migrate.py`
+
+### What This Subsystem Owns
+
+Not just persistence.
+
+It owns:
+
+- run lifecycle records
+- step records
+- status transitions
+- checkpoint snapshots
+- fork / retry lineage
+- sync inspection adapters
+- HTML / notebook explorers for persisted runs
+
+### Core Model
+
+Important types in `checkpointers/types.py`:
+
+- `Run`
+- `StepRecord`
+- `Checkpoint`
+- `WorkflowStatus`
+- `RunTable`
+- `StepTable`
+- `LineageRow`
+- `LineageView`
+
+Architecturally, the important point is:
+
+- steps are the durable source of truth
+- checkpoints are derived snapshots for restore/fork flows
+- lineage is explicit and queryable
+
+### Two Usage Modes
+
+1. **runtime durability**
+   - runners call checkpointer methods during execution
+2. **inspection**
+   - CLI and notebooks query persisted runs without participating in execution
+
+That split is why `inspection.py` exists. It keeps inspection consumers from reaching directly into backend-specific helper methods.
+
+### Backends And Helpers
+
+- `SqliteCheckpointer`: durable, async write path, sync read helpers, lineage queries, migration support
+- `MemoryCheckpointer`: test/lightweight backend with retention policy behavior
+- `SyncCheckpointerProtocol`: lets `SyncRunner` demand sync-write support
+- serializers: JSON vs Pickle payload strategies
+- presenters: rich HTML renderers for explorer-like notebook surfaces
+
+This subsystem is now broad enough that "checkpointer change" can mean any of:
+
+- runtime resume semantics
+- persistence format
+- inspection UX
+- lineage behavior
+- notebook rendering
+
+Those are related, but not interchangeable.
+
+## Zone 4: Observability And UX Surfaces
+
+This zone contains multiple outward-facing surfaces that all reflect execution.
+
+### Events
+
+Key files:
+
+- `src/hypergraph/events/types.py`
+- `src/hypergraph/events/dispatcher.py`
+- `src/hypergraph/events/processor.py`
+- `src/hypergraph/events/rich_progress.py`
+- `src/hypergraph/events/otel.py`
+
+Responsibilities:
+
+- event envelopes and event types
+- processor contracts
+- dispatch fan-out
+- terminal progress
+- OpenTelemetry integration
+
+The key rule remains:
+
+- events are observational, not control-flow.
+
+### Run Logs
+
+Run logs live in runner shared types, but conceptually they are an observability surface.
+
+Important exported types:
+
+- `RunLog`
+- `MapLog`
+- `NodeRecord`
+- `NodeStats`
+
+These are not optional debugging extras anymore. They are part of the user-facing execution contract.
+
+### Visualization
+
+Key files:
+
+- `src/hypergraph/viz/widget.py`
+- `src/hypergraph/viz/mermaid.py`
+- `src/hypergraph/viz/debug.py`
+- `src/hypergraph/viz/renderer/`
+- `src/hypergraph/viz/html/`
+- `src/hypergraph/viz/styles/`
+- `src/hypergraph/viz/assets/`
+
+Current mental model:
+
+```text
+Graph
+  -> flat graph projection
+  -> renderer instructions and precompute passes
+  -> HTML/ReactFlow document generation
+  -> notebook iframe widget or saved HTML file
+```
+
+The viz subsystem also has its own debugging surface:
+
+- `VizDebugger`
+- `validate_graph`
+- `find_issues`
+- debug overlays
+
+This is not just "draw the graph". It is a projection pipeline plus diagnostics.
+
+### CLI
+
+Key files:
+
+- `src/hypergraph/cli/run_cmd.py`
+- `src/hypergraph/cli/graph_cmd.py`
+- `src/hypergraph/cli/runs.py`
+- `src/hypergraph/cli/_config.py`
+- `src/hypergraph/cli/_db.py`
+- `src/hypergraph/cli/_format.py`
+
+Current CLI responsibilities:
+
+- execute graphs from the terminal
+- discover configured graphs
+- inspect topology
+- inspect persisted runs
+- inspect checkpoints
+- query lineage and search surfaces indirectly through the run inspector
+
+`cli/runs.py` is now a serious inspection surface, not a thin debug helper.
+
+## Zone 5: Optional Integrations
+
+Key files:
+
+- `src/hypergraph/integrations/__init__.py`
+- `src/hypergraph/integrations/daft/runner.py`
+
+This subsystem is intentionally small right now, but it is architecturally important.
+
+`DaftRunner` demonstrates a new pattern:
+
+- keep the semantic core the same
+- project execution into a different runtime
+- constrain compatibility explicitly when the external runtime cannot express all Hypergraph semantics
+
+Current Daft constraints:
+
+- DAG only
+- `FunctionNode` only
+- one output per node
+- no interrupts
+- no async nodes
+- no checkpointing
+- no nested `GraphNode` support yet
+
+This makes integrations a separate architectural zone from the main runners.
+
+## Public API Surface
+
+The package exports now span more than the original core abstractions.
+
+High-level public families in `src/hypergraph/__init__.py`:
+
+- node decorators and node classes
+- graph types
+- runners and run-log types
+- events and processors
+- caches
+- checkpointer types
+
+Notably, the public surface now includes:
+
+- `MapLog`
+- `NodeRecord`
+- `NodeStats`
+- `CheckpointPolicy`
+- `SqliteCheckpointer`
+
+That means "architecture-only" changes in these areas often leak into user expectations quickly.
+
+## File Map
+
+```text
+src/hypergraph/
+├── __init__.py                        public API surface
+├── _repr.py                          notebook/HTML rendering primitives
+├── _typing.py                        type-compatibility helpers
+├── _utils.py                         formatting and utility helpers
+├── cache.py                          cache backends and cache contract
+├── exceptions.py                     shared exception types
+│
+├── nodes/                            semantic core
+│   ├── base.py
+│   ├── function.py
+│   ├── gate.py
+│   ├── graph_node.py
+│   ├── interrupt.py
+│   ├── _callable.py
+│   └── _rename.py
+│
+├── graph/                            semantic core
+│   ├── core.py
+│   ├── input_spec.py
+│   ├── validation.py
+│   ├── _helpers.py
+│   └── _conflict.py
+│
+├── runners/                          execution kernel
+│   ├── base.py
+│   ├── _shared/
+│   │   ├── helpers.py
+│   │   ├── types.py
+│   │   ├── protocols.py
+│   │   ├── template_sync.py
+│   │   ├── template_async.py
+│   │   ├── validation.py
+│   │   ├── input_normalization.py
+│   │   ├── checkpoint_helpers.py
+│   │   ├── caching.py
+│   │   ├── event_helpers.py
+│   │   └── run_log.py
+│   ├── sync/
+│   │   ├── runner.py
+│   │   ├── superstep.py
+│   │   └── executors/
+│   └── async_/
+│       ├── runner.py
+│       ├── superstep.py
+│       └── executors/
+│
+├── checkpointers/                    durability and inspection
+│   ├── base.py
+│   ├── sqlite.py
+│   ├── memory.py
+│   ├── inspection.py
+│   ├── presenters.py
+│   ├── protocols.py
+│   ├── serializers.py
+│   ├── types.py
+│   └── _migrate.py
+│
+├── events/                           observability
+│   ├── dispatcher.py
+│   ├── processor.py
+│   ├── types.py
+│   ├── rich_progress.py
+│   └── otel.py
+│
+├── viz/                              visualization
+│   ├── widget.py
+│   ├── mermaid.py
+│   ├── debug.py
+│   ├── geometry.py
+│   ├── _common.py
+│   ├── html/
+│   ├── renderer/
+│   ├── styles/
+│   └── assets/
+│
+├── cli/                              terminal surface
+│   ├── run_cmd.py
+│   ├── graph_cmd.py
+│   ├── runs.py
+│   ├── _config.py
+│   ├── _db.py
+│   └── _format.py
+│
+└── integrations/                     optional runtimes
+    ├── __init__.py
+    └── daft/
+        └── runner.py
+```
+
+## Where Changes Tend To Fan Out
+
+These are the change zones with the highest blast radius:
+
+### 1. `graph/input_spec.py`
+
+Touches:
+
+- graph validation
+- runtime validation
+- runner input handling
+- docs and examples
+
+### 2. `runners/_shared/helpers.py`
+
+Touches:
+
+- readiness
+- staleness
+- SCC planning
+- checkpoint restore behavior
+- gate behavior
+
+### 3. `nodes/graph_node.py` plus graph-node executors
+
+Touches:
+
+- nesting
+- renames
+- checkpointing
+- map-over
+- delegated runners
+- pause propagation
+
+### 4. `template_sync.py` / `template_async.py`
+
+Touches:
+
+- public run semantics
+- resume/fork/retry behavior
+- top-level validation
+- batch persistence
+
+### 5. `checkpointers/types.py` and `presenters.py`
+
+Touches:
+
+- CLI output expectations
+- notebook rendering
+- human inspection workflows
+- serialized display assumptions in docs/tests
+
+## Conversation Vocabulary
+
+Use these terms when discussing changes:
+
+- **semantic core**: node and graph meaning
+- **scope engine**: active-scope and InputSpec computation
+- **execution kernel**: runners, supersteps, scheduler, frontier
+- **scheduler**: readiness, staleness, activation, SCC progression
+- **hierarchy bridge**: `GraphNode` and nested execution behavior
+- **durability layer**: checkpointers, snapshots, lineage, persistence semantics
+- **inspection surface**: CLI and notebook querying of persisted runs
+- **observability layer**: events and run logs
+- **viz projection**: flat graph + render pipeline + HTML/widget output
+- **integration runner**: alternate runtime like Daft that projects the core model elsewhere
+
+## Quick Re-entry Guide
+
+If you need to rebuild context quickly, use this order:
+
+1. `dev/CORE-BELIEFS.md`
+2. `dev/ARCHITECTURE.md`
+3. `src/hypergraph/graph/core.py`
+4. `src/hypergraph/runners/_shared/helpers.py`
+5. `src/hypergraph/runners/_shared/template_sync.py`
+6. `src/hypergraph/runners/_shared/template_async.py`
+7. the specific surface you are touching:
+   - checkpointers
+   - CLI
+   - viz
+   - integrations
+
+That path gets you from meaning to execution to surface behavior in the right order.

--- a/dev/ARCHITECTURE-MAP.md
+++ b/dev/ARCHITECTURE-MAP.md
@@ -202,7 +202,7 @@ Core responsibilities:
 - stale gate-decision clearing
 - readiness detection
 - staleness checks
-- explicit-edge aware producer tracking
+- explicit-edge-aware producer tracking
 - SCC execution planning
 - checkpoint state restoration
 - input resolution precedence
@@ -401,9 +401,9 @@ Current mental model:
 
 ```text
 Graph
-  -> flat graph projection
-  -> renderer instructions and precompute passes
-  -> HTML/ReactFlow document generation
+  -> to_flat_graph()
+  -> renderer/ (nodes, edges, precompute, scope, instructions)
+  -> html/generator.py
   -> notebook iframe widget or saved HTML file
 ```
 

--- a/dev/ARCHITECTURE.md
+++ b/dev/ARCHITECTURE.md
@@ -152,7 +152,9 @@ Graph visualization. Generates interactive HTML with ReactFlow.
 
 ## Public API
 
-Everything exported from `src/hypergraph/__init__.py` with `__all__` is public API. Internal modules use `_` prefix (`_callable.py`, `_rename.py`, `_conflict.py`, `_shared/`).
+Root-level exports from `src/hypergraph/__init__.py` are public API. Package modules with their own `__init__.py` exports, such as `hypergraph.checkpointers`, are also supported package surfaces.
+
+Internal modules remain internal even if they sit under a public package. In particular, `_shared/` is runtime architecture, not public API.
 
 ## Naming Rules
 

--- a/dev/ARCHITECTURE.md
+++ b/dev/ARCHITECTURE.md
@@ -61,7 +61,7 @@ All three are cleared in `_shallow_copy` → `inputs` cache invalidation.
 
 ### runners/
 
-Execution engines. Template Method pattern with pluggable `NodeExecutor` per node type.
+Execution engines. Template Method pattern with pluggable executors per node type.
 
 | File | Purpose |
 |------|---------|
@@ -89,17 +89,36 @@ Practical mental model:
 
 **`_shared/` contents**:
 - `caching.py` — Cache key computation and lookup
+- `checkpoint_helpers.py` — Build persisted `StepRecord`s from runtime state
 - `event_helpers.py` — Emit lifecycle events
 - `gate_execution.py` — Route/ifelse decision execution
 - `helpers.py` — Input resolution, output storage, active-scope computation, SCC planning, and localized readiness scheduling
 - `input_normalization.py` — Normalize user inputs for execution
-- `routing_validation.py` — Validate routing decisions at runtime
-- `template_sync.py` / `template_async.py` — Template Method base for runner lifecycle. Threads runtime select and entrypoint config into validation.
-- `types.py` — `GraphState`, `RunResult`, `RunStatus`, `PauseInfo`
-- `protocols.py` — `NodeExecutor` protocol
+- `protocols.py` — executor protocols for sync and async runners
+- `run_log.py` — always-on `RunLog` collection helpers
+- `template_sync.py` / `template_async.py` — Template Method base for runner lifecycle. Threads runtime select, entrypoint config, and checkpoint semantics into validation and execution.
+- `types.py` — `GraphState`, `RunResult`, `RunStatus`, `PauseInfo`, `RunLog`, `MapLog`, `ExecutionContext`
 - `validation.py` — Runner-level validation, runtime select resolution, InputSpec scoping
 
 **Rule**: Sync and async runners have parallel implementations. Adding a feature to one means adding it to both.
+
+### checkpointers/
+
+Durability, lineage, and inspection for persisted runs.
+
+| File | Purpose |
+|------|---------|
+| `base.py` | `Checkpointer` ABC and `CheckpointPolicy` |
+| `sqlite.py` | Durable SQLite-backed checkpointer |
+| `memory.py` | In-memory checkpointer for tests and lightweight experiments |
+| `types.py` | `Run`, `StepRecord`, `Checkpoint`, lineage and table display types |
+| `inspection.py` | Sync inspection adapters used by CLI and notebooks |
+| `presenters.py` | HTML renderers for explorer/table-style checkpoint widgets |
+| `protocols.py` | Sync write protocol for `SyncRunner` |
+| `serializers.py` | Payload serializers |
+| `_migrate.py` | SQLite schema migrations |
+
+**Rule**: Checkpointing is not just persistence. It participates in resume, fork, retry, lineage, CLI inspection, and notebook UX.
 
 ### events/
 
@@ -111,8 +130,19 @@ Observability system, decoupled from execution logic.
 | `dispatcher.py` | `EventDispatcher` — routes events to processors |
 | `processor.py` | `EventProcessor`, `AsyncEventProcessor`, `TypedEventProcessor` |
 | `rich_progress.py` | `RichProgressProcessor` — Rich console progress bars |
+| `otel.py` | OpenTelemetry processor integration |
 
 **Rule**: Events are best-effort. Observability must never alter execution logic or raise exceptions that break a run.
+
+### integrations/
+
+Optional alternate runtimes that project the core graph model into another execution backend.
+
+| File | Purpose |
+|------|---------|
+| `daft/runner.py` | `DaftRunner` for DataFrame-style DAG execution |
+
+**Rule**: Integrations may intentionally support only a subset of Hypergraph semantics, but those constraints must be explicit and validated.
 
 ### viz/
 

--- a/dev/TESTING-GUIDE.md
+++ b/dev/TESTING-GUIDE.md
@@ -180,6 +180,47 @@ async def test_pause_resume(self, tmp_path):
 
 Without a checkpointer, the runner has no state between calls — each run starts fresh.
 
+### Async Fixtures: Always Close Long-Lived Resources
+
+When a test creates async resources with background helpers or worker threads, teardown must be explicit.
+
+This matters especially for:
+
+- `SqliteCheckpointer`
+- raw `aiosqlite` connections
+- browser/process fixtures outside the shared Playwright setup
+
+`aiosqlite` uses a worker thread behind the async connection. If a test fixture yields a live connection and never awaits `close()`, pytest may tear down the event loop first. The worker thread then tries to report back into a closed loop and you get flaky warnings like:
+
+```text
+PytestUnhandledThreadExceptionWarning
+RuntimeError: Event loop is closed
+```
+
+Prefer async fixtures for async resources:
+
+```python
+import pytest_asyncio
+
+@pytest_asyncio.fixture
+async def checkpointer(tmp_path):
+    cp = SqliteCheckpointer(str(tmp_path / "test.db"))
+    yield cp
+    await cp.close()
+```
+
+Avoid this pattern for async-backed resources:
+
+```python
+@pytest.fixture
+def checkpointer(tmp_path):
+    cp = SqliteCheckpointer(str(tmp_path / "test.db"))
+    yield cp
+    # no await close() -> worker thread may outlive the test loop
+```
+
+For sync-only tests using the sync connection path, close the sync handle explicitly in teardown.
+
 ## Common Gotchas
 
 ### Never Use `asyncio.run()` in Tests
@@ -197,6 +238,26 @@ def test_async_behavior(self):
 async def test_async_behavior(self):
     result = await runner.run(graph, {"x": 5})
 ```
+
+### Treat Thread-Shutdown Warnings As Real Failures
+
+If you see flaky warnings like `PytestUnhandledThreadExceptionWarning`, do not assume they are harmless just because the test body passed.
+
+First isolate the test and promote the warning to an error:
+
+```bash
+uv run pytest tests/test_checkpointer/test_resume.py -k override_workflow_auto_forks_existing_id \
+  -W error::pytest.PytestUnhandledThreadExceptionWarning
+```
+
+This usually turns intermittent teardown noise into a deterministic failure you can debug.
+
+For async checkpointer/resource issues, check:
+
+1. Is the fixture async?
+2. Does teardown explicitly `await close()`?
+3. Are background tasks/threads being awaited before loop shutdown?
+4. Is the warning coming from test cleanup rather than the feature under test?
 
 ### Cycle Tests Need Unique Output Names
 

--- a/dev/TESTING-GUIDE.md
+++ b/dev/TESTING-GUIDE.md
@@ -169,13 +169,16 @@ async def test_pause_resume(self, tmp_path):
     from hypergraph.checkpointers import SqliteCheckpointer
 
     cp = SqliteCheckpointer(str(tmp_path / "test.db"))
-    runner = AsyncRunner(checkpointer=cp)
+    try:
+        runner = AsyncRunner(checkpointer=cp)
 
-    r1 = await runner.run(graph, workflow_id="w", user_input="hello")
-    assert r1.paused
+        r1 = await runner.run(graph, workflow_id="w", user_input="hello")
+        assert r1.paused
 
-    r2 = await runner.run(graph, workflow_id="w", user_input="more")
-    assert r2.paused  # or not, depending on graph logic
+        r2 = await runner.run(graph, workflow_id="w", user_input="more")
+        assert r2.paused  # or not, depending on graph logic
+    finally:
+        await cp.close()
 ```
 
 Without a checkpointer, the runner has no state between calls — each run starts fresh.

--- a/src/hypergraph/cache.py
+++ b/src/hypergraph/cache.py
@@ -14,6 +14,7 @@ import os
 import pickle
 import secrets
 from collections import OrderedDict
+from contextlib import suppress
 from typing import Any, Protocol
 
 logger = logging.getLogger(__name__)
@@ -166,6 +167,17 @@ class DiskCache:
         expanded = os.path.expanduser(cache_dir)
         self._cache = diskcache.Cache(expanded, **kwargs)
         self._hmac_key = _load_or_create_hmac_key(expanded)
+
+    def close(self) -> None:
+        """Close the underlying diskcache connection."""
+        cache = getattr(self, "_cache", None)
+        if cache is not None:
+            cache.close()
+
+    def __del__(self) -> None:
+        """Best-effort cleanup for forgotten disk caches."""
+        with suppress(Exception):
+            self.close()
 
     def get(self, key: str) -> tuple[bool, Any]:
         """Return (hit, value) from disk cache.

--- a/src/hypergraph/checkpointers/sqlite.py
+++ b/src/hypergraph/checkpointers/sqlite.py
@@ -123,6 +123,32 @@ class SqliteCheckpointer(Checkpointer):
         self._init_lock: asyncio.Lock | None = None
         self._aiosqlite = _require_aiosqlite()
 
+    def __del__(self) -> None:
+        """Best-effort cleanup for forgotten checkpointers.
+
+        Tests and callers should still prefer explicit ``await close()``.
+        This fallback only exists to avoid unraisable GC-time warnings when an
+        async sqlite connection is accidentally dropped without teardown.
+        """
+        sync_conn = getattr(self, "_sync_conn", None)
+        with contextlib.suppress(Exception):
+            if sync_conn is not None:
+                sync_conn.close()
+                self._sync_conn = None
+
+        db = getattr(self, "_db", None)
+        if db is None:
+            return
+
+        with contextlib.suppress(Exception):
+            raw_conn = getattr(db, "_connection", None)
+            if raw_conn is not None:
+                raw_conn.close()
+                db._connection = None
+
+        with contextlib.suppress(Exception):
+            db._running = False
+
     def _db_stats(self) -> dict[str, Any]:
         """Gather quick DB stats for display (uses sync connection)."""
         import os

--- a/src/hypergraph/cli/run_cmd.py
+++ b/src/hypergraph/cli/run_cmd.py
@@ -128,6 +128,14 @@ def _warn_sync_workflow_id_ignored(workflow_id: str | None, *, db: str | None) -
         print("Warning: --workflow-id has no persistence effect in sync mode without --db.")
 
 
+def _close_async_runner_resources(runner: Any) -> None:
+    """Best-effort cleanup for async runner resources created by the CLI."""
+    checkpointer = getattr(runner, "_checkpointer", None)
+    if checkpointer is None:
+        return
+    asyncio.run(checkpointer.close())
+
+
 # ---------------------------------------------------------------------------
 # Output formatting
 # ---------------------------------------------------------------------------
@@ -234,7 +242,10 @@ def register_commands(app: typer.Typer) -> None:
             run_kwargs["workflow_id"] = workflow_id
 
         if is_async:
-            result = asyncio.run(runner.run(graph, input_values or None, **run_kwargs))
+            try:
+                result = asyncio.run(runner.run(graph, input_values or None, **run_kwargs))
+            finally:
+                _close_async_runner_resources(runner)
         else:
             _warn_sync_workflow_id_ignored(workflow_id, db=db)
             result = runner.run(graph, input_values or None, **run_kwargs)
@@ -279,9 +290,12 @@ def register_commands(app: typer.Typer) -> None:
             map_kwargs["workflow_id"] = workflow_id
 
         if is_async:
-            if db is not None and workflow_id is None:
-                print("Warning: map checkpointing requires --workflow-id; running without persistence.")
-            result = asyncio.run(runner.map(graph, input_values or None, **map_kwargs))
+            try:
+                if db is not None and workflow_id is None:
+                    print("Warning: map checkpointing requires --workflow-id; running without persistence.")
+                result = asyncio.run(runner.map(graph, input_values or None, **map_kwargs))
+            finally:
+                _close_async_runner_resources(runner)
         else:
             _warn_sync_workflow_id_ignored(workflow_id, db=db)
             result = runner.map(graph, input_values or None, **map_kwargs)

--- a/src/hypergraph/events/otel.py
+++ b/src/hypergraph/events/otel.py
@@ -70,14 +70,16 @@ class OpenTelemetryProcessor(TypedEventProcessor):
 
     def on_run_start(self, event: RunStartEvent) -> None:
         parent_ctx = self._contexts.get(event.parent_span_id) if event.parent_span_id else None
+        attributes = {
+            "hypergraph.run_id": event.run_id,
+            "hypergraph.is_map": event.is_map,
+        }
+        if event.graph_name is not None:
+            attributes["hypergraph.graph_name"] = event.graph_name
         span = self._tracer.start_span(
             name=f"run:{event.graph_name}",
             context=parent_ctx,
-            attributes={
-                "hypergraph.graph_name": event.graph_name,
-                "hypergraph.run_id": event.run_id,
-                "hypergraph.is_map": event.is_map,
-            },
+            attributes=attributes,
         )
         self._spans[event.span_id] = span
         self._contexts[event.span_id] = self._trace.set_span_in_context(span)
@@ -95,13 +97,15 @@ class OpenTelemetryProcessor(TypedEventProcessor):
 
     def on_node_start(self, event: NodeStartEvent) -> None:
         parent_ctx = self._contexts.get(event.parent_span_id) if event.parent_span_id else None
+        attributes = {
+            "hypergraph.node_name": event.node_name,
+        }
+        if event.graph_name is not None:
+            attributes["hypergraph.graph_name"] = event.graph_name
         span = self._tracer.start_span(
             name=f"node:{event.node_name}",
             context=parent_ctx,
-            attributes={
-                "hypergraph.node_name": event.node_name,
-                "hypergraph.graph_name": event.graph_name,
-            },
+            attributes=attributes,
         )
         self._spans[event.span_id] = span
         self._contexts[event.span_id] = self._trace.set_span_in_context(span)

--- a/src/hypergraph/runners/_shared/helpers.py
+++ b/src/hypergraph/runners/_shared/helpers.py
@@ -673,7 +673,16 @@ def apply_node_result(
 
     for gate_name in graph.controlled_by.get(node.name, []):
         decision = state.routing_decisions.get(gate_name)
-        if decision is not None and _is_node_activated_by_decision(node.name, decision):
+        if decision is None:
+            continue
+        if isinstance(decision, list):
+            remaining = [target for target in decision if target != node.name]
+            if remaining:
+                state.routing_decisions[gate_name] = remaining
+            else:
+                del state.routing_decisions[gate_name]
+            continue
+        if _is_node_activated_by_decision(node.name, decision):
             del state.routing_decisions[gate_name]
 
 

--- a/src/hypergraph/runners/_shared/helpers.py
+++ b/src/hypergraph/runners/_shared/helpers.py
@@ -644,6 +644,39 @@ def _is_node_activated_by_decision(node_name: str, decision: Any) -> bool:
     return decision == node_name
 
 
+def apply_node_result(
+    graph: Graph,
+    state: GraphState,
+    node: HyperNode,
+    outputs: dict[str, Any],
+    input_versions: dict[str, int],
+    wait_for_versions: dict[str, int],
+    *,
+    duration_ms: float,
+    cached: bool,
+) -> None:
+    """Apply node execution results to state in place."""
+    for name, value in outputs.items():
+        state.update_value(name, value)
+
+    output_versions = {name: state.get_version(name) for name in outputs}
+
+    state.node_executions[node.name] = NodeExecution(
+        node_name=node.name,
+        input_versions=input_versions,
+        outputs=outputs,
+        output_versions=output_versions,
+        wait_for_versions=wait_for_versions,
+        duration_ms=duration_ms,
+        cached=cached,
+    )
+
+    for gate_name in graph.controlled_by.get(node.name, []):
+        decision = state.routing_decisions.get(gate_name)
+        if decision is not None and _is_node_activated_by_decision(node.name, decision):
+            del state.routing_decisions[gate_name]
+
+
 def _is_node_ready(
     node: HyperNode,
     graph: Graph,

--- a/src/hypergraph/runners/_shared/protocols.py
+++ b/src/hypergraph/runners/_shared/protocols.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Protocol, TypeVar
 
 if TYPE_CHECKING:
     from hypergraph.nodes.base import HyperNode
-    from hypergraph.runners._shared.types import GraphState
+    from hypergraph.runners._shared.types import ExecutionContext, GraphState
 
 N = TypeVar("N", bound="HyperNode", contravariant=True)
 
@@ -31,6 +31,7 @@ class NodeExecutor(Protocol[N]):
         node: N,
         state: GraphState,
         inputs: dict[str, Any],
+        ctx: ExecutionContext,
     ) -> dict[str, Any]: ...
 
 
@@ -53,4 +54,5 @@ class AsyncNodeExecutor(Protocol[N]):
         node: N,
         state: GraphState,
         inputs: dict[str, Any],
+        ctx: ExecutionContext,
     ) -> dict[str, Any]: ...

--- a/src/hypergraph/runners/_shared/types.py
+++ b/src/hypergraph/runners/_shared/types.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import uuid
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field, fields, is_dataclass
 from enum import Enum
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from hypergraph._utils import plural
+
+if TYPE_CHECKING:
+    from hypergraph.events.processor import EventProcessor
 
 ErrorHandling = Literal["raise", "continue"]
 
@@ -659,6 +662,26 @@ class RunnerCapabilities:
     returns_coroutine: bool = False
     supports_interrupts: bool = False
     supports_checkpointing: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionContext:
+    """Per-node execution environment passed to executors.
+
+    Created once per run as a base, then specialized per node via
+    ``dataclasses.replace()`` with the active parent span and nested-log sink.
+
+    Note:
+        ``provided_values`` intentionally remains a shared mutable dict so
+        interrupt resume payloads can be consumed across supersteps.
+    """
+
+    event_processors: list[EventProcessor] | None = None
+    parent_span_id: str | None = None
+    workflow_id: str | None = None
+    provided_values: dict[str, Any] = field(default_factory=dict)
+    is_resuming: bool = False
+    on_inner_log: Callable[[RunLog], None] | None = None
 
 
 @dataclass

--- a/src/hypergraph/runners/async_/executors/function_node.py
+++ b/src/hypergraph/runners/async_/executors/function_node.py
@@ -13,7 +13,7 @@ from hypergraph.runners.async_.superstep import get_concurrency_limiter
 
 if TYPE_CHECKING:
     from hypergraph.nodes.function import FunctionNode
-    from hypergraph.runners._shared.types import GraphState
+    from hypergraph.runners._shared.types import ExecutionContext, GraphState
 
 
 class AsyncFunctionNodeExecutor:
@@ -35,6 +35,7 @@ class AsyncFunctionNodeExecutor:
         node: FunctionNode,
         state: GraphState,
         inputs: dict[str, Any],
+        ctx: ExecutionContext,
     ) -> dict[str, Any]:
         """Execute a FunctionNode asynchronously.
 

--- a/src/hypergraph/runners/async_/executors/graph_node.py
+++ b/src/hypergraph/runners/async_/executors/graph_node.py
@@ -3,16 +3,14 @@
 from __future__ import annotations
 
 import inspect
-from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any
 
 from hypergraph.runners._shared.helpers import collect_as_lists, graphnode_child_workflow_id, map_inputs_to_func_params
 from hypergraph.runners._shared.types import PauseExecution, PauseInfo, RunResult, RunStatus
 
 if TYPE_CHECKING:
-    from hypergraph.events.processor import EventProcessor
     from hypergraph.nodes.graph_node import GraphNode
-    from hypergraph.runners._shared.types import GraphState
+    from hypergraph.runners._shared.types import ExecutionContext, GraphState
     from hypergraph.runners.async_.runner import AsyncRunner
 
 
@@ -23,62 +21,38 @@ class AsyncGraphNodeExecutor:
     - Simple nested graph execution
     - Map-over execution (delegates to runner.map())
 
-    Nested graphs inherit the parent's concurrency limiter via ContextVar,
-    so max_concurrency is shared across all levels of execution.
+    Nested graphs inherit the parent's concurrency limiter, so
+    max_concurrency is shared across all levels of execution.
     """
 
     def __init__(self, runner: AsyncRunner):
-        """Initialize with reference to parent runner.
-
-        Args:
-            runner: The AsyncRunner that owns this executor
-        """
+        """Initialize with reference to parent runner."""
         self.runner = runner
-        self._last_inner_logs: ContextVar[tuple] = ContextVar(
-            "async_graph_node_executor_last_inner_logs",
-            default=(),
-        )
-
-    @property
-    def last_inner_logs(self) -> tuple:
-        """Latest nested logs for the current task context."""
-        return self._last_inner_logs.get()
-
-    def consume_last_inner_logs(self) -> tuple:
-        """Read and clear nested logs for the current task context."""
-        logs = self._last_inner_logs.get()
-        self._last_inner_logs.set(())
-        return logs
 
     async def __call__(
         self,
         node: GraphNode,
         state: GraphState,
         inputs: dict[str, Any],
-        *,
-        event_processors: list[EventProcessor] | None = None,
-        parent_span_id: str | None = None,
-        workflow_id: str | None = None,
+        ctx: ExecutionContext,
     ) -> dict[str, Any]:
         """Execute a GraphNode by running its inner graph.
 
-        Inherits the parent's concurrency limiter via ContextVar.
         All nested operations share the same global concurrency budget.
 
         Args:
             node: The GraphNode to execute
             state: Current graph execution state (unused directly)
             inputs: Input values for the nested graph
-            event_processors: Processors to propagate to nested runs
-            parent_span_id: Span ID of the parent node for event linking
-            workflow_id: Parent workflow ID for hierarchical checkpointing
+            ctx: Execution context with event processors, workflow ID, and
+                nested log sink
 
         Returns:
             Dict mapping output names to their values
         """
         # Translate renamed input keys back to original inner graph names
         inner_inputs = map_inputs_to_func_params(node, inputs)
-        child_workflow_id = graphnode_child_workflow_id(workflow_id, node.name, state)
+        child_workflow_id = graphnode_child_workflow_id(ctx.workflow_id, node.name, state)
         map_config = node.map_config
 
         # Route interrupt resume values into the inner graph.
@@ -104,7 +78,7 @@ class AsyncGraphNodeExecutor:
                 if existing_child_run is not None:
                     inner_inputs = {}
                 elif resume_values:
-                    current_parent_run = await self.runner._checkpointer.get_run_async(workflow_id) if workflow_id else None
+                    current_parent_run = await self.runner._checkpointer.get_run_async(ctx.workflow_id) if ctx.workflow_id else None
                     source_parent_run_id = None
                     if current_parent_run is not None:
                         source_parent_run_id = current_parent_run.retry_of or current_parent_run.forked_from
@@ -139,22 +113,25 @@ class AsyncGraphNodeExecutor:
                 map_mode=mode,
                 clone=node._original_clone(),
                 error_handling=error_handling,
-                event_processors=event_processors,
+                event_processors=ctx.event_processors,
                 workflow_id=child_workflow_id,
-                _parent_span_id=parent_span_id,
-                _parent_run_id=workflow_id,
+                _parent_span_id=ctx.parent_span_id,
+                _parent_run_id=ctx.workflow_id,
             )
             # Delegated runner may be sync (e.g. DaftRunner) — await only if needed
             results = await map_call if inspect.isawaitable(map_call) else map_call
-            self._last_inner_logs.set(tuple(r.log for r in results if r.log is not None))
+            if ctx.on_inner_log:
+                for result in results:
+                    if result.log is not None:
+                        ctx.on_inner_log(result.log)
             return collect_as_lists(results, node, error_handling)
 
         # Only pass checkpoint kwargs if the delegated runner supports checkpointing
         run_kwargs: dict[str, Any] = {
-            "event_processors": event_processors,
+            "event_processors": ctx.event_processors,
             "workflow_id": child_workflow_id,
-            "_parent_span_id": parent_span_id,
-            "_parent_run_id": workflow_id,
+            "_parent_span_id": ctx.parent_span_id,
+            "_parent_run_id": ctx.workflow_id,
         }
         if runner.capabilities.supports_checkpointing:
             run_kwargs["fork_from"] = child_fork_from
@@ -163,7 +140,8 @@ class AsyncGraphNodeExecutor:
         run_call = runner.run(node.graph, inner_inputs, **run_kwargs)
         # Delegated runner may be sync (e.g. DaftRunner) — await only if needed
         result = await run_call if inspect.isawaitable(run_call) else run_call
-        self._last_inner_logs.set((result.log,) if result.log is not None else ())
+        if ctx.on_inner_log and result.log is not None:
+            ctx.on_inner_log(result.log)
         return self._handle_nested_result(node, result)
 
     def _handle_nested_result(self, node: GraphNode, result: RunResult) -> dict[str, Any]:

--- a/src/hypergraph/runners/async_/executors/ifelse_node.py
+++ b/src/hypergraph/runners/async_/executors/ifelse_node.py
@@ -8,7 +8,7 @@ from hypergraph.runners._shared.gate_execution import execute_ifelse
 
 if TYPE_CHECKING:
     from hypergraph.nodes.gate import IfElseNode
-    from hypergraph.runners._shared.types import GraphState
+    from hypergraph.runners._shared.types import ExecutionContext, GraphState
 
 
 class AsyncIfElseNodeExecutor:
@@ -23,5 +23,6 @@ class AsyncIfElseNodeExecutor:
         node: IfElseNode,
         state: GraphState,
         inputs: dict[str, Any],
+        ctx: ExecutionContext,
     ) -> dict[str, Any]:
         return execute_ifelse(node, state, inputs)

--- a/src/hypergraph/runners/async_/executors/interrupt_node.py
+++ b/src/hypergraph/runners/async_/executors/interrupt_node.py
@@ -10,7 +10,7 @@ from hypergraph.runners._shared.types import PauseExecution, PauseInfo
 
 if TYPE_CHECKING:
     from hypergraph.nodes.interrupt import InterruptNode
-    from hypergraph.runners._shared.types import GraphState
+    from hypergraph.runners._shared.types import ExecutionContext, GraphState
 
 
 class AsyncInterruptNodeExecutor:
@@ -21,9 +21,7 @@ class AsyncInterruptNodeExecutor:
         node: InterruptNode,
         state: GraphState,
         inputs: dict[str, Any],
-        *,
-        provided_values: dict[str, Any] | None = None,
-        is_resuming: bool = False,
+        ctx: ExecutionContext,
     ) -> dict[str, Any]:
         data_outputs = node.data_outputs
 
@@ -44,8 +42,8 @@ class AsyncInterruptNodeExecutor:
         # on a fresh run instead of pausing.
         # After consuming, we pop the keys so a second cycle iteration
         # through this node correctly invokes the handler and pauses.
-        if is_resuming:
-            pv = provided_values or {}
+        if ctx.is_resuming:
+            pv = ctx.provided_values
             all_outputs_provided = all(o in pv for o in data_outputs)
             if all_outputs_provided:
                 result = {o: pv.pop(o) for o in data_outputs}

--- a/src/hypergraph/runners/async_/executors/route_node.py
+++ b/src/hypergraph/runners/async_/executors/route_node.py
@@ -8,7 +8,7 @@ from hypergraph.runners._shared.gate_execution import execute_route
 
 if TYPE_CHECKING:
     from hypergraph.nodes.gate import RouteNode
-    from hypergraph.runners._shared.types import GraphState
+    from hypergraph.runners._shared.types import ExecutionContext, GraphState
 
 
 class AsyncRouteNodeExecutor:
@@ -23,5 +23,6 @@ class AsyncRouteNodeExecutor:
         node: RouteNode,
         state: GraphState,
         inputs: dict[str, Any],
+        ctx: ExecutionContext,
     ) -> dict[str, Any]:
         return execute_route(node, state, inputs)

--- a/src/hypergraph/runners/async_/runner.py
+++ b/src/hypergraph/runners/async_/runner.py
@@ -16,6 +16,7 @@ from hypergraph.runners._shared.helpers import ExecutionFrontier, compute_execut
 from hypergraph.runners._shared.protocols import AsyncNodeExecutor
 from hypergraph.runners._shared.template_async import AsyncRunnerTemplate
 from hypergraph.runners._shared.types import (
+    ExecutionContext,
     GraphState,
     PauseExecution,
     RunnerCapabilities,
@@ -168,6 +169,12 @@ class AsyncRunner(AsyncRunnerTemplate):
         try:
             superstep_idx = 0
             frontier = ExecutionFrontier.from_scope(scope, max_iterations)
+            ctx_base = ExecutionContext(
+                event_processors=event_processors,
+                workflow_id=workflow_id,
+                provided_values=values,
+                is_resuming=(checkpoint is not None if self._checkpointer_instance is not None else True),
+            )
 
             while frontier.has_pending_components():
                 try:
@@ -212,15 +219,8 @@ class AsyncRunner(AsyncRunnerTemplate):
                         state,
                         ready_nodes,
                         values,
-                        self._make_execute_node(
-                            event_processors,
-                            workflow_id=workflow_id,
-                            is_resuming=(
-                                checkpoint is not None
-                                if self._checkpointer_instance is not None
-                                else True  # stateless mode: preserve old auto-resolve
-                            ),
-                        ),
+                        self._executors,
+                        ctx_base,
                         max_concurrency,
                         cache=self._cache,
                         dispatcher=dispatcher,
@@ -345,77 +345,6 @@ class AsyncRunner(AsyncRunnerTemplate):
                 step_buffer.append(record)
 
         return step_counter
-
-    def _make_execute_node(
-        self,
-        event_processors: list[EventProcessor] | None,
-        workflow_id: str | None = None,
-        is_resuming: bool = False,
-    ) -> AsyncNodeExecutor:
-        """Create an async node executor closure that carries event context.
-
-        The superstep calls execute_node(node, state, inputs). For GraphNode
-        executors, we need to pass event_processors, parent_span_id, and
-        workflow_id so nested graphs propagate events and checkpointing.
-
-        The superstep sets ``execute_node.current_span_id`` before each
-        call so that nested graph runs know their parent span.
-        """
-        current_span_id: list[str | None] = [None]
-        provided_values_holder: list[dict[str, Any]] = [{}]
-        is_resuming_holder: list[bool] = [is_resuming]
-
-        async def execute_node(
-            node: HyperNode,
-            state: GraphState,
-            inputs: dict[str, Any],
-        ) -> dict[str, Any]:
-            """Execute one node with optional nested-graph context."""
-            node_type = type(node)
-            executor = self._executors.get(node_type)
-
-            if executor is None:
-                raise TypeError(f"No executor registered for node type '{node_type.__name__}'")
-
-            # For GraphNodeExecutor, pass context as params (not mutable state)
-            if isinstance(executor, AsyncGraphNodeExecutor):
-                result = await executor(
-                    node,
-                    state,
-                    inputs,
-                    event_processors=event_processors,
-                    parent_span_id=current_span_id[0],
-                    workflow_id=workflow_id,
-                )
-                return result
-
-            # For InterruptNodeExecutor, pass provided_values and resuming
-            # context so it only auto-resolves on actual resume, not fresh runs.
-            if isinstance(executor, AsyncInterruptNodeExecutor):
-                return await executor(
-                    node,
-                    state,
-                    inputs,
-                    provided_values=provided_values_holder[0],
-                    is_resuming=is_resuming_holder[0],
-                )
-
-            return await executor(node, state, inputs)
-
-        def consume_last_inner_logs() -> tuple:
-            """Read and clear nested logs for the current async task context."""
-            graph_executor = self._executors.get(GraphNode)
-            if isinstance(graph_executor, AsyncGraphNodeExecutor):
-                return graph_executor.consume_last_inner_logs()
-            return ()
-
-        # Expose holders so superstep can set parent span, provided_values,
-        # resuming context, and read nested logs
-        execute_node.current_span_id = current_span_id  # type: ignore[attr-defined]
-        execute_node.provided_values = provided_values_holder  # type: ignore[attr-defined]
-        execute_node.is_resuming = is_resuming_holder  # type: ignore[attr-defined]
-        execute_node.consume_last_inner_logs = consume_last_inner_logs  # type: ignore[attr-defined]
-        return execute_node
 
     # Template hook implementations
 

--- a/src/hypergraph/runners/async_/superstep.py
+++ b/src/hypergraph/runners/async_/superstep.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import asyncio
 import time
 from contextvars import ContextVar
+from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
 from hypergraph.exceptions import ExecutionError
 from hypergraph.nodes.base import HyperNode
-from hypergraph.nodes.gate import END as _END
 from hypergraph.runners._shared.caching import (
     check_cache,
     restore_routing_decision,
@@ -22,18 +22,8 @@ from hypergraph.runners._shared.event_helpers import (
     build_node_start_event,
     build_route_decision_event,
 )
-from hypergraph.runners._shared.helpers import collect_inputs_for_node
-from hypergraph.runners._shared.types import GraphState, NodeExecution, PauseExecution
-
-
-def _decision_activates(node_name: str, decision: Any) -> bool:
-    """Check if a routing decision activates a specific node."""
-    if decision is _END or decision is None:
-        return False
-    if isinstance(decision, list):
-        return node_name in decision
-    return decision == node_name
-
+from hypergraph.runners._shared.helpers import apply_node_result, collect_inputs_for_node
+from hypergraph.runners._shared.types import ExecutionContext, GraphState, PauseExecution
 
 if TYPE_CHECKING:
     from hypergraph.cache import CacheBackend
@@ -65,7 +55,8 @@ async def run_superstep_async(
     state: GraphState,
     ready_nodes: list[HyperNode],
     provided_values: dict[str, Any],
-    execute_node: AsyncNodeExecutor,
+    executors: dict[type[HyperNode], AsyncNodeExecutor[Any]],
+    ctx_base: ExecutionContext,
     max_concurrency: int | None = None,
     *,
     cache: CacheBackend | None = None,
@@ -84,7 +75,8 @@ async def run_superstep_async(
         state: Current state (will be copied, not mutated)
         ready_nodes: Nodes to execute in this superstep
         provided_values: Values provided to runner.run()
-        execute_node: Async function to execute a single node
+        executors: Runner executor registry
+        ctx_base: Per-run execution context
         max_concurrency: Unused (kept for API compatibility)
         dispatcher: Optional event dispatcher for emitting node events
         run_id: Run ID for event correlation
@@ -109,12 +101,6 @@ async def run_superstep_async(
     ) -> tuple[HyperNode, dict[str, Any], dict[str, int], dict[str, int], float, bool]:
         """Execute a single node with event emission."""
         inputs = collect_inputs_for_node(node, graph, state, provided_values)
-
-        # Stash provided_values so the execute_node closure can forward
-        # them to the interrupt executor (distinguishes fresh resume
-        # values from stale cycle values in checkpointed state).
-        if hasattr(execute_node, "provided_values"):
-            execute_node.provided_values[0] = provided_values  # type: ignore[attr-defined]
         input_versions = {param: state.get_version(param) for param in node.inputs}
         wait_for_versions = {name: state.get_version(name) for name in node.wait_for}
 
@@ -142,21 +128,24 @@ async def run_superstep_async(
         if active:
             await dispatcher.emit_async(start_evt)
 
-        # Set node span_id on executor for nested graph propagation
-        if hasattr(execute_node, "current_span_id"):
-            execute_node.current_span_id[0] = node_span_id  # type: ignore[attr-defined]
-
         node_start = time.time()
         try:
+            executor = executors.get(type(node))
+            if executor is None:
+                raise TypeError(f"No executor registered for node type '{type(node).__name__}'")
+
+            inner_logs: list = []
+            ctx = replace(
+                ctx_base,
+                parent_span_id=node_span_id,
+                provided_values=provided_values,
+                on_inner_log=inner_logs.append,
+            )
+
             # Pass new_state so routing decisions are stored in the updated state
-            outputs = await execute_node(node, new_state, inputs)
+            outputs = await executor(node, new_state, inputs, ctx)
 
             duration_ms = (time.time() - node_start) * 1000
-
-            # Capture inner logs from nested graph execution (if any)
-            inner_logs: tuple = ()
-            if hasattr(execute_node, "consume_last_inner_logs"):
-                inner_logs = execute_node.consume_last_inner_logs()  # type: ignore[attr-defined]
 
             # Store result in cache
             if cache is not None and cache_key:
@@ -166,7 +155,17 @@ async def run_superstep_async(
                 route_evt = build_route_decision_event(run_id, run_span_id, node, graph, new_state)
                 if route_evt is not None:
                     await dispatcher.emit_async(route_evt)
-                await dispatcher.emit_async(build_node_end_event(run_id, node_span_id, run_span_id, node, graph, duration_ms, inner_logs=inner_logs))
+                await dispatcher.emit_async(
+                    build_node_end_event(
+                        run_id,
+                        node_span_id,
+                        run_span_id,
+                        node,
+                        graph,
+                        duration_ms,
+                        inner_logs=tuple(inner_logs),
+                    )
+                )
 
             return node, outputs, input_versions, wait_for_versions, duration_ms, False
         except PauseExecution as exc:
@@ -190,25 +189,16 @@ async def run_superstep_async(
                 first_error = result
             continue
         node, outputs, input_versions, wait_for_versions, duration_ms, cached = result
-        for name, value in outputs.items():
-            new_state.update_value(name, value)
-        output_versions = {name: new_state.get_version(name) for name in outputs}
-        new_state.node_executions[node.name] = NodeExecution(
-            node_name=node.name,
-            input_versions=input_versions,
-            outputs=outputs,
-            output_versions=output_versions,
-            wait_for_versions=wait_for_versions,
+        apply_node_result(
+            graph,
+            new_state,
+            node,
+            outputs,
+            input_versions,
+            wait_for_versions,
             duration_ms=duration_ms,
             cached=cached,
         )
-        # Consume routing decisions that activated this node.
-        # Once a gated node executes, the decision is spent — the gate
-        # must re-execute and re-route before this node fires again.
-        for gate_name in graph.controlled_by.get(node.name, []):
-            decision = new_state.routing_decisions.get(gate_name)
-            if decision is not None and _decision_activates(node.name, decision):
-                del new_state.routing_decisions[gate_name]
 
     if first_error is not None:
         # PauseExecution (BaseException) must propagate unwrapped for the

--- a/src/hypergraph/runners/sync/executors/function_node.py
+++ b/src/hypergraph/runners/sync/executors/function_node.py
@@ -11,7 +11,7 @@ from hypergraph.runners._shared.helpers import (
 
 if TYPE_CHECKING:
     from hypergraph.nodes.function import FunctionNode
-    from hypergraph.runners._shared.types import GraphState
+    from hypergraph.runners._shared.types import ExecutionContext, GraphState
 
 
 class SyncFunctionNodeExecutor:
@@ -27,6 +27,7 @@ class SyncFunctionNodeExecutor:
         node: FunctionNode,
         state: GraphState,
         inputs: dict[str, Any],
+        ctx: ExecutionContext,
     ) -> dict[str, Any]:
         """Execute a FunctionNode synchronously.
 

--- a/src/hypergraph/runners/sync/executors/graph_node.py
+++ b/src/hypergraph/runners/sync/executors/graph_node.py
@@ -7,9 +7,8 @@ from typing import TYPE_CHECKING, Any
 from hypergraph.runners._shared.helpers import collect_as_lists, graphnode_child_workflow_id, map_inputs_to_func_params
 
 if TYPE_CHECKING:
-    from hypergraph.events.processor import EventProcessor
     from hypergraph.nodes.graph_node import GraphNode
-    from hypergraph.runners._shared.types import GraphState
+    from hypergraph.runners._shared.types import ExecutionContext, GraphState
     from hypergraph.runners.sync.runner import SyncRunner
 
 
@@ -22,23 +21,15 @@ class SyncGraphNodeExecutor:
     """
 
     def __init__(self, runner: SyncRunner):
-        """Initialize with reference to parent runner.
-
-        Args:
-            runner: The SyncRunner that owns this executor
-        """
+        """Initialize with reference to parent runner."""
         self.runner = runner
-        self.last_inner_logs: tuple = ()
 
     def __call__(
         self,
         node: GraphNode,
         state: GraphState,
         inputs: dict[str, Any],
-        *,
-        event_processors: list[EventProcessor] | None = None,
-        parent_span_id: str | None = None,
-        workflow_id: str | None = None,
+        ctx: ExecutionContext,
     ) -> dict[str, Any]:
         """Execute a GraphNode by running its inner graph.
 
@@ -46,16 +37,15 @@ class SyncGraphNodeExecutor:
             node: The GraphNode to execute
             state: Current graph execution state (unused directly)
             inputs: Input values for the nested graph
-            event_processors: Processors to propagate to nested runs
-            parent_span_id: Span ID of the parent node for event linking
-            workflow_id: Parent workflow ID for hierarchical checkpointing
+            ctx: Execution context with event processors, workflow ID, and
+                nested log sink
 
         Returns:
             Dict mapping output names to their values
         """
         # Translate renamed input keys back to original inner graph names
         inner_inputs = map_inputs_to_func_params(node, inputs)
-        child_workflow_id = graphnode_child_workflow_id(workflow_id, node.name, state)
+        child_workflow_id = graphnode_child_workflow_id(ctx.workflow_id, node.name, state)
         map_config = node.map_config
 
         # Route interrupt resume values into the inner graph.
@@ -92,21 +82,25 @@ class SyncGraphNodeExecutor:
                 map_mode=mode,
                 clone=node._original_clone(),
                 error_handling=error_handling,
-                event_processors=event_processors,
+                event_processors=ctx.event_processors,
                 workflow_id=child_workflow_id,
-                _parent_span_id=parent_span_id,
-                _parent_run_id=workflow_id,
+                _parent_span_id=ctx.parent_span_id,
+                _parent_run_id=ctx.workflow_id,
             )
-            self.last_inner_logs = tuple(r.log for r in results if r.log is not None)
+            if ctx.on_inner_log:
+                for result in results:
+                    if result.log is not None:
+                        ctx.on_inner_log(result.log)
             return collect_as_lists(results, node, error_handling)
 
         result = runner.run(
             node.graph,
             inner_inputs,
-            event_processors=event_processors,
+            event_processors=ctx.event_processors,
             workflow_id=child_workflow_id,
-            _parent_span_id=parent_span_id,
-            _parent_run_id=workflow_id,
+            _parent_span_id=ctx.parent_span_id,
+            _parent_run_id=ctx.workflow_id,
         )
-        self.last_inner_logs = (result.log,) if result.log is not None else ()
+        if ctx.on_inner_log and result.log is not None:
+            ctx.on_inner_log(result.log)
         return node.map_outputs_from_original(result.values)

--- a/src/hypergraph/runners/sync/executors/ifelse_node.py
+++ b/src/hypergraph/runners/sync/executors/ifelse_node.py
@@ -8,7 +8,7 @@ from hypergraph.runners._shared.gate_execution import execute_ifelse
 
 if TYPE_CHECKING:
     from hypergraph.nodes.gate import IfElseNode
-    from hypergraph.runners._shared.types import GraphState
+    from hypergraph.runners._shared.types import ExecutionContext, GraphState
 
 
 class SyncIfElseNodeExecutor:
@@ -19,5 +19,6 @@ class SyncIfElseNodeExecutor:
         node: IfElseNode,
         state: GraphState,
         inputs: dict[str, Any],
+        ctx: ExecutionContext,
     ) -> dict[str, Any]:
         return execute_ifelse(node, state, inputs)

--- a/src/hypergraph/runners/sync/executors/route_node.py
+++ b/src/hypergraph/runners/sync/executors/route_node.py
@@ -8,7 +8,7 @@ from hypergraph.runners._shared.gate_execution import execute_route
 
 if TYPE_CHECKING:
     from hypergraph.nodes.gate import RouteNode
-    from hypergraph.runners._shared.types import GraphState
+    from hypergraph.runners._shared.types import ExecutionContext, GraphState
 
 
 class SyncRouteNodeExecutor:
@@ -19,5 +19,6 @@ class SyncRouteNodeExecutor:
         node: RouteNode,
         state: GraphState,
         inputs: dict[str, Any],
+        ctx: ExecutionContext,
     ) -> dict[str, Any]:
         return execute_route(node, state, inputs)

--- a/src/hypergraph/runners/sync/runner.py
+++ b/src/hypergraph/runners/sync/runner.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import time
-from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from hypergraph.exceptions import ExecutionError, InfiniteLoopError
@@ -14,7 +13,7 @@ from hypergraph.nodes.graph_node import GraphNode
 from hypergraph.runners._shared.helpers import ExecutionFrontier, compute_execution_scope, initialize_state
 from hypergraph.runners._shared.protocols import NodeExecutor
 from hypergraph.runners._shared.template_sync import SyncRunnerTemplate
-from hypergraph.runners._shared.types import GraphState, RunnerCapabilities, _generate_run_id
+from hypergraph.runners._shared.types import ExecutionContext, GraphState, RunnerCapabilities, _generate_run_id
 from hypergraph.runners.sync.executors import (
     SyncFunctionNodeExecutor,
     SyncGraphNodeExecutor,
@@ -138,6 +137,11 @@ class SyncRunner(SyncRunnerTemplate):
 
         superstep_idx = 0
         frontier = ExecutionFrontier.from_scope(scope, max_iterations)
+        ctx_base = ExecutionContext(
+            event_processors=event_processors,
+            workflow_id=workflow_id,
+            provided_values=values,
+        )
 
         while frontier.has_pending_components():
             try:
@@ -180,7 +184,8 @@ class SyncRunner(SyncRunnerTemplate):
                     state,
                     ready_nodes,
                     values,
-                    self._make_execute_node(event_processors, workflow_id=workflow_id),
+                    self._executors,
+                    ctx_base,
                     cache=self._cache,
                     dispatcher=dispatcher,
                     run_id=run_id,
@@ -214,56 +219,6 @@ class SyncRunner(SyncRunnerTemplate):
             superstep_idx += 1
 
         return state
-
-    def _make_execute_node(
-        self,
-        event_processors: list[EventProcessor] | None,
-        workflow_id: str | None = None,
-    ) -> Callable:
-        """Create a node executor closure that carries event context.
-
-        The superstep calls execute_node(node, state, inputs). For GraphNode
-        executors, we need to pass event_processors, parent_span_id, and
-        workflow_id so nested graphs propagate events and checkpointing.
-
-        The superstep sets ``execute_node.current_span_id`` before each
-        call so that nested graph runs know their parent span.
-        """
-        current_span_id: list[str | None] = [None]
-        last_inner_logs: list[tuple] = [()]
-
-        def execute_node(
-            node: HyperNode,
-            state: GraphState,
-            inputs: dict[str, Any],
-        ) -> dict[str, Any]:
-            """Execute one node with optional nested-graph context."""
-            node_type = type(node)
-            executor = self._executors.get(node_type)
-
-            if executor is None:
-                raise TypeError(f"No executor registered for node type '{node_type.__name__}'")
-
-            # For GraphNodeExecutor, pass context as params (not mutable state)
-            if isinstance(executor, SyncGraphNodeExecutor):
-                result = executor(
-                    node,
-                    state,
-                    inputs,
-                    event_processors=event_processors,
-                    parent_span_id=current_span_id[0],
-                    workflow_id=workflow_id,
-                )
-                last_inner_logs[0] = executor.last_inner_logs
-                return result
-
-            last_inner_logs[0] = ()
-            return executor(node, state, inputs)
-
-        # Expose mutable holders so superstep can read/set per-node
-        execute_node.current_span_id = current_span_id  # type: ignore[attr-defined]
-        execute_node.last_inner_logs = last_inner_logs  # type: ignore[attr-defined]
-        return execute_node
 
     # Template hook implementations
 

--- a/src/hypergraph/runners/sync/superstep.py
+++ b/src/hypergraph/runners/sync/superstep.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 import time
-from collections.abc import Callable
+from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
 from hypergraph.exceptions import ExecutionError
 from hypergraph.nodes.base import HyperNode
-from hypergraph.nodes.gate import END as _END
 from hypergraph.runners._shared.caching import (
     check_cache,
     restore_routing_decision,
@@ -21,13 +20,14 @@ from hypergraph.runners._shared.event_helpers import (
     build_node_start_event,
     build_route_decision_event,
 )
-from hypergraph.runners._shared.helpers import collect_inputs_for_node
-from hypergraph.runners._shared.types import GraphState, NodeExecution, PauseExecution
+from hypergraph.runners._shared.helpers import apply_node_result, collect_inputs_for_node
+from hypergraph.runners._shared.types import ExecutionContext, GraphState, PauseExecution
 
 if TYPE_CHECKING:
     from hypergraph.cache import CacheBackend
     from hypergraph.events.dispatcher import EventDispatcher
     from hypergraph.graph import Graph
+    from hypergraph.runners._shared.protocols import NodeExecutor
 
 
 def run_superstep_sync(
@@ -35,7 +35,8 @@ def run_superstep_sync(
     state: GraphState,
     ready_nodes: list[HyperNode],
     provided_values: dict[str, Any],
-    execute_node: Callable,
+    executors: dict[type[HyperNode], NodeExecutor[Any]],
+    ctx_base: ExecutionContext,
     *,
     cache: CacheBackend | None = None,
     dispatcher: EventDispatcher | None = None,
@@ -51,7 +52,8 @@ def run_superstep_sync(
         state: Current state (will be copied, not mutated)
         ready_nodes: Nodes to execute in this superstep
         provided_values: Values provided to runner.run()
-        execute_node: Function to execute a single node
+        executors: Runner executor registry
+        ctx_base: Per-run execution context
         dispatcher: Optional event dispatcher for emitting node events
         run_id: Run ID for event correlation
         run_span_id: Span ID of the parent run
@@ -95,20 +97,22 @@ def run_superstep_sync(
 
             node_start = time.time()
             try:
-                # Set node span_id on executor for nested graph propagation
-                if hasattr(execute_node, "current_span_id"):
-                    execute_node.current_span_id[0] = node_span_id  # type: ignore[attr-defined]
+                executor = executors.get(type(node))
+                if executor is None:
+                    raise TypeError(f"No executor registered for node type '{type(node).__name__}'")
+
+                inner_logs: list = []
+                ctx = replace(
+                    ctx_base,
+                    parent_span_id=node_span_id,
+                    provided_values=provided_values,
+                    on_inner_log=inner_logs.append,
+                )
 
                 # Execute node
-                outputs = execute_node(node, new_state, inputs)
+                outputs = executor(node, new_state, inputs, ctx)
 
                 duration_ms = (time.time() - node_start) * 1000
-
-                # Capture inner logs from nested graph execution (if any)
-                inner_logs: tuple = ()
-                if hasattr(execute_node, "last_inner_logs"):
-                    inner_logs = execute_node.last_inner_logs[0]  # type: ignore[attr-defined]
-                    execute_node.last_inner_logs[0] = ()  # type: ignore[attr-defined]
 
                 # Store result in cache
                 if cache is not None and cache_key:
@@ -118,7 +122,17 @@ def run_superstep_sync(
                     route_evt = build_route_decision_event(run_id, run_span_id, node, graph, new_state)
                     if route_evt is not None:
                         dispatcher.emit(route_evt)
-                    dispatcher.emit(build_node_end_event(run_id, node_span_id, run_span_id, node, graph, duration_ms, inner_logs=inner_logs))
+                    dispatcher.emit(
+                        build_node_end_event(
+                            run_id,
+                            node_span_id,
+                            run_span_id,
+                            node,
+                            graph,
+                            duration_ms,
+                            inner_logs=tuple(inner_logs),
+                        )
+                    )
 
             except BaseException as e:
                 duration_ms = (time.time() - node_start) * 1000
@@ -133,44 +147,17 @@ def run_superstep_sync(
                 # Re-raise other BaseExceptions (KeyboardInterrupt, SystemExit, etc.)
                 raise
 
-        # Update state with outputs
-        for name, value in outputs.items():
-            new_state.update_value(name, value)
-
-        output_versions = {name: new_state.get_version(name) for name in outputs}
-
         # Record wait_for versions
         wait_for_versions = {name: state.get_version(name) for name in node.wait_for}
-
-        # Determine duration and cache status for this node
-        node_duration = 0.0 if cached_outputs is not None else duration_ms
-        node_cached = cached_outputs is not None
-
-        # Record execution
-        new_state.node_executions[node.name] = NodeExecution(
-            node_name=node.name,
-            input_versions=input_versions,
-            outputs=outputs,
-            output_versions=output_versions,
-            wait_for_versions=wait_for_versions,
-            duration_ms=node_duration,
-            cached=node_cached,
+        apply_node_result(
+            graph,
+            new_state,
+            node,
+            outputs,
+            input_versions,
+            wait_for_versions,
+            duration_ms=0.0 if cached_outputs is not None else duration_ms,
+            cached=cached_outputs is not None,
         )
-        # Consume routing decisions that activated this node.
-        # Once a gated node executes, the decision is spent — the gate
-        # must re-execute and re-route before this node fires again.
-        for gate_name in graph.controlled_by.get(node.name, []):
-            decision = new_state.routing_decisions.get(gate_name)
-            if decision is not None and _decision_activates_node(node.name, decision):
-                del new_state.routing_decisions[gate_name]
 
     return new_state
-
-
-def _decision_activates_node(node_name: str, decision: Any) -> bool:
-    """Check if a routing decision activates a specific node."""
-    if decision is _END or decision is None:
-        return False
-    if isinstance(decision, list):
-        return node_name in decision
-    return decision == node_name

--- a/tests/test_checkpointer/test_hierarchical_checkpointing.py
+++ b/tests/test_checkpointer/test_hierarchical_checkpointing.py
@@ -1,6 +1,7 @@
 """Integration tests for hierarchical checkpointing: map(), nested graphs, and cycles."""
 
 import pytest
+import pytest_asyncio
 
 from hypergraph import END, AsyncRunner, Graph, SyncRunner, node, route
 from hypergraph.checkpointers import CheckpointPolicy, SqliteCheckpointer
@@ -24,11 +25,12 @@ def triple(doubled: int) -> int:
 # --- Fixtures ---
 
 
-@pytest.fixture
-def async_cp(tmp_path):
+@pytest_asyncio.fixture
+async def async_cp(tmp_path):
     cp = SqliteCheckpointer(str(tmp_path / "test.db"))
     cp.policy = CheckpointPolicy(durability="sync", retention="full")
     yield cp
+    await cp.close()
 
 
 @pytest.fixture

--- a/tests/test_checkpointer/test_lineage_semantics.py
+++ b/tests/test_checkpointer/test_lineage_semantics.py
@@ -12,6 +12,7 @@ These tests codify the v3 decisions from the checkpoint design sessions:
 from __future__ import annotations
 
 import pytest
+import pytest_asyncio
 
 from hypergraph import END, AsyncRunner, Graph, RunStatus, ifelse, interrupt, node
 from hypergraph.checkpointers import SqliteCheckpointer, WorkflowStatus
@@ -25,10 +26,11 @@ from hypergraph.exceptions import (
 aiosqlite = pytest.importorskip("aiosqlite")
 
 
-@pytest.fixture
-def checkpointer(tmp_path):
+@pytest_asyncio.fixture
+async def checkpointer(tmp_path):
     cp = SqliteCheckpointer(str(tmp_path / "lineage.db"))
     yield cp
+    await cp.close()
 
 
 @node(output_name="doubled")

--- a/tests/test_checkpointer/test_resume.py
+++ b/tests/test_checkpointer/test_resume.py
@@ -1,6 +1,7 @@
 """Tests for checkpoint resume semantics: run() merges state, map() skips completed."""
 
 import pytest
+import pytest_asyncio
 
 from hypergraph import AsyncRunner, Graph, SyncRunner, node
 from hypergraph.checkpointers import SqliteCheckpointer, WorkflowStatus
@@ -31,11 +32,12 @@ def triple(doubled: int) -> int:
 # --- Fixtures ---
 
 
-@pytest.fixture
-def checkpointer(tmp_path):
+@pytest_asyncio.fixture
+async def checkpointer(tmp_path):
     """Checkpointer for each test."""
     cp = SqliteCheckpointer(str(tmp_path / "test.db"))
     yield cp
+    await cp.close()
 
 
 @pytest.fixture

--- a/tests/test_checkpointer/test_runner_integration.py
+++ b/tests/test_checkpointer/test_runner_integration.py
@@ -1,6 +1,7 @@
 """Integration tests: AsyncRunner + SqliteCheckpointer end-to-end."""
 
 import pytest
+import pytest_asyncio
 
 from hypergraph import AsyncRunner, Graph, node
 from hypergraph.checkpointers import (
@@ -14,11 +15,12 @@ from hypergraph.checkpointers import (
 aiosqlite = pytest.importorskip("aiosqlite")
 
 
-@pytest.fixture
-def checkpointer(tmp_path):
+@pytest_asyncio.fixture
+async def checkpointer(tmp_path):
     """Create a fresh SqliteCheckpointer for each test."""
     cp = SqliteCheckpointer(str(tmp_path / "test.db"))
     yield cp
+    await cp.close()
 
 
 # --- Simple pipeline nodes ---

--- a/tests/test_checkpointer/test_sqlite.py
+++ b/tests/test_checkpointer/test_sqlite.py
@@ -5,6 +5,7 @@ from datetime import timedelta, timezone
 from pathlib import Path
 
 import pytest
+import pytest_asyncio
 
 from hypergraph.checkpointers import (
     CheckpointPolicy,
@@ -18,11 +19,12 @@ from hypergraph.checkpointers import (
 aiosqlite = pytest.importorskip("aiosqlite")
 
 
-@pytest.fixture
-def checkpointer(tmp_path):
+@pytest_asyncio.fixture
+async def checkpointer(tmp_path):
     """Create a fresh SqliteCheckpointer for each test."""
     cp = SqliteCheckpointer(str(tmp_path / "test.db"))
     yield cp
+    await cp.close()
 
 
 def _make_step(run_id="wf-1", superstep=0, node_name="embed", index=0, **kwargs):

--- a/tests/test_checkpointer/test_sqlite.py
+++ b/tests/test_checkpointer/test_sqlite.py
@@ -343,9 +343,12 @@ class TestLazyInit:
         """Checkpointer auto-initializes on first use."""
         cp = SqliteCheckpointer(str(tmp_path / "lazy.db"))
         # No explicit initialize() call
-        await cp.create_run("wf-1")
-        r = cp.get_run("wf-1")
-        assert r is not None
+        try:
+            await cp.create_run("wf-1")
+            r = cp.get_run("wf-1")
+            assert r is not None
+        finally:
+            await cp.close()
 
     async def test_concurrent_lazy_initialize_runs_once(self, tmp_path):
         """Concurrent first-use calls should serialize initialization."""
@@ -361,20 +364,25 @@ class TestLazyInit:
 
         cp.initialize = counted_initialize  # type: ignore[method-assign]
 
-        await asyncio.gather(
-            cp.create_run("wf-a"),
-            cp.create_run("wf-b"),
-            cp.create_run("wf-c"),
-        )
-
-        assert init_calls == 1
+        try:
+            await asyncio.gather(
+                cp.create_run("wf-a"),
+                cp.create_run("wf-b"),
+                cp.create_run("wf-c"),
+            )
+            assert init_calls == 1
+        finally:
+            await cp.close()
 
     async def test_memory_db_schema_available_after_initialize(self):
         """In-memory DB initialization creates schema for async operations."""
         cp = SqliteCheckpointer(":memory:")
-        await cp.create_run("wf-mem")
-        run = cp.get_run("wf-mem")
-        assert run is not None
+        try:
+            await cp.create_run("wf-mem")
+            run = cp.get_run("wf-mem")
+            assert run is not None
+        finally:
+            await cp.close()
 
 
 class TestPolicyIntegration:
@@ -415,17 +423,23 @@ class TestPolicyIntegration:
         """Constructor accepts pathlib.Path for filesystem databases."""
         db_path = tmp_path / "path-instance.db"
         cp = SqliteCheckpointer(db_path)
-        await cp.create_run("wf-1")
-        run = cp.get_run("wf-1")
-        assert run is not None
+        try:
+            await cp.create_run("wf-1")
+            run = cp.get_run("wf-1")
+            assert run is not None
+        finally:
+            await cp.close()
 
     async def test_accepts_relative_path_instance(self, tmp_path, monkeypatch):
         """Constructor accepts relative pathlib.Path values."""
         monkeypatch.chdir(tmp_path)
         cp = SqliteCheckpointer(Path("relative-path.db"))
-        await cp.create_run("wf-1")
-        run = cp.get_run("wf-1")
-        assert run is not None
+        try:
+            await cp.create_run("wf-1")
+            run = cp.get_run("wf-1")
+            assert run is not None
+        finally:
+            await cp.close()
 
 
 class TestSyncReads:

--- a/tests/test_cli/test_runs_cli.py
+++ b/tests/test_cli/test_runs_cli.py
@@ -6,6 +6,7 @@ Uses CliRunner to test command output without subprocess overhead.
 import json
 
 import pytest
+import pytest_asyncio
 
 # Skip all if optional dependencies are not installed
 typer = pytest.importorskip("typer")
@@ -36,51 +37,57 @@ def db_path(tmp_path):
     return str(tmp_path / "test.db")
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def populated_db(db_path):
     """Create a DB with a completed run."""
     cp = SqliteCheckpointer(db_path)
     cp.policy = CheckpointPolicy(durability="sync", retention="full")
 
-    r = AsyncRunner(checkpointer=cp)
-    graph = Graph([double, triple])
-    await r.run(graph, {"x": 5}, workflow_id="run-test")
+    try:
+        r = AsyncRunner(checkpointer=cp)
+        graph = Graph([double, triple])
+        await r.run(graph, {"x": 5}, workflow_id="run-test")
+        yield db_path
+    finally:
+        await cp.close()
 
-    return db_path
 
-
-@pytest.fixture
+@pytest_asyncio.fixture
 async def lineage_db(db_path):
     """Create a DB with root + fork lineage."""
     cp = SqliteCheckpointer(db_path)
     cp.policy = CheckpointPolicy(durability="sync", retention="full")
 
-    r = AsyncRunner(checkpointer=cp)
-    graph = Graph([double, triple])
-    await r.run(graph, {"x": 5}, workflow_id="run-test")
-    checkpoint = cp.checkpoint("run-test")
-    await r.run(graph, {"x": 7}, checkpoint=checkpoint, workflow_id="run-test-fork")
+    try:
+        r = AsyncRunner(checkpointer=cp)
+        graph = Graph([double, triple])
+        await r.run(graph, {"x": 5}, workflow_id="run-test")
+        checkpoint = cp.checkpoint("run-test")
+        await r.run(graph, {"x": 7}, checkpoint=checkpoint, workflow_id="run-test-fork")
+        yield db_path
+    finally:
+        await cp.close()
 
-    return db_path
 
-
-@pytest.fixture
+@pytest_asyncio.fixture
 async def hierarchy_db(db_path):
     """Create DB with one parent run and two child runs."""
     cp = SqliteCheckpointer(db_path)
     cp.policy = CheckpointPolicy(durability="sync", retention="full")
 
-    await cp.create_run("batch-1", graph_name="g")
-    await cp.update_run_status("batch-1", WorkflowStatus.COMPLETED, duration_ms=5300.0, node_count=10, error_count=0)
-    await cp.create_run("batch-1/0", graph_name="g", parent_run_id="batch-1")
-    await cp.update_run_status("batch-1/0", WorkflowStatus.COMPLETED, duration_ms=5200.0, node_count=2, error_count=0)
-    await cp.create_run("batch-1/1", graph_name="g", parent_run_id="batch-1")
-    await cp.update_run_status("batch-1/1", WorkflowStatus.FAILED, duration_ms=5400.0, node_count=2, error_count=1)
+    try:
+        await cp.create_run("batch-1", graph_name="g")
+        await cp.update_run_status("batch-1", WorkflowStatus.COMPLETED, duration_ms=5300.0, node_count=10, error_count=0)
+        await cp.create_run("batch-1/0", graph_name="g", parent_run_id="batch-1")
+        await cp.update_run_status("batch-1/0", WorkflowStatus.COMPLETED, duration_ms=5200.0, node_count=2, error_count=0)
+        await cp.create_run("batch-1/1", graph_name="g", parent_run_id="batch-1")
+        await cp.update_run_status("batch-1/1", WorkflowStatus.FAILED, duration_ms=5400.0, node_count=2, error_count=1)
+        yield db_path
+    finally:
+        await cp.close()
 
-    return db_path
 
-
-@pytest.fixture
+@pytest_asyncio.fixture
 async def paused_db(db_path):
     """Create a DB with a paused workflow."""
     cp = SqliteCheckpointer(db_path)
@@ -93,10 +100,13 @@ async def paused_db(db_path):
     def finalize(decision: str) -> str:
         return decision
 
-    graph = Graph([approval, finalize])
-    runner = AsyncRunner(checkpointer=cp)
-    await runner.run(graph, workflow_id="run-paused")
-    return db_path
+    try:
+        graph = Graph([approval, finalize])
+        runner = AsyncRunner(checkpointer=cp)
+        await runner.run(graph, workflow_id="run-paused")
+        yield db_path
+    finally:
+        await cp.close()
 
 
 class TestRunsShow:

--- a/tests/test_gate_activation_scheduling.py
+++ b/tests/test_gate_activation_scheduling.py
@@ -219,32 +219,38 @@ class TestChatAppE2E:
         from hypergraph.checkpointers import SqliteCheckpointer
 
         cp = SqliteCheckpointer(str(tmp_path / "chat.db"))
-        runner = AsyncRunner(checkpointer=cp)
-        graph = CHAT_GRAPH.bind(messages=[], max_turns=3)
+        try:
+            runner = AsyncRunner(checkpointer=cp)
+            graph = CHAT_GRAPH.bind(messages=[], max_turns=3)
 
-        r1 = await runner.run(graph, workflow_id="t", user_input="hello")
-        assert r1.paused
-        msgs = r1["messages"]
-        assert len(msgs) == 2  # user + assistant
-        assert msgs[0]["role"] == "user"
-        assert msgs[1]["role"] == "assistant"
+            r1 = await runner.run(graph, workflow_id="t", user_input="hello")
+            assert r1.paused
+            msgs = r1["messages"]
+            assert len(msgs) == 2  # user + assistant
+            assert msgs[0]["role"] == "user"
+            assert msgs[1]["role"] == "assistant"
 
-        r2 = await runner.run(graph, workflow_id="t", user_input="more")
-        assert r2.paused
-        assert len(r2["messages"]) == 4
+            r2 = await runner.run(graph, workflow_id="t", user_input="more")
+            assert r2.paused
+            assert len(r2["messages"]) == 4
 
-        r3 = await runner.run(graph, workflow_id="t", user_input="last")
-        assert not r3.paused  # max_turns=3 reached
-        assert len(r3["messages"]) == 6
+            r3 = await runner.run(graph, workflow_id="t", user_input="last")
+            assert not r3.paused  # max_turns=3 reached
+            assert len(r3["messages"]) == 6
+        finally:
+            await cp.close()
 
     @pytest.mark.asyncio
     async def test_single_turn_terminates(self, tmp_path):
         from hypergraph.checkpointers import SqliteCheckpointer
 
         cp = SqliteCheckpointer(str(tmp_path / "chat.db"))
-        runner = AsyncRunner(checkpointer=cp)
-        graph = CHAT_GRAPH.bind(messages=[], max_turns=1)
+        try:
+            runner = AsyncRunner(checkpointer=cp)
+            graph = CHAT_GRAPH.bind(messages=[], max_turns=1)
 
-        r = await runner.run(graph, workflow_id="t", user_input="one shot")
-        assert not r.paused
-        assert len(r["messages"]) == 2
+            r = await runner.run(graph, workflow_id="t", user_input="one shot")
+            assert not r.paused
+            assert len(r["messages"]) == 2
+        finally:
+            await cp.close()

--- a/tests/test_run_log/conftest.py
+++ b/tests/test_run_log/conftest.py
@@ -10,7 +10,7 @@ import time
 from hypergraph import node, route
 
 
-@node
+@node(output_name="embedding")
 def mock_embed(text: str) -> list[float]:
     """Simulates an embedding call (fast, ~1ms)."""
     time.sleep(0.001)

--- a/tests/test_run_log/test_otel_processor.py
+++ b/tests/test_run_log/test_otel_processor.py
@@ -12,7 +12,11 @@ from hypergraph import Graph, SyncRunner, node
 try:
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export import SimpleSpanProcessor
-    from opentelemetry.sdk.trace.export.in_memory import InMemorySpanExporter
+
+    try:
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+    except ImportError:  # pragma: no cover - compatibility with older sdk layout
+        from opentelemetry.sdk.trace.export.in_memory import InMemorySpanExporter
 
     HAS_OTEL_SDK = True
 except ImportError:
@@ -59,11 +63,21 @@ class TestOTelProcessor:
         from opentelemetry import trace
 
         self.exporter = InMemorySpanExporter()
-        provider = TracerProvider()
-        provider.add_span_processor(SimpleSpanProcessor(self.exporter))
-        trace.set_tracer_provider(provider)
+        provider = trace.get_tracer_provider()
+        if not isinstance(provider, TracerProvider):
+            provider = TracerProvider()
+            trace._set_tracer_provider(provider, log=False)  # type: ignore[attr-defined]
+
+        self.span_processor = SimpleSpanProcessor(self.exporter)
+        provider.add_span_processor(self.span_processor)
         yield
         self.exporter.clear()
+        provider._active_span_processor._span_processors = tuple(  # type: ignore[attr-defined]
+            processor
+            for processor in provider._active_span_processor._span_processors
+            if processor is not self.span_processor  # type: ignore[attr-defined]
+        )
+        self.span_processor.shutdown()
 
     def test_sync_run_produces_spans(self):
         """SyncRunner with OTelProcessor exports spans."""

--- a/tests/test_runners/test_async_runner.py
+++ b/tests/test_runners/test_async_runner.py
@@ -701,7 +701,7 @@ class TestDisconnectedSubgraphs:
         runner = AsyncRunner()
 
         # Select only from one subgraph
-        result = await runner.run(graph, {"x": 5, "y": 10})
+        result = await runner.run(graph, {"x": 5})
 
         assert result.status == RunStatus.COMPLETED
         assert "a" in result

--- a/tests/test_runners/test_execution.py
+++ b/tests/test_runners/test_execution.py
@@ -14,7 +14,7 @@ from hypergraph.runners._shared.helpers import (
     get_ready_nodes,
     initialize_state,
 )
-from hypergraph.runners._shared.types import GraphState, NodeExecution
+from hypergraph.runners._shared.types import ExecutionContext, GraphState, NodeExecution
 from hypergraph.runners.async_.executors import AsyncFunctionNodeExecutor
 from hypergraph.runners.async_.superstep import (
     reset_concurrency_limiter,
@@ -426,35 +426,36 @@ class TestSyncFunctionNodeExecutor:
     def setup_method(self):
         self.executor = SyncFunctionNodeExecutor()
         self.state = GraphState()
+        self.ctx = ExecutionContext()
 
     def test_executes_function_with_inputs(self):
         """Function is called with provided inputs."""
-        outputs = self.executor(double, self.state, {"x": 5})
+        outputs = self.executor(double, self.state, {"x": 5}, self.ctx)
         assert outputs == {"doubled": 10}
 
     def test_returns_dict_with_outputs(self):
         """Returns dict mapping output names to values."""
-        outputs = self.executor(add, self.state, {"a": 3, "b": 4})
+        outputs = self.executor(add, self.state, {"a": 3, "b": 4}, self.ctx)
         assert outputs == {"sum": 7}
 
     def test_single_output_wrapped_in_dict(self):
         """Single return value is wrapped in dict."""
-        outputs = self.executor(double, self.state, {"x": 10})
+        outputs = self.executor(double, self.state, {"x": 10}, self.ctx)
         assert outputs == {"doubled": 20}
 
     def test_multiple_outputs_unpacked(self):
         """Tuple return is unpacked to multiple outputs."""
-        outputs = self.executor(split, self.state, {"x": 5})
+        outputs = self.executor(split, self.state, {"x": 5}, self.ctx)
         assert outputs == {"first": 5, "second": 6}
 
     def test_generator_accumulated_to_list(self):
         """Generator output is accumulated to list."""
-        outputs = self.executor(gen_items, self.state, {"n": 3})
+        outputs = self.executor(gen_items, self.state, {"n": 3}, self.ctx)
         assert outputs == {"items": [0, 1, 2]}
 
     def test_side_effect_node_returns_empty_dict(self):
         """Side-effect only nodes return empty dict."""
-        outputs = self.executor(side_effect, self.state, {"x": 5})
+        outputs = self.executor(side_effect, self.state, {"x": 5}, self.ctx)
         assert outputs == {}
 
     def test_exception_propagates(self):
@@ -465,7 +466,7 @@ class TestSyncFunctionNodeExecutor:
             raise ValueError("intentional error")
 
         with pytest.raises(ValueError, match="intentional error"):
-            self.executor(failing, self.state, {"x": 1})
+            self.executor(failing, self.state, {"x": 1}, self.ctx)
 
 
 # === Tests for AsyncFunctionNodeExecutor ===
@@ -477,25 +478,26 @@ class TestAsyncFunctionNodeExecutor:
     def setup_method(self):
         self.executor = AsyncFunctionNodeExecutor()
         self.state = GraphState()
+        self.ctx = ExecutionContext()
 
     async def test_executes_sync_function(self):
         """Sync functions work in async context."""
-        outputs = await self.executor(double, self.state, {"x": 5})
+        outputs = await self.executor(double, self.state, {"x": 5}, self.ctx)
         assert outputs == {"doubled": 10}
 
     async def test_executes_async_function(self):
         """Async functions are awaited."""
-        outputs = await self.executor(async_double, self.state, {"x": 5})
+        outputs = await self.executor(async_double, self.state, {"x": 5}, self.ctx)
         assert outputs == {"doubled": 10}
 
     async def test_async_generator_accumulated(self):
         """Async generators are accumulated to list."""
-        outputs = await self.executor(async_gen_items, self.state, {"n": 3})
+        outputs = await self.executor(async_gen_items, self.state, {"n": 3}, self.ctx)
         assert outputs == {"items": [0, 1, 2]}
 
     async def test_sync_generator_in_async(self):
         """Sync generators work in async context."""
-        outputs = await self.executor(gen_items, self.state, {"n": 3})
+        outputs = await self.executor(gen_items, self.state, {"n": 3}, self.ctx)
         assert outputs == {"items": [0, 1, 2]}
 
 
@@ -508,10 +510,6 @@ class TestRunSuperstepSync:
     def setup_method(self):
         self.executor = SyncFunctionNodeExecutor()
 
-    def _execute_node(self, node, state, inputs):
-        """Simple executor that only handles FunctionNode."""
-        return self.executor(node, state, inputs)
-
     def test_executes_all_ready_nodes(self):
         """All ready nodes are executed."""
 
@@ -523,7 +521,14 @@ class TestRunSuperstepSync:
         state = initialize_state(graph, {"x": 5})
         ready = get_ready_nodes(graph, state)
 
-        new_state = run_superstep_sync(graph, state, ready, {"x": 5}, self._execute_node)
+        new_state = run_superstep_sync(
+            graph,
+            state,
+            ready,
+            {"x": 5},
+            {type(double): self.executor, type(triple): self.executor},
+            ExecutionContext(),
+        )
 
         assert new_state.values["doubled"] == 10
         assert new_state.values["tripled"] == 15
@@ -534,7 +539,7 @@ class TestRunSuperstepSync:
         state = initialize_state(graph, {"x": 5})
         ready = get_ready_nodes(graph, state)
 
-        new_state = run_superstep_sync(graph, state, ready, {"x": 5}, self._execute_node)
+        new_state = run_superstep_sync(graph, state, ready, {"x": 5}, {type(double): self.executor}, ExecutionContext())
 
         assert "doubled" in new_state.values
         assert new_state.values["doubled"] == 10
@@ -545,7 +550,7 @@ class TestRunSuperstepSync:
         state = initialize_state(graph, {"x": 5})
         ready = get_ready_nodes(graph, state)
 
-        new_state = run_superstep_sync(graph, state, ready, {"x": 5}, self._execute_node)
+        new_state = run_superstep_sync(graph, state, ready, {"x": 5}, {type(double): self.executor}, ExecutionContext())
 
         assert new_state.versions["doubled"] == 1
 
@@ -555,7 +560,7 @@ class TestRunSuperstepSync:
         state = initialize_state(graph, {"x": 5})
         ready = get_ready_nodes(graph, state)
 
-        new_state = run_superstep_sync(graph, state, ready, {"x": 5}, self._execute_node)
+        new_state = run_superstep_sync(graph, state, ready, {"x": 5}, {type(double): self.executor}, ExecutionContext())
 
         assert new_state is not state
         assert "doubled" not in state.values
@@ -570,10 +575,6 @@ class TestRunSuperstepAsync:
 
     def setup_method(self):
         self.executor = AsyncFunctionNodeExecutor()
-
-    async def _execute_node(self, node, state, inputs):
-        """Simple executor that only handles FunctionNode."""
-        return await self.executor(node, state, inputs)
 
     async def test_executes_nodes_concurrently(self):
         """Multiple nodes execute concurrently."""
@@ -597,7 +598,14 @@ class TestRunSuperstepAsync:
         state = initialize_state(graph, {"x": 5})
         ready = get_ready_nodes(graph, state)
 
-        new_state = await run_superstep_async(graph, state, ready, {"x": 5}, self._execute_node)
+        new_state = await run_superstep_async(
+            graph,
+            state,
+            ready,
+            {"x": 5},
+            {type(slow_a): self.executor, type(slow_b): self.executor},
+            ExecutionContext(),
+        )
 
         # Verify concurrency: each task must have started before the other finished.
         # If sequential, one task's start would be after the other's end.
@@ -641,7 +649,15 @@ class TestRunSuperstepAsync:
 
         try:
             start = time.time()
-            await run_superstep_async(graph, state, ready, {"x": 5}, self._execute_node, max_concurrency=1)
+            await run_superstep_async(
+                graph,
+                state,
+                ready,
+                {"x": 5},
+                {type(track_a): self.executor, type(track_b): self.executor},
+                ExecutionContext(),
+                max_concurrency=1,
+            )
             elapsed = time.time() - start
 
             # With max_concurrency=1, should be sequential (~0.1s)
@@ -655,7 +671,14 @@ class TestRunSuperstepAsync:
         state = initialize_state(graph, {"x": 5})
         ready = get_ready_nodes(graph, state)
 
-        new_state = await run_superstep_async(graph, state, ready, {"x": 5}, self._execute_node)
+        new_state = await run_superstep_async(
+            graph,
+            state,
+            ready,
+            {"x": 5},
+            {type(async_double): self.executor},
+            ExecutionContext(),
+        )
 
         assert new_state.values["doubled"] == 10
 

--- a/tests/test_runners/test_routing.py
+++ b/tests/test_runners/test_routing.py
@@ -239,6 +239,32 @@ class TestMultiTargetRouting:
         assert "result_a" not in result.values
         assert "result_b" not in result.values
 
+    def test_multi_target_keeps_late_sibling_activation(self):
+        """A multi-target decision should survive until all routed siblings run."""
+
+        @node(output_name="seeded")
+        def seed(x):
+            return x
+
+        @route(targets=["a", "c", END], multi_target=True)
+        def decide(seeded):
+            return ["a", "c"]
+
+        @node(output_name="a_out")
+        def a(seeded):
+            return seeded + 1
+
+        @node(output_name="c_out")
+        def c(a_out):
+            return a_out * 2
+
+        graph = Graph([seed, decide, a, c], entrypoint="seed")
+        result = SyncRunner().run(graph, {"x": 3})
+
+        assert result.status == RunStatus.COMPLETED
+        assert result["a_out"] == 4
+        assert result["c_out"] == 8
+
 
 # =============================================================================
 # Graph Validation Tests


### PR DESCRIPTION
## Problem / Bug / Challenge

The runner design had drifted into hidden side-channels and duplicated state-application logic:

- sync and async runners used `_make_execute_node` closures plus mutable function attributes to thread span IDs, resume payloads, and nested inner logs
- sync and async supersteps duplicated the same post-execution state mutation logic
- the original refactor from the closed `#73` PR never landed, so `master` kept the older runner design
- async checkpointer tests also had a flaky teardown path where `SqliteCheckpointer` fixtures could leave `aiosqlite` worker threads alive past event-loop shutdown
- the architecture docs had drifted behind the codebase and `dev/ARCHITECTURE-MAP.md` was missing entirely

## Before / After

**Before:**

```text
Runners relied on `_make_execute_node()` closures and mutable function attributes
like `current_span_id`, `provided_values`, `is_resuming`, and `last_inner_logs`.

Sync/async supersteps each manually:
- wrote outputs into GraphState
- built NodeExecution records
- consumed gate routing decisions

Async sqlite-backed tests could emit intermittent
`PytestUnhandledThreadExceptionWarning: RuntimeError: Event loop is closed`
during teardown because async fixtures did not explicitly `await cp.close()`.

Architecture docs described the older, smaller subsystem layout and did not
cover the current checkpointer/inspection/integration surfaces.
```

**After:**

```text
Executors now take a typed `ExecutionContext` that carries:
- event processors
- parent span IDs
- workflow IDs
- provided values / resume state
- nested inner-log callbacks

`_make_execute_node()` side-channels are removed from sync and async runners.
Supersteps now share `apply_node_result(...)` for post-execution state updates.

Async checkpointer fixtures explicitly `await cp.close()`, eliminating the
aiosqlite worker-thread shutdown warning in test teardown.

Architecture docs are refreshed and `dev/ARCHITECTURE-MAP.md` is restored to
reflect the current codebase: runners/_shared as the execution kernel,
checkpointers as a first-class subsystem, CLI inspection surfaces, and
optional integrations like DaftRunner.
```

## Test Plan

- [x] `uv run ruff check src/hypergraph/runners src/hypergraph/runners/_shared tests/test_runners/test_execution.py`
- [x] `uv run pytest tests/test_runners/test_execution.py`
- [x] `uv run pytest tests/test_runners/test_delegation.py`
- [x] `uv run pytest tests/test_interrupt_node.py`
- [x] `uv run pytest tests/test_checkpointer/test_lineage_semantics.py tests/test_checkpointer/test_memory.py`
- [x] `uv run pytest tests/test_checkpointer/test_resume.py -k override_workflow_auto_forks_existing_id -W error::pytest.PytestUnhandledThreadExceptionWarning`
- [x] `uv run pytest tests/test_checkpointer/test_sqlite.py tests/test_checkpointer/test_runner_integration.py tests/test_checkpointer/test_lineage_semantics.py tests/test_checkpointer/test_hierarchical_checkpointing.py -W error::pytest.PytestUnhandledThreadExceptionWarning`
- [x] `uv run pytest -W error::pytest.PytestUnhandledThreadExceptionWarning`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-node execution context support across sync/async runtimes.

* **Documentation**
  * New architecture overview and expanded testing guide with async resource teardown guidance.

* **Improvements**
  * Execution now uses an executor registry and centralized context; OpenTelemetry span attributes refined.
  * CLI and runner paths include more robust best-effort async resource cleanup; checkpointer finalization improved.

* **Tests**
  * Many fixtures converted to async teardown; added a multi-target routing test and related cleanup patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->