### PR TITLE
Mark data edges from mutex producers as exclusive

### DIFF
--- a/src/hypergraph/nodes/gate.py
+++ b/src/hypergraph/nodes/gate.py
@@ -309,6 +309,7 @@ class RouteNode(GateNode):
         """Branch-specific data for visualization."""
         return {
             "targets": ["END" if t is END else t for t in self.targets],
+            "multi_target": self.multi_target,
         }
 
 

--- a/src/hypergraph/viz/AGENTS.md
+++ b/src/hypergraph/viz/AGENTS.md
@@ -81,6 +81,15 @@ Selection happens in App via `expansionStateToKey()` and lookups in `meta.nodesB
    - `edge_type="ordering"` in NetworkX graph
    - Rendered with dashed style
 
+4. **Exclusive (mutex) data edges** (both modes)
+   - When two producers in different branches of an exclusive gate
+     (`@ifelse`, or `@route` with `multi_target=False`) feed the same input,
+     each contributing edge is tagged with `data.exclusive=True`.
+   - Detection lives in `viz/_common.py::compute_exclusive_data_edges` and
+     reads gate `branch_data` off the flat graph.
+   - React Flow renders them with `strokeDasharray='4 4'`; Mermaid uses the
+     dotted arrow (`-.->`).
+
 ## Input Grouping + Scope
 
 External inputs are grouped by **consumer set** and **bound status**:

--- a/src/hypergraph/viz/_common.py
+++ b/src/hypergraph/viz/_common.py
@@ -294,7 +294,7 @@ def _gate_branch_targets(branch_data: dict) -> list[str]:
     return targets
 
 
-def compute_mutex_groups(flat_graph: nx.DiGraph) -> list[list[set[str]]]:
+def _compute_mutex_groups(flat_graph: nx.DiGraph) -> list[list[set[str]]]:
     """Compute mutex groups from a flat graph using gate ``branch_data``.
 
     Each entry is a list of branch sets (one per gate target); two nodes are
@@ -315,7 +315,7 @@ def compute_mutex_groups(flat_graph: nx.DiGraph) -> list[list[set[str]]]:
     return groups
 
 
-def is_pair_mutex(a: str, b: str, mutex_groups: list[list[set[str]]]) -> bool:
+def _is_pair_mutex(a: str, b: str, mutex_groups: list[list[set[str]]]) -> bool:
     """Return True if two nodes are in different branches of the same gate."""
     for branches in mutex_groups:
         a_branch: int | None = None
@@ -337,7 +337,7 @@ def compute_exclusive_data_edges(flat_graph: nx.DiGraph) -> set[tuple[str, str, 
     same consumer and the two producers live in different branches of the same
     exclusive gate. Returned tuples cover both producers in such pairs.
     """
-    mutex_groups = compute_mutex_groups(flat_graph)
+    mutex_groups = _compute_mutex_groups(flat_graph)
     if not mutex_groups:
         return set()
 
@@ -345,7 +345,10 @@ def compute_exclusive_data_edges(flat_graph: nx.DiGraph) -> set[tuple[str, str, 
     for source, target, attrs in flat_graph.edges(data=True):
         if attrs.get("edge_type") != "data":
             continue
-        for value_name in attrs.get("value_names") or ():
+        # Match renderer behaviour: edges without explicit value names still
+        # emit a single edge keyed by "" — track them under that key too.
+        value_names = attrs.get("value_names") or [""]
+        for value_name in value_names:
             producers_by_input[(target, value_name)].append(source)
 
     exclusive: set[tuple[str, str, str]] = set()
@@ -354,7 +357,7 @@ def compute_exclusive_data_edges(flat_graph: nx.DiGraph) -> set[tuple[str, str, 
             continue
         mutex_sources: set[str] = set()
         for a, b in combinations(producers, 2):
-            if is_pair_mutex(a, b, mutex_groups):
+            if _is_pair_mutex(a, b, mutex_groups):
                 mutex_sources.add(a)
                 mutex_sources.add(b)
         for source in mutex_sources:

--- a/src/hypergraph/viz/_common.py
+++ b/src/hypergraph/viz/_common.py
@@ -7,11 +7,14 @@ one place prevents the two code paths from diverging.
 
 from __future__ import annotations
 
-from itertools import product
+from collections import Counter, defaultdict
+from itertools import combinations, product
 from typing import TYPE_CHECKING
 
+import networkx as nx
+
 if TYPE_CHECKING:
-    import networkx as nx
+    pass
 
 
 # =============================================================================
@@ -267,3 +270,93 @@ def build_output_to_producer_map(
                     output_to_producer[output] = node_id
 
     return output_to_producer
+
+
+# =============================================================================
+# Mutex (exclusive-branch) Detection
+# =============================================================================
+
+
+def _gate_branch_targets(branch_data: dict) -> list[str]:
+    """Return mutex-branch targets for a gate, or [] if not exclusive."""
+    if branch_data.get("multi_target"):
+        return []
+    targets: list[str] = []
+    if "when_true" in branch_data:
+        for key in ("when_true", "when_false"):
+            value = branch_data.get(key)
+            if isinstance(value, str) and value and value != "END":
+                targets.append(value)
+    elif "targets" in branch_data:
+        target_data = branch_data["targets"]
+        values = target_data.values() if isinstance(target_data, dict) else target_data
+        targets = [t for t in values if isinstance(t, str) and t and t != "END"]
+    return targets
+
+
+def compute_mutex_groups(flat_graph: nx.DiGraph) -> list[list[set[str]]]:
+    """Compute mutex groups from a flat graph using gate ``branch_data``.
+
+    Each entry is a list of branch sets (one per gate target); two nodes are
+    mutex iff they appear in different branch sets of the same entry.
+    """
+    groups: list[list[set[str]]] = []
+    for _, attrs in flat_graph.nodes(data=True):
+        branch_data = attrs.get("branch_data") or {}
+        if not branch_data:
+            continue
+        targets = _gate_branch_targets(branch_data)
+        targets = [t for t in targets if t in flat_graph]
+        if len(targets) < 2:
+            continue
+        reachable = {t: set(nx.descendants(flat_graph, t)) | {t} for t in targets}
+        counts = Counter(node for nodes in reachable.values() for node in nodes)
+        groups.append([{n for n in reachable[t] if counts[n] == 1} for t in targets])
+    return groups
+
+
+def is_pair_mutex(a: str, b: str, mutex_groups: list[list[set[str]]]) -> bool:
+    """Return True if two nodes are in different branches of the same gate."""
+    for branches in mutex_groups:
+        a_branch: int | None = None
+        b_branch: int | None = None
+        for i, branch in enumerate(branches):
+            if a in branch:
+                a_branch = i
+            if b in branch:
+                b_branch = i
+        if a_branch is not None and b_branch is not None and a_branch != b_branch:
+            return True
+    return False
+
+
+def compute_exclusive_data_edges(flat_graph: nx.DiGraph) -> set[tuple[str, str, str]]:
+    """Identify ``(source, target, value_name)`` data edges fed by mutex producers.
+
+    An edge is exclusive when another producer of the same value name feeds the
+    same consumer and the two producers live in different branches of the same
+    exclusive gate. Returned tuples cover both producers in such pairs.
+    """
+    mutex_groups = compute_mutex_groups(flat_graph)
+    if not mutex_groups:
+        return set()
+
+    producers_by_input: dict[tuple[str, str], list[str]] = defaultdict(list)
+    for source, target, attrs in flat_graph.edges(data=True):
+        if attrs.get("edge_type") != "data":
+            continue
+        for value_name in attrs.get("value_names") or ():
+            producers_by_input[(target, value_name)].append(source)
+
+    exclusive: set[tuple[str, str, str]] = set()
+    for (target, value_name), producers in producers_by_input.items():
+        if len(producers) < 2:
+            continue
+        mutex_sources: set[str] = set()
+        for a, b in combinations(producers, 2):
+            if is_pair_mutex(a, b, mutex_groups):
+                mutex_sources.add(a)
+                mutex_sources.add(b)
+        for source in mutex_sources:
+            exclusive.add((source, target, value_name))
+    return exclusive

--- a/src/hypergraph/viz/assets/viz.js
+++ b/src/hypergraph/viz/assets/viz.js
@@ -1748,9 +1748,11 @@
         var edgeType = e.data && e.data.edgeType;
         var isControl = edgeType === 'control';
         var isOrdering = edgeType === 'ordering';
+        var isExclusive = !!(e.data && e.data.exclusive);
         var st = { ...edgeOpts.style, strokeWidth: (e.data && e.data.isDataLink) ? 1.5 : 2 };
         if (isControl) st.strokeDasharray = '6 4';
         if (isOrdering) { st.stroke = '#8b5cf6'; st.strokeWidth = 1.5; st.strokeDasharray = '6 3'; }
+        if (isExclusive && !isControl && !isOrdering) st.strokeDasharray = '4 4';
         return { ...e, id: e.id + '_exp_' + (expansionKey ? expansionKey.replace(/,/g, '_') : 'none') + '_mode_' + renderModeKey,
           ...edgeOpts, style: st, markerEnd: edgeOpts.markerEnd, data: e.data };
       });

--- a/src/hypergraph/viz/mermaid.py
+++ b/src/hypergraph/viz/mermaid.py
@@ -22,6 +22,7 @@ from hypergraph.viz._common import (
     build_expansion_state,
     build_output_to_producer_map,
     build_param_to_consumer_map,
+    compute_exclusive_data_edges,
     is_descendant_of,
     is_node_visible,
 )
@@ -312,6 +313,7 @@ def _render_merged_edges(
         flat_graph,
         expansion_state,
     )
+    exclusive_data_edges = compute_exclusive_data_edges(flat_graph)
     seen_edges: set[tuple[str, str, str]] = set()
 
     for source, target, edge_data in flat_graph.edges(data=True):
@@ -374,7 +376,8 @@ def _render_merged_edges(
             if edge_key in seen_edges:
                 continue
             seen_edges.add(edge_key)
-            lines.append(_format_edge(actual_source, actual_target, None))
+            is_exclusive = (source, target, value_name) in exclusive_data_edges
+            lines.append(_format_edge(actual_source, actual_target, None, exclusive=is_exclusive))
 
     return lines
 
@@ -393,6 +396,7 @@ def _render_separate_edges(
         expansion_state,
         use_deepest=True,
     )
+    exclusive_data_edges = compute_exclusive_data_edges(flat_graph)
     seen_edges: set[tuple[str, ...]] = set()
 
     # Function → DATA edges
@@ -436,7 +440,8 @@ def _render_separate_edges(
                 edge_key = (_sanitize_id(data_id), _sanitize_id(target))
                 if edge_key not in seen_edges:
                     seen_edges.add(edge_key)
-                    lines.append(_format_edge(data_id, target, value_name))
+                    is_exclusive = (source, target, value_name) in exclusive_data_edges
+                    lines.append(_format_edge(data_id, target, value_name, exclusive=is_exclusive))
 
         elif edge_type == "ordering":
             value_name = value_names[0] if value_names else ""
@@ -472,12 +477,14 @@ def _format_edge(
     source: str,
     target: str,
     label: str | None,
+    exclusive: bool = False,
 ) -> str:
-    """Format a solid-arrow Mermaid edge."""
+    """Format a Mermaid data edge; dashed when fed by mutex producers."""
     s, t = _sanitize_id(source), _sanitize_id(target)
+    arrow = "-.->" if exclusive else "-->"
     if label:
-        return f"    {s} -->|{label}| {t}"
-    return f"    {s} --> {t}"
+        return f"    {s} {arrow}|{label}| {t}"
+    return f"    {s} {arrow} {t}"
 
 
 def _format_ordering_edge(source: str, target: str, label: str) -> str:

--- a/src/hypergraph/viz/mermaid.py
+++ b/src/hypergraph/viz/mermaid.py
@@ -298,12 +298,14 @@ def _format_node(safe_id: str, label: str, node_type: str) -> str:
 def _render_merged_edges(
     flat_graph: nx.DiGraph,
     expansion_state: dict[str, bool],
-) -> list[str]:
+    exclusive_data_edges: set[tuple[str, str, str]],
+) -> list[tuple[str, str]]:
     """Render edges in merged output mode (no DATA intermediaries).
 
-    Mirrors add_merged_output_edges() from renderer/edges.py.
+    Mirrors add_merged_output_edges() from renderer/edges.py. Returns a list
+    of ``(line, kind)`` tuples where kind ∈ {"data", "control", "ordering"}.
     """
-    lines: list[str] = []
+    out: list[tuple[str, str]] = []
     output_to_producer = build_output_to_producer_map(
         flat_graph,
         expansion_state,
@@ -313,7 +315,6 @@ def _render_merged_edges(
         flat_graph,
         expansion_state,
     )
-    exclusive_data_edges = compute_exclusive_data_edges(flat_graph)
     seen_edges: set[tuple[str, str, str]] = set()
 
     for source, target, edge_data in flat_graph.edges(data=True):
@@ -337,7 +338,7 @@ def _render_merged_edges(
             if edge_key in seen_edges:
                 continue
             seen_edges.add(edge_key)
-            lines.append(_format_control_edge(source, actual_target, label))
+            out.append((_format_control_edge(source, actual_target, label), "control"))
             continue
 
         if edge_type == "ordering":
@@ -348,7 +349,7 @@ def _render_merged_edges(
             if edge_key in seen_edges:
                 continue
             seen_edges.add(edge_key)
-            lines.append(_format_ordering_edge(source, target, value_name))
+            out.append((_format_ordering_edge(source, target, value_name), "ordering"))
             continue
 
         # Data edges
@@ -377,26 +378,27 @@ def _render_merged_edges(
                 continue
             seen_edges.add(edge_key)
             is_exclusive = (source, target, value_name) in exclusive_data_edges
-            lines.append(_format_edge(actual_source, actual_target, None, exclusive=is_exclusive))
+            out.append((_format_edge(actual_source, actual_target, None, exclusive=is_exclusive), "data"))
 
-    return lines
+    return out
 
 
 def _render_separate_edges(
     flat_graph: nx.DiGraph,
     expansion_state: dict[str, bool],
-) -> list[str]:
+    exclusive_data_edges: set[tuple[str, str, str]],
+) -> list[tuple[str, str]]:
     """Render edges in separate output mode (with DATA intermediaries).
 
-    Mirrors add_separate_output_edges() from renderer/edges.py.
+    Mirrors add_separate_output_edges() from renderer/edges.py. Returns a list
+    of ``(line, kind)`` tuples where kind ∈ {"data", "control", "ordering"}.
     """
-    lines: list[str] = []
+    out: list[tuple[str, str]] = []
     output_to_producer = build_output_to_producer_map(
         flat_graph,
         expansion_state,
         use_deepest=True,
     )
-    exclusive_data_edges = compute_exclusive_data_edges(flat_graph)
     seen_edges: set[tuple[str, ...]] = set()
 
     # Function → DATA edges
@@ -410,7 +412,7 @@ def _render_separate_edges(
             edge_key = (_sanitize_id(node_id), _sanitize_id(data_id))
             if edge_key not in seen_edges:
                 seen_edges.add(edge_key)
-                lines.append(_format_edge(node_id, data_id, None))
+                out.append((_format_edge(node_id, data_id, None), "data"))
 
     # DATA → consumer edges + control/ordering edges
     for source, target, edge_data in flat_graph.edges(data=True):
@@ -441,14 +443,14 @@ def _render_separate_edges(
                 if edge_key not in seen_edges:
                     seen_edges.add(edge_key)
                     is_exclusive = (source, target, value_name) in exclusive_data_edges
-                    lines.append(_format_edge(data_id, target, value_name, exclusive=is_exclusive))
+                    out.append((_format_edge(data_id, target, value_name, exclusive=is_exclusive), "data"))
 
         elif edge_type == "ordering":
             value_name = value_names[0] if value_names else ""
             edge_key = (_sanitize_id(source), _sanitize_id(target), f"ord_{value_name}")
             if edge_key not in seen_edges:
                 seen_edges.add(edge_key)
-                lines.append(_format_ordering_edge(source, target, value_name))
+                out.append((_format_ordering_edge(source, target, value_name), "ordering"))
 
         elif edge_type == "control":
             actual_target = _resolve_control_target(
@@ -463,9 +465,9 @@ def _render_separate_edges(
             edge_key = (_sanitize_id(source), _sanitize_id(actual_target), label or "")
             if edge_key not in seen_edges:
                 seen_edges.add(edge_key)
-                lines.append(_format_control_edge(source, actual_target, label))
+                out.append((_format_control_edge(source, actual_target, label), "control"))
 
-    return lines
+    return out
 
 
 # =============================================================================
@@ -847,9 +849,10 @@ def to_mermaid(
         lines.append(_format_node(_sanitize_id(end_id), "End", "END"))
         node_class_map[end_id] = "end"
 
-    # --- Input → consumer edges ---
+    # --- Edge collection (kind-tagged so linkStyle can target ordering only) ---
     lines.append("    %% Edges")
-    lines.extend(_render_start_edges(start_targets))
+    edge_pairs: list[tuple[str, str]] = []
+    edge_pairs.extend((line, "start") for line in _render_start_edges(start_targets))
 
     for group in input_groups:
         params = group["params"]
@@ -857,18 +860,18 @@ def to_mermaid(
 
         targets = _get_input_targets(params, flat_graph, param_to_consumers, expansion_state)
         for tgt in targets:
-            lines.append(_format_edge(input_node_id, tgt, None))
+            edge_pairs.append((_format_edge(input_node_id, tgt, None), "input"))
 
-    # --- Internal edges ---
-    edge_lines = _render_separate_edges(flat_graph, expansion_state) if separate_outputs else _render_merged_edges(flat_graph, expansion_state)
-    lines.extend(edge_lines)
+    exclusive_data_edges = compute_exclusive_data_edges(flat_graph)
+    if separate_outputs:
+        edge_pairs.extend(_render_separate_edges(flat_graph, expansion_state, exclusive_data_edges))
+    else:
+        edge_pairs.extend(_render_merged_edges(flat_graph, expansion_state, exclusive_data_edges))
 
-    # --- END edges ---
-    end_edges = _render_end_edges(flat_graph, expansion_state)
-    lines.extend(end_edges)
+    edge_pairs.extend((line, "end") for line in _render_end_edges(flat_graph, expansion_state))
 
-    # Track ordering edge indices for linkStyle
-    ordering_indices = _find_ordering_edge_indices(lines)
+    ordering_indices = [i for i, (_, kind) in enumerate(edge_pairs) if kind == "ordering"]
+    lines.extend(line for line, _ in edge_pairs)
 
     # --- Styling ---
     lines.append("")
@@ -981,21 +984,3 @@ def _render_end_edges(
 def _render_start_edges(start_targets: list[str]) -> list[str]:
     """Render edges from START to explicitly configured entrypoints."""
     return [_format_edge("__start__", target, None) for target in start_targets]
-
-
-def _find_ordering_edge_indices(lines: list[str]) -> list[int]:
-    """Find 0-based edge indices for ordering (dotted) edges.
-
-    Mermaid linkStyle uses the order edges appear in the document.
-    We count all edge lines (containing --> or -.-> ) and track which
-    are ordering edges.
-    """
-    indices: list[int] = []
-    edge_index = 0
-    for line in lines:
-        stripped = line.strip()
-        if "-->" in stripped or "-.->" in stripped:
-            if "-.->" in stripped:
-                indices.append(edge_index)
-            edge_index += 1
-    return indices

--- a/src/hypergraph/viz/renderer/edges.py
+++ b/src/hypergraph/viz/renderer/edges.py
@@ -14,6 +14,7 @@ import networkx as nx
 from hypergraph.viz._common import (
     build_output_to_producer_map,
     build_param_to_consumer_map,
+    compute_exclusive_data_edges,
     is_descendant_of,
     is_node_visible,
 )
@@ -261,6 +262,7 @@ def add_merged_output_edges(
     """
     param_to_consumers = build_param_to_consumer_map(flat_graph, expansion_state)
     output_to_producer = build_output_to_producer_map(flat_graph, expansion_state, use_deepest=True)
+    exclusive_data_edges = compute_exclusive_data_edges(flat_graph)
 
     for source, target, edge_data in flat_graph.edges(data=True):
         if not is_node_visible(source, flat_graph, expansion_state):
@@ -375,6 +377,7 @@ def add_merged_output_edges(
             if value_name:
                 edge_id = f"e_{actual_source}_{value_name}_{actual_target}"
 
+            is_exclusive = (source, target, value_name) in exclusive_data_edges
             rf_edge = {
                 "id": edge_id,
                 "source": actual_source,
@@ -384,6 +387,7 @@ def add_merged_output_edges(
                 "data": {
                     "edgeType": edge_type,
                     "valueName": value_name,
+                    "exclusive": is_exclusive,
                 },
             }
 
@@ -404,6 +408,7 @@ def add_separate_output_edges(
     """
     output_to_producer = build_output_to_producer_map(flat_graph, expansion_state, use_deepest=True)
     param_to_consumers = build_param_to_consumer_map(flat_graph, expansion_state, use_deepest=True)
+    exclusive_data_edges = compute_exclusive_data_edges(flat_graph)
 
     # 1. Add edges from function nodes to their DATA nodes
     for node_id, attrs in flat_graph.nodes(data=True):
@@ -506,6 +511,7 @@ def add_separate_output_edges(
 
                 edge_id = f"e_{data_node_id}_to_{actual_target}"
 
+                is_exclusive = (source, target, value_name) in exclusive_data_edges
                 edges.append(
                     {
                         "id": edge_id,
@@ -516,6 +522,7 @@ def add_separate_output_edges(
                         "data": {
                             "edgeType": "data",
                             "valueName": value_name,
+                            "exclusive": is_exclusive,
                         },
                     }
                 )

--- a/src/hypergraph/viz/renderer/edges.py
+++ b/src/hypergraph/viz/renderer/edges.py
@@ -254,6 +254,7 @@ def add_merged_output_edges(
     edges: list[dict[str, Any]],
     flat_graph: nx.DiGraph,
     expansion_state: dict[str, bool],
+    exclusive_data_edges: set[tuple[str, str, str]] | None = None,
 ) -> None:
     """Add edges in merged output mode (separateOutputs=false).
 
@@ -262,7 +263,8 @@ def add_merged_output_edges(
     """
     param_to_consumers = build_param_to_consumer_map(flat_graph, expansion_state)
     output_to_producer = build_output_to_producer_map(flat_graph, expansion_state, use_deepest=True)
-    exclusive_data_edges = compute_exclusive_data_edges(flat_graph)
+    if exclusive_data_edges is None:
+        exclusive_data_edges = compute_exclusive_data_edges(flat_graph)
 
     for source, target, edge_data in flat_graph.edges(data=True):
         if not is_node_visible(source, flat_graph, expansion_state):
@@ -399,6 +401,7 @@ def add_separate_output_edges(
     flat_graph: nx.DiGraph,
     expansion_state: dict[str, bool],
     graph_output_visibility: dict[str, set[str]] | None = None,
+    exclusive_data_edges: set[tuple[str, str, str]] | None = None,
 ) -> None:
     """Add edges in separate output mode (separateOutputs=true).
 
@@ -408,7 +411,8 @@ def add_separate_output_edges(
     """
     output_to_producer = build_output_to_producer_map(flat_graph, expansion_state, use_deepest=True)
     param_to_consumers = build_param_to_consumer_map(flat_graph, expansion_state, use_deepest=True)
-    exclusive_data_edges = compute_exclusive_data_edges(flat_graph)
+    if exclusive_data_edges is None:
+        exclusive_data_edges = compute_exclusive_data_edges(flat_graph)
 
     # 1. Add edges from function nodes to their DATA nodes
     for node_id, attrs in flat_graph.nodes(data=True):
@@ -658,10 +662,22 @@ def compute_edges_for_state(
                     )
 
     # 2. Add edges between function nodes
+    exclusive_data_edges = compute_exclusive_data_edges(flat_graph)
     if separate_outputs:
-        add_separate_output_edges(edges, flat_graph, expansion_state, graph_output_visibility)
+        add_separate_output_edges(
+            edges,
+            flat_graph,
+            expansion_state,
+            graph_output_visibility,
+            exclusive_data_edges=exclusive_data_edges,
+        )
     else:
-        add_merged_output_edges(edges, flat_graph, expansion_state)
+        add_merged_output_edges(
+            edges,
+            flat_graph,
+            expansion_state,
+            exclusive_data_edges=exclusive_data_edges,
+        )
 
     # 3. Add edges from START node
     add_start_node_edges(edges, flat_graph, expansion_state)

--- a/tests/viz/test_mermaid.py
+++ b/tests/viz/test_mermaid.py
@@ -367,6 +367,9 @@ class TestEdgeTypes:
 
         assert "branch_a -.-> consumer" in mermaid
         assert "branch_b -.-> consumer" in mermaid
+        # Exclusive (and control) dashed edges must not be styled with the
+        # purple ordering linkStyle — only true ordering edges get that.
+        assert "linkStyle" not in mermaid.source
 
 
 # =============================================================================

--- a/tests/viz/test_mermaid.py
+++ b/tests/viz/test_mermaid.py
@@ -343,6 +343,31 @@ class TestEdgeTypes:
         assert len(true_edges) == 1, f"Expected 1 True→END edge, got {true_edges}"
         assert len(false_edges) == 1, f"Expected 1 False→END edge, got {false_edges}"
 
+    def test_exclusive_branch_data_edge_dashed(self):
+        """Data edges from mutex producers feeding the same consumer use dashed arrows."""
+
+        @ifelse(when_true="branch_a", when_false="branch_b")
+        def decide(x: int) -> bool:
+            return x > 0
+
+        @node(output_name="result")
+        def branch_a(x: int) -> str:
+            return "a"
+
+        @node(output_name="result")
+        def branch_b(x: int) -> str:
+            return "b"
+
+        @node(output_name="final")
+        def consumer(result: str) -> str:
+            return result
+
+        graph = Graph([decide, branch_a, branch_b, consumer])
+        mermaid = graph.to_mermaid()
+
+        assert "branch_a -.-> consumer" in mermaid
+        assert "branch_b -.-> consumer" in mermaid
+
 
 # =============================================================================
 # ID Sanitization

--- a/tests/viz/test_renderer.py
+++ b/tests/viz/test_renderer.py
@@ -741,3 +741,74 @@ class TestExclusiveBranchEdges:
         data_edges = [e for e in result["edges"] if e.get("data", {}).get("edgeType") == "data"]
         assert len(data_edges) == 1
         assert data_edges[0]["data"]["exclusive"] is False
+
+    def test_route_branches_marked_exclusive(self):
+        """N-ary @route with default multi_target=False is also exclusive."""
+
+        @route(targets=["path_a", "path_b"])
+        def decide(x: int) -> str:
+            return "path_a"
+
+        @node(output_name="value")
+        def path_a(x: int) -> int:
+            return 1
+
+        @node(output_name="value")
+        def path_b(x: int) -> int:
+            return 2
+
+        @node(output_name="final")
+        def consumer(value: int) -> int:
+            return value
+
+        graph = Graph([decide, path_a, path_b, consumer])
+        result = render_graph(graph.to_flat_graph())
+
+        data_edges = [e for e in result["edges"] if e.get("data", {}).get("edgeType") == "data" and e["target"] == "consumer"]
+        assert len(data_edges) == 2
+        assert all(e["data"]["exclusive"] is True for e in data_edges)
+
+    def test_multi_target_route_not_marked(self):
+        """multi_target=True routes run targets concurrently, not exclusively."""
+
+        @route(targets=["path_a", "path_b"], multi_target=True)
+        def fan_out(x: int) -> list:
+            return ["path_a", "path_b"]
+
+        @node(output_name="value")
+        def path_a(x: int) -> int:
+            return 1
+
+        @node(output_name="value_b")
+        def path_b(x: int) -> int:
+            return 2
+
+        @node(output_name="final")
+        def consumer(value: int, value_b: int) -> int:
+            return value + value_b
+
+        graph = Graph([fan_out, path_a, path_b, consumer])
+        result = render_graph(graph.to_flat_graph())
+
+        data_edges = [e for e in result["edges"] if e.get("data", {}).get("edgeType") == "data" and e["target"] == "consumer"]
+        assert all(e["data"]["exclusive"] is False for e in data_edges)
+
+    def test_multi_target_route_excluded_from_mutex_groups(self):
+        """Unit-level: parallel routes never claim their branches as mutex."""
+        from hypergraph.viz._common import _compute_mutex_groups
+
+        @route(targets=["path_a", "path_b"], multi_target=True)
+        def fan_out(x: int) -> list:
+            return ["path_a", "path_b"]
+
+        @node(output_name="va")
+        def path_a(x: int) -> int:
+            return 1
+
+        @node(output_name="vb")
+        def path_b(x: int) -> int:
+            return 2
+
+        graph = Graph([fan_out, path_a, path_b])
+        groups = _compute_mutex_groups(graph.to_flat_graph())
+        assert groups == [], "multi_target route must not produce mutex groups"

--- a/tests/viz/test_renderer.py
+++ b/tests/viz/test_renderer.py
@@ -4,7 +4,7 @@ import re
 
 import pytest
 
-from hypergraph import END, Graph, interrupt, node, route
+from hypergraph import END, Graph, ifelse, interrupt, node, route
 from hypergraph.viz import visualize
 from hypergraph.viz.renderer import render_graph
 
@@ -683,3 +683,61 @@ class TestNodeToParentMap:
 
         # Flat graph has no parent relationships
         assert node_to_parent == {}
+
+
+class TestExclusiveBranchEdges:
+    """Edges from mutex producers feeding the same consumer get marked exclusive."""
+
+    @staticmethod
+    def _build_ifelse_merge_graph() -> Graph:
+        @ifelse(when_true="branch_a", when_false="branch_b")
+        def decide(x: int) -> bool:
+            return x > 0
+
+        @node(output_name="result")
+        def branch_a(x: int) -> str:
+            return "a"
+
+        @node(output_name="result")
+        def branch_b(x: int) -> str:
+            return "b"
+
+        @node(output_name="final")
+        def consumer(result: str) -> str:
+            return result
+
+        return Graph([decide, branch_a, branch_b, consumer])
+
+    def test_merged_mode_marks_exclusive(self):
+        graph = self._build_ifelse_merge_graph()
+        result = render_graph(graph.to_flat_graph(), separate_outputs=False)
+
+        data_edges = [e for e in result["edges"] if e.get("data", {}).get("edgeType") == "data"]
+        assert len(data_edges) == 2
+        assert all(e["target"] == "consumer" for e in data_edges)
+        assert all(e["data"]["exclusive"] is True for e in data_edges)
+
+    def test_separate_mode_marks_exclusive(self):
+        graph = self._build_ifelse_merge_graph()
+        result = render_graph(graph.to_flat_graph(), separate_outputs=True)
+
+        consumer_edges = [e for e in result["edges"] if e.get("data", {}).get("edgeType") == "data" and e["target"] == "consumer"]
+        assert len(consumer_edges) == 2
+        assert {e["source"] for e in consumer_edges} == {"data_branch_a_result", "data_branch_b_result"}
+        assert all(e["data"]["exclusive"] is True for e in consumer_edges)
+
+    def test_linear_data_edges_not_marked(self):
+        @node(output_name="x")
+        def first() -> int:
+            return 1
+
+        @node(output_name="y")
+        def second(x: int) -> int:
+            return x + 1
+
+        graph = Graph([first, second])
+        result = render_graph(graph.to_flat_graph())
+
+        data_edges = [e for e in result["edges"] if e.get("data", {}).get("edgeType") == "data"]
+        assert len(data_edges) == 1
+        assert data_edges[0]["data"]["exclusive"] is False


### PR DESCRIPTION
## Problem / Bug / Challenge

When visualizing hypergraphs with exclusive branches (e.g., `ifelse` gates), data edges from producers in different branches feeding the same consumer should be visually distinguished to indicate they are mutually exclusive. Currently, these edges are rendered identically to regular data edges.

## Before / After

**Before:**
- All data edges rendered with solid arrows (`-->`)
- No distinction between regular data flow and exclusive branch merges
- Mermaid diagrams don't indicate which edges are mutually exclusive

**After:**
- Data edges from mutex producers are marked with `exclusive: true` in the renderer
- Mermaid diagrams render exclusive data edges with dashed arrows (`-.->`)
- Visualization clearly shows which data paths cannot execute simultaneously

## Implementation Details

Added mutex detection and exclusive edge identification:

1. **`compute_mutex_groups()`** – Analyzes gate `branch_data` to identify exclusive branch targets and computes which nodes are reachable only from each branch
2. **`is_pair_mutex()`** – Checks if two nodes live in different branches of the same gate
3. **`compute_exclusive_data_edges()`** – Identifies data edges where multiple producers of the same value feed the same consumer and those producers are mutex
4. **Renderer integration** – Both merged and separate output modes now compute and apply the `exclusive` flag to data edges
5. **Mermaid rendering** – Uses dashed arrows (`-.->`) for exclusive edges; solid arrows (`-->`) for regular edges
6. **JavaScript visualization** – Applies dashed stroke styling to exclusive data edges in the interactive graph

## Test Plan

- [x] Added `TestExclusiveBranchEdges` with three test cases:
  - `test_merged_mode_marks_exclusive` – Verifies exclusive flag in merged output mode
  - `test_separate_mode_marks_exclusive` – Verifies exclusive flag in separate output mode
  - `test_linear_data_edges_not_marked` – Ensures non-exclusive edges are not marked
- [x] Added `test_exclusive_branch_data_edge_dashed` in Mermaid tests – Verifies dashed arrow syntax in generated Mermaid diagrams
- [x] Existing tests continue to pass

https://claude.ai/code/session_01G56dZVn2yfdxi2WzxBh7SR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced visualization rendering for exclusive data branches: when conditional branches produce shared outputs consumed by downstream nodes, these connections are now visually distinguished with dashed styling for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->