### PR TITLE
fix(viz): rename input visibility flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ graph.visualize(show_bounded_inputs=True)  # Also show bound inputs in the input
 graph.visualize(filepath="graph.html")     # Save standalone HTML
 ```
 
-Supports dark/light themes, expand/collapse for nested graphs, input toggles (`show_inputs`, `show_bounded_inputs`), and type annotation display. All assets bundled — works offline.
+Supports dark/light themes, expand/collapse for nested graphs, input toggles (`show_inputs`, `show_bounded_inputs` when inputs are shown), and type annotation display. All assets bundled — works offline.
 
 ### Pure Functions Stay Pure
 

--- a/README.md
+++ b/README.md
@@ -225,10 +225,11 @@ See your graph structure instantly — in notebooks or as standalone HTML.
 ```python
 graph.visualize()                          # Display in notebook
 graph.visualize(depth=1, show_types=True)  # Expand nested graphs, show types
+graph.visualize(show_bounded_inputs=True)  # Also show bound inputs in the input lane
 graph.visualize(filepath="graph.html")     # Save standalone HTML
 ```
 
-Supports dark/light themes, expand/collapse for nested graphs, and type annotation display. All assets bundled — works offline.
+Supports dark/light themes, expand/collapse for nested graphs, input toggles (`show_inputs`, `show_bounded_inputs`), and type annotation display. All assets bundled — works offline.
 
 ### Pure Functions Stay Pure
 

--- a/docs/05-how-to/visualize-graphs.md
+++ b/docs/05-how-to/visualize-graphs.md
@@ -25,12 +25,13 @@ This renders an interactive graph diagram inline. Nodes are connected automatica
 
 ```python
 graph.visualize(
-    depth=0,                # How many nested graph levels to expand
-    theme="auto",           # "dark", "light", or "auto"
-    show_types=False,       # Show type annotations on nodes
-    separate_outputs=False, # Render outputs as separate DATA nodes
-    show_external_inputs=False, # Show external INPUT/INPUT_GROUP nodes
-    filepath=None,          # Save to HTML file instead of displaying
+    depth=0,                   # How many nested graph levels to expand
+    theme="auto",              # "dark", "light", or "auto"
+    show_types=False,          # Show type annotations on nodes
+    separate_outputs=False,    # Render outputs as separate DATA nodes
+    show_inputs=True,          # Show INPUT/INPUT_GROUP nodes
+    show_bounded_inputs=False, # Include bound inputs in those INPUT nodes
+    filepath=None,             # Save to HTML file instead of displaying
 )
 ```
 
@@ -71,14 +72,21 @@ graph.visualize(separate_outputs=True)
 
 By default, edges connect functions directly. With `separate_outputs=True`, each output becomes a visible DATA node, making the data flow explicit.
 
-### `show_external_inputs` — Root input visibility
+### `show_inputs` — Root input visibility
 
 ```python
-graph.visualize(show_external_inputs=True)
+graph.visualize(show_inputs=True)
 ```
 
-External INPUT/INPUT_GROUP nodes are hidden by default to reduce clutter in cyclic graphs.  
-Use this option (or the side-panel toggle in the widget) to show or hide them interactively.
+INPUT/INPUT_GROUP nodes are shown by default. Use this option, or the side-panel toggle in the widget, to hide or show them interactively.
+
+### `show_bounded_inputs` — Include bound inputs
+
+```python
+graph.bind(model="gpt-4o").visualize(show_bounded_inputs=True)
+```
+
+Bound inputs are hidden by default so the visualization focuses on the values a caller still needs to provide. Turn this on when you want bound values to appear in the root input lane as INPUT/INPUT_GROUP nodes.
 
 ### `filepath` — Save to HTML
 
@@ -112,7 +120,7 @@ When nested graphs are expanded, cross-boundary edges remap to the visible inter
 
 - Containers are visual groups, not executable endpoints.
 - Dashed/control edges should never originate from a container START marker.
-- Shared values (for example `messages`) anchor to the correct internal endpoint and do not create phantom external links.
+- Shared values (for example `messages`) anchor to the correct internal endpoint and do not create phantom external links or separate INPUT nodes.
 
 ## Works Offline
 

--- a/docs/05-how-to/visualize-graphs.md
+++ b/docs/05-how-to/visualize-graphs.md
@@ -30,7 +30,7 @@ graph.visualize(
     show_types=False,          # Show type annotations on nodes
     separate_outputs=False,    # Render outputs as separate DATA nodes
     show_inputs=True,          # Show INPUT/INPUT_GROUP nodes
-    show_bounded_inputs=False, # Include bound inputs in those INPUT nodes
+    show_bounded_inputs=False, # Include bound inputs when INPUT nodes are shown
     filepath=None,             # Save to HTML file instead of displaying
 )
 ```
@@ -86,7 +86,7 @@ INPUT/INPUT_GROUP nodes are shown by default. Use this option, or the side-panel
 graph.bind(model="gpt-4o").visualize(show_bounded_inputs=True)
 ```
 
-Bound inputs are hidden by default so the visualization focuses on the values a caller still needs to provide. Turn this on when you want bound values to appear in the root input lane as INPUT/INPUT_GROUP nodes.
+Bound inputs are hidden by default so the visualization focuses on the values a caller still needs to provide. Turn this on when you want bound values to appear in the root input lane as INPUT/INPUT_GROUP nodes. If `show_inputs=False`, the widget hides the whole input lane, so `show_bounded_inputs` has no visible effect.
 
 ### `filepath` — Save to HTML
 

--- a/docs/06-api-reference/graph.md
+++ b/docs/06-api-reference/graph.md
@@ -776,9 +776,9 @@ How to fix:
 
 ### In the visualization
 
-Shared params appear as a purple `↕` badge at the bottom-left of the interactive visualization, and as a `%% shared state: messages` comment in Mermaid output.
+Shared params are omitted from the interactive input lane, shown as a purple `↕` badge in the interactive visualization, and rendered as a `%% shared state: messages` comment in Mermaid output.
 
-### `visualize(*, depth=0, theme="auto", show_types=False, separate_outputs=False, show_external_inputs=False, filepath=None)`
+### `visualize(*, depth=0, theme="auto", show_types=False, separate_outputs=False, show_inputs=True, show_bounded_inputs=False, filepath=None)`
 
 Render an interactive visualization of the graph.
 
@@ -793,7 +793,8 @@ graph.visualize(filepath="graph.html")     # Save standalone HTML
 - `theme` (str): `"dark"`, `"light"`, or `"auto"` (detects from notebook environment). Default: `"auto"`.
 - `show_types` (bool): Display type annotations on nodes. Default: False.
 - `separate_outputs` (bool): Render outputs as separate DATA nodes instead of direct edges. Default: False.
-- `show_external_inputs` (bool): Show external INPUT/INPUT_GROUP nodes. Default: False.
+- `show_inputs` (bool): Show INPUT/INPUT_GROUP nodes. Default: True.
+- `show_bounded_inputs` (bool): Include bound INPUT/INPUT_GROUP nodes when `show_inputs=True`. Default: False.
 - `filepath` (str | None): Save to HTML file instead of displaying inline. Default: None.
 
 **Returns:** `ScrollablePipelineWidget` if `filepath=None`, otherwise `None` (saves to file).

--- a/docs/06-api-reference/graph.md
+++ b/docs/06-api-reference/graph.md
@@ -776,7 +776,7 @@ How to fix:
 
 ### In the visualization
 
-Shared params are omitted from the interactive input lane, shown as a purple `↕` badge in the interactive visualization, and rendered as a `%% shared state: messages` comment in Mermaid output.
+Shared params are omitted from the interactive input lane and from INPUT/INPUT_GROUP rendering, and are rendered as a `%% shared state: messages` comment in Mermaid output.
 
 ### `visualize(*, depth=0, theme="auto", show_types=False, separate_outputs=False, show_inputs=True, show_bounded_inputs=False, filepath=None)`
 
@@ -794,7 +794,7 @@ graph.visualize(filepath="graph.html")     # Save standalone HTML
 - `show_types` (bool): Display type annotations on nodes. Default: False.
 - `separate_outputs` (bool): Render outputs as separate DATA nodes instead of direct edges. Default: False.
 - `show_inputs` (bool): Show INPUT/INPUT_GROUP nodes. Default: True.
-- `show_bounded_inputs` (bool): Include bound INPUT/INPUT_GROUP nodes when `show_inputs=True`. Default: False.
+- `show_bounded_inputs` (bool): Include bound INPUT/INPUT_GROUP nodes when `show_inputs=True`. If `show_inputs=False`, the input lane stays hidden. Default: False.
 - `filepath` (str | None): Save to HTML file instead of displaying inline. Default: None.
 
 **Returns:** `ScrollablePipelineWidget` if `filepath=None`, otherwise `None` (saves to file).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -28,7 +28,7 @@
 - **Runtime scope overrides removed** — passing runtime `select=` or `entrypoint=` to runners now raises `ValueError`. Configure scope on the graph instance instead.
 - **Cycles require constructor entrypoint** — constructing a cyclic graph without `Graph(..., entrypoint=...)` now raises `GraphConfigError`.
 - **Internal output injection tightened** — user-provided values for edge-produced internal parameters are rejected deterministically.
-- **Visualization defaults simplified** — external inputs are hidden by default in `.visualize()` and can be toggled with `show_external_inputs` (API) or the side-panel control.
+- **Visualization defaults simplified** — `.visualize()` now shows unbound external inputs by default via `show_inputs=True`, keeps bound inputs hidden unless `show_bounded_inputs=True`, and never renders shared params as external inputs.
 - **Visualization edge contract tightened** — rendered views now follow the Python-precomputed edge set (no JS-only transitive pruning), so what you see matches the canonical NetworkX topology.
 - **Implicit producer shadow-elimination** — for contested input `p`, edge `u -> v (p)` is removed iff every valid path from `u` to `v` for `p` crosses another producer of `p` first; unresolved cases raise `GraphConfigError` at build time.
 

--- a/notebooks/visualization_examples.ipynb
+++ b/notebooks/visualization_examples.ipynb
@@ -141,7 +141,7 @@
    "source": [
     "## 5. Bound Inputs\n",
     "\n",
-    "Inputs that have been bound to specific values appear differently."
+    "Bound inputs are hidden by default. Turn on `show_bounded_inputs=True` when you want them rendered in the input lane."
    ]
   },
   {
@@ -152,7 +152,7 @@
    "source": [
     "# Bind top_k to 5\n",
     "rag_bound = rag.bind(top_k=5)\n",
-    "rag_bound.visualize(show_types=True)"
+    "rag_bound.visualize(show_types=True, show_bounded_inputs=True)"
    ]
   },
   {

--- a/scripts/render_notebook_viz.py
+++ b/scripts/render_notebook_viz.py
@@ -218,6 +218,8 @@ def build_index(output_dir: Path, records: list[VizRecord], *, iframe_height: in
                 "theme",
                 "show_types",
                 "separate_outputs",
+                "show_inputs",
+                "show_bounded_inputs",
                 "width",
                 "height",
             ):

--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -1343,7 +1343,7 @@ class Graph:
         theme: str = "auto",
         show_types: bool = False,
         separate_outputs: bool = False,
-        show_inputs: bool = True,
+        show_inputs: bool | None = None,
         show_bounded_inputs: bool = False,
         show_external_inputs: bool | None = None,
         filepath: str | None = None,
@@ -1358,7 +1358,7 @@ class Graph:
             theme: "dark", "light", or "auto" to detect from environment
             show_types: Whether to show type annotations on nodes
             separate_outputs: Whether to render outputs as separate DATA nodes
-            show_inputs: Whether to show INPUT/INPUT_GROUP nodes
+            show_inputs: Whether to show INPUT/INPUT_GROUP nodes (default: True)
             show_bounded_inputs: Whether to include bound INPUT/INPUT_GROUP nodes
                 when show_inputs=True
             show_external_inputs: Deprecated alias for show_inputs
@@ -1376,12 +1376,16 @@ class Graph:
         from hypergraph.viz import visualize as viz_func
 
         if show_external_inputs is not None:
+            if show_inputs is not None and show_inputs != show_external_inputs:
+                raise TypeError("Pass either show_inputs or show_external_inputs, not both.")
             warnings.warn(
                 "show_external_inputs is deprecated; use show_inputs instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )
             show_inputs = show_external_inputs
+        elif show_inputs is None:
+            show_inputs = True
 
         return viz_func(
             self,

--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -1342,7 +1342,8 @@ class Graph:
         theme: str = "auto",
         show_types: bool = False,
         separate_outputs: bool = False,
-        show_external_inputs: bool = False,
+        show_inputs: bool = True,
+        show_bounded_inputs: bool = False,
         filepath: str | None = None,
     ) -> Any:
         """Create an interactive visualization of this graph.
@@ -1355,7 +1356,8 @@ class Graph:
             theme: "dark", "light", or "auto" to detect from environment
             show_types: Whether to show type annotations on nodes
             separate_outputs: Whether to render outputs as separate DATA nodes
-            show_external_inputs: Whether to show external INPUT/INPUT_GROUP nodes
+            show_inputs: Whether to show INPUT/INPUT_GROUP nodes
+            show_bounded_inputs: Whether to include bound INPUT/INPUT_GROUP nodes
             filepath: Path to save HTML file (default: None, display in notebook)
 
         Returns:
@@ -1375,7 +1377,8 @@ class Graph:
             theme=theme,
             show_types=show_types,
             separate_outputs=separate_outputs,
-            show_external_inputs=show_external_inputs,
+            show_inputs=show_inputs,
+            show_bounded_inputs=show_bounded_inputs,
             filepath=filepath,
         )
 

--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import functools
 import hashlib
+import warnings
 from typing import TYPE_CHECKING, Any
 
 import networkx as nx
@@ -1344,6 +1345,7 @@ class Graph:
         separate_outputs: bool = False,
         show_inputs: bool = True,
         show_bounded_inputs: bool = False,
+        show_external_inputs: bool | None = None,
         filepath: str | None = None,
     ) -> Any:
         """Create an interactive visualization of this graph.
@@ -1358,6 +1360,8 @@ class Graph:
             separate_outputs: Whether to render outputs as separate DATA nodes
             show_inputs: Whether to show INPUT/INPUT_GROUP nodes
             show_bounded_inputs: Whether to include bound INPUT/INPUT_GROUP nodes
+                when show_inputs=True
+            show_external_inputs: Deprecated alias for show_inputs
             filepath: Path to save HTML file (default: None, display in notebook)
 
         Returns:
@@ -1370,6 +1374,14 @@ class Graph:
             >>> graph.visualize(filepath="graph.html")  # Save to HTML file
         """
         from hypergraph.viz import visualize as viz_func
+
+        if show_external_inputs is not None:
+            warnings.warn(
+                "show_external_inputs is deprecated; use show_inputs instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            show_inputs = show_external_inputs
 
         return viz_func(
             self,

--- a/src/hypergraph/viz/AGENTS.md
+++ b/src/hypergraph/viz/AGENTS.md
@@ -58,9 +58,9 @@ Controlled by `EDGE_CONVERGE_TO_CENTER` flag (default: `false`):
 Nodes and edges are **precomputed** for all valid expansion states (and both `separate_outputs` modes).
 
 Key format:
-- `"nodeId:0|sep:0"` (collapsed, merged outputs)
-- `"nodeId:1|sep:1"` (expanded, separate outputs)
-- `"sep:0"` / `"sep:1"` (no expandable nodes)
+- `"nodeId:0|sep:0|ext:1"` (collapsed, merged outputs, inputs shown)
+- `"nodeId:1|sep:1|ext:0"` (expanded, separate outputs, inputs hidden)
+- `"sep:0|ext:1"` / `"sep:1|ext:0"` (no expandable nodes)
 
 Selection happens in App via `expansionStateToKey()` and lookups in `meta.nodesByState` / `meta.edgesByState`.
 

--- a/src/hypergraph/viz/assets/viz.js
+++ b/src/hypergraph/viz/assets/viz.js
@@ -1804,7 +1804,7 @@
           panOnScroll=${Boolean(initialData.meta && initialData.meta.pan_on_scroll)}
           initialSeparateOutputs=${Boolean(initialData.meta && initialData.meta.separate_outputs)}
           initialShowTypes=${Boolean((initialData.meta && initialData.meta.show_types) !== false)}
-          initialShowInputs=${Boolean(initialData.meta && initialData.meta.show_inputs)} />
+          initialShowInputs=${Boolean((initialData.meta && initialData.meta.show_inputs) !== false)} />
       <//>
     `);
     if (fallback) fallback.remove();

--- a/src/hypergraph/viz/assets/viz.js
+++ b/src/hypergraph/viz/assets/viz.js
@@ -1225,7 +1225,7 @@
         <${TooltipButton} onClick=${props.onToggleSeparate} tooltip=${props.separateOutputs ? "Merge Outputs" : "Separate Outputs"} isActive=${props.separateOutputs} theme=${props.theme}>
           ${props.separateOutputs ? html`<${Icons.MergeOutputs} />` : html`<${Icons.SplitOutputs} />`}
         <//>
-        <${TooltipButton} onClick=${props.onToggleExternalInputs} tooltip=${props.showExternalInputs ? "Hide External Inputs" : "Show External Inputs"} isActive=${props.showExternalInputs} theme=${props.theme}><${Icons.ExternalInputs} /><//>
+        <${TooltipButton} onClick=${props.onToggleInputs} tooltip=${props.showInputs ? "Hide Inputs" : "Show Inputs"} isActive=${props.showInputs} theme=${props.theme}><${Icons.ExternalInputs} /><//>
         <${TooltipButton} onClick=${props.onToggleTypes} tooltip=${props.showTypes ? "Hide Types" : "Show Types"} isActive=${props.showTypes} theme=${props.theme}><${Icons.Type} /><//>
         <div className=${'h-px my-1 ' + (props.theme === 'light' ? 'bg-slate-200' : 'bg-slate-700')}></div>
         <${TooltipButton} onClick=${props.onToggleTheme} tooltip=${props.theme === 'dark' ? "Switch to Light Theme" : "Switch to Dark Theme"} theme=${props.theme}>
@@ -1305,8 +1305,8 @@
     var separateOutputs = sepState[0], setSeparateOutputs = sepState[1];
     var typState = useState(props.initialShowTypes);
     var showTypes = typState[0], setShowTypes = typState[1];
-    var extInputsState = useState(props.initialShowExternalInputs);
-    var showExternalInputs = extInputsState[0], setShowExternalInputs = extInputsState[1];
+    var inputsState = useState(props.initialShowInputs);
+    var showInputs = inputsState[0], setShowInputs = inputsState[1];
 
     // Edge convergence state (dev-only controls)
     var convState = useState(EDGE_CONVERGE_TO_CENTER);
@@ -1326,9 +1326,9 @@
       root.__hypergraphVizReady = false;
       setShowTypes(function(p) { return typeof v === 'boolean' ? v : !p; });
     }, []);
-    var onToggleExternalInputs = useCallback(function(v) {
+    var onToggleInputs = useCallback(function(v) {
       root.__hypergraphVizReady = false;
-      setShowExternalInputs(function(p) { return typeof v === 'boolean' ? v : !p; });
+      setShowInputs(function(p) { return typeof v === 'boolean' ? v : !p; });
     }, []);
 
     // Render options hook for tests and dev gallery
@@ -1337,7 +1337,7 @@
         if (!opts) return;
         if (Object.prototype.hasOwnProperty.call(opts, 'separateOutputs')) onToggleSep(!!opts.separateOutputs);
         if (Object.prototype.hasOwnProperty.call(opts, 'showTypes')) onToggleTyp(!!opts.showTypes);
-        if (Object.prototype.hasOwnProperty.call(opts, 'showExternalInputs')) onToggleExternalInputs(!!opts.showExternalInputs);
+        if (Object.prototype.hasOwnProperty.call(opts, 'showInputs')) onToggleInputs(!!opts.showInputs);
         if (Object.prototype.hasOwnProperty.call(opts, 'convergeToCenter')) {
           root.__hypergraphVizReady = false;
           setConvergeToCenter(!!opts.convergeToCenter);
@@ -1369,7 +1369,7 @@
         delete root.__hypergraphVizSetRenderOptions;
         root.removeEventListener('message', onMessage);
       };
-    }, [onToggleSep, onToggleTyp, onToggleExternalInputs, setConvergeToCenter, setConvergenceOffset, setEndpointPadding, setRanksep]);
+    }, [onToggleSep, onToggleTyp, onToggleInputs, setConvergeToCenter, setConvergenceOffset, setEndpointPadding, setRanksep]);
 
     var detState = useState(function() { return detectHostTheme(); });
     var detectedTheme = detState[0], setDetectedTheme = detState[1];
@@ -1388,9 +1388,9 @@
     var nodesByState = (initialData.meta && initialData.meta.nodesByState) || {};
     var expandableNodes = (initialData.meta && initialData.meta.expandableNodes) || [];
 
-    var expansionStateToKey = function(es, sep, showExternalInputs) {
+    var expansionStateToKey = function(es, sep, showInputs) {
       var sepKey = 'sep:' + (sep ? '1' : '0');
-      var extKey = 'ext:' + (showExternalInputs ? '1' : '0');
+      var extKey = 'ext:' + (showInputs ? '1' : '0');
       if (!expandableNodes.length) return sepKey + '|' + extKey;
       var parts = [];
       expandableNodes.forEach(function(id) { parts.push(id + ':' + (es.get(id) ? '1' : '0')); });
@@ -1447,14 +1447,14 @@
 
     // Select precomputed nodes
     var selectedNodes = useMemo(function() {
-      var key = expansionStateToKey(expansionState, separateOutputs, showExternalInputs);
+      var key = expansionStateToKey(expansionState, separateOutputs, showInputs);
       var base = Object.prototype.hasOwnProperty.call(nodesByState, key)
         ? nodesByState[key]
         : (Object.prototype.hasOwnProperty.call(nodesByState, expansionStateToKey(expansionState, separateOutputs, true))
           ? nodesByState[expansionStateToKey(expansionState, separateOutputs, true)]
           : initialData.nodes);
       return base.map(function(n) { return { ...n, data: { ...n.data, theme: activeTheme, showTypes: showTypes, separateOutputs: separateOutputs } }; });
-    }, [expansionState, separateOutputs, showTypes, showExternalInputs, activeTheme, nodesByState, initialData.nodes]);
+    }, [expansionState, separateOutputs, showTypes, showInputs, activeTheme, nodesByState, initialData.nodes]);
 
     var nodesWithCb = useMemo(function() {
       return selectedNodes.map(function(n) {
@@ -1502,11 +1502,11 @@
 
     // Select edges
     var selectedEdges = useMemo(function() {
-      var key = expansionStateToKey(expansionState, separateOutputs, showExternalInputs);
+      var key = expansionStateToKey(expansionState, separateOutputs, showInputs);
       if (Object.prototype.hasOwnProperty.call(edgesByState, key)) return edgesByState[key];
       var fallback = expansionStateToKey(expansionState, separateOutputs, true);
       return Object.prototype.hasOwnProperty.call(edgesByState, fallback) ? edgesByState[fallback] : (initialData.edges || []);
-    }, [expansionState, separateOutputs, showExternalInputs, edgesByState, initialData.edges]);
+    }, [expansionState, separateOutputs, showInputs, edgesByState, initialData.edges]);
 
     useEffect(function() {
       nodesRef.current = nodesWithCb;
@@ -1527,8 +1527,6 @@
     var layoutError = layoutResult.layoutError;
     var layoutVersion = layoutResult.layoutVersion;
     var isLayouting = layoutResult.isLayouting;
-
-    var sharedParams = (initialData.meta && initialData.meta.shared) || [];
 
     var rf = useReactFlow();
     var updateNI = useUpdateNodeInternals();
@@ -1597,8 +1595,8 @@
       return Array.from(expansionState.entries()).filter(function(e) { return !e[1]; }).map(function(e) { return e[0]; }).sort().join(',');
     }, [expansionState]);
     var renderModeKey = useMemo(function() {
-      return 'sep:' + (separateOutputs ? '1' : '0') + '|types:' + (showTypes ? '1' : '0') + '|ext_inputs:' + (showExternalInputs ? '1' : '0');
-    }, [separateOutputs, showTypes, showExternalInputs]);
+      return 'sep:' + (separateOutputs ? '1' : '0') + '|types:' + (showTypes ? '1' : '0') + '|inputs:' + (showInputs ? '1' : '0');
+    }, [separateOutputs, showTypes, showInputs]);
     var refreshKey = useMemo(function() { return expansionKey + '|' + renderModeKey; }, [expansionKey, renderModeKey]);
     var prevRefresh = useRef(null);
     useEffect(function() {
@@ -1772,8 +1770,8 @@
           <${Background} color=${theme === 'light' ? '#94a3b8' : '#334155'} gap=${24} size=${1} variant="dots" />
           <${CustomControls} theme=${theme} onToggleTheme=${toggleTheme} separateOutputs=${separateOutputs}
             onToggleSeparate=${function() { onToggleSep(); }} showTypes=${showTypes}
-            onToggleTypes=${function() { onToggleTyp(); }} showExternalInputs=${showExternalInputs}
-            onToggleExternalInputs=${function() { onToggleExternalInputs(); }} onFitView=${fitWithFixedPadding} />
+            onToggleTypes=${function() { onToggleTyp(); }} showInputs=${showInputs}
+            onToggleInputs=${function() { onToggleInputs(); }} onFitView=${fitWithFixedPadding} />
           ${root.__hypergraph_debug_viz ? html`
             <${DevEdgeControls} theme=${theme} convergeToCenter=${convergeToCenter}
               convergenceOffset=${convergenceOffset} endpointPadding=${endpointPadding} ranksep=${ranksep}
@@ -1783,19 +1781,6 @@
               onChangeRanksep=${function(v) { root.__hypergraphVizReady = false; setRanksep(v); }} />
           ` : null}
         <//>
-        ${sharedParams.length ? html`
-          <div style=${{ position: 'absolute', top: '12px', left: '12px', display: 'flex', gap: '6px', alignItems: 'center', pointerEvents: 'none', zIndex: 5 }}>
-            ${sharedParams.map(function(p) {
-              return html`<span key=${p} style=${{
-                display: 'inline-flex', alignItems: 'center', gap: '4px',
-                padding: '3px 10px', borderRadius: '12px', fontSize: '11px', fontFamily: 'monospace',
-                background: theme === 'light' ? 'rgba(139,92,246,0.1)' : 'rgba(139,92,246,0.15)',
-                border: '1px solid ' + (theme === 'light' ? 'rgba(139,92,246,0.3)' : 'rgba(139,92,246,0.3)'),
-                color: theme === 'light' ? '#6d28d9' : '#a78bfa',
-              }}>↕ ${p}</span>`;
-            })}
-          </div>
-        ` : null}
         ${(!isLayouting && (layoutError || !layoutedNodes.length)) ? html`
           <div className="absolute inset-0 pointer-events-none flex items-center justify-center">
             <div className="px-4 py-2 rounded-lg border text-xs font-mono bg-slate-900/80 text-amber-200 border-amber-500/40 shadow-lg pointer-events-auto">
@@ -1819,7 +1804,7 @@
           panOnScroll=${Boolean(initialData.meta && initialData.meta.pan_on_scroll)}
           initialSeparateOutputs=${Boolean(initialData.meta && initialData.meta.separate_outputs)}
           initialShowTypes=${Boolean((initialData.meta && initialData.meta.show_types) !== false)}
-          initialShowExternalInputs=${Boolean(initialData.meta && initialData.meta.show_external_inputs)} />
+          initialShowInputs=${Boolean(initialData.meta && initialData.meta.show_inputs)} />
       <//>
     `);
     if (fallback) fallback.remove();

--- a/src/hypergraph/viz/debug.py
+++ b/src/hypergraph/viz/debug.py
@@ -582,7 +582,8 @@ async def _extract_debug_data_async(
     depth: int = 0,
     theme: str = "auto",
     separate_outputs: bool = False,
-    show_external_inputs: bool = True,
+    show_inputs: bool = True,
+    show_bounded_inputs: bool = False,
     headless: bool = True,
     timeout: int = 5000,
 ) -> RenderedDebugData:
@@ -603,7 +604,8 @@ async def _extract_debug_data_async(
         depth=depth,
         theme=theme,
         separate_outputs=separate_outputs,
-        show_external_inputs=show_external_inputs,
+        show_inputs=show_inputs,
+        show_bounded_inputs=show_bounded_inputs,
         filepath=temp_path,
         _debug_overlays=True,
     )
@@ -635,7 +637,8 @@ def _extract_debug_data_sync(
     depth: int = 0,
     theme: str = "auto",
     separate_outputs: bool = False,
-    show_external_inputs: bool = True,
+    show_inputs: bool = True,
+    show_bounded_inputs: bool = False,
     headless: bool = True,
     timeout: int = 5000,
 ) -> RenderedDebugData:
@@ -656,7 +659,8 @@ def _extract_debug_data_sync(
         depth=depth,
         theme=theme,
         separate_outputs=separate_outputs,
-        show_external_inputs=show_external_inputs,
+        show_inputs=show_inputs,
+        show_bounded_inputs=show_bounded_inputs,
         filepath=temp_path,
         _debug_overlays=True,
     )
@@ -726,7 +730,8 @@ def _run_async_extract_in_thread(
     depth: int,
     theme: str,
     separate_outputs: bool,
-    show_external_inputs: bool,
+    show_inputs: bool,
+    show_bounded_inputs: bool,
     headless: bool,
     timeout: int,
 ) -> RenderedDebugData:
@@ -751,7 +756,8 @@ def _run_async_extract_in_thread(
                     depth=depth,
                     theme=theme,
                     separate_outputs=separate_outputs,
-                    show_external_inputs=show_external_inputs,
+                    show_inputs=show_inputs,
+                    show_bounded_inputs=show_bounded_inputs,
                     headless=headless,
                     timeout=timeout,
                 )
@@ -783,7 +789,8 @@ def extract_debug_data(
     depth: int = 0,
     theme: str = "auto",
     separate_outputs: bool = False,
-    show_external_inputs: bool = True,
+    show_inputs: bool = True,
+    show_bounded_inputs: bool = False,
     headless: bool = True,
     timeout: int = 5000,
 ) -> RenderedDebugData:
@@ -799,7 +806,8 @@ def extract_debug_data(
         depth: How many levels of nested graphs to expand (default: 0)
         theme: "dark", "light", or "auto" (default: "auto")
         separate_outputs: Show outputs as separate DATA nodes (default: False)
-        show_external_inputs: Show external INPUT/INPUT_GROUP nodes (default: True)
+        show_inputs: Show INPUT/INPUT_GROUP nodes (default: True)
+        show_bounded_inputs: Show bound INPUT/INPUT_GROUP nodes (default: False)
         headless: Run browser in headless mode (default: True)
         timeout: Max time to wait for layout in ms (default: 5000)
 
@@ -832,7 +840,8 @@ def extract_debug_data(
             depth=depth,
             theme=theme,
             separate_outputs=separate_outputs,
-            show_external_inputs=show_external_inputs,
+            show_inputs=show_inputs,
+            show_bounded_inputs=show_bounded_inputs,
             headless=headless,
             timeout=timeout,
         )
@@ -842,7 +851,8 @@ def extract_debug_data(
             depth=depth,
             theme=theme,
             separate_outputs=separate_outputs,
-            show_external_inputs=show_external_inputs,
+            show_inputs=show_inputs,
+            show_bounded_inputs=show_bounded_inputs,
             headless=headless,
             timeout=timeout,
         )

--- a/src/hypergraph/viz/debug.py
+++ b/src/hypergraph/viz/debug.py
@@ -30,6 +30,7 @@ Usage:
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -791,6 +792,7 @@ def extract_debug_data(
     separate_outputs: bool = False,
     show_inputs: bool = True,
     show_bounded_inputs: bool = False,
+    show_external_inputs: bool | None = None,
     headless: bool = True,
     timeout: int = 5000,
 ) -> RenderedDebugData:
@@ -807,7 +809,9 @@ def extract_debug_data(
         theme: "dark", "light", or "auto" (default: "auto")
         separate_outputs: Show outputs as separate DATA nodes (default: False)
         show_inputs: Show INPUT/INPUT_GROUP nodes (default: True)
-        show_bounded_inputs: Show bound INPUT/INPUT_GROUP nodes (default: False)
+        show_bounded_inputs: Show bound INPUT/INPUT_GROUP nodes when show_inputs=True
+            (default: False)
+        show_external_inputs: Deprecated alias for show_inputs
         headless: Run browser in headless mode (default: True)
         timeout: Max time to wait for layout in ms (default: 5000)
 
@@ -833,6 +837,14 @@ def extract_debug_data(
         raise ImportError(
             "playwright is required for extract_debug_data. Install with: pip install playwright && playwright install chromium"
         ) from None
+
+    if show_external_inputs is not None:
+        warnings.warn(
+            "show_external_inputs is deprecated; use show_inputs instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        show_inputs = show_external_inputs
 
     if _is_in_async_context():
         return _run_async_extract_in_thread(

--- a/src/hypergraph/viz/debug.py
+++ b/src/hypergraph/viz/debug.py
@@ -790,7 +790,7 @@ def extract_debug_data(
     depth: int = 0,
     theme: str = "auto",
     separate_outputs: bool = False,
-    show_inputs: bool = True,
+    show_inputs: bool | None = None,
     show_bounded_inputs: bool = False,
     show_external_inputs: bool | None = None,
     headless: bool = True,
@@ -839,12 +839,16 @@ def extract_debug_data(
         ) from None
 
     if show_external_inputs is not None:
+        if show_inputs is not None and show_inputs != show_external_inputs:
+            raise TypeError("Pass either show_inputs or show_external_inputs, not both.")
         warnings.warn(
             "show_external_inputs is deprecated; use show_inputs instead.",
             DeprecationWarning,
             stacklevel=2,
         )
         show_inputs = show_external_inputs
+    elif show_inputs is None:
+        show_inputs = True
 
     if _is_in_async_context():
         return _run_async_extract_in_thread(

--- a/src/hypergraph/viz/mermaid.py
+++ b/src/hypergraph/viz/mermaid.py
@@ -753,7 +753,13 @@ def to_mermaid(
         node_class_map[start_id] = "start"
 
     # --- Input nodes ---
-    input_groups = build_input_groups(input_spec, param_to_consumers, bound_params)
+    input_groups = build_input_groups(
+        input_spec,
+        param_to_consumers,
+        bound_params,
+        set(shared_params),
+        False,
+    )
     if input_groups:
         lines.append("    %% Inputs")
     for group in input_groups:

--- a/src/hypergraph/viz/renderer/__init__.py
+++ b/src/hypergraph/viz/renderer/__init__.py
@@ -33,7 +33,8 @@ def render_graph(
     theme: str = "auto",
     show_types: bool = False,
     separate_outputs: bool = False,
-    show_external_inputs: bool = True,
+    show_inputs: bool = True,
+    show_bounded_inputs: bool = False,
     debug_overlays: bool = False,
 ) -> dict[str, Any]:
     """Convert a flattened NetworkX graph to React Flow JSON format.
@@ -44,7 +45,8 @@ def render_graph(
         theme: "dark", "light", or "auto" (detect from environment)
         show_types: Whether to show type annotations
         separate_outputs: Whether to render outputs as separate DATA nodes
-        show_external_inputs: Whether to show external INPUT/INPUT_GROUP nodes by default
+        show_inputs: Whether to show INPUT/INPUT_GROUP nodes by default
+        show_bounded_inputs: Whether to include bound INPUT/INPUT_GROUP nodes by default
         debug_overlays: Whether to enable debug overlays (internal use)
 
     Returns:
@@ -69,6 +71,7 @@ def render_graph(
         input_spec,
         show_types,
         theme,
+        show_bounded_inputs=show_bounded_inputs,
         input_groups=None,
         graph_output_visibility=graph_output_visibility,
         input_consumer_mode=input_consumer_mode,
@@ -80,6 +83,7 @@ def render_graph(
         input_spec,
         show_types,
         theme,
+        show_bounded_inputs=show_bounded_inputs,
         graph_output_visibility=graph_output_visibility,
         input_groups=None,
         input_consumer_mode=input_consumer_mode,
@@ -88,7 +92,7 @@ def render_graph(
     # Use pre-computed edges for the initial state
     initial_state_key = expansion_state_to_key(expansion_state)
     sep_key = "sep:1" if separate_outputs else "sep:0"
-    ext_key = "ext:1" if show_external_inputs else "ext:0"
+    ext_key = "ext:1" if show_inputs else "ext:0"
     base_key = f"{initial_state_key}|{sep_key}" if initial_state_key else sep_key
     full_initial_key = f"{base_key}|{ext_key}"
     initial_edges = edges_by_state.get(full_initial_key, [])
@@ -106,7 +110,8 @@ def render_graph(
             "initial_depth": depth,
             "separate_outputs": separate_outputs,
             "show_types": show_types,
-            "show_external_inputs": show_external_inputs,
+            "show_inputs": show_inputs,
+            "show_bounded_inputs": show_bounded_inputs,
             "debug_overlays": debug_overlays,
             "output_to_producer": output_to_producer_deepest,
             "param_to_consumer": param_to_consumer_deepest,

--- a/src/hypergraph/viz/renderer/edges.py
+++ b/src/hypergraph/viz/renderer/edges.py
@@ -588,7 +588,8 @@ def compute_edges_for_state(
     show_types: bool,
     theme: str,
     separate_outputs: bool = False,
-    show_external_inputs: bool = True,
+    show_inputs: bool = True,
+    show_bounded_inputs: bool = False,
     input_groups: list[dict[str, Any]] | None = None,
     graph_output_visibility: dict[str, set[str]] | None = None,
     input_consumer_mode: str = "all",
@@ -596,7 +597,7 @@ def compute_edges_for_state(
     """Compute edges for a specific expansion state."""
     edges: list[dict[str, Any]] = []
 
-    if show_external_inputs:
+    if show_inputs:
         param_to_consumers = build_param_to_consumer_map(
             flat_graph,
             expansion_state,
@@ -604,8 +605,15 @@ def compute_edges_for_state(
         )
 
         bound_params = set(input_spec.get("bound", {}).keys())
+        shared_params = set(flat_graph.graph.get("shared", ()))
         if input_groups is None:
-            input_groups = build_input_groups(input_spec, param_to_consumers, bound_params)
+            input_groups = build_input_groups(
+                input_spec,
+                param_to_consumers,
+                bound_params,
+                shared_params,
+                show_bounded_inputs,
+            )
 
         # 1. Add edges from INPUT/INPUT_GROUP nodes to their consumers
         for group in input_groups:

--- a/src/hypergraph/viz/renderer/nodes.py
+++ b/src/hypergraph/viz/renderer/nodes.py
@@ -46,11 +46,15 @@ def build_input_groups(
     input_spec: dict[str, Any],
     param_to_consumers: dict[str, list[str]],
     bound_params: set[str],
+    shared_params: set[str],
+    show_bounded_inputs: bool,
 ) -> list[dict[str, Any]]:
     """Build stable input groups for rendering and edge routing."""
     required = input_spec.get("required", ())
     optional = input_spec.get("optional", ())
-    external_inputs = set(required) | set(optional)
+    external_inputs = (set(required) | set(optional)) - shared_params
+    if not show_bounded_inputs:
+        external_inputs -= bound_params
 
     groups = group_inputs_by_consumers_and_bound(external_inputs, param_to_consumers, bound_params)
 
@@ -70,11 +74,15 @@ def build_input_groups(
 def build_classic_input_groups(
     input_spec: dict[str, Any],
     bound_params: set[str],
+    shared_params: set[str],
+    show_bounded_inputs: bool,
 ) -> list[dict[str, Any]]:
     """Build single-parameter input groups (classic layout behavior)."""
     required = input_spec.get("required", ())
     optional = input_spec.get("optional", ())
-    params = sorted(set(required) | set(optional))
+    params = sorted((set(required) | set(optional)) - shared_params)
+    if not show_bounded_inputs:
+        params = [param for param in params if param not in bound_params]
     return [{"params": [param], "is_bound": param in bound_params} for param in params]
 
 
@@ -201,10 +209,18 @@ def create_input_nodes(
     param_to_consumers: dict[str, list[str]],
     expansion_state: dict[str, bool],
     input_groups: list[dict[str, Any]] | None = None,
+    show_bounded_inputs: bool = False,
 ) -> None:
     """Create INPUT nodes for external input parameters, grouping where possible."""
     if input_groups is None:
-        input_groups = build_input_groups(input_spec, param_to_consumers, bound_params)
+        shared_params = set(flat_graph.graph.get("shared", ()))
+        input_groups = build_input_groups(
+            input_spec,
+            param_to_consumers,
+            bound_params,
+            shared_params,
+            show_bounded_inputs,
+        )
 
     for group in input_groups:
         params = group["params"]

--- a/src/hypergraph/viz/renderer/precompute.py
+++ b/src/hypergraph/viz/renderer/precompute.py
@@ -36,7 +36,8 @@ def compute_nodes_for_state(
     show_types: bool,
     theme: str,
     separate_outputs: bool = False,
-    show_external_inputs: bool = True,
+    show_inputs: bool = True,
+    show_bounded_inputs: bool = False,
     input_groups: list[dict[str, Any]] | None = None,
     input_consumer_mode: str = "all",
     graph_output_visibility: dict[str, set[str]] | None = None,
@@ -47,14 +48,21 @@ def compute_nodes_for_state(
     self_loop_nodes = {source for source, target in flat_graph.edges() if source == target and is_node_visible(source, flat_graph, expansion_state)}
 
     bound_params = set(input_spec.get("bound", {}).keys())
-    if show_external_inputs:
+    shared_params = set(flat_graph.graph.get("shared", ()))
+    if show_inputs:
         param_to_consumer = build_param_to_consumer_map(
             flat_graph,
             expansion_state,
             mode=input_consumer_mode,
         )
         if input_groups is None:
-            input_groups = build_input_groups(input_spec, param_to_consumer, bound_params)
+            input_groups = build_input_groups(
+                input_spec,
+                param_to_consumer,
+                bound_params,
+                shared_params,
+                show_bounded_inputs,
+            )
 
         create_input_nodes(
             nodes,
@@ -66,6 +74,7 @@ def compute_nodes_for_state(
             param_to_consumer,
             expansion_state,
             input_groups,
+            show_bounded_inputs=show_bounded_inputs,
         )
 
     for node_id, attrs in flat_graph.nodes(data=True):
@@ -118,6 +127,7 @@ def precompute_all_edges(
     input_spec: dict[str, Any],
     show_types: bool,
     theme: str,
+    show_bounded_inputs: bool = False,
     input_groups: list[dict[str, Any]] | None = None,
     graph_output_visibility: dict[str, set[str]] | None = None,
     input_consumer_mode: str = "all",
@@ -128,7 +138,7 @@ def precompute_all_edges(
     if not expandable_nodes:
         edges_by_state: dict[str, list[dict[str, Any]]] = {}
         for separate_outputs in (False, True):
-            for show_external_inputs in (False, True):
+            for show_inputs in (False, True):
                 edges = compute_edges_for_state(
                     flat_graph,
                     {},
@@ -136,14 +146,15 @@ def precompute_all_edges(
                     show_types,
                     theme,
                     separate_outputs=separate_outputs,
-                    show_external_inputs=show_external_inputs,
+                    show_inputs=show_inputs,
+                    show_bounded_inputs=show_bounded_inputs,
                     input_groups=input_groups,
                     graph_output_visibility=graph_output_visibility,
                     input_consumer_mode=input_consumer_mode,
                 )
-                key = _compose_state_key("", separate_outputs, show_external_inputs)
+                key = _compose_state_key("", separate_outputs, show_inputs)
                 edges_by_state[key] = edges
-                if show_external_inputs:
+                if show_inputs:
                     edges_by_state[_compose_legacy_state_key("", separate_outputs)] = edges
         return edges_by_state, []
 
@@ -153,7 +164,7 @@ def precompute_all_edges(
     for state in valid_states:
         exp_key = expansion_state_to_key(state)
         for separate_outputs in (False, True):
-            for show_external_inputs in (False, True):
+            for show_inputs in (False, True):
                 edges = compute_edges_for_state(
                     flat_graph,
                     state,
@@ -161,14 +172,15 @@ def precompute_all_edges(
                     show_types,
                     theme,
                     separate_outputs=separate_outputs,
-                    show_external_inputs=show_external_inputs,
+                    show_inputs=show_inputs,
+                    show_bounded_inputs=show_bounded_inputs,
                     input_groups=input_groups,
                     graph_output_visibility=graph_output_visibility,
                     input_consumer_mode=input_consumer_mode,
                 )
-                key = _compose_state_key(exp_key, separate_outputs, show_external_inputs)
+                key = _compose_state_key(exp_key, separate_outputs, show_inputs)
                 edges_by_state[key] = edges
-                if show_external_inputs:
+                if show_inputs:
                     edges_by_state[_compose_legacy_state_key(exp_key, separate_outputs)] = edges
 
     return edges_by_state, expandable_nodes
@@ -179,6 +191,7 @@ def precompute_all_nodes(
     input_spec: dict[str, Any],
     show_types: bool,
     theme: str,
+    show_bounded_inputs: bool = False,
     graph_output_visibility: dict[str, set[str]] | None = None,
     input_groups: list[dict[str, Any]] | None = None,
     input_consumer_mode: str = "all",
@@ -189,7 +202,7 @@ def precompute_all_nodes(
     if not expandable_nodes:
         nodes_by_state: dict[str, list[dict[str, Any]]] = {}
         for separate_outputs in (False, True):
-            for show_external_inputs in (False, True):
+            for show_inputs in (False, True):
                 nodes = compute_nodes_for_state(
                     flat_graph,
                     {},
@@ -197,14 +210,15 @@ def precompute_all_nodes(
                     show_types,
                     theme,
                     separate_outputs=separate_outputs,
-                    show_external_inputs=show_external_inputs,
+                    show_inputs=show_inputs,
+                    show_bounded_inputs=show_bounded_inputs,
                     graph_output_visibility=graph_output_visibility,
                     input_groups=input_groups,
                     input_consumer_mode=input_consumer_mode,
                 )
-                key = _compose_state_key("", separate_outputs, show_external_inputs)
+                key = _compose_state_key("", separate_outputs, show_inputs)
                 nodes_by_state[key] = nodes
-                if show_external_inputs:
+                if show_inputs:
                     nodes_by_state[_compose_legacy_state_key("", separate_outputs)] = nodes
         return nodes_by_state, []
 
@@ -214,7 +228,7 @@ def precompute_all_nodes(
     for state in valid_states:
         exp_key = expansion_state_to_key(state)
         for separate_outputs in (False, True):
-            for show_external_inputs in (False, True):
+            for show_inputs in (False, True):
                 nodes = compute_nodes_for_state(
                     flat_graph,
                     state,
@@ -222,14 +236,15 @@ def precompute_all_nodes(
                     show_types,
                     theme,
                     separate_outputs=separate_outputs,
-                    show_external_inputs=show_external_inputs,
+                    show_inputs=show_inputs,
+                    show_bounded_inputs=show_bounded_inputs,
                     graph_output_visibility=graph_output_visibility,
                     input_groups=input_groups,
                     input_consumer_mode=input_consumer_mode,
                 )
-                key = _compose_state_key(exp_key, separate_outputs, show_external_inputs)
+                key = _compose_state_key(exp_key, separate_outputs, show_inputs)
                 nodes_by_state[key] = nodes
-                if show_external_inputs:
+                if show_inputs:
                     nodes_by_state[_compose_legacy_state_key(exp_key, separate_outputs)] = nodes
 
     return nodes_by_state, expandable_nodes
@@ -244,9 +259,9 @@ def _compose_legacy_state_key(expansion_key: str, separate_outputs: bool) -> str
 def _compose_state_key(
     expansion_key: str,
     separate_outputs: bool,
-    show_external_inputs: bool,
+    show_inputs: bool,
 ) -> str:
     """State key including separate-outputs and external-input visibility flags."""
     base = _compose_legacy_state_key(expansion_key, separate_outputs)
-    ext_key = "ext:1" if show_external_inputs else "ext:0"
+    ext_key = "ext:1" if show_inputs else "ext:0"
     return f"{base}|{ext_key}"

--- a/src/hypergraph/viz/widget.py
+++ b/src/hypergraph/viz/widget.py
@@ -69,7 +69,8 @@ def visualize(
     theme: str = "auto",
     show_types: bool = False,
     separate_outputs: bool = False,
-    show_external_inputs: bool = False,
+    show_inputs: bool = True,
+    show_bounded_inputs: bool = False,
     filepath: str | None = None,
     _debug_overlays: bool = False,
 ) -> ScrollablePipelineWidget | None:
@@ -81,7 +82,8 @@ def visualize(
         theme: "dark", "light", or "auto" (default: "auto")
         show_types: Whether to show type annotations (default: False)
         separate_outputs: Whether to render outputs as separate nodes (default: False)
-        show_external_inputs: Whether to show external INPUT/INPUT_GROUP nodes (default: False)
+        show_inputs: Whether to show INPUT/INPUT_GROUP nodes (default: True)
+        show_bounded_inputs: Whether to include bound INPUT/INPUT_GROUP nodes (default: False)
         filepath: Path to save HTML file (default: None, display in notebook)
         _debug_overlays: Internal flag to enable debug overlays (use VizDebugger.visualize())
 
@@ -117,7 +119,8 @@ def visualize(
         theme=theme,
         show_types=show_types,
         separate_outputs=separate_outputs,
-        show_external_inputs=show_external_inputs,
+        show_inputs=show_inputs,
+        show_bounded_inputs=show_bounded_inputs,
         debug_overlays=_debug_overlays,
     )
 

--- a/src/hypergraph/viz/widget.py
+++ b/src/hypergraph/viz/widget.py
@@ -70,7 +70,7 @@ def visualize(
     theme: str = "auto",
     show_types: bool = False,
     separate_outputs: bool = False,
-    show_inputs: bool = True,
+    show_inputs: bool | None = None,
     show_bounded_inputs: bool = False,
     show_external_inputs: bool | None = None,
     filepath: str | None = None,
@@ -104,12 +104,16 @@ def visualize(
         >>> visualize(graph, filepath="graph.html")  # Save to HTML file
     """
     if show_external_inputs is not None:
+        if show_inputs is not None and show_inputs != show_external_inputs:
+            raise TypeError("Pass either show_inputs or show_external_inputs, not both.")
         warnings.warn(
             "show_external_inputs is deprecated; use show_inputs instead.",
             DeprecationWarning,
             stacklevel=2,
         )
         show_inputs = show_external_inputs
+    elif show_inputs is None:
+        show_inputs = True
 
     # Estimate dimensions if not provided
     est_width, est_height = estimate_layout(

--- a/src/hypergraph/viz/widget.py
+++ b/src/hypergraph/viz/widget.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import html as html_module
+import warnings
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -71,6 +72,7 @@ def visualize(
     separate_outputs: bool = False,
     show_inputs: bool = True,
     show_bounded_inputs: bool = False,
+    show_external_inputs: bool | None = None,
     filepath: str | None = None,
     _debug_overlays: bool = False,
 ) -> ScrollablePipelineWidget | None:
@@ -83,7 +85,9 @@ def visualize(
         show_types: Whether to show type annotations (default: False)
         separate_outputs: Whether to render outputs as separate nodes (default: False)
         show_inputs: Whether to show INPUT/INPUT_GROUP nodes (default: True)
-        show_bounded_inputs: Whether to include bound INPUT/INPUT_GROUP nodes (default: False)
+        show_bounded_inputs: Whether to include bound INPUT/INPUT_GROUP nodes when
+            show_inputs=True (default: False)
+        show_external_inputs: Deprecated alias for show_inputs
         filepath: Path to save HTML file (default: None, display in notebook)
         _debug_overlays: Internal flag to enable debug overlays (use VizDebugger.visualize())
 
@@ -99,6 +103,14 @@ def visualize(
         >>> widget = visualize(graph)  # Display in notebook
         >>> visualize(graph, filepath="graph.html")  # Save to HTML file
     """
+    if show_external_inputs is not None:
+        warnings.warn(
+            "show_external_inputs is deprecated; use show_inputs instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        show_inputs = show_external_inputs
+
     # Estimate dimensions if not provided
     est_width, est_height = estimate_layout(
         graph,

--- a/tests/viz/conftest.py
+++ b/tests/viz/conftest.py
@@ -155,7 +155,8 @@ def _viz_cache_key(
     theme: str,
     show_types: bool,
     separate_outputs: bool,
-    show_external_inputs: bool,
+    show_inputs: bool,
+    show_bounded_inputs: bool,
     debug_overlays: bool,
 ) -> tuple:
     """Build a stable cache key for HTML rendering within a test run."""
@@ -172,7 +173,8 @@ def _viz_cache_key(
         theme,
         show_types,
         separate_outputs,
-        show_external_inputs,
+        show_inputs,
+        show_bounded_inputs,
         debug_overlays,
     )
 
@@ -184,7 +186,8 @@ def _cached_html_path(
     theme: str = "auto",
     show_types: bool = False,
     separate_outputs: bool = False,
-    show_external_inputs: bool = True,
+    show_inputs: bool = True,
+    show_bounded_inputs: bool = False,
     debug_overlays: bool = False,
 ) -> str:
     """Render HTML once per cache key and return the cached file path."""
@@ -194,7 +197,8 @@ def _cached_html_path(
         theme,
         show_types,
         separate_outputs,
-        show_external_inputs,
+        show_inputs,
+        show_bounded_inputs,
         debug_overlays,
     )
     digest = hashlib.sha256(repr(cache_key).encode("utf-8")).hexdigest()
@@ -208,7 +212,8 @@ def _cached_html_path(
             theme=theme,
             show_types=show_types,
             separate_outputs=separate_outputs,
-            show_external_inputs=show_external_inputs,
+            show_inputs=show_inputs,
+            show_bounded_inputs=show_bounded_inputs,
             debug_overlays=debug_overlays,
         )
         html_content = generate_widget_html(graph_data)
@@ -581,17 +586,33 @@ def click_to_collapse_container(page, container_id: str) -> None:
     )
 
 
-def render_and_extract(page, graph: Graph, depth: int, temp_path: str, *, show_external_inputs: bool = True) -> dict:
+def render_and_extract(
+    page,
+    graph: Graph,
+    depth: int,
+    temp_path: str,
+    *,
+    show_inputs: bool = True,
+    show_bounded_inputs: bool = False,
+) -> dict:
     """Render graph at given depth and extract edge routing."""
-    cache_path = _cached_html_path(graph, depth=depth, show_external_inputs=show_external_inputs)
+    cache_path = _cached_html_path(graph, depth=depth, show_inputs=show_inputs, show_bounded_inputs=show_bounded_inputs)
     shutil.copyfile(cache_path, temp_path)
     page.goto(f"file://{temp_path}")
     return extract_edge_routing(page)
 
 
-def render_to_page(page, graph: Graph, depth: int, temp_path: str, *, show_external_inputs: bool = True) -> None:
+def render_to_page(
+    page,
+    graph: Graph,
+    depth: int,
+    temp_path: str,
+    *,
+    show_inputs: bool = True,
+    show_bounded_inputs: bool = False,
+) -> None:
     """Render graph to a temp HTML file and navigate the page to it."""
-    cache_path = _cached_html_path(graph, depth=depth, show_external_inputs=show_external_inputs)
+    cache_path = _cached_html_path(graph, depth=depth, show_inputs=show_inputs, show_bounded_inputs=show_bounded_inputs)
     shutil.copyfile(cache_path, temp_path)
     page.goto(f"file://{temp_path}")
     wait_for_debug_ready(page)

--- a/tests/viz/test_interactive_expand.py
+++ b/tests/viz/test_interactive_expand.py
@@ -264,7 +264,7 @@ class TestInteractiveExpandEdgeRouting:
         """Regression: expanding llm must keep should_continue -> ask_user* as feedback edge."""
         graph = make_interrupt_cycle_graph()
 
-        render_and_extract(page, graph, depth=0, temp_path=temp_html_file, show_external_inputs=False)
+        render_and_extract(page, graph, depth=0, temp_path=temp_html_file, show_inputs=False)
         click_to_expand_container(page, "llm")
 
         edge = page.evaluate("""() => {
@@ -291,7 +291,7 @@ class TestInteractiveExpandEdgeRouting:
     def test_interrupt_cycle_depth2_keeps_llm_messages_edge_to_ask_user_entry(self, page, temp_html_file):
         """Depth=2 should render the Python edge llm/add_assistant_message -> ask_user/ask_slack."""
         graph = make_interrupt_cycle_graph()
-        data = render_and_extract(page, graph, depth=2, temp_path=temp_html_file, show_external_inputs=False)
+        data = render_and_extract(page, graph, depth=2, temp_path=temp_html_file, show_inputs=False)
 
         matches = [
             edge for edge in data["edges"].values() if edge["source"] == "llm/add_assistant_message" and edge["target"] == "ask_user/ask_slack"
@@ -301,7 +301,7 @@ class TestInteractiveExpandEdgeRouting:
     def test_interrupt_cycle_after_collapsing_llm_keeps_edge_and_vertical_order(self, page, temp_html_file):
         """Interactive state: collapse llm after depth=2 keeps edge + should_continue below llm."""
         graph = make_interrupt_cycle_graph()
-        render_to_page(page, graph, depth=2, temp_path=temp_html_file, show_external_inputs=False)
+        render_to_page(page, graph, depth=2, temp_path=temp_html_file, show_inputs=False)
         click_to_collapse_container(page, "llm")
 
         data = extract_edge_routing(page)

--- a/tests/viz/test_mermaid.py
+++ b/tests/viz/test_mermaid.py
@@ -149,6 +149,31 @@ class TestBasicMermaid:
         assert "input_text" in mermaid
         assert "input_query" in mermaid
 
+    def test_shared_and_bound_inputs_not_rendered(self):
+        """Shared params and bound inputs stay out of Mermaid input nodes."""
+
+        @node(output_name="messages")
+        def add_message(messages: list[str], user_input: str) -> list[str]:
+            return [*messages, user_input]
+
+        @node(output_name="result")
+        def summarize(messages: list[str], temperature: float) -> str:
+            return "\n".join(messages)
+
+        graph = Graph(
+            nodes=[add_message, summarize],
+            edges=[(add_message, summarize)],
+            shared="messages",
+            entrypoint="add_message",
+        ).bind(temperature=0.7)
+
+        mermaid = graph.to_mermaid()
+
+        assert "input_user_input" in mermaid
+        assert "input_messages" not in mermaid
+        assert "input_temperature" not in mermaid
+        assert "%% shared state: messages" in mermaid
+
     def test_no_emojis_in_output(self):
         """Output contains no emoji characters."""
         graph = Graph(nodes=[embed, retrieve, generate])

--- a/tests/viz/test_renderer.py
+++ b/tests/viz/test_renderer.py
@@ -199,19 +199,60 @@ class TestRenderGraph:
             theme="dark",
             show_types=True,
             depth=2,
-            show_external_inputs=True,
+            show_inputs=True,
+            show_bounded_inputs=True,
         )
 
         assert result["meta"]["theme_preference"] == "dark"
         assert result["meta"]["show_types"] is True
         assert result["meta"]["initial_depth"] == 2
-        assert result["meta"]["show_external_inputs"] is True
+        assert result["meta"]["show_inputs"] is True
+        assert result["meta"]["show_bounded_inputs"] is True
 
-    def test_render_options_external_inputs_visible_by_default(self):
-        """Renderer defaults to including external INPUT/INPUT_GROUP nodes."""
+    def test_render_options_inputs_visible_by_default(self):
+        """Renderer defaults to including INPUT/INPUT_GROUP nodes."""
         graph = Graph(nodes=[double])
         result = render_graph(graph.to_flat_graph())
-        assert result["meta"]["show_external_inputs"] is True
+        assert result["meta"]["show_inputs"] is True
+        assert result["meta"]["show_bounded_inputs"] is False
+
+    def test_render_hides_bound_input_nodes_by_default(self):
+        """Bound inputs stay hidden unless show_bounded_inputs=True."""
+        graph = Graph(nodes=[add]).bind(a=5)
+
+        default_result = render_graph(graph.to_flat_graph())
+        default_input_ids = {n["id"] for n in default_result["nodes"] if n["data"]["nodeType"] in {"INPUT", "INPUT_GROUP"}}
+        assert default_input_ids == {"input_b"}
+
+        expanded_result = render_graph(graph.to_flat_graph(), show_bounded_inputs=True)
+        expanded_input_ids = {n["id"] for n in expanded_result["nodes"] if n["data"]["nodeType"] in {"INPUT", "INPUT_GROUP"}}
+        assert expanded_input_ids == {"input_a", "input_b"}
+
+    def test_render_never_shows_shared_inputs(self):
+        """Shared params should not create INPUT nodes or input edges."""
+
+        @node(output_name="messages")
+        def add_message(messages: list[str], user_input: str) -> list[str]:
+            return [*messages, user_input]
+
+        @node(output_name="result")
+        def summarize(messages: list[str]) -> str:
+            return "\n".join(messages)
+
+        graph = Graph(
+            nodes=[add_message, summarize],
+            edges=[(add_message, summarize)],
+            shared="messages",
+            entrypoint="add_message",
+        )
+
+        result = render_graph(graph.to_flat_graph(), show_bounded_inputs=True)
+        input_ids = {n["id"] for n in result["nodes"] if n["data"]["nodeType"] in {"INPUT", "INPUT_GROUP"}}
+        input_edges = {(e["source"], e["target"]) for e in result["edges"] if e.get("data", {}).get("edgeType") == "input"}
+
+        assert "input_messages" not in input_ids
+        assert input_ids == {"input_user_input"}
+        assert all(source != "input_messages" for source, _ in input_edges)
 
     def test_keeps_dag_dependencies_without_transitive_pruning(self):
         """DAG visualization should keep all declared/inferred dependencies."""
@@ -322,11 +363,11 @@ class TestRenderGraph:
         double_node = next(n for n in result["nodes"] if n["id"] == "inner/double")
         assert double_node.get("parentNode") == "inner"
 
-    def test_interrupt_cycle_hides_all_inputs_when_external_inputs_disabled(self):
+    def test_interrupt_cycle_hides_all_inputs_when_inputs_disabled(self):
         """Notebook regression: no INPUT nodes/edges should appear in any ext:0 state."""
         graph = _build_interrupt_cycle_graph()
 
-        result = render_graph(graph.to_flat_graph(), depth=0, show_external_inputs=False)
+        result = render_graph(graph.to_flat_graph(), depth=0, show_inputs=False)
 
         # Initial state should hide input nodes and input edges.
         assert all(n["data"]["nodeType"] not in {"INPUT", "INPUT_GROUP"} for n in result["nodes"])
@@ -348,7 +389,7 @@ class TestRenderGraph:
         """Notebook regression: should_continue -> ask_user control edge must not disappear."""
         graph = _build_interrupt_cycle_graph()
 
-        result = render_graph(graph.to_flat_graph(), depth=0, show_external_inputs=False)
+        result = render_graph(graph.to_flat_graph(), depth=0, show_inputs=False)
         edges_by_state = result["meta"]["edgesByState"]
         ext0_keys = [k for k in edges_by_state if k.endswith("|ext:0")]
         assert ext0_keys, "Expected ext:0 precomputed states"
@@ -370,7 +411,7 @@ class TestRenderGraph:
     def test_interrupt_cycle_expected_edges_for_0_1_2_expanded_graph_nodes(self):
         """Notebook demo: edge routing should be correct for collapsed/1-expanded/2-expanded states."""
         graph = _build_interrupt_cycle_graph()
-        result = render_graph(graph.to_flat_graph(), depth=0, show_external_inputs=False)
+        result = render_graph(graph.to_flat_graph(), depth=0, show_inputs=False)
         edges_by_state = result["meta"]["edgesByState"]
 
         expected_by_state = {
@@ -426,7 +467,7 @@ class TestRenderGraph:
     def test_interrupt_cycle_messages_feedback_edge_present_in_separate_outputs_mode(self):
         """Notebook regression: llm messages edge to ask_user should not disappear in sep mode."""
         graph = _build_interrupt_cycle_graph()
-        result = render_graph(graph.to_flat_graph(), depth=0, show_external_inputs=False)
+        result = render_graph(graph.to_flat_graph(), depth=0, show_inputs=False)
         edges_by_state = result["meta"]["edgesByState"]
 
         state_collapsed_target = "ask_user:0,llm:1|sep:1|ext:0"

--- a/tests/viz/test_renderer.py
+++ b/tests/viz/test_renderer.py
@@ -1,5 +1,7 @@
 """Tests for the visualization renderer."""
 
+import re
+
 import pytest
 
 from hypergraph import END, Graph, interrupt, node, route
@@ -228,6 +230,8 @@ class TestRenderGraph:
             graph.visualize(show_external_inputs=False, filepath=str(output))
 
         assert output.exists()
+        html = output.read_text()
+        assert re.search(r'"show_inputs"\s*:\s*false', html)
 
     def test_visualize_accepts_show_external_inputs_alias(self, tmp_path):
         """Top-level visualize keeps the old flag as a deprecated alias."""
@@ -238,6 +242,15 @@ class TestRenderGraph:
             visualize(graph, show_external_inputs=False, filepath=str(output))
 
         assert output.exists()
+        html = output.read_text()
+        assert re.search(r'"show_inputs"\s*:\s*false', html)
+
+    def test_visualize_rejects_conflicting_input_flags(self):
+        """Conflicting new/old input flags should fail loudly."""
+        graph = Graph(nodes=[double])
+
+        with pytest.raises(TypeError, match="Pass either show_inputs or show_external_inputs"):
+            visualize(graph, show_inputs=True, show_external_inputs=False)
 
     def test_render_hides_bound_input_nodes_by_default(self):
         """Bound inputs stay hidden unless show_bounded_inputs=True."""

--- a/tests/viz/test_renderer.py
+++ b/tests/viz/test_renderer.py
@@ -1,6 +1,9 @@
 """Tests for the visualization renderer."""
 
+import pytest
+
 from hypergraph import END, Graph, interrupt, node, route
+from hypergraph.viz import visualize
 from hypergraph.viz.renderer import render_graph
 
 
@@ -215,6 +218,26 @@ class TestRenderGraph:
         result = render_graph(graph.to_flat_graph())
         assert result["meta"]["show_inputs"] is True
         assert result["meta"]["show_bounded_inputs"] is False
+
+    def test_graph_visualize_accepts_show_external_inputs_alias(self, tmp_path):
+        """Graph.visualize keeps the old flag as a deprecated alias."""
+        graph = Graph(nodes=[double])
+        output = tmp_path / "graph.html"
+
+        with pytest.warns(DeprecationWarning, match="show_external_inputs is deprecated"):
+            graph.visualize(show_external_inputs=False, filepath=str(output))
+
+        assert output.exists()
+
+    def test_visualize_accepts_show_external_inputs_alias(self, tmp_path):
+        """Top-level visualize keeps the old flag as a deprecated alias."""
+        graph = Graph(nodes=[double])
+        output = tmp_path / "widget.html"
+
+        with pytest.warns(DeprecationWarning, match="show_external_inputs is deprecated"):
+            visualize(graph, show_external_inputs=False, filepath=str(output))
+
+        assert output.exists()
 
     def test_render_hides_bound_input_nodes_by_default(self):
         """Bound inputs stay hidden unless show_bounded_inputs=True."""

--- a/tests/viz/test_scope_aware_visibility.py
+++ b/tests/viz/test_scope_aware_visibility.py
@@ -231,7 +231,7 @@ class TestInputPositioningInsideContainers:
         from hypergraph.viz import extract_debug_data
 
         graph = make_generation_graph()
-        data = extract_debug_data(graph, depth=1, show_external_inputs=True)
+        data = extract_debug_data(graph, depth=1, show_inputs=True)
 
         # Find prompt_building container bounds
         container = None
@@ -283,7 +283,7 @@ class TestInputPositioningInsideContainers:
         from hypergraph.viz import extract_debug_data
 
         graph = make_generation_graph()
-        data = extract_debug_data(graph, depth=1, show_external_inputs=True)
+        data = extract_debug_data(graph, depth=1, show_inputs=True)
 
         # Find prompt_building container bounds
         container = None
@@ -334,7 +334,7 @@ class TestInputPositioningInsideContainers:
         from hypergraph.viz import extract_debug_data
 
         graph = make_generation_graph()
-        data = extract_debug_data(graph, depth=1, show_external_inputs=True)
+        data = extract_debug_data(graph, depth=1, show_inputs=True)
 
         # Find prompt_building container bounds
         container = None
@@ -747,7 +747,7 @@ class TestInputVisibilityWhenCollapsed:
         from hypergraph.viz import extract_debug_data
 
         graph = make_generation_graph()
-        data = extract_debug_data(graph, depth=0, show_external_inputs=True)
+        data = extract_debug_data(graph, depth=0, show_inputs=True)
 
         node_ids = {n["id"] for n in data.nodes}
 

--- a/tests/viz/test_visual_layout_issues.py
+++ b/tests/viz/test_visual_layout_issues.py
@@ -423,7 +423,7 @@ class TestEdgeGaps:
     def test_cross_boundary_edges_do_not_cross_visible_nodes(self, page, temp_html_file):
         """Cross-boundary rerouted edges must avoid crossing unrelated visible nodes."""
         graph = build_triple_nested_graph()
-        render_to_page(page, graph, depth=1, temp_path=temp_html_file, show_external_inputs=True)
+        render_to_page(page, graph, depth=1, temp_path=temp_html_file, show_inputs=True)
 
         result = page.evaluate("""() => {
             const debug = window.__hypergraphVizDebug;
@@ -837,7 +837,7 @@ class TestInputNodeHorizontalSpread:
             return f"{system_prompt} {max_tokens}"
 
         graph = Graph(nodes=[generate])
-        render_to_page(page, graph, depth=1, temp_path=temp_html_file, show_external_inputs=True)
+        render_to_page(page, graph, depth=1, temp_path=temp_html_file, show_inputs=True)
 
         result = page.evaluate("""() => {
             const debug = window.__hypergraphVizDebug;
@@ -889,7 +889,7 @@ class TestInputNodeHorizontalSpread:
             return f"{input_b} {step1_out}"
 
         graph = Graph(nodes=[step1, step2])
-        render_to_page(page, graph, depth=1, temp_path=temp_html_file, show_external_inputs=True)
+        render_to_page(page, graph, depth=1, temp_path=temp_html_file, show_inputs=True)
 
         result = page.evaluate("""() => {
             const debug = window.__hypergraphVizDebug;
@@ -968,7 +968,7 @@ class TestInputNodeHorizontalSpread:
         graph = Graph(nodes=[generate])
         # Bind 2 of the 4 inputs
         bound_graph = graph.bind(temperature=0.7, model="gpt-4")
-        render_to_page(page, bound_graph, depth=1, temp_path=temp_html_file, show_external_inputs=True)
+        render_to_page(page, bound_graph, depth=1, temp_path=temp_html_file, show_inputs=True, show_bounded_inputs=True)
 
         result = page.evaluate("""() => {
             const debug = window.__hypergraphVizDebug;


### PR DESCRIPTION
## Problem / Bug / Challenge

The visualization API still exposed the old `show_external_inputs` flag, which no longer matched the desired defaults:
- `.visualize()` should show inputs by default
- bound inputs should stay hidden by default
- shared params should not render as INPUT/INPUT_GROUP nodes

The docs and notebook showcase also drifted from the new behavior, especially the bound-input example.

## Before / After

**Before:**

```python
graph.visualize(show_external_inputs=False)
rag.bind(top_k=5).visualize(show_types=True)
```

- `.visualize()` used the old public flag name
- the visualization notebook's "Bound Inputs" example no longer actually showed bound inputs
- shared params could still be described/rendered inconsistently across code/docs

**After:**

```python
graph.visualize(show_inputs=True, show_bounded_inputs=False)
rag.bind(top_k=5).visualize(show_types=True, show_bounded_inputs=True)
```

- public API now uses `show_inputs` and `show_bounded_inputs`
- unbound inputs are shown by default, bound inputs are opt-in
- shared params are omitted from INPUT/INPUT_GROUP rendering and remain represented via shared-state UI
- docs/README/notebook showcase now describe and demonstrate the new behavior consistently

## Test Plan

- [x] `uv run pytest tests/viz/test_renderer.py tests/viz/test_scope_aware_visibility.py tests/viz/test_interactive_expand.py tests/viz/test_visual_layout_issues.py -q`
- [x] `uv run python scripts/render_notebook_viz.py --no-open`
- [x] `uv run python scripts/render_notebook_viz.py --no-open notebooks/visualization_examples.ipynb`
- [x] Verified the generated gallery HTML and sample screenshots for the updated visualization examples


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added show_bounded_inputs to optionally display bound inputs in graph visualizations.

* **Updates**
  * Renamed show_external_inputs → show_inputs; inputs are shown by default, bound inputs remain hidden unless enabled.
  * show_bounded_inputs only takes effect when show_inputs is enabled.
  * Deprecated alias for the old flag now emits a deprecation warning.
  * Documentation, examples, notebooks, UI controls, and tests updated to reflect the new controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->