### PR TITLE
feat(runners): add show_progress flag and fix progress bar bugs

### DIFF
--- a/src/hypergraph/events/rich_progress.py
+++ b/src/hypergraph/events/rich_progress.py
@@ -359,6 +359,7 @@ class RichProgressProcessor(TypedEventProcessor, AsyncEventProcessor):
         self._started = False
         self._last_refresh: float = 0.0  # monotonic timestamp of last notebook refresh
         self._refresh_dirty = False  # pending refresh not yet flushed
+        self._needs_async_flush = False  # set by _refresh_structural, cleared by on_event_async
         self._manual_notebook_refresh = False
         self._uses_rich_progress = False
 
@@ -437,13 +438,15 @@ class RichProgressProcessor(TypedEventProcessor, AsyncEventProcessor):
         """Force refresh for structural changes (new bars, removed bars).
 
         Bypasses the 100ms throttle since structural updates are infrequent
-        and must be visible immediately.
+        and must be visible immediately. Also signals the async path to yield
+        so Jupyter can flush IOPub.
         """
         if not self._notebook or self._progress is None:
             return
         self._progress.refresh()
         self._last_refresh = time.monotonic()
         self._refresh_dirty = False
+        self._needs_async_flush = True
 
     def _ensure_started(self) -> None:
         """Start the Rich progress display if not already started."""
@@ -590,10 +593,17 @@ class RichProgressProcessor(TypedEventProcessor, AsyncEventProcessor):
                                 self._progress.remove_task(old_bar.rich_task_id)
                             else:
                                 self._progress.update(old_bar.rich_task_id, visible=False)
-                        # Clean up _map_children references
+                        # Clean up _map_children references and fix tree markers
                         for children in self._map_children.values():
                             if old_key in children:
                                 children.remove(old_key)
+                                # Update new last child's marker from ├─ to └─
+                                if children:
+                                    last_key = children[-1]
+                                    last_bar = self._node_bars.get(last_key)
+                                    if last_bar is not None:
+                                        last_desc = self._make_child_description(last_bar.name, last_bar.depth, is_last=True)
+                                        self._progress.update(last_bar.rich_task_id, description=last_desc)
                     parent_info.node_bar_key = None
 
             if self._tty_mode:
@@ -814,11 +824,16 @@ class RichProgressProcessor(TypedEventProcessor, AsyncEventProcessor):
             self._started = False
 
     async def on_event_async(self, event: object) -> None:
-        """Async event handler — dispatches synchronously then yields for notebook flush."""
+        """Async event handler — dispatches synchronously, yields on structural changes.
+
+        Only yields to the event loop after structural updates (bar creation/removal)
+        to flush Jupyter IOPub. High-frequency events (advance/stats) skip the yield.
+        """
         self.on_event(event)
-        if self._notebook:
+        if self._needs_async_flush:
             import asyncio
 
+            self._needs_async_flush = False
             await asyncio.sleep(0)
 
     async def shutdown_async(self) -> None:

--- a/src/hypergraph/events/rich_progress.py
+++ b/src/hypergraph/events/rich_progress.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import html as _html
 import re
 import sys
@@ -11,7 +12,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Literal
 
 from hypergraph._repr import ALIGNUI_WIDGET_THEME, FONT_MONO_STYLE, FONT_SANS_STYLE, MUTED_COLOR, STATUS_COLORS, theme_wrap
-from hypergraph.events.processor import TypedEventProcessor
+from hypergraph.events.processor import AsyncEventProcessor, TypedEventProcessor
 from hypergraph.events.types import RunStatus
 
 if TYPE_CHECKING:
@@ -62,6 +63,7 @@ class _SpanInfo:
     map_parent: str | None = None  # Map span that owns this run
     failures: int = 0  # Failed item count (for map spans)
     succeeded: int = 0  # Succeeded item count (for map spans)
+    node_bar_key: _NodeKey | None = None  # Set by on_node_start, consumed by on_run_start
 
 
 @dataclass
@@ -133,6 +135,12 @@ class _NotebookProgress:
         self._tasks[task_id] = _NotebookTask(description=description, total=max(0, int(total or 0)), stats=stats)
         self._task_order.append(task_id)
         return task_id
+
+    def remove_task(self, task_id: int) -> None:
+        """Remove a task from the display."""
+        self._tasks.pop(task_id, None)
+        with contextlib.suppress(ValueError):
+            self._task_order.remove(task_id)
 
     def update(
         self,
@@ -314,7 +322,7 @@ class _NonTTYMapState:
     logged_milestones: set[int] = field(default_factory=set)
 
 
-class RichProgressProcessor(TypedEventProcessor):
+class RichProgressProcessor(TypedEventProcessor, AsyncEventProcessor):
     """Displays hierarchical progress bars using Rich.
 
     Tracks graph execution events and renders live progress bars with
@@ -424,6 +432,18 @@ class RichProgressProcessor(TypedEventProcessor):
             self._progress.refresh()
             self._last_refresh = time.monotonic()
             self._refresh_dirty = False
+
+    def _refresh_structural(self) -> None:
+        """Force refresh for structural changes (new bars, removed bars).
+
+        Bypasses the 100ms throttle since structural updates are infrequent
+        and must be visible immediately.
+        """
+        if not self._notebook or self._progress is None:
+            return
+        self._progress.refresh()
+        self._last_refresh = time.monotonic()
+        self._refresh_dirty = False
 
     def _ensure_started(self) -> None:
         """Start the Rich progress display if not already started."""
@@ -549,12 +569,41 @@ class RichProgressProcessor(TypedEventProcessor):
 
         if event.is_map and event.map_size is not None:
             info.map_size = event.map_size
+
+            # Detect and remove duplicate node bar from a GraphNode parent.
+            # When a GraphNode triggers runner.map(), we get both a NodeStartEvent
+            # (creating a 0/1 node bar) and this RunStartEvent(is_map=True).
+            # The map bar replaces the node bar at the same depth.
+            replaced_name: str | None = None
+            if parent is not None:
+                parent_info = self._spans.get(parent)
+                if parent_info is not None and parent_info.node_bar_key is not None:
+                    old_key = parent_info.node_bar_key
+                    old_bar = self._node_bars.pop(old_key, None)
+                    if old_bar is not None:
+                        replaced_name = old_bar.name
+                        # Use same depth as the removed bar
+                        info.depth = old_bar.depth
+                        # Hide in Rich TTY / remove from notebook
+                        if self._tty_mode:
+                            if self._notebook and hasattr(self._progress, "remove_task"):
+                                self._progress.remove_task(old_bar.rich_task_id)
+                            else:
+                                self._progress.update(old_bar.rich_task_id, visible=False)
+                        # Clean up _map_children references
+                        for children in self._map_children.values():
+                            if old_key in children:
+                                children.remove(old_key)
+                    parent_info.node_bar_key = None
+
             if self._tty_mode:
-                desc = self._make_map_description(event.graph_name or "Map", info.depth)
+                # Use the parent node's public name if we replaced a bar, else graph name
+                bar_name = replaced_name or event.graph_name or "Map"
+                desc = self._make_map_description(bar_name, info.depth)
                 info.rich_task_id = self._progress.add_task(desc, total=event.map_size, stats="")
-                self._refresh()
+                self._refresh_structural()
             else:
-                name = event.graph_name or "Map"
+                name = replaced_name or event.graph_name or "Map"
                 self._nontty_map_states[span] = _NonTTYMapState(total=event.map_size, name=name)
 
         # If this run is a child of a map, track the relationship
@@ -582,6 +631,10 @@ class RichProgressProcessor(TypedEventProcessor):
         total = self._get_node_total(span)
         map_span = self._find_map_ancestor(span)
 
+        # Record node bar key on span so on_run_start can find it
+        # (used to detect and remove duplicate bars for GraphNode maps)
+        info.node_bar_key = key
+
         if self._tty_mode:
             bar = self._node_bars.get(key)
             if bar is None:
@@ -597,7 +650,7 @@ class RichProgressProcessor(TypedEventProcessor):
 
                 bar.rich_task_id = self._progress.add_task(desc, total=total, stats="")
                 self._node_bars[key] = bar
-                self._refresh()
+                self._refresh_structural()
             elif bar.total < total:
                 bar.total = total
                 self._progress.update(bar.rich_task_id, total=total)
@@ -759,3 +812,15 @@ class RichProgressProcessor(TypedEventProcessor):
             if self._tty_mode:
                 self._progress.stop()
             self._started = False
+
+    async def on_event_async(self, event: object) -> None:
+        """Async event handler — dispatches synchronously then yields for notebook flush."""
+        self.on_event(event)
+        if self._notebook:
+            import asyncio
+
+            await asyncio.sleep(0)
+
+    async def shutdown_async(self) -> None:
+        """Async shutdown — delegates to sync cleanup."""
+        self.shutdown()

--- a/src/hypergraph/runners/_shared/helpers.py
+++ b/src/hypergraph/runners/_shared/helpers.py
@@ -1525,6 +1525,22 @@ def _generate_product_inputs(
         }
 
 
+def ensure_progress_processor(
+    event_processors: list[Any] | None,
+) -> list[Any]:
+    """Ensure exactly one RichProgressProcessor is in the list.
+
+    Returns a new list. If a RichProgressProcessor is already present,
+    the list is returned as-is (copied). Otherwise a default one is prepended.
+    """
+    from hypergraph.events.rich_progress import RichProgressProcessor
+
+    processors = list(event_processors) if event_processors else []
+    if not any(isinstance(p, RichProgressProcessor) for p in processors):
+        processors.insert(0, RichProgressProcessor())
+    return processors
+
+
 def collect_as_lists(
     results: Sequence[RunResult],
     node: GraphNode,

--- a/src/hypergraph/runners/_shared/helpers.py
+++ b/src/hypergraph/runners/_shared/helpers.py
@@ -1528,7 +1528,7 @@ def _generate_product_inputs(
 def ensure_progress_processor(
     event_processors: list[Any] | None,
 ) -> list[Any]:
-    """Ensure exactly one RichProgressProcessor is in the list.
+    """Ensure at least one RichProgressProcessor is in the list.
 
     Returns a new list. If a RichProgressProcessor is already present,
     the list is returned as-is (copied). Otherwise a default one is prepended.

--- a/src/hypergraph/runners/_shared/input_normalization.py
+++ b/src/hypergraph/runners/_shared/input_normalization.py
@@ -9,6 +9,7 @@ RUN_RESERVED_OPTION_NAMES = frozenset(
         "select",
         "max_iterations",
         "event_processors",
+        "show_progress",
         "on_internal_override",
         "_parent_span_id",
     }
@@ -30,6 +31,7 @@ MAP_RESERVED_OPTION_NAMES = frozenset(
         "select",
         "error_handling",
         "event_processors",
+        "show_progress",
         "on_internal_override",
         "_parent_span_id",
     }

--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -183,6 +183,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
         max_concurrency: int | None = None,
         error_handling: ErrorHandling = "raise",
         event_processors: list[EventProcessor] | None = None,
+        show_progress: bool | None = None,
         checkpoint: Any | None = None,
         workflow_id: str | None = None,
         override_workflow: bool = False,
@@ -312,6 +313,11 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                     )
 
         max_iter = max_iterations or self.default_max_iterations
+        effective_show_progress = show_progress if show_progress is not None else getattr(self, "_show_progress", False)
+        if effective_show_progress:
+            from hypergraph.runners._shared.helpers import ensure_progress_processor
+
+            event_processors = ensure_progress_processor(event_processors)
         collector = RunLogCollector()
         all_processors = [collector] + (event_processors or [])
         dispatcher = self._create_dispatcher(all_processors)
@@ -535,6 +541,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
         max_concurrency: int | None = None,
         error_handling: ErrorHandling = "raise",
         event_processors: list[EventProcessor] | None = None,
+        show_progress: bool | None = None,
         workflow_id: str | None = None,
         _parent_span_id: str | None = None,
         _parent_run_id: str | None = None,
@@ -546,6 +553,13 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
             input_values,
             reserved_option_names=ASYNC_MAP_RESERVED_OPTION_NAMES,
         )
+
+        # Resolve show_progress and merge processors
+        effective_show_progress = show_progress if show_progress is not None else getattr(self, "_show_progress", False)
+        if effective_show_progress:
+            from hypergraph.runners._shared.helpers import ensure_progress_processor
+
+            event_processors = ensure_progress_processor(event_processors)
 
         # One-time graph-structural validation
         validate_runner_compatibility(graph, self.capabilities)
@@ -639,6 +653,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                     max_concurrency=max_concurrency,
                     error_handling="continue",
                     event_processors=event_processors,
+                    show_progress=False,
                     workflow_id=child_workflow_id,
                     _parent_span_id=map_span_id,
                     _parent_run_id=workflow_id,

--- a/src/hypergraph/runners/_shared/template_sync.py
+++ b/src/hypergraph/runners/_shared/template_sync.py
@@ -177,6 +177,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
         max_iterations: int | None = None,
         error_handling: ErrorHandling = "raise",
         event_processors: list[EventProcessor] | None = None,
+        show_progress: bool | None = None,
         checkpoint: Any | None = None,
         workflow_id: str | None = None,
         override_workflow: bool = False,
@@ -305,6 +306,11 @@ class SyncRunnerTemplate(BaseRunner, ABC):
                     )
 
         max_iter = max_iterations or self.default_max_iterations
+        effective_show_progress = show_progress if show_progress is not None else getattr(self, "_show_progress", False)
+        if effective_show_progress:
+            from hypergraph.runners._shared.helpers import ensure_progress_processor
+
+            event_processors = ensure_progress_processor(event_processors)
         collector = RunLogCollector()
         all_processors = [collector] + (event_processors or [])
         dispatcher = self._create_dispatcher(all_processors)
@@ -496,6 +502,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
         entrypoint: str | None = None,
         error_handling: ErrorHandling = "raise",
         event_processors: list[EventProcessor] | None = None,
+        show_progress: bool | None = None,
         workflow_id: str | None = None,
         _parent_span_id: str | None = None,
         _parent_run_id: str | None = None,
@@ -507,6 +514,13 @@ class SyncRunnerTemplate(BaseRunner, ABC):
             input_values,
             reserved_option_names=ASYNC_MAP_RESERVED_OPTION_NAMES,
         )
+
+        # Resolve show_progress and merge processors
+        effective_show_progress = show_progress if show_progress is not None else getattr(self, "_show_progress", False)
+        if effective_show_progress:
+            from hypergraph.runners._shared.helpers import ensure_progress_processor
+
+            event_processors = ensure_progress_processor(event_processors)
 
         # One-time graph-structural validation
         validate_runner_compatibility(graph, self.capabilities)
@@ -593,6 +607,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
                     entrypoint=entrypoint,
                     error_handling="continue",
                     event_processors=event_processors,
+                    show_progress=False,
                     workflow_id=child_workflow_id,
                     _parent_span_id=map_span_id,
                     _parent_run_id=workflow_id,

--- a/src/hypergraph/runners/_shared/types.py
+++ b/src/hypergraph/runners/_shared/types.py
@@ -691,6 +691,7 @@ class ExecutionContext:
     """
 
     event_processors: list[EventProcessor] | None = None
+    show_progress: bool | None = None
     parent_span_id: str | None = None
     workflow_id: str | None = None
     run_id: str = ""

--- a/src/hypergraph/runners/async_/executors/graph_node.py
+++ b/src/hypergraph/runners/async_/executors/graph_node.py
@@ -112,6 +112,7 @@ class AsyncGraphNodeExecutor:
                 "clone": node._original_clone(),
                 "error_handling": error_handling,
                 "event_processors": ctx.event_processors,
+                "show_progress": ctx.show_progress,
                 "workflow_id": child_workflow_id,
                 "_parent_span_id": ctx.parent_span_id,
                 "_parent_run_id": ctx.workflow_id,
@@ -130,6 +131,7 @@ class AsyncGraphNodeExecutor:
         # Only pass checkpoint kwargs if the delegated runner supports checkpointing
         run_kwargs: dict[str, Any] = {
             "event_processors": ctx.event_processors,
+            "show_progress": ctx.show_progress,
             "workflow_id": child_workflow_id,
             "_parent_span_id": ctx.parent_span_id,
             "_parent_run_id": ctx.workflow_id,

--- a/src/hypergraph/runners/async_/runner.py
+++ b/src/hypergraph/runners/async_/runner.py
@@ -203,6 +203,8 @@ class AsyncRunner(AsyncRunnerTemplate):
             frontier = ExecutionFrontier.from_scope(scope, max_iterations)
             ctx_base = ExecutionContext(
                 event_processors=event_processors,
+                # Always False: processors already merged above; prevents GraphNode
+                # sub-runners from double-adding RichProgressProcessor.
                 show_progress=False,
                 workflow_id=workflow_id,
                 run_id=run_id,

--- a/src/hypergraph/runners/async_/runner.py
+++ b/src/hypergraph/runners/async_/runner.py
@@ -79,6 +79,7 @@ class AsyncRunner(AsyncRunnerTemplate):
         self,
         cache: CacheBackend | None = None,
         checkpointer: Checkpointer | None = None,
+        show_progress: bool = False,
     ):
         """Initialize AsyncRunner with its node executors.
 
@@ -88,9 +89,12 @@ class AsyncRunner(AsyncRunnerTemplate):
             checkpointer: Optional checkpointer for workflow persistence.
                 Enables save/resume, crash recovery, and cross-process queries.
                 Pass a workflow_id to run() to activate persistence.
+            show_progress: If True, automatically add a RichProgressProcessor
+                to every run() and map() call. Can be overridden per-call.
         """
         self._cache = cache
         self._checkpointer_instance = checkpointer
+        self._show_progress = show_progress
         self._active_signals: dict[str, StopSignal] = {}
         self._executors: dict[type[HyperNode], AsyncNodeExecutor] = {
             FunctionNode: AsyncFunctionNodeExecutor(),
@@ -199,6 +203,7 @@ class AsyncRunner(AsyncRunnerTemplate):
             frontier = ExecutionFrontier.from_scope(scope, max_iterations)
             ctx_base = ExecutionContext(
                 event_processors=event_processors,
+                show_progress=False,
                 workflow_id=workflow_id,
                 run_id=run_id,
                 provided_values=values,

--- a/src/hypergraph/runners/base.py
+++ b/src/hypergraph/runners/base.py
@@ -47,6 +47,7 @@ class BaseRunner(ABC):
         max_iterations: int | None = None,
         error_handling: ErrorHandling = "raise",
         event_processors: list[EventProcessor] | None = None,
+        show_progress: bool | None = None,
         **input_values: Any,
     ) -> RunResult:
         """Execute a graph.
@@ -62,6 +63,8 @@ class BaseRunner(ABC):
                 "raise" (default) re-raises the original exception.
                 "continue" returns RunResult with status=FAILED and partial values.
             event_processors: Optional list of event processors to receive execution events
+            show_progress: Override runner-level show_progress for this call.
+                None = use runner default, True/False = explicit override.
             **input_values: Input values shorthand (merged with values)
 
         Returns:
@@ -81,6 +84,7 @@ class BaseRunner(ABC):
         select: str | list[str] = _UNSET_SELECT,
         on_missing: Literal["ignore", "warn", "error"] = "ignore",
         event_processors: list[EventProcessor] | None = None,
+        show_progress: bool | None = None,
         **input_values: Any,
     ) -> MapResult:
         """Execute a graph multiple times with different inputs.
@@ -97,6 +101,8 @@ class BaseRunner(ABC):
             select: Which outputs to return. "**" (default) = all outputs.
             on_missing: How to handle missing selected outputs.
             event_processors: Optional list of event processors to receive execution events
+            show_progress: Override runner-level show_progress for this call.
+                None = use runner default, True/False = explicit override.
             **input_values: Input values shorthand (merged with values)
 
         Returns:

--- a/src/hypergraph/runners/daft/runner.py
+++ b/src/hypergraph/runners/daft/runner.py
@@ -108,6 +108,7 @@ class DaftRunner(BaseRunner):
         max_iterations: int | None = None,
         error_handling: Literal["raise", "continue"] = "raise",
         event_processors: list[EventProcessor] | None = None,
+        show_progress: bool | None = None,
         **input_values: Any,
     ) -> RunResult:
         """Execute graph once via a 1-row Daft plan."""
@@ -116,7 +117,7 @@ class DaftRunner(BaseRunner):
             input_values,
             reserved_option_names=RUN_RESERVED_OPTION_NAMES,
         )
-        self._warn_ignored(event_processors=event_processors)
+        self._warn_ignored(event_processors=event_processors, show_progress=show_progress)
 
         validate_runner_compatibility(graph, self.capabilities)
         _validate_no_runner_overrides(graph)
@@ -168,6 +169,7 @@ class DaftRunner(BaseRunner):
         select: str | list[str] = _UNSET_SELECT,
         on_missing: Literal["ignore", "warn", "error"] = "ignore",
         event_processors: list[EventProcessor] | None = None,
+        show_progress: bool | None = None,
         error_handling: Literal["raise", "continue"] = "raise",
         **input_values: Any,
     ) -> MapResult:
@@ -177,7 +179,7 @@ class DaftRunner(BaseRunner):
             input_values,
             reserved_option_names=MAP_RESERVED_OPTION_NAMES,
         )
-        self._warn_ignored(event_processors=event_processors)
+        self._warn_ignored(event_processors=event_processors, show_progress=show_progress)
 
         validate_runner_compatibility(graph, self.capabilities)
         _validate_no_runner_overrides(graph)
@@ -400,11 +402,18 @@ class DaftRunner(BaseRunner):
     def _warn_ignored(
         *,
         event_processors: list[EventProcessor] | None = None,
+        show_progress: bool | None = None,
     ) -> None:
-        """Warn if event_processors is non-empty (DaftRunner ignores events)."""
+        """Warn if event_processors or show_progress is set (DaftRunner ignores events)."""
         if event_processors:
             warnings.warn(
                 "DaftRunner does not support event_processors. The provided processors will be ignored.",
+                UserWarning,
+                stacklevel=3,
+            )
+        if show_progress:
+            warnings.warn(
+                "DaftRunner does not support show_progress. The flag will be ignored.",
                 UserWarning,
                 stacklevel=3,
             )

--- a/src/hypergraph/runners/sync/executors/graph_node.py
+++ b/src/hypergraph/runners/sync/executors/graph_node.py
@@ -81,6 +81,7 @@ class SyncGraphNodeExecutor:
                 "clone": node._original_clone(),
                 "error_handling": error_handling,
                 "event_processors": ctx.event_processors,
+                "show_progress": ctx.show_progress,
                 "workflow_id": child_workflow_id,
                 "_parent_span_id": ctx.parent_span_id,
                 "_parent_run_id": ctx.workflow_id,
@@ -96,6 +97,7 @@ class SyncGraphNodeExecutor:
 
         run_kwargs: dict[str, Any] = {
             "event_processors": ctx.event_processors,
+            "show_progress": ctx.show_progress,
             "workflow_id": child_workflow_id,
             "_parent_span_id": ctx.parent_span_id,
             "_parent_run_id": ctx.workflow_id,

--- a/src/hypergraph/runners/sync/runner.py
+++ b/src/hypergraph/runners/sync/runner.py
@@ -170,6 +170,8 @@ class SyncRunner(SyncRunnerTemplate):
         frontier = ExecutionFrontier.from_scope(scope, max_iterations)
         ctx_base = ExecutionContext(
             event_processors=event_processors,
+            # Always False: processors already merged above; prevents GraphNode
+            # sub-runners from double-adding RichProgressProcessor.
             show_progress=False,
             workflow_id=workflow_id,
             run_id=run_id,

--- a/src/hypergraph/runners/sync/runner.py
+++ b/src/hypergraph/runners/sync/runner.py
@@ -61,6 +61,7 @@ class SyncRunner(SyncRunnerTemplate):
         self,
         cache: CacheBackend | None = None,
         checkpointer: Checkpointer | None = None,
+        show_progress: bool = False,
     ):
         """Initialize SyncRunner with its node executors.
 
@@ -70,9 +71,12 @@ class SyncRunner(SyncRunnerTemplate):
             checkpointer: Optional checkpointer for workflow persistence.
                 Must implement SyncCheckpointerProtocol (e.g. SqliteCheckpointer).
                 Pass a workflow_id to run() to activate persistence.
+            show_progress: If True, automatically add a RichProgressProcessor
+                to every run() and map() call. Can be overridden per-call.
         """
         self._cache = cache
         self._checkpointer_instance = checkpointer
+        self._show_progress = show_progress
         self._active_signals: dict[str, StopSignal] = {}
         self._executors: dict[type[HyperNode], NodeExecutor] = {
             FunctionNode: SyncFunctionNodeExecutor(),
@@ -166,6 +170,7 @@ class SyncRunner(SyncRunnerTemplate):
         frontier = ExecutionFrontier.from_scope(scope, max_iterations)
         ctx_base = ExecutionContext(
             event_processors=event_processors,
+            show_progress=False,
             workflow_id=workflow_id,
             run_id=run_id,
             provided_values=values,


### PR DESCRIPTION
## Problem

Three related progress bar issues:
1. **Verbose API**: Users must pass `event_processors=[RichProgressProcessor()]` to every `run()`/`map()` call to get progress bars — unlike `cache` and `checkpointer` which live on the constructor.
2. **Duplicate bars**: When a GraphNode triggers `runner.map()`, a redundant `query_llm 0/1` node bar appears alongside the real `◈ query_llm 7/14` map bar.
3. **Delayed rendering**: In notebooks, progress bars don't appear for ~10 seconds during nested map execution, then all appear at once when the first item completes.

## Before

```python
# Verbose — must repeat on every call
runner = AsyncRunner()
result = await runner.run(graph, x=1, event_processors=[RichProgressProcessor()])
result = await runner.run(graph, x=2, event_processors=[RichProgressProcessor()])
```

Progress bar output with duplicate:
```
query_llm          0/1       ← useless, never advances
  ◈ query_llm      7/14      ← the real map bar
    ├─ build_prompt 14/14
    └─ query_gemini  8/14
```

## After

```python
# Simple — set once on constructor
runner = AsyncRunner(show_progress=True)
result = await runner.run(graph, x=1)
result = await runner.run(graph, x=2)

# Override per-call
result = await runner.run(graph, x=3, show_progress=False)
```

Progress bar output — single bar, correct hierarchy:
```
◈ query_llm      7/14  7✓
    ├─ build_prompt 14/14  14✓ ~0ms
    └─ query_gemini  8/14  8✓ ~13.3s
```

## Changes

### Part A: `show_progress` flag
- `SyncRunner`/`AsyncRunner` constructor: `show_progress: bool = False`
- `run()`/`map()`: `show_progress: bool | None = None` (None = use runner default)
- Idempotent `ensure_progress_processor()` — won't duplicate if user also passes one explicitly
- `ExecutionContext.show_progress` propagates `False` to nested GraphNode calls
- `DaftRunner`: accepted with warning
- Reserved in input normalization kwargs

### Part B: Fix duplicate bars
- `_SpanInfo.node_bar_key` tracks which node bar a span created
- `on_run_start(is_map=True)` finds parent's node bar via span chain and removes it
- Map bar inherits the removed bar's depth and public name (handles aliased GraphNodes)
- `_NotebookProgress.remove_task()` for clean notebook removal

### Part C: Fix notebook flushing
- `_refresh_structural()` bypasses 100ms throttle for bar creation/removal
- `RichProgressProcessor` extends `AsyncEventProcessor` (multiple inheritance)
- `on_event_async` yields via `asyncio.sleep(0)` in notebook mode to flush IOPub
- `shutdown_async` delegates to sync `shutdown()` (prevents silent skip)

## Test plan

- [x] `uv run pytest -W error -W 'ignore::pytest.PytestUnraisableExceptionWarning'` — 2347 passed
- [x] `show_progress=True` doesn't duplicate when user also passes `RichProgressProcessor()`
- [ ] Manual notebook test: single bar for GraphNode map, bars appear immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added show_progress option for run() and map() (configurable per-run or at runner init); child/nested runs disable progress by default.
  * Progress tracking is automatically applied when enabled.

* **Improvements**
  * Progress display updates more responsively on structural changes and supports asynchronous event handling for smoother real-time output.
  * Notebook-backed progress display can now remove tasks cleanly.

* **Behavior**
  * DaftRunner will warn if show_progress is provided (not supported).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->