### PR TITLE
fix(graph): scope describe bound values

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ print(graph.inputs)
 
 # Get a compact human-readable summary of the active graph scope
 print(graph.describe())
-# rag
+# unnamed
 #   Inputs:
 #     required: text (str), query (str)
 #     optional: top_k (int)
@@ -209,7 +209,7 @@ focused = graph.select("answer", "confidence")
 partial = graph.with_entrypoint("retrieve")
 
 print(partial.describe())
-# rag
+# unnamed
 #   Inputs:
 #     required: embedding (list[float]), query (str)
 #     optional: top_k (int)

--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -1302,7 +1302,9 @@ class Graph:
             selected=self._selected,
         )
         lines = [f"# {self.name or 'unnamed'}", "  Inputs:"]
-        bound_names = set(self.inputs.bound)
+        active_input_names = set(self.inputs.all)
+        bound_in_scope = tuple(name for name in self.inputs.bound if name in active_input_names)
+        bound_names = set(bound_in_scope)
 
         if self.inputs.required:
             formatted = ", ".join(self._describe_input(param, active_nodes, show_types=show_types) for param in self.inputs.required)
@@ -1311,8 +1313,8 @@ class Graph:
         if optional_inputs:
             formatted = ", ".join(self._describe_input(param, active_nodes, show_types=show_types) for param in optional_inputs)
             lines.append(f"    optional: {formatted}")
-        if self.inputs.bound:
-            lines.append(f"    bound: {', '.join(self.inputs.bound)}")
+        if bound_in_scope:
+            lines.append(f"    bound: {', '.join(bound_in_scope)}")
         for node_name, params in self.inputs.entrypoints.items():
             formatted = ", ".join(self._describe_input(param, active_nodes, show_types=show_types) for param in params)
             lines.append(f"    entrypoint[{node_name}]: {formatted}")

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -149,6 +149,36 @@ class TestGraphDescribe:
 
         assert graph.describe() == ("# scoped\n  Inputs:\n    required: a (int)\n  Outputs: b (int)\n  Nodes: consume")
 
+    def test_describe_entrypoint_scope_omits_out_of_scope_bound_values(self):
+        @node(output_name="a")
+        def produce(x: int) -> int:
+            return x + 1
+
+        @node(output_name="b")
+        def consume(a: int, cfg: int = 5) -> int:
+            return a + cfg
+
+        graph = Graph([produce, consume], name="scoped").bind(x=1, cfg=9).with_entrypoint("consume")
+
+        assert graph.describe() == ("# scoped\n  Inputs:\n    required: a (int)\n    bound: cfg\n  Outputs: b (int)\n  Nodes: consume")
+
+    def test_describe_select_scope_excludes_inactive_nodes_and_outputs(self):
+        @node(output_name="a")
+        def produce(x: int) -> int:
+            return x + 1
+
+        @node(output_name="b")
+        def consume(a: int) -> int:
+            return a * 2
+
+        @node(output_name="extra")
+        def extra_branch(y: int) -> int:
+            return y - 1
+
+        graph = Graph([produce, consume, extra_branch], name="selected").select("b")
+
+        assert graph.describe() == ("# selected\n  Inputs:\n    required: x (int)\n  Outputs: a (int) → b (int)\n  Nodes: produce → consume")
+
     def test_describe_does_not_use_arrows_for_ordering_only_edges(self):
         @node(output_name="x")
         def step_a(raw: int) -> int:


### PR DESCRIPTION
## Problem / Bug / Challenge

PR #79 was merged before all review bots finished. Two true-positive follow-ups landed after merge:

1. `Graph.describe()` could show bound keys that were no longer inputs in the active scope after `with_entrypoint()` / `select()`.
2. The README example for `graph.describe()` showed `# rag` even though the snippet did not construct a named graph.

## Before / After

**Before:**

```python
graph = Graph([produce, consume], name="scoped").bind(x=1, cfg=9).with_entrypoint("consume")
print(graph.describe())
# scoped
#   Inputs:
#     required: a (int)
#     bound: x, cfg
#   Outputs: b (int)
#   Nodes: consume
```

**After:**

```python
graph = Graph([produce, consume], name="scoped").bind(x=1, cfg=9).with_entrypoint("consume")
print(graph.describe())
# scoped
#   Inputs:
#     required: a (int)
#     bound: cfg
#   Outputs: b (int)
#   Nodes: consume
```

Also adds a `select()`-scoped regression test and fixes the README example headers to match an unnamed graph.

## Test Plan

- [x] `uv run pytest tests/test_graph.py -k describe`
- [x] `uv run pytest tests/test_repr.py -k GraphRepr`
- [x] `uv run pytest tests/test_graph.py`
