### PR TITLE
Strengthen Hypergraph's OpenTelemetry export semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,26 @@ result = await runner.run(graph, {
 # Completed!
 ```
 
+### Native Debugging and OTel Export
+
+- **Native-first** - Hypergraph's inspect UI, `RunView`, failure display, and checkpoint history stay the primary debugging tools.
+- **OTel opt-in** - Add `OpenTelemetryProcessor()` only when you want to export execution data to Jaeger, Honeycomb, Datadog, or another tracing backend.
+- **Structured spans** - Hypergraph exports graph/map run spans, child node spans, and explicit attributes such as `workflow_id`, `run_id`, `item_index`, `graph_name`, and `node_name`.
+
+```python
+from hypergraph import SyncRunner
+from hypergraph.events.otel import OpenTelemetryProcessor
+
+runner = SyncRunner()
+result = runner.run(
+    graph,
+    {"query": "What changed in our RAG index?"},
+    event_processors=[OpenTelemetryProcessor()],
+)
+```
+
+Nested graphs and `map()` runs show up as a span tree rather than a flat log, while rich inspect-only payloads stay inside Hypergraph. See [execution observability](docs/05-how-to/observe-execution.md) for the full setup and emitted span structure.
+
 See the docs for more patterns: [multi-agent orchestration](https://gilad-rubin.gitbook.io/hypergraph/patterns/05-multi-agent), [rename & adapt](docs/05-how-to/rename-and-adapt.md), [batch processing with map](https://gilad-rubin.gitbook.io/hypergraph/how-to-guides/batch-processing), [streaming](docs/03-patterns/06-streaming.md), and [caching](docs/03-patterns/08-caching.md).
 
 ## Key Features

--- a/docs/05-how-to/observe-execution.md
+++ b/docs/05-how-to/observe-execution.md
@@ -63,6 +63,70 @@ processor = RichProgressProcessor(force_mode="non-tty")
 processor = RichProgressProcessor(force_mode="tty")
 ```
 
+## OpenTelemetry Export
+
+Use OpenTelemetry when you want Hypergraph runs to show up in external
+observability backends such as Jaeger, Honeycomb, Datadog, or Logfire.
+Hypergraph's native inspect UI, `RunView`, failure display, and checkpoint
+tools remain the primary debugging experience; OTel is the export layer.
+
+```bash
+pip install 'hypergraph[otel]'
+```
+
+```python
+from hypergraph import SyncRunner
+from hypergraph.events.otel import OpenTelemetryProcessor
+
+runner = SyncRunner()
+result = runner.run(
+    graph,
+    inputs,
+    event_processors=[OpenTelemetryProcessor()],
+)
+```
+
+Hypergraph emits:
+
+- Run spans for graph and `map()` scopes
+- Child node spans for node execution
+- Span events for supersteps, routing, cache hits, pauses, stops, forks, resumes, and retries
+- Explicit attributes such as `workflow_id`, `run_id`, `item_index`, `graph_name`, `node_name`, and batch summary counts
+
+Typical hierarchy:
+
+```text
+graph outer
+└── node inner
+    └── graph inner
+        └── node double
+```
+
+Mapped work uses a parent `map` span plus child graph spans per item:
+
+```text
+map evaluate_batch
+├── graph evaluate_batch   item_index=0
+├── graph evaluate_batch   item_index=1
+└── graph evaluate_batch   item_index=2
+```
+
+Parent `map` spans export aggregate outcome attributes instead of vague blobs:
+
+- `hypergraph.batch.total_items`
+- `hypergraph.batch.completed_items`
+- `hypergraph.batch.failed_items`
+- `hypergraph.batch.paused_items`
+- `hypergraph.batch.stopped_items`
+- `hypergraph.batch.outcome`
+
+Rich native debugging data stays inside Hypergraph on purpose:
+
+- Raw inputs and outputs
+- Checkpoint snapshots
+- Streamed chunks
+- Inspect-only UI payloads
+
 ## Custom Event Processors
 
 ### Collect All Events

--- a/docs/06-api-reference/events.md
+++ b/docs/06-api-reference/events.md
@@ -39,6 +39,8 @@ class BaseEvent:
     run_id: str                    # Unique identifier for the run
     span_id: str                   # Unique identifier for this event's scope
     parent_span_id: str | None     # Parent scope, or None for root runs
+    workflow_id: str | None        # Persisted workflow identifier, if any
+    item_index: int | None         # Mapped child index, if any
     timestamp: float               # Unix timestamp
 ```
 
@@ -52,9 +54,14 @@ Emitted when a graph run begins.
 @dataclass(frozen=True)
 class RunStartEvent(BaseEvent):
     graph_name: str              # Name of the graph
-    workflow_id: str | None      # Optional workflow tracking ID
     is_map: bool                 # True if this is a map() operation
     map_size: int | None         # Number of items in map, if applicable
+    parent_workflow_id: str | None
+    forked_from: str | None
+    fork_superstep: int | None
+    retry_of: str | None
+    retry_index: int | None
+    is_resume: bool
 ```
 
 ### RunEndEvent
@@ -65,9 +72,15 @@ Emitted when a graph run completes (successfully or not).
 @dataclass(frozen=True)
 class RunEndEvent(BaseEvent):
     graph_name: str              # Name of the graph
-    status: str                  # "completed" or "failed"
+    status: str                  # "completed", "failed", "paused", "partial", or "stopped"
     error: str | None            # Error message if failed
     duration_ms: float           # Wall-clock duration in milliseconds
+    batch_total_items: int | None
+    batch_completed_items: int | None
+    batch_failed_items: int | None
+    batch_paused_items: int | None
+    batch_stopped_items: int | None
+    batch_outcome: str | None
 ```
 
 ### NodeStartEvent
@@ -79,6 +92,7 @@ Emitted when a node begins execution.
 class NodeStartEvent(BaseEvent):
     node_name: str               # Name of the node
     graph_name: str              # Graph containing the node
+    superstep: int | None        # Zero-indexed superstep, if known
 ```
 
 ### NodeEndEvent
@@ -90,6 +104,7 @@ Emitted when a node completes successfully.
 class NodeEndEvent(BaseEvent):
     node_name: str               # Name of the node
     graph_name: str              # Graph containing the node
+    superstep: int | None        # Zero-indexed superstep, if known
     duration_ms: float           # Wall-clock duration in milliseconds
     cached: bool                 # True if result was served from cache
 ```
@@ -105,6 +120,7 @@ class NodeErrorEvent(BaseEvent):
     graph_name: str              # Graph containing the node
     error: str                   # Error message
     error_type: str              # Fully qualified exception type
+    superstep: int | None        # Zero-indexed superstep, if known
 ```
 
 ### RouteDecisionEvent
@@ -117,6 +133,8 @@ class RouteDecisionEvent(BaseEvent):
     node_name: str               # Name of the routing node
     graph_name: str              # Graph containing the node
     decision: str | list[str]    # Chosen target(s)
+    node_span_id: str | None     # Routing node span, when available
+    superstep: int | None        # Zero-indexed superstep, if known
 ```
 
 ### InterruptEvent
@@ -128,9 +146,9 @@ Emitted when execution pauses for human-in-the-loop input.
 class InterruptEvent(BaseEvent):
     node_name: str               # Node that triggered the interrupt
     graph_name: str              # Graph containing the node
-    workflow_id: str | None      # Workflow identifier
     value: object                # Interrupt payload
     response_param: str          # Parameter name for the response
+    superstep: int | None        # Zero-indexed superstep, if known
 ```
 
 ### StopRequestedEvent
@@ -140,7 +158,8 @@ Emitted when a stop is requested on a workflow.
 ```python
 @dataclass(frozen=True)
 class StopRequestedEvent(BaseEvent):
-    workflow_id: str | None      # Workflow identifier
+    graph_name: str              # Graph being stopped
+    info: object                 # Optional stop metadata
 ```
 
 ### CacheHitEvent
@@ -153,6 +172,7 @@ class CacheHitEvent(BaseEvent):
     node_name: str               # Name of the cached node
     graph_name: str              # Graph containing the node
     cache_key: str               # The cache key that was hit
+    superstep: int | None        # Zero-indexed superstep, if known
 ```
 
 ### Event (Union Type)

--- a/src/hypergraph/checkpointers/memory.py
+++ b/src/hypergraph/checkpointers/memory.py
@@ -82,7 +82,11 @@ class MemoryCheckpointer(Checkpointer):
             duration_ms=duration_ms if duration_ms is not None else existing.duration_ms,
             node_count=node_count if node_count is not None else existing.node_count,
             error_count=error_count if error_count is not None else existing.error_count,
-            completed_at=datetime.now(timezone.utc) if status in {WorkflowStatus.COMPLETED, WorkflowStatus.FAILED} else None,
+            completed_at=(
+                datetime.now(timezone.utc)
+                if status in {WorkflowStatus.COMPLETED, WorkflowStatus.FAILED, WorkflowStatus.PARTIAL, WorkflowStatus.STOPPED}
+                else None
+            ),
         )
 
     async def get_state(self, run_id: str, *, superstep: int | None = None) -> dict[str, Any]:

--- a/src/hypergraph/checkpointers/presenters.py
+++ b/src/hypergraph/checkpointers/presenters.py
@@ -120,6 +120,7 @@ def _explorer_script(
         "failed": ("#dc2626", "#fef2f2"),
         "active": ("#d97706", "#fffbeb"),
         "paused": ("#7c3aed", "#f5f3ff"),
+        "stopped": ("#92400e", "#fff7ed"),
         "partial": ("#d97706", "#fffbeb"),
         "cached": ("#2563eb", "#eff6ff"),
     }
@@ -515,13 +516,18 @@ def render_run_table_html(table: Any) -> str:
     def _synth_parent(group_id: str, members: list[Any]) -> Any:
         from hypergraph.checkpointers.types import Run, WorkflowStatus
 
+        statuses = {r.status for r in members}
         status = WorkflowStatus.COMPLETED
-        if any(r.status == WorkflowStatus.ACTIVE for r in members):
+        if WorkflowStatus.ACTIVE in statuses:
             status = WorkflowStatus.ACTIVE
-        elif any(r.status == WorkflowStatus.PAUSED for r in members):
+        elif WorkflowStatus.PAUSED in statuses:
             status = WorkflowStatus.PAUSED
-        elif any(r.status == WorkflowStatus.FAILED for r in members):
+        elif WorkflowStatus.PARTIAL in statuses or (WorkflowStatus.FAILED in statuses and len(statuses) > 1):
+            status = WorkflowStatus.PARTIAL
+        elif WorkflowStatus.FAILED in statuses:
             status = WorkflowStatus.FAILED
+        elif WorkflowStatus.STOPPED in statuses:
+            status = WorkflowStatus.STOPPED
         created = max((r.created_at for r in members), default=_utcnow())
         return Run(
             id=group_id,

--- a/src/hypergraph/checkpointers/sqlite.py
+++ b/src/hypergraph/checkpointers/sqlite.py
@@ -381,7 +381,11 @@ class SqliteCheckpointer(Checkpointer):
     ) -> None:
         """Update run status with optional stats."""
         await self._ensure_db()
-        completed_at = datetime.now(timezone.utc).isoformat() if status in {WorkflowStatus.COMPLETED, WorkflowStatus.FAILED} else None
+        completed_at = (
+            datetime.now(timezone.utc).isoformat()
+            if status in {WorkflowStatus.COMPLETED, WorkflowStatus.FAILED, WorkflowStatus.PARTIAL, WorkflowStatus.STOPPED}
+            else None
+        )
 
         # Build SET clause dynamically based on what's provided
         sets = ["status = ?", "completed_at = ?"]
@@ -1130,7 +1134,11 @@ class SqliteCheckpointer(Checkpointer):
     ) -> None:
         """Update run status with optional stats synchronously."""
         db = self._sync_db()
-        completed_at = datetime.now(timezone.utc).isoformat() if status in {WorkflowStatus.COMPLETED, WorkflowStatus.FAILED} else None
+        completed_at = (
+            datetime.now(timezone.utc).isoformat()
+            if status in {WorkflowStatus.COMPLETED, WorkflowStatus.FAILED, WorkflowStatus.PARTIAL, WorkflowStatus.STOPPED}
+            else None
+        )
 
         sets = ["status = ?", "completed_at = ?"]
         params: list[Any] = [status.value, completed_at]

--- a/src/hypergraph/checkpointers/types.py
+++ b/src/hypergraph/checkpointers/types.py
@@ -28,6 +28,8 @@ class WorkflowStatus(Enum):
 
     ACTIVE = "active"
     PAUSED = "paused"
+    STOPPED = "stopped"
+    PARTIAL = "partial"
     COMPLETED = "completed"
     FAILED = "failed"
 

--- a/src/hypergraph/events/otel.py
+++ b/src/hypergraph/events/otel.py
@@ -1,34 +1,30 @@
-"""OpenTelemetry export processor — converts Hypergraph events to OTel spans.
+"""OpenTelemetry export processor for Hypergraph execution events.
 
-Opt-in via::
-
-    pip install hypergraph[otel]
-
-Usage::
-
-    from hypergraph.events.otel import OpenTelemetryProcessor
-
-    runner = AsyncRunner(processors=[OpenTelemetryProcessor()])
-
-Events stream to whatever OTel backend is configured (Logfire, Jaeger,
-Datadog, Honeycomb, etc.). RunLog still works in parallel — they're
-independent.
+Hypergraph events remain the source of truth. This processor projects those
+events into an OpenTelemetry span tree so runs can be exported to external
+observability backends without replacing Hypergraph's native inspect/debug UX.
 """
 
 from __future__ import annotations
 
+from collections import OrderedDict
+from threading import Lock
 from typing import TYPE_CHECKING, Any
 
 from hypergraph.events.processor import TypedEventProcessor
 
 if TYPE_CHECKING:
     from hypergraph.events.types import (
+        CacheHitEvent,
+        InterruptEvent,
         NodeEndEvent,
         NodeErrorEvent,
         NodeStartEvent,
         RouteDecisionEvent,
         RunEndEvent,
         RunStartEvent,
+        StopRequestedEvent,
+        SuperstepStartEvent,
     )
 
 
@@ -44,68 +40,191 @@ def _require_opentelemetry() -> None:
         ) from None
 
 
-class OpenTelemetryProcessor(TypedEventProcessor):
-    """Converts Hypergraph events to OpenTelemetry spans.
+def _set_attrs(span: Any, attributes: dict[str, Any]) -> None:
+    """Set only bounded, non-null attributes on a span."""
+    for key, value in attributes.items():
+        if value is None:
+            continue
+        span.set_attribute(key, value)
 
-    Mapping:
-        RunStartEvent    → root span (``run:{graph_name}``)
-        NodeStartEvent   → child span (``node:{node_name}``)
-        NodeEndEvent     → end child span with attributes
-        RouteDecisionEvent → span event on the run span
-        NodeErrorEvent   → error status + end child span
-        RunEndEvent      → end root span
-    """
+
+def _clean_attrs(attributes: dict[str, Any]) -> dict[str, Any]:
+    """Drop null attributes before sending them to the OTel SDK."""
+    return {key: value for key, value in attributes.items() if value is not None}
+
+
+def _base_attrs(event: Any) -> dict[str, Any]:
+    return {
+        "hypergraph.run_id": event.run_id,
+        "hypergraph.workflow_id": event.workflow_id,
+        "hypergraph.item_index": event.item_index,
+    }
+
+
+def _lineage_kind(event: RunStartEvent) -> str | None:
+    if event.retry_of:
+        return "retry"
+    if event.forked_from:
+        return "fork"
+    if event.is_resume:
+        return "resume"
+    return None
+
+
+_MAX_LINEAGE_CONTEXTS = 256
+
+
+class OpenTelemetryProcessor(TypedEventProcessor):
+    """Convert Hypergraph events into OTel spans and span events."""
 
     def __init__(self, tracer_name: str = "hypergraph") -> None:
         _require_opentelemetry()
         from opentelemetry import trace
-        from opentelemetry.trace import Status, StatusCode
+        from opentelemetry.trace import Link, Status, StatusCode
 
-        self._tracer = trace.get_tracer(tracer_name)
         self._trace = trace
+        self._tracer = trace.get_tracer(tracer_name)
+        self._Link = Link
         self._Status = Status
         self._StatusCode = StatusCode
-        self._spans: dict[str, Any] = {}  # span_id → OTel Span
-        self._contexts: dict[str, Any] = {}  # span_id → OTel Context
+        self._spans: dict[str, Any] = {}
+        self._contexts: dict[str, Any] = {}
+        self._workflow_span_contexts: OrderedDict[str, Any] = OrderedDict()
+        self._workflow_span_contexts_lock = Lock()
+
+    def _get_linked_workflow_context(self, workflow_id: str | None) -> Any | None:
+        """Return a recent workflow span context, or None if evicted/missing."""
+        if workflow_id is None:
+            return None
+        with self._workflow_span_contexts_lock:
+            span_context = self._workflow_span_contexts.pop(workflow_id, None)
+            if span_context is None:
+                return None
+            self._workflow_span_contexts[workflow_id] = span_context
+            return span_context
+
+    def _remember_workflow_context(self, workflow_id: str | None, span_context: Any) -> None:
+        """Remember the most recent span context for a workflow in a bounded cache."""
+        if workflow_id is None:
+            return
+        with self._workflow_span_contexts_lock:
+            self._workflow_span_contexts.pop(workflow_id, None)
+            self._workflow_span_contexts[workflow_id] = span_context
+            if len(self._workflow_span_contexts) > _MAX_LINEAGE_CONTEXTS:
+                self._workflow_span_contexts.popitem(last=False)
 
     def on_run_start(self, event: RunStartEvent) -> None:
         parent_ctx = self._contexts.get(event.parent_span_id) if event.parent_span_id else None
+        links = []
+        lineage_kind = _lineage_kind(event)
+        source_workflow_id = event.retry_of or event.forked_from or (event.workflow_id if event.is_resume else None)
+        if lineage_kind is not None and source_workflow_id is not None:
+            source_ctx = self._get_linked_workflow_context(source_workflow_id)
+            if source_ctx is not None:
+                links.append(
+                    self._Link(
+                        source_ctx,
+                        attributes={"hypergraph.lineage.relationship": lineage_kind},
+                    )
+                )
+
+        name = f"{'map' if event.is_map else 'graph'} {event.graph_name}"
         attributes = {
-            "hypergraph.run_id": event.run_id,
+            **_base_attrs(event),
+            "hypergraph.graph_name": event.graph_name,
             "hypergraph.is_map": event.is_map,
+            "hypergraph.map_size": event.map_size,
+            "hypergraph.parent_workflow_id": event.parent_workflow_id,
+            "hypergraph.forked_from": event.forked_from,
+            "hypergraph.fork_superstep": event.fork_superstep,
+            "hypergraph.retry_of": event.retry_of,
+            "hypergraph.retry_index": event.retry_index,
+            "hypergraph.is_resume": event.is_resume,
         }
-        if event.graph_name is not None:
-            attributes["hypergraph.graph_name"] = event.graph_name
         span = self._tracer.start_span(
-            name=f"run:{event.graph_name}",
+            name=name,
             context=parent_ctx,
-            attributes=attributes,
+            attributes={k: v for k, v in attributes.items() if v is not None},
+            links=links,
         )
         self._spans[event.span_id] = span
         self._contexts[event.span_id] = self._trace.set_span_in_context(span)
+
+        if event.is_resume:
+            span.add_event(
+                "hypergraph.resume",
+                attributes=_clean_attrs({"hypergraph.source_workflow_id": event.workflow_id}),
+            )
+        if event.forked_from is not None:
+            span.add_event(
+                "hypergraph.fork",
+                attributes=_clean_attrs(
+                    {
+                        "hypergraph.source_workflow_id": event.forked_from,
+                        "hypergraph.source_superstep": event.fork_superstep,
+                    }
+                ),
+            )
+        if event.retry_of is not None:
+            span.add_event(
+                "hypergraph.retry",
+                attributes=_clean_attrs(
+                    {
+                        "hypergraph.source_workflow_id": event.retry_of,
+                        "hypergraph.retry_index": event.retry_index,
+                    }
+                ),
+            )
 
     def on_run_end(self, event: RunEndEvent) -> None:
         span = self._spans.pop(event.span_id, None)
         self._contexts.pop(event.span_id, None)
         if span is None:
             return
-        span.set_attribute("hypergraph.duration_ms", event.duration_ms)
-        span.set_attribute("hypergraph.status", event.status.value)
+
+        _set_attrs(
+            span,
+            {
+                "hypergraph.graph_name": event.graph_name,
+                "hypergraph.run.outcome": event.status.value,
+                "hypergraph.duration_ms": event.duration_ms,
+                "hypergraph.batch.total_items": event.batch_total_items,
+                "hypergraph.batch.completed_items": event.batch_completed_items,
+                "hypergraph.batch.failed_items": event.batch_failed_items,
+                "hypergraph.batch.paused_items": event.batch_paused_items,
+                "hypergraph.batch.stopped_items": event.batch_stopped_items,
+                "hypergraph.batch.outcome": event.batch_outcome,
+            },
+        )
         if event.error:
             span.set_status(self._Status(self._StatusCode.ERROR, event.error))
+            span.add_event(
+                "exception",
+                attributes=_clean_attrs(
+                    {
+                        "exception.message": event.error,
+                    }
+                ),
+            )
+        if event.workflow_id is not None:
+            self._remember_workflow_context(event.workflow_id, span.get_span_context())
         span.end()
 
     def on_node_start(self, event: NodeStartEvent) -> None:
         parent_ctx = self._contexts.get(event.parent_span_id) if event.parent_span_id else None
-        attributes = {
-            "hypergraph.node_name": event.node_name,
-        }
-        if event.graph_name is not None:
-            attributes["hypergraph.graph_name"] = event.graph_name
         span = self._tracer.start_span(
-            name=f"node:{event.node_name}",
+            name=f"node {event.node_name}",
             context=parent_ctx,
-            attributes=attributes,
+            attributes={
+                k: v
+                for k, v in {
+                    **_base_attrs(event),
+                    "hypergraph.node_name": event.node_name,
+                    "hypergraph.graph_name": event.graph_name,
+                    "hypergraph.superstep": event.superstep,
+                }.items()
+                if v is not None
+            },
         )
         self._spans[event.span_id] = span
         self._contexts[event.span_id] = self._trace.set_span_in_context(span)
@@ -115,32 +234,126 @@ class OpenTelemetryProcessor(TypedEventProcessor):
         self._contexts.pop(event.span_id, None)
         if span is None:
             return
-        span.set_attribute("hypergraph.duration_ms", event.duration_ms)
-        span.set_attribute("hypergraph.cached", event.cached)
-        span.end()
-
-    def on_route_decision(self, event: RouteDecisionEvent) -> None:
-        # Attach as event on the run span (parent)
-        run_span = self._spans.get(event.parent_span_id) if event.parent_span_id else None
-        if run_span is None:
-            return
-        decision = event.decision if isinstance(event.decision, str) else ",".join(event.decision)
-        run_span.add_event(
-            "route_decision",
-            attributes={"node_name": event.node_name, "decision": decision},
+        _set_attrs(
+            span,
+            {
+                "hypergraph.duration_ms": event.duration_ms,
+                "hypergraph.cached": event.cached,
+                "hypergraph.superstep": event.superstep,
+            },
         )
+        span.end()
 
     def on_node_error(self, event: NodeErrorEvent) -> None:
         span = self._spans.pop(event.span_id, None)
         self._contexts.pop(event.span_id, None)
         if span is None:
             return
+        _set_attrs(
+            span,
+            {
+                "hypergraph.error_type": event.error_type,
+                "hypergraph.superstep": event.superstep,
+            },
+        )
         span.set_status(self._Status(self._StatusCode.ERROR, event.error))
-        span.set_attribute("hypergraph.error_type", event.error_type)
+        span.add_event(
+            "exception",
+            attributes=_clean_attrs(
+                {
+                    "exception.type": event.error_type,
+                    "exception.message": event.error,
+                }
+            ),
+        )
         span.end()
 
+    def on_superstep_start(self, event: SuperstepStartEvent) -> None:
+        span = self._spans.get(event.parent_span_id) if event.parent_span_id else None
+        if span is None:
+            return
+        span.add_event(
+            "hypergraph.superstep.start",
+            attributes=_clean_attrs(
+                {
+                    "hypergraph.superstep": event.superstep,
+                    "hypergraph.graph_name": event.graph_name,
+                    "hypergraph.item_index": event.item_index,
+                }
+            ),
+        )
+
+    def on_route_decision(self, event: RouteDecisionEvent) -> None:
+        target_span = self._spans.get(event.node_span_id or "") or (self._spans.get(event.parent_span_id) if event.parent_span_id else None)
+        if target_span is None:
+            return
+        decision = event.decision if isinstance(event.decision, str) else ",".join(event.decision)
+        target_span.add_event(
+            "hypergraph.route.decision",
+            attributes=_clean_attrs(
+                {
+                    "hypergraph.node_name": event.node_name,
+                    "hypergraph.graph_name": event.graph_name,
+                    "hypergraph.decision": decision,
+                    "hypergraph.superstep": event.superstep,
+                    "hypergraph.item_index": event.item_index,
+                }
+            ),
+        )
+
+    def on_cache_hit(self, event: CacheHitEvent) -> None:
+        span = self._spans.get(event.span_id)
+        if span is None:
+            return
+        span.add_event(
+            "hypergraph.cache.hit",
+            attributes=_clean_attrs(
+                {
+                    "hypergraph.node_name": event.node_name,
+                    "hypergraph.graph_name": event.graph_name,
+                    "hypergraph.superstep": event.superstep,
+                }
+            ),
+        )
+
+    def on_interrupt(self, event: InterruptEvent) -> None:
+        span = self._spans.get(event.span_id) or (self._spans.get(event.parent_span_id) if event.parent_span_id else None)
+        if span is None:
+            return
+        span.add_event(
+            "hypergraph.pause",
+            attributes=_clean_attrs(
+                {
+                    "hypergraph.node_name": event.node_name,
+                    "hypergraph.graph_name": event.graph_name,
+                    "hypergraph.response_param": event.response_param,
+                    "hypergraph.superstep": event.superstep,
+                    "hypergraph.item_index": event.item_index,
+                }
+            ),
+        )
+        # InterruptEvent reuses the paused node span id. End that span cleanly.
+        if event.span_id in self._spans:
+            paused_span = self._spans.pop(event.span_id)
+            self._contexts.pop(event.span_id, None)
+            paused_span.end()
+
+    def on_stop_requested(self, event: StopRequestedEvent) -> None:
+        span = self._spans.get(event.span_id) or (self._spans.get(event.parent_span_id) if event.parent_span_id else None)
+        if span is None:
+            return
+        span.add_event(
+            "hypergraph.stop.requested",
+            attributes=_clean_attrs(
+                {
+                    "hypergraph.graph_name": event.graph_name,
+                    "hypergraph.item_index": event.item_index,
+                }
+            ),
+        )
+
     def shutdown(self) -> None:
-        """End any remaining open spans (safety net)."""
+        """End any remaining spans while preserving bounded lineage history."""
         for span in self._spans.values():
             span.end()
         self._spans.clear()

--- a/src/hypergraph/events/otel.py
+++ b/src/hypergraph/events/otel.py
@@ -332,8 +332,9 @@ class OpenTelemetryProcessor(TypedEventProcessor):
                 }
             ),
         )
-        # InterruptEvent reuses the paused node span id. End that span cleanly.
-        if event.span_id in self._spans:
+        # InterruptEvent should normally reuse the paused node span id.
+        # If a fallback run span id slips through, don't end the parent span early.
+        if event.span_id in self._spans and event.span_id != event.parent_span_id:
             paused_span = self._spans.pop(event.span_id)
             self._contexts.pop(event.span_id, None)
             paused_span.end()

--- a/src/hypergraph/events/otel.py
+++ b/src/hypergraph/events/otel.py
@@ -144,7 +144,7 @@ class OpenTelemetryProcessor(TypedEventProcessor):
         span = self._tracer.start_span(
             name=name,
             context=parent_ctx,
-            attributes={k: v for k, v in attributes.items() if v is not None},
+            attributes=_clean_attrs(attributes),
             links=links,
         )
         self._spans[event.span_id] = span
@@ -284,7 +284,7 @@ class OpenTelemetryProcessor(TypedEventProcessor):
         )
 
     def on_route_decision(self, event: RouteDecisionEvent) -> None:
-        target_span = self._spans.get(event.node_span_id or "") or (self._spans.get(event.parent_span_id) if event.parent_span_id else None)
+        target_span = self._spans.get(event.node_span_id) or (self._spans.get(event.parent_span_id) if event.parent_span_id else None)
         if target_span is None:
             return
         decision = event.decision if isinstance(event.decision, str) else ",".join(event.decision)

--- a/src/hypergraph/events/rich_progress.py
+++ b/src/hypergraph/events/rich_progress.py
@@ -749,7 +749,7 @@ class RichProgressProcessor(TypedEventProcessor, AsyncEventProcessor):
                 if self._tty_mode and map_info.rich_task_id is not None:
                     self._progress.advance(map_info.rich_task_id, 1)
 
-                    if event.status == RunStatus.FAILED:
+                    if event.status in (RunStatus.FAILED, RunStatus.PARTIAL):
                         map_info.failures += 1
                     elif event.status in (RunStatus.PAUSED, RunStatus.STOPPED):
                         pass
@@ -772,6 +772,8 @@ class RichProgressProcessor(TypedEventProcessor, AsyncEventProcessor):
             elif self._tty_mode:
                 if event.status == RunStatus.COMPLETED:
                     self._progress.console.print(f"[bold green]✓ {event.graph_name or 'Run'} completed![/bold green]")
+                elif event.status == RunStatus.PARTIAL:
+                    self._progress.console.print(f"[bold yellow]◐ {event.graph_name or 'Run'} completed with failures[/bold yellow]")
                 elif event.status == RunStatus.PAUSED:
                     self._progress.console.print(f"[bold yellow]‖ {event.graph_name or 'Run'} paused[/bold yellow]")
                 elif event.status == RunStatus.STOPPED:
@@ -782,6 +784,8 @@ class RichProgressProcessor(TypedEventProcessor, AsyncEventProcessor):
                 name = event.graph_name or "Run"
                 if event.status == RunStatus.COMPLETED:
                     self._print(f"✓ {name} completed!")
+                elif event.status == RunStatus.PARTIAL:
+                    self._print(f"◐ {name} completed with failures")
                 elif event.status == RunStatus.PAUSED:
                     self._print(f"‖ {name} paused")
                 elif event.status == RunStatus.STOPPED:
@@ -802,6 +806,9 @@ class RichProgressProcessor(TypedEventProcessor, AsyncEventProcessor):
         if event.status == RunStatus.COMPLETED:
             color = STATUS_COLORS["completed"]
             msg = f"✓ {name} completed!"
+        elif event.status == RunStatus.PARTIAL:
+            color = STATUS_COLORS["partial"]
+            msg = f"◐ {name} completed with failures"
         elif event.status == RunStatus.PAUSED:
             color = STATUS_COLORS["paused"]
             msg = f"‖ {name} paused"

--- a/src/hypergraph/events/types.py
+++ b/src/hypergraph/events/types.py
@@ -210,7 +210,7 @@ class InterruptEvent(BaseEvent):
     Attributes:
         node_name: Name of the node that triggered the interrupt.
         graph_name: Name of the graph containing the node.
-        workflow_id: Optional workflow identifier.
+        workflow_id: Inherited from BaseEvent — workflow identifier, if any.
         value: The interrupt payload.
         response_param: Parameter name expected for the response.
         superstep: Zero-indexed superstep number, if known.
@@ -241,7 +241,7 @@ class StopRequestedEvent(BaseEvent):
     """Emitted when a stop is requested on a workflow.
 
     Attributes:
-        workflow_id: Optional workflow identifier.
+        workflow_id: Inherited from BaseEvent — workflow identifier, if any.
         graph_name: Name of the graph being stopped.
         info: Optional metadata from ``runner.stop(workflow_id, info=...)``.
     """

--- a/src/hypergraph/events/types.py
+++ b/src/hypergraph/events/types.py
@@ -15,11 +15,14 @@ class RunStatus(Enum):
         COMPLETED: Run finished successfully.
         FAILED: Run encountered an error.
         PAUSED: Run paused at an interrupt.
+        PARTIAL: Run completed with mixed item outcomes.
+        STOPPED: Run stopped cooperatively.
     """
 
     COMPLETED = "completed"
     FAILED = "failed"
     PAUSED = "paused"
+    PARTIAL = "partial"
     STOPPED = "stopped"
 
 
@@ -41,12 +44,16 @@ class BaseEvent:
         run_id: Unique identifier for the run that produced this event.
         span_id: Unique identifier for this event's scope.
         parent_span_id: Span ID of the parent scope, or None for root runs.
+        workflow_id: Optional workflow identifier for related persisted runs.
+        item_index: Item index for mapped child runs, if applicable.
         timestamp: Unix timestamp when the event was created.
     """
 
     run_id: str
     span_id: str = field(default_factory=_generate_span_id)
     parent_span_id: str | None = None
+    workflow_id: str | None = None
+    item_index: int | None = None
     timestamp: float = field(default_factory=_now)
 
 
@@ -56,15 +63,25 @@ class RunStartEvent(BaseEvent):
 
     Attributes:
         graph_name: Name of the graph being executed.
-        workflow_id: Optional workflow identifier for tracking related runs.
         is_map: Whether this run is part of a map operation.
         map_size: Number of items in the map operation, if applicable.
+        parent_workflow_id: Parent workflow id for nested runs, if any.
+        forked_from: Source workflow id when this run is a fork.
+        fork_superstep: Source superstep for a fork checkpoint.
+        retry_of: Source workflow id when this run is a retry.
+        retry_index: Retry sequence number for retry runs.
+        is_resume: Whether this run resumed an existing workflow.
     """
 
     graph_name: str = ""
-    workflow_id: str | None = None
     is_map: bool = False
     map_size: int | None = None
+    parent_workflow_id: str | None = None
+    forked_from: str | None = None
+    fork_superstep: int | None = None
+    retry_of: str | None = None
+    retry_index: int | None = None
+    is_resume: bool = False
 
 
 @dataclass(frozen=True)
@@ -73,15 +90,23 @@ class RunEndEvent(BaseEvent):
 
     Attributes:
         graph_name: Name of the graph that was executed.
-        status: Outcome of the run (completed, failed, or paused).
+        status: Outcome of the run (completed, failed, paused, partial, stopped).
         error: Error message if status is FAILED.
         duration_ms: Wall-clock duration in milliseconds.
+        batch_*: Aggregate mapped-item counts for parent map runs.
+        batch_outcome: Aggregate mapped-item outcome for parent map runs.
     """
 
     graph_name: str = ""
     status: RunStatus = RunStatus.COMPLETED
     error: str | None = None
     duration_ms: float = 0.0
+    batch_total_items: int | None = None
+    batch_completed_items: int | None = None
+    batch_failed_items: int | None = None
+    batch_paused_items: int | None = None
+    batch_stopped_items: int | None = None
+    batch_outcome: str | None = None
 
     def __post_init__(self) -> None:
         # Coerce string status values to RunStatus enum
@@ -96,10 +121,12 @@ class NodeStartEvent(BaseEvent):
     Attributes:
         node_name: Name of the node.
         graph_name: Name of the graph containing the node.
+        superstep: Zero-indexed superstep number, if known.
     """
 
     node_name: str = ""
     graph_name: str = ""
+    superstep: int | None = None
 
 
 @dataclass(frozen=True)
@@ -110,10 +137,12 @@ class NodeEndEvent(BaseEvent):
         node_name: Name of the node.
         graph_name: Name of the graph containing the node.
         duration_ms: Wall-clock duration in milliseconds.
+        superstep: Zero-indexed superstep number, if known.
     """
 
     node_name: str = ""
     graph_name: str = ""
+    superstep: int | None = None
     duration_ms: float = 0.0
     cached: bool = False
     inner_logs: tuple = ()  # tuple[RunLog, ...] at runtime; untyped to avoid import
@@ -127,11 +156,13 @@ class CacheHitEvent(BaseEvent):
         node_name: Name of the cached node.
         graph_name: Name of the graph containing the node.
         cache_key: The cache key that was hit.
+        superstep: Zero-indexed superstep number, if known.
     """
 
     node_name: str = ""
     graph_name: str = ""
     cache_key: str = ""
+    superstep: int | None = None
 
 
 @dataclass(frozen=True)
@@ -143,12 +174,14 @@ class NodeErrorEvent(BaseEvent):
         graph_name: Name of the graph containing the node.
         error: Error message.
         error_type: Fully qualified exception type name.
+        superstep: Zero-indexed superstep number, if known.
     """
 
     node_name: str = ""
     graph_name: str = ""
     error: str = ""
     error_type: str = ""
+    superstep: int | None = None
 
 
 @dataclass(frozen=True)
@@ -159,11 +192,15 @@ class RouteDecisionEvent(BaseEvent):
         node_name: Name of the routing node.
         graph_name: Name of the graph containing the node.
         decision: The chosen target(s).
+        node_span_id: Span id of the routing node span, when available.
+        superstep: Zero-indexed superstep number, if known.
     """
 
     node_name: str = ""
     graph_name: str = ""
     decision: str | list[str] = ""
+    node_span_id: str | None = None
+    superstep: int | None = None
 
 
 @dataclass(frozen=True)
@@ -176,13 +213,14 @@ class InterruptEvent(BaseEvent):
         workflow_id: Optional workflow identifier.
         value: The interrupt payload.
         response_param: Parameter name expected for the response.
+        superstep: Zero-indexed superstep number, if known.
     """
 
     node_name: str = ""
     graph_name: str = ""
-    workflow_id: str | None = None
     value: object = None
     response_param: str = ""
+    superstep: int | None = None
 
 
 @dataclass(frozen=True)
@@ -204,10 +242,11 @@ class StopRequestedEvent(BaseEvent):
 
     Attributes:
         workflow_id: Optional workflow identifier.
+        graph_name: Name of the graph being stopped.
         info: Optional metadata from ``runner.stop(workflow_id, info=...)``.
     """
 
-    workflow_id: str | None = None
+    graph_name: str = ""
     info: object = None
 
 

--- a/src/hypergraph/runners/_shared/event_helpers.py
+++ b/src/hypergraph/runners/_shared/event_helpers.py
@@ -10,6 +10,14 @@ import sys
 import time
 from typing import TYPE_CHECKING, Any
 
+from hypergraph.runners._shared.event_metadata import (
+    DEFAULT_RUN_CONTEXT,
+    DEFAULT_RUN_LINEAGE,
+    BatchSummary,
+    RunContext,
+    RunLineage,
+)
+
 if TYPE_CHECKING:
     from hypergraph.events.dispatcher import EventDispatcher
     from hypergraph.events.processor import EventProcessor
@@ -37,6 +45,10 @@ def build_node_start_event(
     run_span_id: str,
     node: HyperNode,
     graph: Graph,
+    *,
+    workflow_id: str | None = None,
+    item_index: int | None = None,
+    superstep: int | None = None,
 ) -> tuple[str, Any]:
     """Build a NodeStartEvent. Returns (span_id, event)."""
     from hypergraph.events.types import NodeStartEvent, _generate_span_id
@@ -46,8 +58,11 @@ def build_node_start_event(
         run_id=run_id,
         span_id=span_id,
         parent_span_id=run_span_id,
+        workflow_id=workflow_id,
+        item_index=item_index,
         node_name=node.name,
         graph_name=graph.name,
+        superstep=superstep,
     )
     return span_id, event
 
@@ -61,6 +76,10 @@ def build_node_end_event(
     duration_ms: float,
     cached: bool = False,
     inner_logs: tuple = (),
+    *,
+    workflow_id: str | None = None,
+    item_index: int | None = None,
+    superstep: int | None = None,
 ) -> Any:
     """Build a NodeEndEvent."""
     from hypergraph.events.types import NodeEndEvent
@@ -69,8 +88,11 @@ def build_node_end_event(
         run_id=run_id,
         span_id=node_span_id,
         parent_span_id=run_span_id,
+        workflow_id=workflow_id,
+        item_index=item_index,
         node_name=node.name,
         graph_name=graph.name,
+        superstep=superstep,
         duration_ms=duration_ms,
         cached=cached,
         inner_logs=inner_logs,
@@ -84,6 +106,10 @@ def build_cache_hit_event(
     node: HyperNode,
     graph: Graph,
     cache_key: str,
+    *,
+    workflow_id: str | None = None,
+    item_index: int | None = None,
+    superstep: int | None = None,
 ) -> Any:
     """Build a CacheHitEvent."""
     from hypergraph.events.types import CacheHitEvent
@@ -92,9 +118,12 @@ def build_cache_hit_event(
         run_id=run_id,
         span_id=node_span_id,
         parent_span_id=run_span_id,
+        workflow_id=workflow_id,
+        item_index=item_index,
         node_name=node.name,
         graph_name=graph.name,
         cache_key=cache_key,
+        superstep=superstep,
     )
 
 
@@ -104,6 +133,10 @@ def build_node_error_event(
     run_span_id: str,
     node: HyperNode,
     graph: Graph,
+    *,
+    workflow_id: str | None = None,
+    item_index: int | None = None,
+    superstep: int | None = None,
 ) -> Any:
     """Build a NodeErrorEvent from the current exception context."""
     from hypergraph.events.types import NodeErrorEvent
@@ -113,19 +146,27 @@ def build_node_error_event(
         run_id=run_id,
         span_id=node_span_id,
         parent_span_id=run_span_id,
+        workflow_id=workflow_id,
+        item_index=item_index,
         node_name=node.name,
         graph_name=graph.name,
         error=str(exc_val) if exc_val else "",
         error_type=f"{exc_type.__module__}.{exc_type.__qualname__}" if exc_type else "",
+        superstep=superstep,
     )
 
 
 def build_route_decision_event(
     run_id: str,
     run_span_id: str,
+    node_span_id: str,
     node: HyperNode,
     graph: Graph,
     state: GraphState,
+    *,
+    workflow_id: str | None = None,
+    item_index: int | None = None,
+    superstep: int | None = None,
 ) -> Any | None:
     """Build a RouteDecisionEvent if the node made a routing decision.
 
@@ -143,9 +184,13 @@ def build_route_decision_event(
     return RouteDecisionEvent(
         run_id=run_id,
         parent_span_id=run_span_id,
+        workflow_id=workflow_id,
+        item_index=item_index,
         node_name=node.name,
         graph_name=graph.name,
         decision=state.routing_decisions[node.name],
+        node_span_id=node_span_id,
+        superstep=superstep,
     )
 
 
@@ -158,8 +203,10 @@ def build_run_start_event(
     graph: Graph,
     parent_span_id: str | None,
     *,
+    context: RunContext = DEFAULT_RUN_CONTEXT,
     is_map: bool = False,
     map_size: int | None = None,
+    lineage: RunLineage = DEFAULT_RUN_LINEAGE,
 ) -> tuple[str, str, Any]:
     """Build a RunStartEvent. Returns (run_id, span_id, event)."""
     from hypergraph.events.types import RunStartEvent, _generate_span_id
@@ -171,9 +218,17 @@ def build_run_start_event(
         run_id=run_id,
         span_id=span_id,
         parent_span_id=parent_span_id,
+        workflow_id=context.workflow_id,
+        item_index=context.item_index,
         graph_name=graph.name,
         is_map=is_map,
         map_size=map_size,
+        parent_workflow_id=lineage.parent_workflow_id,
+        forked_from=lineage.forked_from,
+        fork_superstep=lineage.fork_superstep,
+        retry_of=lineage.retry_of,
+        retry_index=lineage.retry_index,
+        is_resume=lineage.is_resume,
     )
     return run_id, span_id, event
 
@@ -185,7 +240,10 @@ def build_run_end_event(
     start_time: float,
     parent_span_id: str | None,
     *,
+    context: RunContext = DEFAULT_RUN_CONTEXT,
+    status: str | None = None,
     error: BaseException | None = None,
+    batch_summary: BatchSummary | None = None,
 ) -> Any:
     """Build a RunEndEvent."""
     from hypergraph.events.types import RunEndEvent, RunStatus
@@ -195,8 +253,16 @@ def build_run_end_event(
         run_id=run_id,
         span_id=span_id,
         parent_span_id=parent_span_id,
+        workflow_id=context.workflow_id,
+        item_index=context.item_index,
         graph_name=graph.name,
-        status=RunStatus.FAILED if error else RunStatus.COMPLETED,
+        status=RunStatus(status) if status is not None else (RunStatus.FAILED if error else RunStatus.COMPLETED),
         error=str(error) if error else None,
         duration_ms=duration_ms,
+        batch_total_items=batch_summary.total_items if batch_summary is not None else None,
+        batch_completed_items=batch_summary.completed_items if batch_summary is not None else None,
+        batch_failed_items=batch_summary.failed_items if batch_summary is not None else None,
+        batch_paused_items=batch_summary.paused_items if batch_summary is not None else None,
+        batch_stopped_items=batch_summary.stopped_items if batch_summary is not None else None,
+        batch_outcome=batch_summary.outcome if batch_summary is not None else None,
     )

--- a/src/hypergraph/runners/_shared/event_metadata.py
+++ b/src/hypergraph/runners/_shared/event_metadata.py
@@ -1,0 +1,106 @@
+"""Shared internal metadata objects for execution events."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from hypergraph.runners._shared.types import RunResult
+
+
+@dataclass(frozen=True, slots=True)
+class RunContext:
+    """Stable execution context shared by run-level events."""
+
+    workflow_id: str | None = None
+    item_index: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RunLineage:
+    """Lineage metadata exported on run start."""
+
+    parent_workflow_id: str | None = None
+    forked_from: str | None = None
+    fork_superstep: int | None = None
+    retry_of: str | None = None
+    retry_index: int | None = None
+    is_resume: bool = False
+
+
+DEFAULT_RUN_CONTEXT = RunContext()
+DEFAULT_RUN_LINEAGE = RunLineage()
+
+
+@dataclass(frozen=True, slots=True)
+class BatchSummary:
+    """Bounded aggregate summary for parent map runs."""
+
+    total_items: int
+    completed_items: int
+    failed_items: int
+    paused_items: int
+    stopped_items: int
+    outcome: str
+
+    @classmethod
+    def from_results(cls, results: Sequence[RunResult]) -> BatchSummary:
+        """Build a summary from mapped child run results."""
+        from hypergraph.runners._shared.types import RunStatus
+
+        total_items = len(results)
+        completed_items = sum(1 for result in results if result.status == RunStatus.COMPLETED)
+        failed_items = sum(1 for result in results if result.status == RunStatus.FAILED)
+        paused_items = sum(1 for result in results if result.status == RunStatus.PAUSED)
+        stopped_items = sum(1 for result in results if result.status == RunStatus.STOPPED)
+        return cls(
+            total_items=total_items,
+            completed_items=completed_items,
+            failed_items=failed_items,
+            paused_items=paused_items,
+            stopped_items=stopped_items,
+            outcome=_batch_outcome(
+                total_items=total_items,
+                completed_items=completed_items,
+                failed_items=failed_items,
+                paused_items=paused_items,
+                stopped_items=stopped_items,
+            ),
+        )
+
+    @property
+    def event_status_value(self) -> str:
+        """Status value to export on the parent RunEndEvent."""
+        if self.outcome == "failed":
+            return "failed"
+        if self.outcome == "partial":
+            return "partial"
+        if self.outcome == "paused":
+            return "paused"
+        if self.outcome == "stopped":
+            return "stopped"
+        return "completed"
+
+
+def _batch_outcome(
+    *,
+    total_items: int,
+    completed_items: int,
+    failed_items: int,
+    paused_items: int,
+    stopped_items: int,
+) -> str:
+    """Summarize mapped child outcomes for export-oriented observability."""
+    if total_items == 0:
+        return "completed"
+    if failed_items == total_items:
+        return "failed"
+    if failed_items > 0:
+        return "partial"
+    if paused_items > 0:
+        return "paused"
+    if stopped_items > 0:
+        return "stopped"
+    return "completed"

--- a/src/hypergraph/runners/_shared/event_metadata.py
+++ b/src/hypergraph/runners/_shared/event_metadata.py
@@ -73,6 +73,11 @@ class BatchSummary:
     @property
     def event_status_value(self) -> str:
         """Status value to export on the parent RunEndEvent."""
+        return self.workflow_status_value
+
+    @property
+    def workflow_status_value(self) -> str:
+        """Status value to persist for parent map runs."""
         if self.outcome == "failed":
             return "failed"
         if self.outcome == "partial":

--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -18,6 +18,13 @@ from hypergraph.exceptions import (
     WorkflowAlreadyCompletedError,
     WorkflowForkError,
 )
+from hypergraph.runners._shared.event_metadata import (
+    DEFAULT_RUN_CONTEXT,
+    DEFAULT_RUN_LINEAGE,
+    BatchSummary,
+    RunContext,
+    RunLineage,
+)
 from hypergraph.runners._shared.helpers import (
     _UNSET_SELECT,
     _validate_error_handling,
@@ -108,6 +115,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
         checkpoint: Any | None = None,
         step_buffer: list[Any] | None = None,
         _complete_on_stop: bool = False,
+        item_index: int | None = None,
     ) -> GraphState:
         """Execute graph and return final state."""
         ...
@@ -127,8 +135,10 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
         graph: Graph,
         parent_span_id: str | None,
         *,
+        context: RunContext = DEFAULT_RUN_CONTEXT,
         is_map: bool = False,
         map_size: int | None = None,
+        lineage: RunLineage = DEFAULT_RUN_LINEAGE,
     ) -> tuple[str, str]:
         """Emit run-start event."""
         ...
@@ -143,7 +153,10 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
         start_time: float,
         parent_span_id: str | None,
         *,
+        context: RunContext = DEFAULT_RUN_CONTEXT,
+        status: str | None = None,
         error: BaseException | None = None,
+        batch_summary: BatchSummary | None = None,
     ) -> None:
         """Emit run-end event."""
         ...
@@ -194,6 +207,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
         _validation_ctx: _InputValidationContext | None = None,
         _run_config: dict[str, Any] | None = None,
         _complete_on_stop: bool = False,
+        _item_index: int | None = None,
         **input_values: Any,
     ) -> RunResult:
         """Execute a graph once."""
@@ -267,6 +281,16 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
             fork_superstep = getattr(resume_checkpoint, "source_superstep", None)
             retry_of = getattr(resume_checkpoint, "retry_of", None)
             retry_index = getattr(resume_checkpoint, "retry_index", None)
+        is_resume = resume_checkpoint is not None and forked_from is None and retry_of is None
+        run_context = RunContext(workflow_id=workflow_id, item_index=_item_index)
+        run_lineage = RunLineage(
+            parent_workflow_id=_parent_run_id,
+            forked_from=forked_from,
+            fork_superstep=fork_superstep,
+            retry_of=retry_of,
+            retry_index=retry_index,
+            is_resume=is_resume,
+        )
 
         validation_values = build_resume_validation_values(graph, normalized_values, resume_checkpoint)
 
@@ -325,6 +349,8 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
             dispatcher,
             graph,
             _parent_span_id,
+            context=run_context,
+            lineage=run_lineage,
         )
         start_time = time.time()
 
@@ -364,6 +390,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                 checkpoint=resume_checkpoint,
                 step_buffer=step_buffer,
                 _complete_on_stop=_complete_on_stop,
+                item_index=_item_index,
             )
             output_values = filter_outputs(state, graph, select, on_missing)
             total_duration_ms = (time.time() - start_time) * 1000
@@ -381,6 +408,8 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                         span_id=run_span_id,
                         parent_span_id=_parent_span_id,
                         workflow_id=workflow_id,
+                        item_index=_item_index,
+                        graph_name=graph.name,
                         info=stop_info,
                     )
                 )
@@ -399,6 +428,8 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                 graph,
                 start_time,
                 _parent_span_id,
+                context=run_context,
+                status=status.value,
             )
             # Flush buffered steps ("exit" mode) and mark run completed
             if has_checkpointer:
@@ -424,30 +455,30 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
             partial_values = filter_outputs(partial_state, graph, select) if partial_state is not None else {}
             total_duration_ms = (time.time() - start_time) * 1000
             if dispatcher.active:
-                from hypergraph.events.types import InterruptEvent, RunEndEvent
-                from hypergraph.events.types import RunStatus as EventRunStatus
+                from hypergraph.events.types import InterruptEvent
 
                 await dispatcher.emit_async(
                     InterruptEvent(
                         run_id=run_id,
                         span_id=pause.span_id or run_span_id,
                         parent_span_id=run_span_id,
+                        workflow_id=workflow_id,
+                        item_index=_item_index,
                         node_name=pause.pause_info.node_name,
                         graph_name=graph.name,
-                        workflow_id=workflow_id,
                         value=pause.pause_info.value,
                         response_param=pause.pause_info.output_param,
                     )
                 )
-                await dispatcher.emit_async(
-                    RunEndEvent(
-                        run_id=run_id,
-                        span_id=run_span_id,
-                        parent_span_id=_parent_span_id,
-                        graph_name=graph.name,
-                        status=EventRunStatus.PAUSED,
-                        duration_ms=total_duration_ms,
-                    )
+                await self._emit_run_end_async(
+                    dispatcher,
+                    run_id,
+                    run_span_id,
+                    graph,
+                    start_time,
+                    _parent_span_id,
+                    context=run_context,
+                    status=RunStatus.PAUSED.value,
                 )
             if has_checkpointer:
                 for record in step_buffer:
@@ -487,6 +518,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                 graph,
                 start_time,
                 _parent_span_id,
+                context=run_context,
                 error=error,
             )
 
@@ -545,6 +577,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
         workflow_id: str | None = None,
         _parent_span_id: str | None = None,
         _parent_run_id: str | None = None,
+        _item_index: int | None = None,
         **input_values: Any,
     ) -> MapResult:
         """Execute a graph multiple times with different inputs."""
@@ -594,8 +627,10 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
             dispatcher,
             graph,
             _parent_span_id,
+            context=RunContext(workflow_id=workflow_id, item_index=_item_index),
             is_map=True,
             map_size=len(input_variations),
+            lineage=RunLineage(parent_workflow_id=_parent_run_id),
         )
         start_time = time.time()
 
@@ -659,6 +694,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                     _parent_run_id=workflow_id,
                     _validation_ctx=ctx,
                     _run_config={_MAP_SIGNATURE_CONFIG_KEY: item_signature},
+                    _item_index=idx,
                 )
             except Exception as e:
                 # Catch validation errors (e.g., MissingInputError) that raise
@@ -718,6 +754,8 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                         if result.status == RunStatus.FAILED:
                             raise result.error  # type: ignore[misc]
 
+            batch_summary = BatchSummary.from_results(results)
+
             await self._emit_run_end_async(
                 dispatcher,
                 map_run_id,
@@ -725,6 +763,9 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                 graph,
                 start_time,
                 _parent_span_id,
+                context=RunContext(workflow_id=workflow_id, item_index=_item_index),
+                status=batch_summary.event_status_value,
+                batch_summary=batch_summary,
             )
             total_duration_ms = (time.time() - start_time) * 1000
 

--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -433,9 +433,10 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
             )
             # Flush buffered steps ("exit" mode) and mark run completed
             if has_checkpointer:
+                from hypergraph.checkpointers.types import WorkflowStatus
+
                 for record in step_buffer:
                     await checkpointer.save_step(record)
-                from hypergraph.checkpointers.types import WorkflowStatus
                 from hypergraph.runners._shared.checkpoint_helpers import checkpoint_offsets
 
                 _, step_offset = checkpoint_offsets(resume_checkpoint)
@@ -443,7 +444,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                 error_count = sum(1 for r in collector._records if r.status == "failed")
                 await checkpointer.update_run_status(
                     workflow_id,
-                    WorkflowStatus.COMPLETED,
+                    WorkflowStatus.STOPPED if status == RunStatus.STOPPED else WorkflowStatus.COMPLETED,
                     duration_ms=total_duration_ms,
                     node_count=step_count,
                     error_count=error_count,
@@ -774,10 +775,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                 from hypergraph.checkpointers.types import WorkflowStatus
 
                 error_count = sum(1 for r in results if r.status == RunStatus.FAILED)
-                paused_count = sum(1 for r in results if r.status == RunStatus.PAUSED)
-                persisted_status = (
-                    WorkflowStatus.FAILED if error_count > 0 else WorkflowStatus.PAUSED if paused_count > 0 else WorkflowStatus.COMPLETED
-                )
+                persisted_status = WorkflowStatus(batch_summary.workflow_status_value)
                 await checkpointer.update_run_status(
                     workflow_id,
                     persisted_status,

--- a/src/hypergraph/runners/_shared/template_sync.py
+++ b/src/hypergraph/runners/_shared/template_sync.py
@@ -17,6 +17,13 @@ from hypergraph.exceptions import (
     WorkflowAlreadyCompletedError,
     WorkflowForkError,
 )
+from hypergraph.runners._shared.event_metadata import (
+    DEFAULT_RUN_CONTEXT,
+    DEFAULT_RUN_LINEAGE,
+    BatchSummary,
+    RunContext,
+    RunLineage,
+)
 from hypergraph.runners._shared.helpers import (
     _UNSET_SELECT,
     _validate_error_handling,
@@ -97,6 +104,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
         checkpoint: Any | None = None,
         step_buffer: list[Any] | None = None,
         _complete_on_stop: bool = False,
+        item_index: int | None = None,
     ) -> GraphState:
         """Execute graph and return final state."""
         ...
@@ -116,8 +124,10 @@ class SyncRunnerTemplate(BaseRunner, ABC):
         graph: Graph,
         parent_span_id: str | None,
         *,
+        context: RunContext = DEFAULT_RUN_CONTEXT,
         is_map: bool = False,
         map_size: int | None = None,
+        lineage: RunLineage = DEFAULT_RUN_LINEAGE,
     ) -> tuple[str, str]:
         """Emit run-start event."""
         ...
@@ -132,7 +142,10 @@ class SyncRunnerTemplate(BaseRunner, ABC):
         start_time: float,
         parent_span_id: str | None,
         *,
+        context: RunContext = DEFAULT_RUN_CONTEXT,
+        status: str | None = None,
         error: BaseException | None = None,
+        batch_summary: BatchSummary | None = None,
     ) -> None:
         """Emit run-end event."""
         ...
@@ -188,6 +201,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
         _validation_ctx: _InputValidationContext | None = None,
         _run_config: dict[str, Any] | None = None,
         _complete_on_stop: bool = False,
+        _item_index: int | None = None,
         **input_values: Any,
     ) -> RunResult:
         """Execute a graph once."""
@@ -260,6 +274,16 @@ class SyncRunnerTemplate(BaseRunner, ABC):
             fork_superstep = getattr(resume_checkpoint, "source_superstep", None)
             retry_of = getattr(resume_checkpoint, "retry_of", None)
             retry_index = getattr(resume_checkpoint, "retry_index", None)
+        is_resume = resume_checkpoint is not None and forked_from is None and retry_of is None
+        run_context = RunContext(workflow_id=workflow_id, item_index=_item_index)
+        run_lineage = RunLineage(
+            parent_workflow_id=_parent_run_id,
+            forked_from=forked_from,
+            fork_superstep=fork_superstep,
+            retry_of=retry_of,
+            retry_index=retry_index,
+            is_resume=is_resume,
+        )
 
         validation_values = build_resume_validation_values(graph, normalized_values, resume_checkpoint)
 
@@ -314,7 +338,13 @@ class SyncRunnerTemplate(BaseRunner, ABC):
         collector = RunLogCollector()
         all_processors = [collector] + (event_processors or [])
         dispatcher = self._create_dispatcher(all_processors)
-        run_id, run_span_id = self._emit_run_start_sync(dispatcher, graph, _parent_span_id)
+        run_id, run_span_id = self._emit_run_start_sync(
+            dispatcher,
+            graph,
+            _parent_span_id,
+            context=run_context,
+            lineage=run_lineage,
+        )
         start_time = time.time()
 
         # Checkpointer lifecycle — upsert run record
@@ -351,6 +381,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
                 checkpoint=resume_checkpoint,
                 step_buffer=step_buffer,
                 _complete_on_stop=_complete_on_stop,
+                item_index=_item_index,
             )
             output_values = filter_outputs(state, graph, select, on_missing)
             total_duration_ms = (time.time() - start_time) * 1000
@@ -368,6 +399,8 @@ class SyncRunnerTemplate(BaseRunner, ABC):
                         span_id=run_span_id,
                         parent_span_id=_parent_span_id,
                         workflow_id=workflow_id,
+                        item_index=_item_index,
+                        graph_name=graph.name,
                         info=stop_info,
                     )
                 )
@@ -386,6 +419,8 @@ class SyncRunnerTemplate(BaseRunner, ABC):
                 graph,
                 start_time,
                 _parent_span_id,
+                context=run_context,
+                status=status.value,
             )
             # Flush buffered steps and mark run completed
             if sync_cp is not None:
@@ -399,30 +434,30 @@ class SyncRunnerTemplate(BaseRunner, ABC):
             partial_values = filter_outputs(partial_state, graph, select) if partial_state is not None else {}
             total_duration_ms = (time.time() - start_time) * 1000
             if dispatcher.active:
-                from hypergraph.events.types import InterruptEvent, RunEndEvent
-                from hypergraph.events.types import RunStatus as EventRunStatus
+                from hypergraph.events.types import InterruptEvent
 
                 dispatcher.emit(
                     InterruptEvent(
                         run_id=run_id,
                         span_id=pause.span_id or run_span_id,
                         parent_span_id=run_span_id,
+                        workflow_id=workflow_id,
+                        item_index=_item_index,
                         node_name=pause.pause_info.node_name,
                         graph_name=graph.name,
-                        workflow_id=workflow_id,
                         value=pause.pause_info.value,
                         response_param=pause.pause_info.output_param,
                     )
                 )
-                dispatcher.emit(
-                    RunEndEvent(
-                        run_id=run_id,
-                        span_id=run_span_id,
-                        parent_span_id=_parent_span_id,
-                        graph_name=graph.name,
-                        status=EventRunStatus.PAUSED,
-                        duration_ms=total_duration_ms,
-                    )
+                self._emit_run_end_sync(
+                    dispatcher,
+                    run_id,
+                    run_span_id,
+                    graph,
+                    start_time,
+                    _parent_span_id,
+                    context=run_context,
+                    status=RunStatus.PAUSED.value,
                 )
             if sync_cp is not None:
                 from hypergraph.checkpointers.types import WorkflowStatus
@@ -462,6 +497,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
                 graph,
                 start_time,
                 _parent_span_id,
+                context=run_context,
                 error=error,
             )
 
@@ -506,6 +542,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
         workflow_id: str | None = None,
         _parent_span_id: str | None = None,
         _parent_run_id: str | None = None,
+        _item_index: int | None = None,
         **input_values: Any,
     ) -> MapResult:
         """Execute a graph multiple times with different inputs."""
@@ -550,8 +587,10 @@ class SyncRunnerTemplate(BaseRunner, ABC):
             dispatcher,
             graph,
             _parent_span_id,
+            context=RunContext(workflow_id=workflow_id, item_index=_item_index),
             is_map=True,
             map_size=len(input_variations),
+            lineage=RunLineage(parent_workflow_id=_parent_run_id),
         )
         start_time = time.time()
 
@@ -613,10 +652,13 @@ class SyncRunnerTemplate(BaseRunner, ABC):
                     _parent_run_id=workflow_id,
                     _validation_ctx=ctx,
                     _run_config={_MAP_SIGNATURE_CONFIG_KEY: item_signature},
+                    _item_index=idx,
                 )
                 results.append(result)
                 if error_handling == "raise" and result.status == RunStatus.FAILED:
                     raise result.error  # type: ignore[misc]
+
+            batch_summary = BatchSummary.from_results(results)
 
             self._emit_run_end_sync(
                 dispatcher,
@@ -625,6 +667,9 @@ class SyncRunnerTemplate(BaseRunner, ABC):
                 graph,
                 start_time,
                 _parent_span_id,
+                context=RunContext(workflow_id=workflow_id, item_index=_item_index),
+                status=batch_summary.event_status_value,
+                batch_summary=batch_summary,
             )
             total_duration_ms = (time.time() - start_time) * 1000
 

--- a/src/hypergraph/runners/_shared/template_sync.py
+++ b/src/hypergraph/runners/_shared/template_sync.py
@@ -424,10 +424,19 @@ class SyncRunnerTemplate(BaseRunner, ABC):
             )
             # Flush buffered steps and mark run completed
             if sync_cp is not None:
+                from hypergraph.checkpointers.types import WorkflowStatus
                 from hypergraph.runners._shared.checkpoint_helpers import checkpoint_offsets
 
                 _, _step_offset = checkpoint_offsets(resume_checkpoint)
-                _flush_and_complete(sync_cp, workflow_id, step_buffer, collector, total_duration_ms, step_offset=_step_offset)
+                _flush_and_complete(
+                    sync_cp,
+                    workflow_id,
+                    step_buffer,
+                    collector,
+                    total_duration_ms,
+                    step_offset=_step_offset,
+                    status=WorkflowStatus.STOPPED if status == RunStatus.STOPPED else WorkflowStatus.COMPLETED,
+                )
             return result
         except PauseExecution as pause:
             partial_state = getattr(pause, "_partial_state", None)
@@ -678,10 +687,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
                 from hypergraph.checkpointers.types import WorkflowStatus
 
                 error_count = sum(1 for r in results if r.status == RunStatus.FAILED)
-                paused_count = sum(1 for r in results if r.status == RunStatus.PAUSED)
-                persisted_status = (
-                    WorkflowStatus.FAILED if error_count > 0 else WorkflowStatus.PAUSED if paused_count > 0 else WorkflowStatus.COMPLETED
-                )
+                persisted_status = WorkflowStatus(batch_summary.workflow_status_value)
                 sync_cp.update_run_status_sync(
                     workflow_id,
                     persisted_status,
@@ -728,18 +734,24 @@ class SyncRunnerTemplate(BaseRunner, ABC):
 
 
 def _flush_and_complete(
-    sync_cp: Any, workflow_id: str, step_buffer: list, collector: RunLogCollector, total_duration_ms: float, *, step_offset: int = 0
+    sync_cp: Any,
+    workflow_id: str,
+    step_buffer: list,
+    collector: RunLogCollector,
+    total_duration_ms: float,
+    *,
+    step_offset: int = 0,
+    status: Any,
 ) -> None:
-    """Flush buffered steps and mark run completed."""
+    """Flush buffered steps and mark a terminal run status."""
     for record in step_buffer:
         sync_cp.save_step_sync(record)
-    from hypergraph.checkpointers.types import WorkflowStatus
 
     step_count = step_offset + len(collector._records)
     error_count = sum(1 for r in collector._records if r.status == "failed")
     sync_cp.update_run_status_sync(
         workflow_id,
-        WorkflowStatus.COMPLETED,
+        status,
         duration_ms=total_duration_ms,
         node_count=step_count,
         error_count=error_count,

--- a/src/hypergraph/runners/_shared/types.py
+++ b/src/hypergraph/runners/_shared/types.py
@@ -694,6 +694,7 @@ class ExecutionContext:
     show_progress: bool | None = None
     parent_span_id: str | None = None
     workflow_id: str | None = None
+    item_index: int | None = None
     run_id: str = ""
     provided_values: dict[str, Any] = field(default_factory=dict)
     is_resuming: bool = False

--- a/src/hypergraph/runners/async_/executors/graph_node.py
+++ b/src/hypergraph/runners/async_/executors/graph_node.py
@@ -116,6 +116,7 @@ class AsyncGraphNodeExecutor:
                 "workflow_id": child_workflow_id,
                 "_parent_span_id": ctx.parent_span_id,
                 "_parent_run_id": ctx.workflow_id,
+                "_item_index": ctx.item_index,
             }
             if getattr(node, "_complete_on_stop", False):
                 map_kwargs["_complete_on_stop"] = True
@@ -135,6 +136,7 @@ class AsyncGraphNodeExecutor:
             "workflow_id": child_workflow_id,
             "_parent_span_id": ctx.parent_span_id,
             "_parent_run_id": ctx.workflow_id,
+            "_item_index": ctx.item_index,
         }
         if runner.capabilities.supports_checkpointing:
             run_kwargs["fork_from"] = child_fork_from

--- a/src/hypergraph/runners/async_/runner.py
+++ b/src/hypergraph/runners/async_/runner.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import time
 from typing import TYPE_CHECKING, Any
 
 from hypergraph.exceptions import ExecutionError, InfiniteLoopError, WorkflowAlreadyRunningError
@@ -12,6 +11,13 @@ from hypergraph.nodes.function import FunctionNode
 from hypergraph.nodes.gate import IfElseNode, RouteNode
 from hypergraph.nodes.graph_node import GraphNode
 from hypergraph.nodes.interrupt import InterruptNode
+from hypergraph.runners._shared.event_metadata import (
+    DEFAULT_RUN_CONTEXT,
+    DEFAULT_RUN_LINEAGE,
+    BatchSummary,
+    RunContext,
+    RunLineage,
+)
 from hypergraph.runners._shared.helpers import ExecutionFrontier, compute_execution_scope, initialize_state
 from hypergraph.runners._shared.protocols import AsyncNodeExecutor
 from hypergraph.runners._shared.stop import StopSignal, get_stop_signal, reset_stop_signal, set_stop_signal
@@ -21,7 +27,6 @@ from hypergraph.runners._shared.types import (
     GraphState,
     PauseExecution,
     RunnerCapabilities,
-    _generate_run_id,
 )
 from hypergraph.runners.async_.executors import (
     AsyncFunctionNodeExecutor,
@@ -161,6 +166,7 @@ class AsyncRunner(AsyncRunnerTemplate):
         checkpoint: Any | None = None,
         step_buffer: list[Any] | None = None,
         _complete_on_stop: bool = False,
+        item_index: int | None = None,
     ) -> GraphState:
         """Execute graph until no more ready nodes or max_iterations reached.
 
@@ -208,6 +214,7 @@ class AsyncRunner(AsyncRunnerTemplate):
                 show_progress=False,
                 workflow_id=workflow_id,
                 run_id=run_id,
+                item_index=item_index,
                 provided_values=values,
                 is_resuming=(checkpoint is not None if self._checkpointer_instance is not None else True),
                 emit_fn=dispatcher.emit if dispatcher.active else None,
@@ -240,6 +247,8 @@ class AsyncRunner(AsyncRunnerTemplate):
                             run_id=run_id,
                             span_id=_generate_span_id(),
                             parent_span_id=run_span_id,
+                            workflow_id=workflow_id,
+                            item_index=ctx_base.item_index,
                             graph_name=graph.name,
                             superstep=superstep_idx,
                         )
@@ -268,6 +277,7 @@ class AsyncRunner(AsyncRunnerTemplate):
                         dispatcher=dispatcher,
                         run_id=run_id,
                         run_span_id=run_span_id,
+                        superstep_idx=superstep_idx,
                     )
                 except PauseExecution:
                     # Save step records before propagating the pause.
@@ -415,16 +425,20 @@ class AsyncRunner(AsyncRunnerTemplate):
         graph: Graph,
         parent_span_id: str | None,
         *,
+        context: RunContext = DEFAULT_RUN_CONTEXT,
         is_map: bool = False,
         map_size: int | None = None,
+        lineage: RunLineage = DEFAULT_RUN_LINEAGE,
     ) -> tuple[str, str]:
         """Emit run-start event via async helper."""
         return await _emit_run_start(
             dispatcher,
             graph,
             parent_span_id,
+            context=context,
             is_map=is_map,
             map_size=map_size,
+            lineage=lineage,
         )
 
     async def _emit_run_end_async(
@@ -436,7 +450,10 @@ class AsyncRunner(AsyncRunnerTemplate):
         start_time: float,
         parent_span_id: str | None,
         *,
+        context: RunContext = DEFAULT_RUN_CONTEXT,
+        status: str | None = None,
         error: BaseException | None = None,
+        batch_summary: BatchSummary | None = None,
     ) -> None:
         """Emit run-end event via async helper."""
         await _emit_run_end(
@@ -446,7 +463,10 @@ class AsyncRunner(AsyncRunnerTemplate):
             graph,
             start_time,
             parent_span_id,
+            context=context,
+            status=status,
             error=error,
+            batch_summary=batch_summary,
         )
 
     async def _shutdown_dispatcher_async(self, dispatcher: EventDispatcher) -> None:
@@ -486,30 +506,27 @@ async def _emit_run_start(
     graph: Graph,
     parent_span_id: str | None,
     *,
+    context: RunContext = DEFAULT_RUN_CONTEXT,
     is_map: bool = False,
     map_size: int | None = None,
+    lineage: RunLineage = DEFAULT_RUN_LINEAGE,
 ) -> tuple[str, str]:
     """Emit RunStartEvent and return (run_id, span_id)."""
-    from hypergraph.events.types import _generate_span_id
+    from hypergraph.runners._shared.event_helpers import build_run_start_event
 
-    run_id = _generate_run_id()
-    span_id = _generate_span_id()
+    run_id, span_id, event = build_run_start_event(
+        graph,
+        parent_span_id,
+        context=context,
+        is_map=is_map,
+        map_size=map_size,
+        lineage=lineage,
+    )
 
     if not dispatcher.active:
         return run_id, span_id
 
-    from hypergraph.events.types import RunStartEvent
-
-    await dispatcher.emit_async(
-        RunStartEvent(
-            run_id=run_id,
-            span_id=span_id,
-            parent_span_id=parent_span_id,
-            graph_name=graph.name,
-            is_map=is_map,
-            map_size=map_size,
-        )
-    )
+    await dispatcher.emit_async(event)
     return run_id, span_id
 
 
@@ -521,23 +538,27 @@ async def _emit_run_end(
     start_time: float,
     parent_span_id: str | None,
     *,
+    context: RunContext = DEFAULT_RUN_CONTEXT,
+    status: str | None = None,
     error: BaseException | None = None,
+    batch_summary: BatchSummary | None = None,
 ) -> None:
     """Emit RunEndEvent."""
     if not dispatcher.active:
         return
 
-    from hypergraph.events.types import RunEndEvent
+    from hypergraph.runners._shared.event_helpers import build_run_end_event
 
-    duration_ms = (time.time() - start_time) * 1000
     await dispatcher.emit_async(
-        RunEndEvent(
-            run_id=run_id,
-            span_id=span_id,
-            parent_span_id=parent_span_id,
-            graph_name=graph.name,
-            status="failed" if error else "completed",
-            error=str(error) if error else None,
-            duration_ms=duration_ms,
+        build_run_end_event(
+            run_id,
+            span_id,
+            graph,
+            start_time,
+            parent_span_id,
+            context=context,
+            status=status,
+            error=error,
+            batch_summary=batch_summary,
         )
     )

--- a/src/hypergraph/runners/async_/superstep.py
+++ b/src/hypergraph/runners/async_/superstep.py
@@ -63,6 +63,7 @@ async def run_superstep_async(
     dispatcher: EventDispatcher | None = None,
     run_id: str = "",
     run_span_id: str = "",
+    superstep_idx: int | None = None,
 ) -> GraphState:
     """Execute one superstep with concurrent node execution.
 
@@ -113,18 +114,69 @@ async def run_superstep_async(
             outputs = cached_outputs
             restore_routing_decision(node, outputs, new_state)
             # Emit NodeStartEvent -> CacheHitEvent -> RouteDecision? -> NodeEndEvent(cached=True)
-            node_span_id, start_evt = build_node_start_event(run_id, run_span_id, node, graph)
+            node_span_id, start_evt = build_node_start_event(
+                run_id,
+                run_span_id,
+                node,
+                graph,
+                workflow_id=ctx_base.workflow_id,
+                item_index=ctx_base.item_index,
+                superstep=superstep_idx,
+            )
             if active:
                 await dispatcher.emit_async(start_evt)
-                await dispatcher.emit_async(build_cache_hit_event(run_id, node_span_id, run_span_id, node, graph, cache_key))
-                route_evt = build_route_decision_event(run_id, run_span_id, node, graph, new_state)
+                await dispatcher.emit_async(
+                    build_cache_hit_event(
+                        run_id,
+                        node_span_id,
+                        run_span_id,
+                        node,
+                        graph,
+                        cache_key,
+                        workflow_id=ctx_base.workflow_id,
+                        item_index=ctx_base.item_index,
+                        superstep=superstep_idx,
+                    )
+                )
+                route_evt = build_route_decision_event(
+                    run_id,
+                    run_span_id,
+                    node_span_id,
+                    node,
+                    graph,
+                    new_state,
+                    workflow_id=ctx_base.workflow_id,
+                    item_index=ctx_base.item_index,
+                    superstep=superstep_idx,
+                )
                 if route_evt is not None:
                     await dispatcher.emit_async(route_evt)
-                await dispatcher.emit_async(build_node_end_event(run_id, node_span_id, run_span_id, node, graph, duration_ms=0.0, cached=True))
+                await dispatcher.emit_async(
+                    build_node_end_event(
+                        run_id,
+                        node_span_id,
+                        run_span_id,
+                        node,
+                        graph,
+                        duration_ms=0.0,
+                        cached=True,
+                        workflow_id=ctx_base.workflow_id,
+                        item_index=ctx_base.item_index,
+                        superstep=superstep_idx,
+                    )
+                )
             return node, outputs, input_versions, wait_for_versions, 0.0, True
 
         # Emit NodeStartEvent
-        node_span_id, start_evt = build_node_start_event(run_id, run_span_id, node, graph)
+        node_span_id, start_evt = build_node_start_event(
+            run_id,
+            run_span_id,
+            node,
+            graph,
+            workflow_id=ctx_base.workflow_id,
+            item_index=ctx_base.item_index,
+            superstep=superstep_idx,
+        )
         if active:
             await dispatcher.emit_async(start_evt)
 
@@ -152,7 +204,17 @@ async def run_superstep_async(
                 store_in_cache(node, outputs, new_state, cache, cache_key)
 
             if active:
-                route_evt = build_route_decision_event(run_id, run_span_id, node, graph, new_state)
+                route_evt = build_route_decision_event(
+                    run_id,
+                    run_span_id,
+                    node_span_id,
+                    node,
+                    graph,
+                    new_state,
+                    workflow_id=ctx_base.workflow_id,
+                    item_index=ctx_base.item_index,
+                    superstep=superstep_idx,
+                )
                 if route_evt is not None:
                     await dispatcher.emit_async(route_evt)
                 await dispatcher.emit_async(
@@ -164,6 +226,9 @@ async def run_superstep_async(
                         graph,
                         duration_ms,
                         inner_logs=tuple(inner_logs),
+                        workflow_id=ctx_base.workflow_id,
+                        item_index=ctx_base.item_index,
+                        superstep=superstep_idx,
                     )
                 )
 
@@ -173,7 +238,18 @@ async def run_superstep_async(
             raise
         except Exception:
             if active:
-                await dispatcher.emit_async(build_node_error_event(run_id, node_span_id, run_span_id, node, graph))
+                await dispatcher.emit_async(
+                    build_node_error_event(
+                        run_id,
+                        node_span_id,
+                        run_span_id,
+                        node,
+                        graph,
+                        workflow_id=ctx_base.workflow_id,
+                        item_index=ctx_base.item_index,
+                        superstep=superstep_idx,
+                    )
+                )
             raise
 
     # Execute all ready nodes concurrently

--- a/src/hypergraph/runners/sync/executors/graph_node.py
+++ b/src/hypergraph/runners/sync/executors/graph_node.py
@@ -59,14 +59,37 @@ class SyncGraphNodeExecutor:
         # Only inject on first execution: on cycle loop-back the node has already
         # executed so the inner interrupt should fire again, not skip.
         if node.name not in state.node_executions:
-            sync_cp = self.runner._get_sync_checkpointer(child_workflow_id)
-            if map_config is None and sync_cp is not None and sync_cp.get_run(child_workflow_id) is not None:
-                inner_inputs = {}
             prefix = f"{node.name}."
-            for key in state.values:
-                if key.startswith(prefix):
-                    inner_key = node.resolve_original_output_name(key[len(prefix) :])
-                    inner_inputs[inner_key] = state.values[key]
+            resume_values = {
+                node.resolve_original_output_name(key[len(prefix) :]): value for key, value in state.values.items() if key.startswith(prefix)
+            }
+            child_fork_from: str | None = None
+            child_retry_from: str | None = None
+
+            sync_cp = self.runner._get_sync_checkpointer(child_workflow_id)
+            if map_config is None and sync_cp is not None:
+                existing_child_run = sync_cp.get_run(child_workflow_id)
+                if existing_child_run is not None:
+                    inner_inputs = {}
+                elif resume_values:
+                    current_parent_run = sync_cp.get_run(ctx.workflow_id) if ctx.workflow_id else None
+                    source_parent_run_id = None
+                    if current_parent_run is not None:
+                        source_parent_run_id = current_parent_run.retry_of or current_parent_run.forked_from
+                    if source_parent_run_id is not None:
+                        source_child_run_id = graphnode_child_workflow_id(source_parent_run_id, node.name, state)
+                        source_child_run = sync_cp.get_run(source_child_run_id) if source_child_run_id is not None else None
+                        if source_child_run is not None:
+                            inner_inputs = {}
+                            if current_parent_run is not None and current_parent_run.retry_of is not None:
+                                child_retry_from = source_child_run_id
+                            else:
+                                child_fork_from = source_child_run_id
+
+            inner_inputs.update(resume_values)
+        else:
+            child_fork_from = None
+            child_retry_from = None
 
         # Use delegated runner if configured, otherwise inherit parent
         runner = node.runner_override or self.runner
@@ -85,6 +108,7 @@ class SyncGraphNodeExecutor:
                 "workflow_id": child_workflow_id,
                 "_parent_span_id": ctx.parent_span_id,
                 "_parent_run_id": ctx.workflow_id,
+                "_item_index": ctx.item_index,
             }
             if getattr(node, "_complete_on_stop", False):
                 map_kwargs["_complete_on_stop"] = True
@@ -101,7 +125,11 @@ class SyncGraphNodeExecutor:
             "workflow_id": child_workflow_id,
             "_parent_span_id": ctx.parent_span_id,
             "_parent_run_id": ctx.workflow_id,
+            "_item_index": ctx.item_index,
         }
+        if runner.capabilities.supports_checkpointing:
+            run_kwargs["fork_from"] = child_fork_from
+            run_kwargs["retry_from"] = child_retry_from
         if getattr(node, "_complete_on_stop", False):
             run_kwargs["_complete_on_stop"] = True
 

--- a/src/hypergraph/runners/sync/runner.py
+++ b/src/hypergraph/runners/sync/runner.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import time
 from typing import TYPE_CHECKING, Any
 
 from hypergraph.exceptions import ExecutionError, InfiniteLoopError, WorkflowAlreadyRunningError
@@ -10,11 +9,18 @@ from hypergraph.nodes.base import HyperNode
 from hypergraph.nodes.function import FunctionNode
 from hypergraph.nodes.gate import IfElseNode, RouteNode
 from hypergraph.nodes.graph_node import GraphNode
+from hypergraph.runners._shared.event_metadata import (
+    DEFAULT_RUN_CONTEXT,
+    DEFAULT_RUN_LINEAGE,
+    BatchSummary,
+    RunContext,
+    RunLineage,
+)
 from hypergraph.runners._shared.helpers import ExecutionFrontier, compute_execution_scope, initialize_state
 from hypergraph.runners._shared.protocols import NodeExecutor
 from hypergraph.runners._shared.stop import StopSignal, get_stop_signal, reset_stop_signal, set_stop_signal
 from hypergraph.runners._shared.template_sync import SyncRunnerTemplate
-from hypergraph.runners._shared.types import ExecutionContext, GraphState, RunnerCapabilities, _generate_run_id
+from hypergraph.runners._shared.types import ExecutionContext, GraphState, RunnerCapabilities
 from hypergraph.runners.sync.executors import (
     SyncFunctionNodeExecutor,
     SyncGraphNodeExecutor,
@@ -139,6 +145,7 @@ class SyncRunner(SyncRunnerTemplate):
         checkpoint: Any | None = None,
         step_buffer: list[Any] | None = None,
         _complete_on_stop: bool = False,
+        item_index: int | None = None,
     ) -> GraphState:
         """Execute graph until no more ready nodes or max_iterations reached.
 
@@ -174,6 +181,7 @@ class SyncRunner(SyncRunnerTemplate):
             # sub-runners from double-adding RichProgressProcessor.
             show_progress=False,
             workflow_id=workflow_id,
+            item_index=item_index,
             run_id=run_id,
             provided_values=values,
             emit_fn=dispatcher.emit if dispatcher.active else None,
@@ -208,6 +216,8 @@ class SyncRunner(SyncRunnerTemplate):
                             run_id=run_id,
                             span_id=_generate_span_id(),
                             parent_span_id=run_span_id,
+                            workflow_id=workflow_id,
+                            item_index=ctx_base.item_index,
                             graph_name=graph.name,
                             superstep=superstep_idx,
                         )
@@ -233,6 +243,7 @@ class SyncRunner(SyncRunnerTemplate):
                         dispatcher=dispatcher,
                         run_id=run_id,
                         run_span_id=run_span_id,
+                        superstep_idx=superstep_idx,
                     )
                 except ExecutionError as e:
                     superstep_error = e
@@ -287,16 +298,20 @@ class SyncRunner(SyncRunnerTemplate):
         graph: Graph,
         parent_span_id: str | None,
         *,
+        context: RunContext = DEFAULT_RUN_CONTEXT,
         is_map: bool = False,
         map_size: int | None = None,
+        lineage: RunLineage = DEFAULT_RUN_LINEAGE,
     ) -> tuple[str, str]:
         """Emit run-start event via sync helper."""
         return _emit_run_start(
             dispatcher,
             graph,
             parent_span_id,
+            context=context,
             is_map=is_map,
             map_size=map_size,
+            lineage=lineage,
         )
 
     def _emit_run_end_sync(
@@ -308,7 +323,10 @@ class SyncRunner(SyncRunnerTemplate):
         start_time: float,
         parent_span_id: str | None,
         *,
+        context: RunContext = DEFAULT_RUN_CONTEXT,
+        status: str | None = None,
         error: BaseException | None = None,
+        batch_summary: BatchSummary | None = None,
     ) -> None:
         """Emit run-end event via sync helper."""
         _emit_run_end(
@@ -318,7 +336,10 @@ class SyncRunner(SyncRunnerTemplate):
             graph,
             start_time,
             parent_span_id,
+            context=context,
+            status=status,
             error=error,
+            batch_summary=batch_summary,
         )
 
     def _shutdown_dispatcher_sync(self, dispatcher: EventDispatcher) -> None:
@@ -392,30 +413,27 @@ def _emit_run_start(
     graph: Graph,
     parent_span_id: str | None,
     *,
+    context: RunContext = DEFAULT_RUN_CONTEXT,
     is_map: bool = False,
     map_size: int | None = None,
+    lineage: RunLineage = DEFAULT_RUN_LINEAGE,
 ) -> tuple[str, str]:
     """Emit RunStartEvent and return (run_id, span_id)."""
-    from hypergraph.events.types import _generate_span_id
+    from hypergraph.runners._shared.event_helpers import build_run_start_event
 
-    run_id = _generate_run_id()
-    span_id = _generate_span_id()
+    run_id, span_id, event = build_run_start_event(
+        graph,
+        parent_span_id,
+        context=context,
+        is_map=is_map,
+        map_size=map_size,
+        lineage=lineage,
+    )
 
     if not dispatcher.active:
         return run_id, span_id
 
-    from hypergraph.events.types import RunStartEvent
-
-    dispatcher.emit(
-        RunStartEvent(
-            run_id=run_id,
-            span_id=span_id,
-            parent_span_id=parent_span_id,
-            graph_name=graph.name,
-            is_map=is_map,
-            map_size=map_size,
-        )
-    )
+    dispatcher.emit(event)
     return run_id, span_id
 
 
@@ -427,23 +445,27 @@ def _emit_run_end(
     start_time: float,
     parent_span_id: str | None,
     *,
+    context: RunContext = DEFAULT_RUN_CONTEXT,
+    status: str | None = None,
     error: BaseException | None = None,
+    batch_summary: BatchSummary | None = None,
 ) -> None:
     """Emit RunEndEvent."""
     if not dispatcher.active:
         return
 
-    from hypergraph.events.types import RunEndEvent
+    from hypergraph.runners._shared.event_helpers import build_run_end_event
 
-    duration_ms = (time.time() - start_time) * 1000
     dispatcher.emit(
-        RunEndEvent(
-            run_id=run_id,
-            span_id=span_id,
-            parent_span_id=parent_span_id,
-            graph_name=graph.name,
-            status="failed" if error else "completed",
-            error=str(error) if error else None,
-            duration_ms=duration_ms,
+        build_run_end_event(
+            run_id,
+            span_id,
+            graph,
+            start_time,
+            parent_span_id,
+            context=context,
+            status=status,
+            error=error,
+            batch_summary=batch_summary,
         )
     )

--- a/src/hypergraph/runners/sync/superstep.py
+++ b/src/hypergraph/runners/sync/superstep.py
@@ -216,6 +216,7 @@ def run_superstep_sync(
                     )
                 # Re-raise PauseExecution unwrapped (needed for InterruptNode)
                 if isinstance(e, PauseExecution):
+                    e.span_id = node_span_id
                     raise
                 # Wrap only Exception subclasses
                 if isinstance(e, Exception):

--- a/src/hypergraph/runners/sync/superstep.py
+++ b/src/hypergraph/runners/sync/superstep.py
@@ -42,6 +42,7 @@ def run_superstep_sync(
     dispatcher: EventDispatcher | None = None,
     run_id: str = "",
     run_span_id: str = "",
+    superstep_idx: int | None = None,
 ) -> GraphState:
     """Execute one superstep: run all ready nodes and update state.
 
@@ -81,17 +82,68 @@ def run_superstep_sync(
             outputs = cached_outputs
             restore_routing_decision(node, outputs, new_state)
             # Emit NodeStartEvent -> CacheHitEvent -> NodeEndEvent(cached=True)
-            node_span_id, start_evt = build_node_start_event(run_id, run_span_id, node, graph)
+            node_span_id, start_evt = build_node_start_event(
+                run_id,
+                run_span_id,
+                node,
+                graph,
+                workflow_id=ctx_base.workflow_id,
+                item_index=ctx_base.item_index,
+                superstep=superstep_idx,
+            )
             if active:
                 dispatcher.emit(start_evt)
-                dispatcher.emit(build_cache_hit_event(run_id, node_span_id, run_span_id, node, graph, cache_key))
-                route_evt = build_route_decision_event(run_id, run_span_id, node, graph, new_state)
+                dispatcher.emit(
+                    build_cache_hit_event(
+                        run_id,
+                        node_span_id,
+                        run_span_id,
+                        node,
+                        graph,
+                        cache_key,
+                        workflow_id=ctx_base.workflow_id,
+                        item_index=ctx_base.item_index,
+                        superstep=superstep_idx,
+                    )
+                )
+                route_evt = build_route_decision_event(
+                    run_id,
+                    run_span_id,
+                    node_span_id,
+                    node,
+                    graph,
+                    new_state,
+                    workflow_id=ctx_base.workflow_id,
+                    item_index=ctx_base.item_index,
+                    superstep=superstep_idx,
+                )
                 if route_evt is not None:
                     dispatcher.emit(route_evt)
-                dispatcher.emit(build_node_end_event(run_id, node_span_id, run_span_id, node, graph, duration_ms=0.0, cached=True))
+                dispatcher.emit(
+                    build_node_end_event(
+                        run_id,
+                        node_span_id,
+                        run_span_id,
+                        node,
+                        graph,
+                        duration_ms=0.0,
+                        cached=True,
+                        workflow_id=ctx_base.workflow_id,
+                        item_index=ctx_base.item_index,
+                        superstep=superstep_idx,
+                    )
+                )
         else:
             # Emit NodeStartEvent
-            node_span_id, start_evt = build_node_start_event(run_id, run_span_id, node, graph)
+            node_span_id, start_evt = build_node_start_event(
+                run_id,
+                run_span_id,
+                node,
+                graph,
+                workflow_id=ctx_base.workflow_id,
+                item_index=ctx_base.item_index,
+                superstep=superstep_idx,
+            )
             if active:
                 dispatcher.emit(start_evt)
 
@@ -119,7 +171,17 @@ def run_superstep_sync(
                     store_in_cache(node, outputs, new_state, cache, cache_key)
 
                 if active:
-                    route_evt = build_route_decision_event(run_id, run_span_id, node, graph, new_state)
+                    route_evt = build_route_decision_event(
+                        run_id,
+                        run_span_id,
+                        node_span_id,
+                        node,
+                        graph,
+                        new_state,
+                        workflow_id=ctx_base.workflow_id,
+                        item_index=ctx_base.item_index,
+                        superstep=superstep_idx,
+                    )
                     if route_evt is not None:
                         dispatcher.emit(route_evt)
                     dispatcher.emit(
@@ -131,13 +193,27 @@ def run_superstep_sync(
                             graph,
                             duration_ms,
                             inner_logs=tuple(inner_logs),
+                            workflow_id=ctx_base.workflow_id,
+                            item_index=ctx_base.item_index,
+                            superstep=superstep_idx,
                         )
                     )
 
             except BaseException as e:
                 duration_ms = (time.time() - node_start) * 1000
                 if active:
-                    dispatcher.emit(build_node_error_event(run_id, node_span_id, run_span_id, node, graph))
+                    dispatcher.emit(
+                        build_node_error_event(
+                            run_id,
+                            node_span_id,
+                            run_span_id,
+                            node,
+                            graph,
+                            workflow_id=ctx_base.workflow_id,
+                            item_index=ctx_base.item_index,
+                            superstep=superstep_idx,
+                        )
+                    )
                 # Re-raise PauseExecution unwrapped (needed for InterruptNode)
                 if isinstance(e, PauseExecution):
                     raise

--- a/tests/events/test_nontty_progress.py
+++ b/tests/events/test_nontty_progress.py
@@ -90,6 +90,14 @@ class TestNonTTYNodeProgress:
         output = capsys.readouterr().out
         assert re.search(rf"{_TS} ✗ g failed: timeout", output)
 
+    def test_run_partial_logged(self, capsys):
+        proc = _make_processor()
+        proc.on_run_start(_run_start("r1"))
+        proc.on_run_end(_run_end("r1", graph="g", status=RunStatus.PARTIAL))
+
+        output = capsys.readouterr().out
+        assert re.search(rf"{_TS} ◐ g completed with failures", output)
+
 
 class TestNonTTYMapMilestones:
     """Test milestone-based logging for map operations."""
@@ -147,6 +155,20 @@ class TestNonTTYMapMilestones:
         output = capsys.readouterr().out
         assert output.count("100%") == 1
         assert output.count("25%") == 1
+
+    def test_tty_map_treats_partial_child_as_failure(self):
+        proc = RichProgressProcessor(force_mode="tty")
+        try:
+            proc.on_run_start(_run_start("r1"))
+            proc.on_run_start(_run_start("map1", parent="r1", graph="process", is_map=True, map_size=1))
+            proc.on_run_start(_run_start("item1", parent="map1", graph="process"))
+            proc.on_run_end(_run_end("item1", parent="map1", graph="process", status=RunStatus.PARTIAL))
+
+            map_info = proc._spans["map1"]
+            assert map_info.failures == 1
+            assert map_info.succeeded == 0
+        finally:
+            proc.shutdown()
 
 
 class TestNonTTYAutoDetect:

--- a/tests/test_checkpointer/test_runner_integration.py
+++ b/tests/test_checkpointer/test_runner_integration.py
@@ -3,7 +3,7 @@
 import pytest
 import pytest_asyncio
 
-from hypergraph import AsyncRunner, Graph, node
+from hypergraph import AsyncRunner, Graph, SyncRunner, node
 from hypergraph.checkpointers import (
     CheckpointPolicy,
     SqliteCheckpointer,
@@ -194,6 +194,54 @@ class TestRunnerCheckpointIntegration:
         # succeed_a should be COMPLETED, fail_b should be FAILED
         assert statuses["succeed_a"] == StepStatus.COMPLETED
         assert statuses["fail_b"] == StepStatus.FAILED
+
+    async def test_async_map_partial_persists_parent_status(self, checkpointer):
+        """Parent map runs persist PARTIAL when child items have mixed outcomes."""
+        checkpointer.policy = CheckpointPolicy(durability="sync", retention="full")
+
+        @node(output_name="value")
+        def maybe_fail(x: int) -> int:
+            if x == 2:
+                raise RuntimeError("boom")
+            return x
+
+        runner = AsyncRunner(checkpointer=checkpointer)
+        result = await runner.map(
+            Graph([maybe_fail]),
+            {"x": [1, 2, 3]},
+            map_over="x",
+            error_handling="continue",
+            workflow_id="wf-map-partial-async",
+        )
+
+        assert result.partial is True
+        stored = checkpointer.get_run("wf-map-partial-async")
+        assert stored is not None
+        assert stored.status == WorkflowStatus.PARTIAL
+
+    def test_sync_map_partial_persists_parent_status(self, checkpointer):
+        """Sync parent map runs also persist PARTIAL for mixed child outcomes."""
+        checkpointer.policy = CheckpointPolicy(durability="sync", retention="full")
+
+        @node(output_name="value")
+        def maybe_fail(x: int) -> int:
+            if x == 2:
+                raise RuntimeError("boom")
+            return x
+
+        runner = SyncRunner(checkpointer=checkpointer)
+        result = runner.map(
+            Graph([maybe_fail]),
+            {"x": [1, 2, 3]},
+            map_over="x",
+            error_handling="continue",
+            workflow_id="wf-map-partial-sync",
+        )
+
+        assert result.partial is True
+        stored = checkpointer.get_run("wf-map-partial-sync")
+        assert stored is not None
+        assert stored.status == WorkflowStatus.PARTIAL
 
     async def test_cyclic_re_execution_persists(self, checkpointer):
         """Cyclic nodes that re-execute get new step records per superstep."""

--- a/tests/test_run_log/test_otel_processor.py
+++ b/tests/test_run_log/test_otel_processor.py
@@ -4,6 +4,8 @@ The import guard test always runs. SDK-dependent tests are skipped
 if opentelemetry-sdk is not installed.
 """
 
+import asyncio
+
 import pytest
 
 from hypergraph import Graph, SyncRunner, node
@@ -24,6 +26,16 @@ except ImportError:
     HAS_OTEL_SDK = False
 
 requires_otel = pytest.mark.skipif(not HAS_OTEL_SDK, reason="opentelemetry-sdk not installed")
+
+
+@pytest.fixture
+def sqlite_checkpointer(tmp_path):
+    """Provide an explicitly closed SQLite checkpointer for OTel tests."""
+    from hypergraph.checkpointers import SqliteCheckpointer
+
+    cp = SqliteCheckpointer(str(tmp_path / "otel-lineage.db"))
+    yield cp
+    asyncio.run(cp.close())
 
 
 class TestImportGuard:
@@ -144,28 +156,21 @@ class TestOTelProcessor:
         child_item_spans = [span for span in spans if span.name.startswith("graph ") and span.attributes.get("hypergraph.item_index") is not None]
         assert sorted(span.attributes["hypergraph.item_index"] for span in child_item_spans) == [0, 1, 2]
 
-    def test_forked_run_adds_lineage_link_when_source_span_is_known(self, tmp_path):
+    def test_forked_run_adds_lineage_link_when_source_span_is_known(self, sqlite_checkpointer):
         """Forked runs link back to the source run span when both are in-process."""
-        from hypergraph.checkpointers import SqliteCheckpointer
         from hypergraph.events.otel import OpenTelemetryProcessor
 
-        cp = SqliteCheckpointer(str(tmp_path / "otel-lineage.db"))
         processor = OpenTelemetryProcessor()
-        runner = SyncRunner(checkpointer=cp)
+        runner = SyncRunner(checkpointer=sqlite_checkpointer)
 
-        try:
-            root = runner.run(Graph([double]), {"x": 5}, workflow_id="wf-root", event_processors=[processor])
-            fork = runner.run(
-                Graph([double]),
-                {"x": 9},
-                workflow_id="wf-root-fork",
-                fork_from="wf-root",
-                event_processors=[processor],
-            )
-        finally:
-            import asyncio
-
-            asyncio.run(cp.close())
+        root = runner.run(Graph([double]), {"x": 5}, workflow_id="wf-root", event_processors=[processor])
+        fork = runner.run(
+            Graph([double]),
+            {"x": 9},
+            workflow_id="wf-root-fork",
+            fork_from="wf-root",
+            event_processors=[processor],
+        )
 
         assert root.completed
         assert fork.completed
@@ -178,31 +183,24 @@ class TestOTelProcessor:
         event_names = [event.name for event in fork_span.events]
         assert "hypergraph.fork" in event_names
 
-    def test_evicted_lineage_context_does_not_create_stale_link(self, tmp_path, monkeypatch):
+    def test_evicted_lineage_context_does_not_create_stale_link(self, sqlite_checkpointer, monkeypatch):
         """Eviction should degrade to no lineage link instead of reusing stale context."""
         import hypergraph.events.otel as otel_module
-        from hypergraph.checkpointers import SqliteCheckpointer
 
         monkeypatch.setattr(otel_module, "_MAX_LINEAGE_CONTEXTS", 1)
 
-        cp = SqliteCheckpointer(str(tmp_path / "otel-eviction.db"))
         processor = otel_module.OpenTelemetryProcessor()
-        runner = SyncRunner(checkpointer=cp)
+        runner = SyncRunner(checkpointer=sqlite_checkpointer)
 
-        try:
-            runner.run(Graph([double]), {"x": 1}, workflow_id="wf-root-1", event_processors=[processor])
-            runner.run(Graph([double]), {"x": 2}, workflow_id="wf-root-2", event_processors=[processor])
-            fork = runner.run(
-                Graph([double]),
-                {"x": 3},
-                workflow_id="wf-root-1-fork",
-                fork_from="wf-root-1",
-                event_processors=[processor],
-            )
-        finally:
-            import asyncio
-
-            asyncio.run(cp.close())
+        runner.run(Graph([double]), {"x": 1}, workflow_id="wf-root-1", event_processors=[processor])
+        runner.run(Graph([double]), {"x": 2}, workflow_id="wf-root-2", event_processors=[processor])
+        fork = runner.run(
+            Graph([double]),
+            {"x": 3},
+            workflow_id="wf-root-1-fork",
+            fork_from="wf-root-1",
+            event_processors=[processor],
+        )
 
         assert fork.completed
         spans = self.exporter.get_finished_spans()
@@ -254,4 +252,5 @@ class TestOTelProcessor:
         attrs = dict(run_span.attributes)
         assert attrs["hypergraph.run.outcome"] == "paused"
         assert attrs["hypergraph.duration_ms"] == 12.5
+        # Keep this internal check: paused runs must retain span context for resume links.
         assert "wf-sync-pause" in processor._workflow_span_contexts

--- a/tests/test_run_log/test_otel_processor.py
+++ b/tests/test_run_log/test_otel_processor.py
@@ -212,3 +212,46 @@ class TestOTelProcessor:
         assert len(fork_span.links) == 0
         event_names = [event.name for event in fork_span.events]
         assert "hypergraph.fork" in event_names
+
+    def test_interrupt_fallback_does_not_end_run_span_early(self):
+        """Fallback interrupt span ids must not prevent paused run metadata from exporting."""
+        from hypergraph.events.otel import OpenTelemetryProcessor
+        from hypergraph.events.types import InterruptEvent, RunEndEvent, RunStartEvent, RunStatus
+
+        processor = OpenTelemetryProcessor()
+        processor.on_run_start(
+            RunStartEvent(
+                run_id="run-sync-pause",
+                span_id="run-span",
+                workflow_id="wf-sync-pause",
+                graph_name="approval_flow",
+            )
+        )
+        processor.on_interrupt(
+            InterruptEvent(
+                run_id="run-sync-pause",
+                span_id="run-span",
+                parent_span_id="run-span",
+                workflow_id="wf-sync-pause",
+                node_name="approval",
+                graph_name="approval_flow",
+                response_param="decision",
+            )
+        )
+        processor.on_run_end(
+            RunEndEvent(
+                run_id="run-sync-pause",
+                span_id="run-span",
+                workflow_id="wf-sync-pause",
+                graph_name="approval_flow",
+                status=RunStatus.PAUSED,
+                duration_ms=12.5,
+            )
+        )
+
+        spans = self.exporter.get_finished_spans()
+        run_span = next(span for span in spans if span.name == "graph approval_flow")
+        attrs = dict(run_span.attributes)
+        assert attrs["hypergraph.run.outcome"] == "paused"
+        assert attrs["hypergraph.duration_ms"] == 12.5
+        assert "wf-sync-pause" in processor._workflow_span_contexts

--- a/tests/test_run_log/test_otel_processor.py
+++ b/tests/test_run_log/test_otel_processor.py
@@ -12,6 +12,7 @@ from hypergraph import Graph, SyncRunner, node
 try:
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.trace import StatusCode
 
     try:
         from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
@@ -55,6 +56,13 @@ def triple(doubled: int) -> int:
     return doubled + doubled // 2
 
 
+@node(output_name="value")
+def unstable(x: int) -> int:
+    if x == 2:
+        raise ValueError("boom")
+    return x
+
+
 @requires_otel
 class TestOTelProcessor:
     @pytest.fixture(autouse=True)
@@ -79,8 +87,8 @@ class TestOTelProcessor:
         )
         self.span_processor.shutdown()
 
-    def test_sync_run_produces_spans(self):
-        """SyncRunner with OTelProcessor exports spans."""
+    def test_sync_run_produces_graph_and_node_spans(self):
+        """SyncRunner with OTelProcessor exports graph + node spans."""
         from hypergraph.events.otel import OpenTelemetryProcessor
 
         graph = Graph([double, triple])
@@ -90,12 +98,12 @@ class TestOTelProcessor:
         assert result.completed
         spans = self.exporter.get_finished_spans()
         span_names = [s.name for s in spans]
-        assert any("node:double" in n for n in span_names)
-        assert any("node:triple" in n for n in span_names)
-        assert any("run:" in n for n in span_names)
+        assert any(name == "node double" for name in span_names)
+        assert any(name == "node triple" for name in span_names)
+        assert any(name.startswith("graph ") for name in span_names)
 
     def test_span_attributes_include_node_info(self):
-        """Node spans carry hypergraph-specific attributes."""
+        """Node spans carry Hypergraph execution attributes."""
         from hypergraph.events.otel import OpenTelemetryProcessor
 
         graph = Graph([double])
@@ -103,7 +111,104 @@ class TestOTelProcessor:
         SyncRunner().run(graph, {"x": 5}, event_processors=[processor])
 
         spans = self.exporter.get_finished_spans()
-        node_spans = [s for s in spans if s.name.startswith("node:")]
+        node_spans = [s for s in spans if s.name == "node double"]
         assert len(node_spans) >= 1
         attrs = dict(node_spans[0].attributes)
         assert attrs["hypergraph.node_name"] == "double"
+        assert attrs["hypergraph.superstep"] == 0
+
+    def test_map_parent_span_uses_batch_summary_attributes(self):
+        """Parent map spans export bounded aggregate outcome metadata."""
+        from hypergraph.events.otel import OpenTelemetryProcessor
+
+        graph = Graph([unstable])
+        processor = OpenTelemetryProcessor()
+        results = SyncRunner().map(
+            graph,
+            {"x": [1, 2, 3]},
+            map_over="x",
+            error_handling="continue",
+            event_processors=[processor],
+        )
+
+        assert results.partial
+        spans = self.exporter.get_finished_spans()
+        map_span = next(span for span in spans if span.attributes.get("hypergraph.is_map") is True)
+        attrs = dict(map_span.attributes)
+        assert attrs["hypergraph.batch.total_items"] == 3
+        assert attrs["hypergraph.batch.completed_items"] == 2
+        assert attrs["hypergraph.batch.failed_items"] == 1
+        assert attrs["hypergraph.batch.outcome"] == "partial"
+        assert map_span.status.status_code == StatusCode.UNSET
+
+        child_item_spans = [span for span in spans if span.name.startswith("graph ") and span.attributes.get("hypergraph.item_index") is not None]
+        assert sorted(span.attributes["hypergraph.item_index"] for span in child_item_spans) == [0, 1, 2]
+
+    def test_forked_run_adds_lineage_link_when_source_span_is_known(self, tmp_path):
+        """Forked runs link back to the source run span when both are in-process."""
+        from hypergraph.checkpointers import SqliteCheckpointer
+        from hypergraph.events.otel import OpenTelemetryProcessor
+
+        cp = SqliteCheckpointer(str(tmp_path / "otel-lineage.db"))
+        processor = OpenTelemetryProcessor()
+        runner = SyncRunner(checkpointer=cp)
+
+        try:
+            root = runner.run(Graph([double]), {"x": 5}, workflow_id="wf-root", event_processors=[processor])
+            fork = runner.run(
+                Graph([double]),
+                {"x": 9},
+                workflow_id="wf-root-fork",
+                fork_from="wf-root",
+                event_processors=[processor],
+            )
+        finally:
+            import asyncio
+
+            asyncio.run(cp.close())
+
+        assert root.completed
+        assert fork.completed
+        spans = self.exporter.get_finished_spans()
+        fork_span = next(span for span in spans if span.name.startswith("graph ") and span.attributes.get("hypergraph.workflow_id") == "wf-root-fork")
+        assert len(fork_span.links) == 1
+        link_attrs = dict(fork_span.links[0].attributes or {})
+        assert link_attrs["hypergraph.lineage.relationship"] == "fork"
+
+        event_names = [event.name for event in fork_span.events]
+        assert "hypergraph.fork" in event_names
+
+    def test_evicted_lineage_context_does_not_create_stale_link(self, tmp_path, monkeypatch):
+        """Eviction should degrade to no lineage link instead of reusing stale context."""
+        import hypergraph.events.otel as otel_module
+        from hypergraph.checkpointers import SqliteCheckpointer
+
+        monkeypatch.setattr(otel_module, "_MAX_LINEAGE_CONTEXTS", 1)
+
+        cp = SqliteCheckpointer(str(tmp_path / "otel-eviction.db"))
+        processor = otel_module.OpenTelemetryProcessor()
+        runner = SyncRunner(checkpointer=cp)
+
+        try:
+            runner.run(Graph([double]), {"x": 1}, workflow_id="wf-root-1", event_processors=[processor])
+            runner.run(Graph([double]), {"x": 2}, workflow_id="wf-root-2", event_processors=[processor])
+            fork = runner.run(
+                Graph([double]),
+                {"x": 3},
+                workflow_id="wf-root-1-fork",
+                fork_from="wf-root-1",
+                event_processors=[processor],
+            )
+        finally:
+            import asyncio
+
+            asyncio.run(cp.close())
+
+        assert fork.completed
+        spans = self.exporter.get_finished_spans()
+        fork_span = next(
+            span for span in spans if span.name.startswith("graph ") and span.attributes.get("hypergraph.workflow_id") == "wf-root-1-fork"
+        )
+        assert len(fork_span.links) == 0
+        event_names = [event.name for event in fork_span.events]
+        assert "hypergraph.fork" in event_names

--- a/tests/test_stop_and_stream.py
+++ b/tests/test_stop_and_stream.py
@@ -402,6 +402,41 @@ class TestStoppedStatus:
         assert result.stopped is True
         assert result.status == RunStatus.STOPPED
 
+    @pytest.mark.asyncio
+    async def test_async_stopped_run_persists_stopped_status(self, tmp_path):
+        from hypergraph.checkpointers import SqliteCheckpointer, WorkflowStatus
+
+        node_started = asyncio.Event()
+
+        @node(output_name="a")
+        async def step_a(ctx: NodeContext) -> int:
+            node_started.set()
+            for _ in range(100):
+                if ctx.stop_requested:
+                    return 0
+                await asyncio.sleep(0.001)
+            return 42
+
+        cp = SqliteCheckpointer(str(tmp_path / "async-stopped.db"))
+        try:
+            runner = AsyncRunner(checkpointer=cp)
+
+            async def stop_soon():
+                await node_started.wait()
+                await asyncio.sleep(0.01)
+                runner.stop("wf-async-stopped")
+
+            task = asyncio.create_task(stop_soon())
+            result = await runner.run(Graph([step_a]), workflow_id="wf-async-stopped")
+            await task
+
+            assert result.status == RunStatus.STOPPED
+            stored = await cp.get_run_async("wf-async-stopped")
+            assert stored is not None
+            assert stored.status == WorkflowStatus.STOPPED
+        finally:
+            await cp.close()
+
 
 # ---------------------------------------------------------------------------
 # 8. Resume after stop
@@ -818,6 +853,48 @@ class TestSyncRunnerStop:
 
         assert result.stopped is True
         assert result.status == RunStatus.STOPPED
+
+    def test_sync_stopped_run_persists_stopped_status(self, tmp_path):
+        import time as _time
+
+        from hypergraph.checkpointers import SqliteCheckpointer, WorkflowStatus
+
+        node_started = threading.Event()
+
+        @node(output_name="result")
+        def slow_node(ctx: NodeContext) -> str:
+            node_started.set()
+            for _ in range(1000):
+                if ctx.stop_requested:
+                    return "stopped"
+                _time.sleep(0.0001)
+            return "done"
+
+        cp = SqliteCheckpointer(str(tmp_path / "sync-stopped.db"))
+        try:
+            runner = SyncRunner(checkpointer=cp)
+
+            def stop_from_thread():
+                import time
+
+                node_started.wait(timeout=1.0)
+                time.sleep(0.01)
+                runner.stop("wf-sync-stopped")
+
+            t = threading.Thread(target=stop_from_thread)
+            t.start()
+
+            result = runner.run(Graph([slow_node]), workflow_id="wf-sync-stopped")
+            t.join()
+
+            assert result.status == RunStatus.STOPPED
+            stored = cp.get_run("wf-sync-stopped")
+            assert stored is not None
+            assert stored.status == WorkflowStatus.STOPPED
+        finally:
+            import asyncio
+
+            asyncio.run(cp.close())
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem / Bug / Challenge

Hypergraph already had opt-in OpenTelemetry support, but the export story was still thin for real observability use:
- run/node spans carried limited Hypergraph-specific semantics
- map, nested graph, stop, pause, resume, retry, and fork behavior were only partially represented
- lineage linking worked only as an implementation detail and had no bounded memory policy
- pause used a separate run-end event path, which made terminal-run semantics easier to drift

The goal of this PR is to make OTel a stronger interoperability/export layer while keeping Hypergraph's native inspect/debug UX as the primary debugging experience.

## Before / After

**Before:**

```python
runner = SyncRunner()
result = runner.run(graph, {"query": "What changed?"}, event_processors=[OpenTelemetryProcessor()])

# OTel exported basic run/node spans, but lineage, map outcomes, and terminal
# semantics were thin and some terminal paths had custom event construction.
```

**After:**

```python
runner = SyncRunner()
result = runner.run(graph, {"query": "What changed?"}, event_processors=[OpenTelemetryProcessor()])

# OTel now exports:
# - graph/map run spans and child node spans
# - explicit attrs like workflow_id, run_id, item_index, graph_name, node_name
# - lineage attrs/events for fork, retry, and resume
# - batch summary attrs for map parents
# - consistent terminal run-end semantics across complete/fail/pause/stop paths
```

Span shape example:

```text
graph outer
└── node inner
    └── graph inner
        └── node double
```

## Test Plan

- [x] `uv run ruff check src/ tests/`
- [x] `uv run ruff format --check src/ tests/`
- [x] `uv run pytest -W error -W 'ignore::pytest.PytestUnraisableExceptionWarning'`
- [x] Focused verification during development for OTel/events/checkpointer paths:
  - `uv run pytest tests/test_run_log/test_otel_processor.py tests/events/test_types.py tests/events/test_sync_events.py tests/events/test_async_events.py`
  - `uv run pytest tests/test_checkpointer/test_memory.py tests/test_checkpointer/test_resume.py tests/test_stop_and_stream.py tests/test_run_log/test_workflow_id.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add OpenTelemetry export of execution traces with span hierarchies, lineage linking (fork/retry/resume), per-item indexing, superstep context, and batch-level aggregate attributes; introduce `partial` and `stopped` run statuses.

* **Documentation**
  * Add OTel export guide, installation/usage examples, and update event reference with lineage, batch summary, and execution-context fields.

* **Tests**
  * Add tests validating span naming, batch-summary attributes, lineage linking/eviction, error/partial outcomes, and interrupt behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->