### PR TITLE
feat(graph): add describe summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,15 @@ See the docs for more patterns: [multi-agent orchestration](https://gilad-rubin.
 print(graph.inputs)
 # InputSpec(required=('text', 'query'), optional=('config',), ...)
 
+# Get a compact human-readable summary of the active graph scope
+print(graph.describe())
+# rag
+#   Inputs:
+#     required: text (str), query (str)
+#     optional: top_k (int)
+#   Outputs: embedding (list[float]) → docs (list[str]) → answer (str)
+#   Nodes: embed → retrieve → generate
+
 # Pre-fill inputs for reuse
 configured = graph.bind(model="gpt-4", temperature=0.7)
 
@@ -198,6 +207,17 @@ focused = graph.select("answer", "confidence")
 
 # Start execution from a specific node (skip upstream)
 partial = graph.with_entrypoint("retrieve")
+
+print(partial.describe())
+# rag
+#   Inputs:
+#     required: embedding (list[float]), query (str)
+#     optional: top_k (int)
+#   Outputs: docs (list[str]) → answer (str)
+#   Nodes: retrieve → generate
+
+# Hide type hints when you just want names
+print(graph.describe(show_types=False))
 
 # Enable build-time type checking across node boundaries
 graph = Graph(nodes=[...], strict_types=True)

--- a/docs/06-api-reference/graph.md
+++ b/docs/06-api-reference/graph.md
@@ -229,6 +229,68 @@ The hash excludes:
 
 ## Methods
 
+### `describe(*, show_types=True) -> str`
+
+Return a multiline summary of the active graph scope.
+
+Use `describe()` when you want one scan-friendly answer to:
+- what inputs the graph expects
+- which values are already bound
+- which outputs the configured graph can produce
+- which nodes are active in the current scope
+
+Unlike `graph.outputs`, the summary respects scope-defining configuration such as `with_entrypoint()` and `select()`.
+
+By default, type hints are included for both inputs and outputs when available.
+
+```python
+@node(output_name="embedding")
+def embed(text: str) -> list[float]:
+    return [0.1, 0.2, 0.3]
+
+@node(output_name="docs")
+def retrieve(embedding: list[float], query: str, top_k: int = 5) -> list[str]:
+    return ["doc1", "doc2"]
+
+@node(output_name="answer")
+def generate(docs: list[str]) -> str:
+    return "done"
+
+g = Graph([embed, retrieve, generate], name="rag")
+print(g.describe())
+```
+
+```text
+# rag
+#   Inputs:
+#     required: text (str), query (str)
+#     optional: top_k (int)
+#   Outputs: embedding (list[float]) → docs (list[str]) → answer (str)
+#   Nodes: embed → retrieve → generate
+```
+
+When you slice the graph, the summary follows the active subgraph:
+
+```python
+partial = g.with_entrypoint("retrieve")
+print(partial.describe())
+```
+
+```text
+# rag
+#   Inputs:
+#     required: embedding (list[float]), query (str)
+#     optional: top_k (int)
+#   Outputs: docs (list[str]) → answer (str)
+#   Nodes: retrieve → generate
+```
+
+Hide type hints when you only want names:
+
+```python
+print(g.describe(show_types=False))
+```
+
 ### `bind(**values) -> Graph`
 
 Pre-fill input parameters with values. Returns a new Graph (immutable pattern).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@
 - **`checkpoint=` on `runner.run()`** — explicit fork entrypoint from a saved checkpoint snapshot (`values + steps`).
 - **First-class fork/retry helpers** — low-level `SqliteCheckpointer.fork_workflow()` / `retry_workflow()` (sync) and `fork_workflow_async()` / `retry_workflow_async()` (async) prepare lineage-aware checkpoints when you need manual control.
 - **Graph `structural_hash`** — structure-level compatibility hash used to guard same-`workflow_id` resumes.
+- **`graph.describe()`** — compact human-readable graph summary covering scoped inputs, bound values, outputs, and active nodes. Type hints are shown by default, with `show_types=False` for name-only output.
 - **Run lineage metadata** — persisted `forked_from`, `fork_superstep`, `retry_of`, `retry_index` fields on runs.
 - **Gate decision value persistence** — gates now emit internal `_gate_name` values so routing intent is checkpoint-visible and reconstructible.
 - **Auto-generated workflow IDs for `run()`** — when a checkpointer is configured and `workflow_id` is omitted.

--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -4,14 +4,15 @@ from __future__ import annotations
 
 import functools
 import hashlib
+import types
 import warnings
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Union, get_args, get_origin
 
 import networkx as nx
 
 from hypergraph.graph._conflict import validate_output_conflicts
 from hypergraph.graph._helpers import get_edge_produced_values, sources_of
-from hypergraph.graph.input_spec import InputSpec, compute_input_spec
+from hypergraph.graph.input_spec import InputSpec, _compute_active_scope, _data_only_subgraph, compute_input_spec
 from hypergraph.graph.validation import GraphConfigError, validate_graph
 from hypergraph.nodes.base import HyperNode
 
@@ -70,6 +71,29 @@ def _unique_outputs(nodes: Iterable[HyperNode]) -> tuple[str, ...]:
     """
     all_outputs = [o for n in nodes for o in n.outputs]
     return tuple(dict.fromkeys(all_outputs))
+
+
+def _format_type_hint(type_hint: Any) -> str:
+    """Format a type annotation for human-readable summaries."""
+    if type_hint is type(None):
+        return "None"
+
+    origin = get_origin(type_hint)
+    if origin in (types.UnionType, Union):
+        return " | ".join(_format_type_hint(arg) for arg in get_args(type_hint))
+
+    if origin is not None:
+        origin_name = getattr(origin, "__name__", str(origin).replace("typing.", ""))
+        args = get_args(type_hint)
+        if not args:
+            return origin_name
+        formatted_args = ", ".join(_format_type_hint(arg) for arg in args)
+        return f"{origin_name}[{formatted_args}]"
+
+    if hasattr(type_hint, "__name__"):
+        return type_hint.__name__
+
+    return str(type_hint).replace("typing.", "")
 
 
 class Graph:
@@ -1268,6 +1292,112 @@ class Graph:
         if runner is not None:
             return node.with_runner(runner)
         return node
+
+    def describe(self, *, show_types: bool = True) -> str:
+        """Return a compact human-readable summary of the configured graph."""
+        active_nodes, active_subgraph = _compute_active_scope(
+            self._nodes,
+            self._nx_graph,
+            entrypoints=self._entrypoints,
+            selected=self._selected,
+        )
+        lines = [f"# {self.name or 'unnamed'}", "  Inputs:"]
+        bound_names = set(self.inputs.bound)
+
+        if self.inputs.required:
+            formatted = ", ".join(self._describe_input(param, active_nodes, show_types=show_types) for param in self.inputs.required)
+            lines.append(f"    required: {formatted}")
+        optional_inputs = tuple(param for param in self.inputs.optional if param not in bound_names)
+        if optional_inputs:
+            formatted = ", ".join(self._describe_input(param, active_nodes, show_types=show_types) for param in optional_inputs)
+            lines.append(f"    optional: {formatted}")
+        if self.inputs.bound:
+            lines.append(f"    bound: {', '.join(self.inputs.bound)}")
+        for node_name, params in self.inputs.entrypoints.items():
+            formatted = ", ".join(self._describe_input(param, active_nodes, show_types=show_types) for param in params)
+            lines.append(f"    entrypoint[{node_name}]: {formatted}")
+        if len(lines) == 2:
+            lines.append("    none")
+
+        node_order = self._linear_node_order(active_nodes, active_subgraph)
+        active_outputs = _unique_outputs(active_nodes.values())
+        if node_order and all(len(active_nodes[name].outputs) == 1 for name in node_order):
+            outputs = " → ".join(self._describe_output(active_nodes[name].outputs[0], active_nodes, show_types=show_types) for name in node_order)
+            nodes = " → ".join(node_order)
+        else:
+            outputs = ", ".join(self._describe_output(output, active_nodes, show_types=show_types) for output in active_outputs) or "none"
+            nodes = ", ".join(active_nodes) or "none"
+
+        lines.append(f"  Outputs: {outputs}")
+        lines.append(f"  Nodes: {nodes}")
+        return "\n".join(lines)
+
+    def _describe_input(self, param: str, nodes: dict[str, HyperNode], *, show_types: bool) -> str:
+        """Format one graph input, including merged type hints when available."""
+        if not show_types:
+            return param
+
+        formatted_types: list[str] = []
+        for node in nodes.values():
+            if param not in node.inputs:
+                continue
+            input_type = node.get_input_type(param)
+            if input_type is None:
+                continue
+            formatted = _format_type_hint(input_type)
+            if formatted not in formatted_types:
+                formatted_types.append(formatted)
+
+        if not formatted_types:
+            return param
+        return f"{param} ({' | '.join(formatted_types)})"
+
+    def _describe_output(self, output: str, nodes: dict[str, HyperNode], *, show_types: bool) -> str:
+        """Format one graph output, including merged producer type hints."""
+        if not show_types:
+            return output
+
+        formatted_types: list[str] = []
+        for node in nodes.values():
+            if output not in node.outputs:
+                continue
+            output_type = node.get_output_type(output)
+            if output_type is None:
+                continue
+            formatted = _format_type_hint(output_type)
+            if formatted not in formatted_types:
+                formatted_types.append(formatted)
+
+        if not formatted_types:
+            return output
+        return f"{output} ({' | '.join(formatted_types)})"
+
+    def _linear_node_order(
+        self,
+        nodes: dict[str, HyperNode],
+        nx_graph: nx.DiGraph,
+    ) -> tuple[str, ...] | None:
+        """Return node order for a simple linear data-flow chain, else None."""
+        if not nodes:
+            return ()
+        if len(nodes) == 1:
+            return tuple(nodes)
+
+        data_graph = _data_only_subgraph(nx_graph)
+        if not nx.is_directed_acyclic_graph(data_graph):
+            return None
+        if not nx.is_weakly_connected(data_graph):
+            return None
+        if data_graph.number_of_edges() != len(nodes) - 1:
+            return None
+
+        sources = [name for name in data_graph if data_graph.in_degree(name) == 0]
+        sinks = [name for name in data_graph if data_graph.out_degree(name) == 0]
+        if len(sources) != 1 or len(sinks) != 1:
+            return None
+        if any(data_graph.in_degree(name) > 1 or data_graph.out_degree(name) > 1 for name in data_graph):
+            return None
+        return tuple(nx.topological_sort(data_graph))
 
     def __repr__(self) -> str:
         from hypergraph._utils import plural

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -74,6 +74,106 @@ class TestInputSpec:
         assert spec.all == ("r1", "r2", "o1", "o2", "s1", "s2")
 
 
+class TestGraphDescribe:
+    """Tests for Graph.describe()."""
+
+    def test_describe_linear_graph_with_typed_inputs_and_bound_values(self):
+        class FilterCriteria:
+            pass
+
+        store = object()
+        metadata_filter = object()
+        keyword_filter = object()
+
+        @node(output_name="loaded")
+        def load_items(criteria: FilterCriteria | None, terms: list[str], store) -> list:
+            return []
+
+        @node(output_name="metadata_filtered")
+        def filter_by_metadata(loaded: list, metadata_filter) -> list:
+            return loaded
+
+        @node(output_name="keyword_filtered")
+        def filter_by_keywords(metadata_filtered: list, keyword_filter) -> list:
+            return metadata_filtered
+
+        graph = Graph(
+            [load_items, filter_by_metadata, filter_by_keywords],
+            name="get_candidates",
+        ).bind(
+            store=store,
+            metadata_filter=metadata_filter,
+            keyword_filter=keyword_filter,
+        )
+
+        assert graph.describe() == (
+            "# get_candidates\n"
+            "  Inputs:\n"
+            "    required: criteria (FilterCriteria | None), terms (list[str])\n"
+            "    bound: store, metadata_filter, keyword_filter\n"
+            "  Outputs: loaded (list) → metadata_filtered (list) → keyword_filtered (list)\n"
+            "  Nodes: load_items → filter_by_metadata → filter_by_keywords"
+        )
+
+    def test_describe_branching_graph_uses_lists_instead_of_linear_arrows(self):
+        @node(output_name="a_out")
+        def node_a(x: int) -> int:
+            return x
+
+        @node(output_name="b_out")
+        def node_b(a_out: int) -> int:
+            return a_out * 2
+
+        @node(output_name="c_out")
+        def node_c(a_out: int) -> int:
+            return a_out * 3
+
+        graph = Graph([node_a, node_b, node_c], name="fan_out")
+        lines = graph.describe().splitlines()
+
+        assert lines[0] == "# fan_out"
+        assert "    required: x (int)" in lines
+        assert "  Outputs: a_out (int), b_out (int), c_out (int)" in lines
+        assert "  Nodes: node_a, node_b, node_c" in lines
+
+    def test_describe_entrypoint_scope_excludes_inactive_upstream_nodes_and_outputs(self):
+        @node(output_name="a")
+        def produce(x: int) -> int:
+            return x + 1
+
+        @node(output_name="b")
+        def consume(a: int) -> int:
+            return a * 2
+
+        graph = Graph([produce, consume], name="scoped").with_entrypoint("consume")
+
+        assert graph.describe() == ("# scoped\n  Inputs:\n    required: a (int)\n  Outputs: b (int)\n  Nodes: consume")
+
+    def test_describe_does_not_use_arrows_for_ordering_only_edges(self):
+        @node(output_name="x")
+        def step_a(raw: int) -> int:
+            return raw + 1
+
+        @node(output_name="y")
+        def step_b(other: int) -> int:
+            return other * 2
+
+        graph = Graph([step_a, step_b], name="ordering_only", edges=[(step_a, step_b)])
+        lines = graph.describe().splitlines()
+
+        assert "  Outputs: x (int), y (int)" in lines
+        assert "  Nodes: step_a, step_b" in lines
+
+    def test_describe_can_hide_types(self):
+        @node(output_name="result")
+        def single(x: int) -> int:
+            return x * 2
+
+        graph = Graph([single], name="simple")
+
+        assert graph.describe(show_types=False) == ("# simple\n  Inputs:\n    required: x\n  Outputs: result\n  Nodes: single")
+
+
 class TestGraphConstruction:
     """Test Graph class construction and basic properties."""
 


### PR DESCRIPTION
## Problem / Bug / Challenge

Hypergraph already exposes rich graph introspection primitives (`inputs`, `outputs`, `leaf_outputs`, `get_input_type`, `get_output_type`), but there was no single human-readable summary that combined them. That made it awkward to quickly inspect a graph's active scope, especially after `bind()`, `select()`, or `with_entrypoint()`.

## Before / After

**Before:**

```python
print(graph.inputs.required)
print(graph.inputs.bound)
print(graph.outputs)
print(graph.leaf_outputs)
```

**After:**

```python
print(graph.describe())
# rag
#   Inputs:
#     required: text (str), query (str)
#     optional: top_k (int)
#   Outputs: embedding (list[float]) → docs (list[str]) → answer (str)
#   Nodes: embed → retrieve → generate

print(graph.with_entrypoint("retrieve").describe())
# rag
#   Inputs:
#     required: embedding (list[float]), query (str)
#     optional: top_k (int)
#   Outputs: docs (list[str]) → answer (str)
#   Nodes: retrieve → generate
```

## Test Plan

- [x] `uv run pytest tests/test_graph.py -k describe`
- [x] `uv run pytest tests/test_graph.py`
- [x] `uv run pytest tests/test_repr.py -k GraphRepr`
- [x] `uv run pytest -W error -W 'ignore::pytest.PytestUnraisableExceptionWarning'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `describe()` method to Graph API that returns a compact, human-readable summary of the graph scope.
  * Summary includes inputs (required/optional), bound values, outputs, and node topology with type hints.
  * Use `show_types=False` to hide type information in the description output.
  * Works with partial graphs and respects scope-defining configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->