### PR TITLE
Implement lexical scope for nested subgraph inputs (issue #94)

### DIFF
--- a/dev/CONTRIBUTING.md
+++ b/dev/CONTRIBUTING.md
@@ -60,7 +60,7 @@ uv run pytest -k "test_name"              # single test
 uv run pytest -m slow                      # slow tests
 uv run pytest -m full_matrix               # full capability matrix
 
-# CI-equivalent (run before PR)
+# CI-equivalent (run before PR) — see "CI parity" below for required setup
 uv run pytest -W error -W 'ignore::pytest.PytestUnraisableExceptionWarning'
 
 # Lint & format
@@ -71,6 +71,27 @@ uv run pre-commit run --all-files          # all hooks
 # Viz tests
 uv run pytest tests/viz/                   # requires Playwright
 ```
+
+### CI parity — install ALL extras before the gate
+
+CI's test job installs `daft` and runs `playwright install chromium`, then parses
+`pytest.xml` and **fails on any skipped test or warning**. A "passing" local run
+that shows `2394 passed, 110 skipped` will fail in CI because each skip — daft
+tests, viz tests, and any conditional skip — counts.
+
+Before pushing a behavior change that touches runners, viz, examples, or
+public input/output addressing, run the full CI gate locally:
+
+```bash
+uv sync --group dev --extra daft
+uv run playwright install chromium
+uv run pytest -W error -W 'ignore::pytest.PytestUnraisableExceptionWarning'
+```
+
+The skip-zero / warning-zero invariant catches bugs that the default `uv run pytest`
+silently skips past: e.g. test migrations that miss daft- or playwright-only
+fixtures, and `UserWarning`s emitted by code paths only some optional extras
+exercise.
 
 ## Workflow
 

--- a/dev/REVIEW-CHECKLIST.md
+++ b/dev/REVIEW-CHECKLIST.md
@@ -22,6 +22,10 @@ rg -F -- '<old_value>' docs/ README.md examples/ notebooks/ src/hypergraph/
 **Scope:** docstrings, doc pages, README, examples, notebooks, `__init__.py` exports,
 viz/CLI output strings, error messages.
 
+**Note:** files under `examples/` are exercised by `tests/test_examples_*.py` via
+`runpy` — they're tests, not just docs. A behavior migration that updates tests
+must also update example scripts that hit the same code path.
+
 For public event changes, mirrors specifically include:
 - `src/hypergraph/events/__init__.py`
 - `src/hypergraph/__init__.py`
@@ -101,7 +105,8 @@ A single unstable dep can produce an exponentially-runaway state machine where e
 
 Before pushing or creating a PR:
 
-- [ ] **Tests pass (CI-equivalent)**: `uv run pytest -W error -W 'ignore::pytest.PytestUnraisableExceptionWarning'`
+- [ ] **All extras installed** so CI-skipped tests run locally: `uv sync --group dev --extra daft && uv run playwright install chromium`. CI fails on `skipped > 0` — see [CONTRIBUTING.md § CI parity](CONTRIBUTING.md#ci-parity--install-all-extras-before-the-gate).
+- [ ] **Tests pass (CI-equivalent)**: `uv run pytest -W error -W 'ignore::pytest.PytestUnraisableExceptionWarning'` reports `0 skipped` and `0 failed`.
 - [ ] **Lint passes**: `uv run ruff check src/ tests/`
 - [ ] **Format correct**: `uv run ruff format --check src/ tests/`
 - [ ] **New public API** added to `__init__.py` `__all__`?

--- a/docs/03-patterns/04-hierarchical.md
+++ b/docs/03-patterns/04-hierarchical.md
@@ -150,11 +150,14 @@ evaluation = Graph([
     aggregate_metrics,
 ], name="evaluation")
 
-# Run evaluation: the cyclic conversation runs inside the DAG
+# Run evaluation: the cyclic conversation runs inside the DAG.
+# `query` is consumed only inside the nested `conversation` graph, so at the
+# evaluation scope it is private to that GraphNode — address it via the
+# dot-path. `history` is declared by `score_responses` here, so it stays flat.
 runner = AsyncRunner()
 report = await runner.run(evaluation, {
     "dataset_path": "test_conversations.json",
-    "query": "initial query",  # First query for each test case
+    "conversation.query": "initial query",  # First query for each test case
     "history": [],
 })
 ```
@@ -348,6 +351,109 @@ graph_node = my_graph.as_node().map_over("items")
 - Type annotations flow through for `strict_types` validation
 
 ---
+
+## Addressing private subgraph inputs
+
+Each subgraph is its own scope. An input that's only declared inside a nested `GraphNode` — not consumed or produced by any leaf at the parent scope, and not exposed as a `GraphNode` output there — stays **private** to that subgraph. The parent addresses it under the `GraphNode`'s name.
+
+This keeps composed graphs **refactor-safe**: renaming or rewiring inputs inside one subgraph never silently affects a sibling.
+
+### The mental model
+
+```python
+from hypergraph import Graph, SyncRunner, node
+
+@node(output_name="result")
+def double(x: int) -> int:
+    return x * 2
+
+inner = Graph([double], name="inner")
+outer = Graph([inner.as_node()], name="outer")
+
+# 'x' is only declared inside `inner` — at the outer scope it's private
+print(outer.inputs.required)  # ('inner.x',)
+```
+
+If a leaf at the outer scope also declares `x` (consumes or produces it), the inner `x` auto-links to it and the dot-path goes away. Lexical scope is doing exactly what local variable scoping does in Python.
+
+### Sibling isolation
+
+Two sibling subgraphs that share an input name remain independent:
+
+```python
+@node(output_name="out_a")
+def use_a(x: int) -> int:
+    return x + 1
+
+@node(output_name="out_b")
+def use_b(x: int) -> int:
+    return x * 10
+
+inner_a = Graph([use_a], name="A")
+inner_b = Graph([use_b], name="B")
+outer = Graph([inner_a.as_node(), inner_b.as_node()], name="outer")
+
+print(outer.inputs.required)  # ('A.x', 'B.x')
+
+# A bind on A's input does NOT leak into B
+configured = outer.bind({"A.x": 1})
+print(configured.inputs.required)  # ('B.x',)
+print(configured.inputs.bound)     # {'A.x': 1}
+```
+
+### Four equivalent addressing forms
+
+For an input `x` private to a `GraphNode` named `inner`, all four forms below are equivalent:
+
+```python
+@node(output_name="result")
+def double(x: int) -> int:
+    return x * 2
+
+inner = Graph([double], name="inner")
+outer = Graph([inner.as_node()], name="outer")
+runner = SyncRunner()
+
+# 1. Run-time dot-path
+runner.run(outer, {"inner.x": 5})
+
+# 2. Run-time nested-dict
+runner.run(outer, {"inner": {"x": 5}})
+
+# 3. Build-time dot-path
+configured = outer.bind({"inner.x": 5})
+runner.run(configured, {})
+
+# 4. Build-time nested-dict kwarg
+configured = outer.bind(inner={"x": 5})
+runner.run(configured, {})
+```
+
+Binding directly on the inner graph (`Graph([inner.bind(x=5).as_node()], name="outer")`) before composing is also valid and produces the same `outer.inputs.bound == {"inner.x": 5}`.
+
+Use the dot-path form for single-key addressing; reach for the nested-dict form when you're grouping several private inputs of the same `GraphNode`.
+
+### Bind-conflict is caught at build time
+
+If you bind an input on an inner subgraph whose leaf name is also declared at any ancestor scope, graph construction raises `GraphConfigError` immediately:
+
+```python
+@node(output_name="result")
+def inner_func(x: int) -> int:
+    return x * 2
+
+@node(output_name="final")
+def outer_func(result: int, x: int) -> int:  # outer also consumes 'x'
+    return result + x
+
+inner = Graph([inner_func], name="inner").bind(x=5)
+Graph([inner.as_node(), outer_func], name="outer")
+# GraphConfigError: Bind on 'inner.x' is shadowed at scope 'outer' by node
+# 'outer_func' (consumes 'x'). At run time the parent's value would silently
+# override the bind. ...
+```
+
+The error names both the bind's full dot-path and the shadowing leaf so you can navigate straight to the source. Fix it by removing the inner bind, or by renaming the inner input via `with_inputs(...)` so it no longer collides.
 
 ## When to Use Hierarchical Composition
 

--- a/docs/03-patterns/05-multi-agent.md
+++ b/docs/03-patterns/05-multi-agent.md
@@ -147,8 +147,10 @@ research_team = Graph([
 ], name="research_team")
 
 # Run the team
+# `topic` is consumed only inside `researcher`, so at the outer scope it is
+# private to that GraphNode — address it via the dot-path.
 runner = SyncRunner()
-result = runner.run(research_team, {"topic": "Quantum Computing in 2024"})
+result = runner.run(research_team, {"researcher.topic": "Quantum Computing in 2024"})
 print(result["report"])
 ```
 
@@ -251,7 +253,8 @@ def test_writer():
 
 def test_team():
     runner = SyncRunner()
-    result = runner.run(research_team, {"topic": "test topic"})
+    # `topic` is private to the inner `researcher` GraphNode at this scope.
+    result = runner.run(research_team, {"researcher.topic": "test topic"})
 
     assert result["review_score"] >= 0.7
 ```

--- a/docs/06-api-reference/graph.md
+++ b/docs/06-api-reference/graph.md
@@ -291,7 +291,7 @@ Hide type hints when you only want names:
 print(g.describe(show_types=False))
 ```
 
-### `bind(**values) -> Graph`
+### `bind(values=None, /, **kwargs) -> Graph`
 
 Pre-fill input parameters with values. Returns a new Graph (immutable pattern).
 
@@ -308,12 +308,61 @@ print(g.inputs.required)  # ('x',)
 ```
 
 **Args:**
-- `**values`: Named values to bind. Keys must be graph inputs in the current scope.
+- `values` (dict, positional-only): Optional mapping of input names to values. Supports dot-paths for nested subgraph inputs.
+- `**kwargs`: Named values to bind. Keys must be graph inputs in the current scope. A nested-dict value addresses a nested `GraphNode`'s private inputs.
 
 **Returns:** New Graph with bindings applied
 
 **Raises:**
-- `ValueError` - If binding a name not recognized as a graph input in the current scope
+- `ValueError` - If binding a name not recognized as a graph input in the current scope, or if the same key is provided in both the positional dict and as a kwarg.
+- `GraphConfigError` - At graph-construction time, if an inner subgraph's bind is shadowed by a leaf declared at an ancestor scope (see below).
+
+#### Addressing nested subgraph inputs
+
+A nested `GraphNode`'s private inputs (inputs not declared at the parent scope) are addressed under the `GraphNode`'s name. `bind()` accepts three equivalent forms:
+
+```python
+@node(output_name="result")
+def inner_func(x: int) -> int:
+    return x * 2
+
+inner = Graph([inner_func], name="inner")
+outer = Graph([inner.as_node()], name="outer")
+
+# 1. Positional dict, dot-path
+outer.bind({"inner.x": 5})
+
+# 2. Kwarg, nested-dict
+outer.bind(inner={"x": 5})
+
+# 3. Bind on the inner graph before composing
+Graph([inner.bind(x=5).as_node()], name="outer")
+```
+
+All three produce the same `outer.inputs.bound == {"inner.x": 5}`.
+
+For multi-level nesting, dot-paths chain (`"middle.inner.x"`) and nested-dicts nest (`{"middle": {"inner": {"x": 5}}}`).
+
+#### Bind-conflict validation
+
+If you bind an inner subgraph input whose leaf name is also declared at any ancestor scope, graph construction raises `GraphConfigError`. At run time, the parent scope's value would silently override the bind, so the conflict is reported up front:
+
+```python
+@node(output_name="result")
+def inner_func(x: int) -> int:
+    return x * 2
+
+@node(output_name="final")
+def outer_func(result: int, x: int) -> int:  # outer also consumes 'x'
+    return result + x
+
+inner = Graph([inner_func], name="inner").bind(x=5)
+Graph([inner.as_node(), outer_func], name="outer")
+# GraphConfigError: Bind on 'inner.x' is shadowed at scope 'outer' by node
+# 'outer_func' (consumes 'x'). At run time the parent's value would silently
+# override the bind. Fix: either remove the bind on the inner subgraph, or
+# rename the input via with_inputs(...) so it no longer matches the ancestor.
+```
 
 #### Shared State and Non-Copyable Objects
 

--- a/docs/06-api-reference/inputspec.md
+++ b/docs/06-api-reference/inputspec.md
@@ -158,6 +158,72 @@ print(g.inputs.required)    # ('state', 'input')
 print(g.inputs.entrypoints) # {}
 ```
 
+### Nested Subgraph Inputs
+
+When a graph contains nested `GraphNode`s, each subgraph is its own scope. An input name not declared at a graph's scope — meaning no leaf node consumes or produces it, and no nested `GraphNode` exposes it as an output — is **private** to its subgraph and surfaces in the outer `InputSpec` under a dot-path: `"<graphnode_name>.<input>"`.
+
+This applies to both `inputs.required` and `inputs.bound`.
+
+```python
+from hypergraph import Graph, node
+
+@node(output_name="result")
+def inner_func(x: int) -> int:
+    return x * 2
+
+inner = Graph([inner_func], name="inner")
+outer = Graph([inner.as_node()], name="outer")
+
+print(outer.inputs.required)  # ('inner.x',)
+```
+
+Sibling subgraphs that share an input name stay independent — there is no merge:
+
+```python
+@node(output_name="out_a")
+def use_a(x: int) -> int:
+    return x + 1
+
+@node(output_name="out_b")
+def use_b(x: int) -> int:
+    return x * 10
+
+inner_a = Graph([use_a], name="A")
+inner_b = Graph([use_b], name="B")
+outer = Graph([inner_a.as_node(), inner_b.as_node()], name="outer")
+
+print(outer.inputs.required)  # ('A.x', 'B.x')
+```
+
+Adding a leaf node at the outer scope that declares the same name links the two together — the inner `GraphNode`'s input auto-wires to the outer-scope name, and the dot-path goes away:
+
+```python
+@node(output_name="result")
+def inner_func(x: int) -> int:
+    return x * 2
+
+@node(output_name="final")
+def outer_func(result: int, x: int) -> int:  # outer also consumes 'x'
+    return result + x
+
+inner = Graph([inner_func], name="inner")
+outer = Graph([inner.as_node(), outer_func], name="outer")
+
+print(outer.inputs.required)  # ('x',) — outer 'x' feeds both leaves
+```
+
+A bound value on an inner subgraph surfaces under the same dot-path:
+
+```python
+inner = Graph([inner_func], name="inner").bind(x=5)
+outer = Graph([inner.as_node()], name="outer")
+
+print(outer.inputs.bound)     # {'inner.x': 5}
+print(outer.inputs.required)  # ()
+```
+
+If a `bind` on an inner subgraph would be shadowed by a leaf at any ancestor scope, graph construction fails with `GraphConfigError` at build time. See [Graph.bind](graph.md) for the addressing forms accepted by `bind()`.
+
 ### Scope Narrowing (Entrypoint and Select)
 
 `with_entrypoint()` and `select()` narrow which nodes are considered when computing InputSpec. Parameters from excluded nodes do not appear in `required`, `optional`, or `entrypoints`.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- **Lexical scope for nested subgraph inputs (breaking)** — An input name not declared at a graph's scope (no leaf node consumes or produces it, and no nested `GraphNode` exposes it as an output) is now **private** to its subgraph. Outer code addresses a private input via a dot-path (`"inner.x"`) or an equivalent nested dict (`{"inner": {"x": ...}}`). The previous "auto-lift" behavior — where an inner input silently surfaced at the outermost scope — has been removed. ([#94](https://github.com/gilad-rubin/hypergraph/issues/94))
+
+  **Why:** auto-lift was a silent-leak hazard. Two sibling subgraphs that happened to share an input name would collide at the outer scope, and a `bind` on the outer graph could silently flow into a deeply nested input the user didn't intend to reach. Lexical scope makes addressing explicit and refactor-safe.
+
+  **Migration.** Anywhere you previously passed a flat name that belonged to a nested subgraph, address it under its owning `GraphNode`. The four equivalent forms for an input `x` private to a `GraphNode` named `inner`:
+
+  ```python
+  # Run-time (positional dict, dot-path):
+  runner.run(outer, {"inner.x": 5})
+
+  # Run-time (positional dict, nested-dict):
+  runner.run(outer, {"inner": {"x": 5}})
+
+  # Build-time (positional dict, dot-path):
+  outer.bind({"inner.x": 5})
+
+  # Build-time (kwarg, nested-dict):
+  outer.bind(inner={"x": 5})
+  ```
+
+  Binding directly on the inner graph (`inner.bind(x=5)`) before composing it is also valid and equivalent in result.
+
+- **Bind-conflict is a build-time error** — A `bind` on an inner subgraph input whose leaf name is also declared at any ancestor scope now raises `GraphConfigError` at construction time. The error names the bind's full dot-path and the shadowing leaf node so you can fix the source directly. Previously this case silently overrode the bind at run time.
+
+- **Run-time override of a bound value emits a `UserWarning`** — Passing a value at `runner.run(...)` for a key already present in `inputs.bound` is allowed but warned. The warning shows the old and new value for primitive types and a generic message for opaque types, so accidental overrides surface in test logs.
+
+- **`with_inputs(...)` only renames the leaf label** — It no longer moves an input out of its subgraph's scope. Combined with lexical scope, this means renaming an inner input does not promote it to the outer namespace.
+
+- **`inputs.required` and `inputs.bound` use dot-paths** — When a graph has nested `GraphNode`s with private inputs, the outer graph's `InputSpec` now reports those inputs as dot-pathed entries (e.g. `"inner.x"`). See [InputSpec API Reference](06-api-reference/inputspec.md#nested-subgraph-inputs).
+
 ## March 2026
 
 ### Added

--- a/examples/daft/nested_review_objects.py
+++ b/examples/daft/nested_review_objects.py
@@ -70,11 +70,14 @@ def main() -> None:
     runner = DaftRunner()
     result = runner.run(
         workflow,
-        reviews=[
-            Review("Ava", 9, "Loved it"),
-            Review("Ben", 4, "It broke during setup"),
-            Review("Chen", 6, "Good, but not great"),
-        ],
+        # `reviews` is private to the `assess_reviews` GraphNode at outer scope.
+        {
+            "assess_reviews.reviews": [
+                Review("Ava", 9, "Loved it"),
+                Review("Ben", 4, "It broke during setup"),
+                Review("Chen", 6, "Good, but not great"),
+            ]
+        },
     )
 
     print(result["summary"])

--- a/examples/daft/scenario_sweeps.py
+++ b/examples/daft/scenario_sweeps.py
@@ -56,15 +56,18 @@ def build_scenario_sweep_graph() -> Graph:
 def main() -> None:
     graph = build_scenario_sweep_graph()
     runner = DaftRunner()
+    # `weights` and `candidates` are private to the `evaluate_candidates`
+    # GraphNode at outer scope; address via dot-path. `scenario_id` is
+    # consumed at the outer scope by `choose_best` so it stays flat.
     results = runner.map(
         graph,
         {
             "scenario_id": ["latency_sensitive", "quality_first"],
-            "weights": [
+            "evaluate_candidates.weights": [
                 {"accuracy": 1.0, "latency": 0.01, "cost": 0.5},
                 {"accuracy": 2.5, "latency": 0.002, "cost": 0.2},
             ],
-            "candidates": [
+            "evaluate_candidates.candidates": [
                 [
                     {"name": "fast-small", "accuracy": 0.81, "latency_ms": 40, "cost": 0.01},
                     {"name": "balanced", "accuracy": 0.9, "latency_ms": 85, "cost": 0.03},
@@ -75,7 +78,7 @@ def main() -> None:
                 ],
             ],
         },
-        map_over=["scenario_id", "weights", "candidates"],
+        map_over=["scenario_id", "evaluate_candidates.weights", "evaluate_candidates.candidates"],
     )
 
     print(results["best_candidate"])

--- a/src/hypergraph/graph/_helpers.py
+++ b/src/hypergraph/graph/_helpers.py
@@ -47,14 +47,23 @@ def flatten_subgraph_addressing(values: dict[str, Any], graph: Graph) -> dict[st
 
     Raises:
         ValueError: when the same leaf is addressed both as dot-path and
-            as nested-dict in the same call.
+            as nested-dict in the same call, OR when a key is ambiguous
+            because it names BOTH a child GraphNode AND a flat input
+            declared at this scope.
     """
     from hypergraph.nodes.graph_node import GraphNode
 
+    flat_input_names = set(graph.inputs.all)
     flat: dict[str, Any] = {}
     for key, value in values.items():
         child = graph._nodes.get(key) if isinstance(graph._nodes.get(key), GraphNode) else None
         if isinstance(value, dict) and child is not None:
+            if key in flat_input_names:
+                raise ValueError(
+                    f"Ambiguous addressing: {key!r} is both a flat input of this graph and the "
+                    f"name of a child GraphNode. Pass a flat dict value via the dot-path form "
+                    f"(e.g., {{{key + '.<inner>'!r}: ...}}) to disambiguate."
+                )
             for sub_key, sub_value in flatten_subgraph_addressing(value, child.graph).items():
                 full_key = f"{key}.{sub_key}"
                 if full_key in flat:

--- a/src/hypergraph/graph/_helpers.py
+++ b/src/hypergraph/graph/_helpers.py
@@ -5,11 +5,12 @@ These utilities are used by both core.py and input_spec.py to avoid duplication.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import networkx as nx
 
 if TYPE_CHECKING:
+    from hypergraph.graph.core import Graph
     from hypergraph.nodes.base import HyperNode
 
 
@@ -29,6 +30,41 @@ def get_edge_produced_values(nx_graph: nx.DiGraph) -> set[str]:
 def sources_of(output: str, nodes: dict[str, HyperNode]) -> list[str]:
     """Get all node names that produce the given output."""
     return [node.name for node in nodes.values() if output in node.outputs]
+
+
+def flatten_subgraph_addressing(values: dict[str, Any], graph: Graph) -> dict[str, Any]:
+    """Canonicalize nested-dict addressing into dot-paths for a graph's inputs.
+
+    A user can address a GraphNode's private input either as a dot-path
+    (``{"A.x": v}``) or as a nested dict (``{"A": {"x": v}}``). This walks
+    the graph's child GraphNodes recursively and flattens nested-dict entries
+    whose outer key names a child into dot-paths. Dict values whose outer key
+    is NOT a child GraphNode pass through unchanged (the dict IS the value).
+
+    Single source of truth used by both the runner boundary
+    (``normalize_inputs``) and ``Graph.bind`` so the two surfaces stay in
+    lockstep.
+
+    Raises:
+        ValueError: when the same leaf is addressed both as dot-path and
+            as nested-dict in the same call.
+    """
+    from hypergraph.nodes.graph_node import GraphNode
+
+    flat: dict[str, Any] = {}
+    for key, value in values.items():
+        child = graph._nodes.get(key) if isinstance(graph._nodes.get(key), GraphNode) else None
+        if isinstance(value, dict) and child is not None:
+            for sub_key, sub_value in flatten_subgraph_addressing(value, child.graph).items():
+                full_key = f"{key}.{sub_key}"
+                if full_key in flat:
+                    raise ValueError(f"Input key {full_key!r} provided twice (mixed dot-path and nested-dict).")
+                flat[full_key] = sub_value
+        else:
+            if key in flat:
+                raise ValueError(f"Input key {key!r} provided twice (mixed dot-path and nested-dict).")
+            flat[key] = value
+    return flat
 
 
 def describe_addressed_input(path: str) -> str:

--- a/src/hypergraph/graph/_helpers.py
+++ b/src/hypergraph/graph/_helpers.py
@@ -29,3 +29,20 @@ def get_edge_produced_values(nx_graph: nx.DiGraph) -> set[str]:
 def sources_of(output: str, nodes: dict[str, HyperNode]) -> list[str]:
     """Get all node names that produce the given output."""
     return [node.name for node in nodes.values() if output in node.outputs]
+
+
+def describe_addressed_input(path: str) -> str:
+    """Render a human-readable description of a (possibly dot-pathed) input.
+
+    Single source of truth for inlining input addresses into error / warning
+    text. A flat name renders as ``"'x'"``; a dot-pathed name renders as
+    ``"'x' of subgraph 'inner'"`` (one level) or
+    ``"'x' of subgraph 'middle.inner'"`` (multi-level chain).
+
+    The format is stable and grep-friendly: callers can interpolate it
+    directly without further punctuation choices.
+    """
+    if "." not in path:
+        return f"{path!r}"
+    head, leaf = path.rsplit(".", 1)
+    return f"{leaf!r} of subgraph {head!r}"

--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -946,22 +946,42 @@ class Graph:
 
         return False
 
-    def bind(self, **values: Any) -> Graph:
+    def bind(self, _values: dict[str, Any] | None = None, /, **values: Any) -> Graph:
         """Bind default values. Returns new Graph (immutable).
 
-        Accepts graph input names in the current configured scope.
-        Bound values act as pre-filled run() values — overridable at run time.
-        If you want to bind a value that would normally be produced upstream,
-        first slice the graph with ``with_entrypoint()`` / ``select()`` so that
-        value becomes a true graph input.
+        Accepts graph input names in the current configured scope. A private
+        subgraph input may be addressed three equivalent ways:
+
+            graph.bind(A={"x": v})       # nested-dict kwarg (recommended)
+            graph.bind({"A.x": v})       # positional dict with dot-path
+            inner.bind(x=v)              # bind on the inner Graph itself
+
+        Bound values act as pre-filled run() values -- overridable at run time
+        (an override emits a UserWarning). If you want to bind a value that
+        would normally be produced upstream, first slice the graph with
+        ``with_entrypoint()`` / ``select()`` so that value becomes a true
+        graph input.
 
         Raises:
-            ValueError: If key is not a valid graph input in the current scope
+            ValueError: If a key is not a valid graph input in the current scope.
         """
+        from hypergraph.graph._helpers import flatten_subgraph_addressing
+
+        merged: dict[str, Any] = {}
+        if _values is not None:
+            merged.update(_values)
+        if values:
+            overlap = sorted(set(merged) & set(values))
+            if overlap:
+                raise ValueError(f"Bind keys provided in both positional dict and kwargs: {overlap}. Use one source per key.")
+            merged.update(values)
+
+        canonical = flatten_subgraph_addressing(merged, self)
+
         valid_names = set(self.inputs.all)
         output_names = set(self.outputs)
 
-        for key in values:
+        for key in canonical:
             if key not in valid_names:
                 if key in output_names:
                     raise ValueError(
@@ -975,7 +995,7 @@ class Graph:
                 raise ValueError(f"Cannot bind '{key}': not a graph input in the current scope. Valid inputs: {sorted(valid_names)}")
 
         new_graph = self._shallow_copy()
-        new_graph._bound = {**self._bound, **values}
+        new_graph._bound = {**self._bound, **canonical}
         return new_graph
 
     def unbind(self, *keys: str) -> Graph:

--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -188,6 +188,8 @@ class Graph:
         self._cached_structural_hash: str | None = None
         self._controlled_by: dict[str, list[str]] | None = None
         self._validate()
+        # Eagerly compute inputs so bind-conflict validation fires at build time.
+        _ = self.inputs
 
     def _normalize_constructor_entrypoints(
         self,

--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -357,6 +357,7 @@ class Graph:
             self._bound,
             entrypoints=self._entrypoints,
             selected=self._selected,
+            graph_name=self.name,
         )
 
     @functools.cached_property

--- a/src/hypergraph/graph/input_spec.py
+++ b/src/hypergraph/graph/input_spec.py
@@ -412,10 +412,11 @@ def _collect_bound_values(
 ) -> dict[str, Any]:
     """Collect all bound values from graph and nested GraphNodes under lexical scope.
 
-    Inner binds whose public name is declared at this scope (consumed/produced by a
-    leaf node here) auto-link upward and surface as a flat key on the outer bound
-    dict. Inner binds whose public name is private to the subgraph surface as
-    dot-pathed keys (``"<graphnode_name>.<public_name>"``).
+    Inner binds surface as dot-pathed keys (``"<graphnode_name>.<public_name>"``)
+    on the outer bound dict. If an inner bind's public name is declared at this
+    scope (would auto-link to an ancestor's same-named input), the bind would be
+    silently overridden by the ancestor's value at run time -- so this is a
+    build-time error pointing to both the bind site and the ancestor scope.
 
     Args:
         nodes: Map of node name -> HyperNode
@@ -423,7 +424,11 @@ def _collect_bound_values(
 
     Returns:
         Merged dict of all bound values (current graph + nested graphs)
+
+    Raises:
+        GraphConfigError: when a nested bind is shadowed by an ancestor-declared name.
     """
+    from hypergraph.graph.validation import GraphConfigError
     from hypergraph.nodes.graph_node import GraphNode
 
     all_bound = dict(bound)
@@ -435,13 +440,14 @@ def _collect_bound_values(
         for inner_key, value in node.graph.inputs.bound.items():
             public_key = node.map_input_name_from_original(inner_key)
             if public_key in declared:
-                # Auto-link to ancestor: set as flat default if not already set.
-                all_bound.setdefault(public_key, value)
-            else:
-                # Private to subgraph: dot-path it. The leaf label is the public
-                # name as seen on the GraphNode (post with_inputs rename), so a
-                # rename only changes the leaf without moving scope.
-                all_bound[f"{node_name}.{public_key}"] = value
+                raise GraphConfigError(
+                    f"Bind on '{node_name}.{public_key}' is shadowed by '{public_key}' "
+                    f"declared at this scope (a node here consumes or produces it). "
+                    f"At run time the parent's value would silently override the bind. "
+                    f"Fix: either remove the bind on the inner subgraph, or rename "
+                    f"the input via with_inputs(...) so it no longer matches the ancestor."
+                )
+            all_bound[f"{node_name}.{public_key}"] = value
 
     return all_bound
 

--- a/src/hypergraph/graph/input_spec.py
+++ b/src/hypergraph/graph/input_spec.py
@@ -413,14 +413,20 @@ def _collect_bound_values(
             continue
         for inner_key, value in node.graph.inputs.bound.items():
             public_key = node.map_input_name_from_original(inner_key)
-            if public_key in declared:
+            full_path = f"{node_name}.{public_key}"
+            # Conflict surfaces at the OUTERMOST scope that declares the bind's
+            # leaf name. For a deeply-nested bind addressed `a.b.c` reaching
+            # this scope, the leaf is `c`; if a leaf at this scope consumes or
+            # produces `c`, the bind would be silently overridden.
+            leaf = public_key.rsplit(".", 1)[-1]
+            if leaf in declared:
                 raise GraphConfigError(
-                    f"Bind on '{node_name}.{public_key}' is shadowed by '{public_key}' "
+                    f"Bind on '{full_path}' is shadowed by '{leaf}' "
                     f"declared at this scope (a node here consumes or produces it). "
                     f"At run time the parent's value would silently override the bind. "
                     f"Fix: either remove the bind on the inner subgraph, or rename "
                     f"the input via with_inputs(...) so it no longer matches the ancestor."
                 )
-            all_bound[f"{node_name}.{public_key}"] = value
+            all_bound[full_path] = value
 
     return all_bound

--- a/src/hypergraph/graph/input_spec.py
+++ b/src/hypergraph/graph/input_spec.py
@@ -155,16 +155,6 @@ def _compute_cycle_seed_params(
     return required
 
 
-def _unique_params(nodes: dict[str, HyperNode]) -> Iterator[str]:
-    """Yield each unique parameter name across all nodes."""
-    seen: set[str] = set()
-    for node in nodes.values():
-        for param in node.inputs:
-            if param not in seen:
-                seen.add(param)
-                yield param
-
-
 def _names_declared_at_scope(nodes: dict[str, HyperNode]) -> set[str]:
     """Names declared directly at this graph's scope.
 
@@ -216,22 +206,6 @@ def _addressed_params(
                 if param not in seen_flat:
                     seen_flat.add(param)
                     yield (param, param, None)
-
-
-def _categorize_param(
-    param: str,
-    edge_produced: set[str],
-    bound: dict[str, Any],
-    nodes: dict[str, HyperNode],
-) -> str | None:
-    """Categorize a non-cycle parameter: 'required', 'optional', or None (edge-produced)."""
-    if param in edge_produced:
-        return None  # Produced by an edge, not a user input
-
-    if param in bound or _all_consumers_have_default(param, nodes):
-        return "optional"
-
-    return "required"
 
 
 def _categorize_addressed_param(
@@ -450,23 +424,3 @@ def _collect_bound_values(
             all_bound[f"{node_name}.{public_key}"] = value
 
     return all_bound
-
-
-def _all_values_equal(values: list[Any]) -> bool:
-    """Best-effort equality check for merged nested bound values."""
-    if len(values) <= 1:
-        return True
-    first = values[0]
-    for value in values[1:]:
-        if first is value:
-            continue
-        try:
-            equal = first == value
-            if hasattr(equal, "__iter__"):
-                if not all(equal):
-                    return False
-            elif not bool(equal):
-                return False
-        except Exception:
-            return False
-    return True

--- a/src/hypergraph/graph/input_spec.py
+++ b/src/hypergraph/graph/input_spec.py
@@ -449,10 +449,7 @@ def _bind_conflict_message(
             shadowers.append(f"{n_name!r} (produces {leaf!r})")
 
     scope_text = f" at scope {graph_name!r}" if graph_name else " at this scope"
-    if shadowers:
-        shadow_text = f"by node {' / '.join(shadowers)}"
-    else:
-        shadow_text = f"by '{leaf}' declared at this scope"
+    shadow_text = f"by node {' / '.join(shadowers)}" if shadowers else f"by '{leaf}' declared at this scope"
 
     return (
         f"Bind on {full_path!r} is shadowed{scope_text} {shadow_text}. "

--- a/src/hypergraph/graph/input_spec.py
+++ b/src/hypergraph/graph/input_spec.py
@@ -54,6 +54,7 @@ def compute_input_spec(
     entrypoints: tuple[str, ...] | None = None,
     selected: tuple[str, ...] | None = None,
     _active_scope: tuple[dict[str, HyperNode], nx.DiGraph] | None = None,
+    graph_name: str | None = None,
 ) -> InputSpec:
     """Compute input specification for a graph.
 
@@ -87,7 +88,7 @@ def compute_input_spec(
 
     data_subgraph = _data_only_subgraph(active_subgraph)
     edge_produced = get_edge_produced_values(active_subgraph)
-    all_bound = _collect_bound_values(active_nodes, bound)
+    all_bound = _collect_bound_values(active_nodes, bound, graph_name=graph_name)
     cycle_seed_params = _compute_cycle_seed_params(
         active_nodes,
         data_subgraph,
@@ -383,6 +384,8 @@ def _active_from_selection(
 def _collect_bound_values(
     nodes: dict[str, HyperNode],
     bound: dict[str, Any],
+    *,
+    graph_name: str | None = None,
 ) -> dict[str, Any]:
     """Collect all bound values from graph and nested GraphNodes under lexical scope.
 
@@ -420,13 +423,40 @@ def _collect_bound_values(
             # produces `c`, the bind would be silently overridden.
             leaf = public_key.rsplit(".", 1)[-1]
             if leaf in declared:
-                raise GraphConfigError(
-                    f"Bind on '{full_path}' is shadowed by '{leaf}' "
-                    f"declared at this scope (a node here consumes or produces it). "
-                    f"At run time the parent's value would silently override the bind. "
-                    f"Fix: either remove the bind on the inner subgraph, or rename "
-                    f"the input via with_inputs(...) so it no longer matches the ancestor."
-                )
+                raise GraphConfigError(_bind_conflict_message(full_path, leaf, nodes, graph_name))
             all_bound[full_path] = value
 
     return all_bound
+
+
+def _bind_conflict_message(
+    full_path: str,
+    leaf: str,
+    nodes: dict[str, HyperNode],
+    graph_name: str | None,
+) -> str:
+    """Compose a build-time bind-conflict error naming the scope and the
+    specific shadowing node so the user can navigate straight to the source."""
+    from hypergraph.nodes.graph_node import GraphNode
+
+    shadowers: list[str] = []
+    for n_name, n in nodes.items():
+        if isinstance(n, GraphNode):
+            continue
+        if leaf in n.inputs:
+            shadowers.append(f"{n_name!r} (consumes {leaf!r})")
+        elif leaf in n.outputs:
+            shadowers.append(f"{n_name!r} (produces {leaf!r})")
+
+    scope_text = f" at scope {graph_name!r}" if graph_name else " at this scope"
+    if shadowers:
+        shadow_text = f"by node {' / '.join(shadowers)}"
+    else:
+        shadow_text = f"by '{leaf}' declared at this scope"
+
+    return (
+        f"Bind on {full_path!r} is shadowed{scope_text} {shadow_text}. "
+        f"At run time the parent's value would silently override the bind. "
+        f"Fix: either remove the bind on the inner subgraph, or rename "
+        f"the input via with_inputs(...) so it no longer matches the ancestor."
+    )

--- a/src/hypergraph/graph/input_spec.py
+++ b/src/hypergraph/graph/input_spec.py
@@ -100,14 +100,14 @@ def compute_input_spec(
     required, optional = [], []
     declared = _names_declared_at_scope(active_nodes)
 
-    for addressed, original, _source in _addressed_params(active_nodes, declared):
+    for addressed, original, source in _addressed_params(active_nodes, declared):
         if original in cycle_seed_params:
             if addressed in all_bound:
                 optional.append(addressed)
             else:
                 required.append(addressed)
             continue
-        category = _categorize_addressed_param(addressed, original, edge_produced, all_bound, active_nodes)
+        category = _categorize_addressed_param(addressed, original, source, edge_produced, all_bound, active_nodes)
         if category == "required":
             required.append(addressed)
         elif category == "optional":
@@ -212,16 +212,28 @@ def _addressed_params(
 def _categorize_addressed_param(
     addressed: str,
     original: str,
+    source: str | None,
     edge_produced: set[str],
     bound: dict[str, Any],
     nodes: dict[str, HyperNode],
 ) -> str | None:
-    """Categorize an addressed parameter: 'required', 'optional', or None (edge-produced)."""
+    """Categorize an addressed parameter: 'required', 'optional', or None (edge-produced).
+
+    For a flat (declared-at-scope) param, ``source`` is None and optionality
+    is decided by ``_all_consumers_have_default(original, nodes)``. For a
+    private dot-pathed param, ``source`` names the owning GraphNode and
+    optionality is decided by THAT node's defaults specifically -- siblings'
+    defaults don't influence each other.
+    """
     # Edge-produced is checked against the original name, since edges act in scope.
     if original in edge_produced and addressed == original:
         return None
 
     if addressed in bound:
+        return "optional"
+
+    if source is not None and nodes[source].has_default_for(original):
+        # Private dot-pathed input whose owning GraphNode supplies a default.
         return "optional"
 
     if addressed == original and _all_consumers_have_default(original, nodes):

--- a/src/hypergraph/graph/input_spec.py
+++ b/src/hypergraph/graph/input_spec.py
@@ -168,20 +168,25 @@ def _unique_params(nodes: dict[str, HyperNode]) -> Iterator[str]:
 def _names_declared_at_scope(nodes: dict[str, HyperNode]) -> set[str]:
     """Names declared directly at this graph's scope.
 
-    A name is declared at this scope if a leaf (non-GraphNode) node here
-    consumes or produces it. Sibling GraphNodes happening to share an input
-    name does NOT count as declaration at the parent scope -- under lexical
-    scope, each GraphNode is its own subscope, and an unshared inner input
-    stays private.
+    A name is declared at this scope if any node here can produce it (leaf
+    output OR GraphNode output, since both surface at this scope) or if a
+    leaf node here consumes it. GraphNode inputs do NOT count -- they are
+    private to the subscope unless declared by something else here.
+
+    Two siblings GraphNodes that happen to share an input name therefore stay
+    private to each. But a GraphNode whose output flows (via edge) to a sibling
+    GraphNode's same-named input auto-links, because the producer's output is
+    declared at this scope.
     """
     from hypergraph.nodes.graph_node import GraphNode
 
     names: set[str] = set()
     for node in nodes.values():
         if isinstance(node, GraphNode):
-            continue
-        names.update(node.inputs)
-        names.update(node.outputs)
+            names.update(node.outputs)
+        else:
+            names.update(node.inputs)
+            names.update(node.outputs)
     return names
 
 

--- a/src/hypergraph/graph/input_spec.py
+++ b/src/hypergraph/graph/input_spec.py
@@ -97,19 +97,20 @@ def compute_input_spec(
     )
 
     required, optional = [], []
+    declared = _names_declared_at_scope(active_nodes)
 
-    for param in _unique_params(active_nodes):
-        if param in cycle_seed_params:
-            if param in bound:
-                optional.append(param)
+    for addressed, original, _source in _addressed_params(active_nodes, declared):
+        if original in cycle_seed_params:
+            if addressed in all_bound:
+                optional.append(addressed)
             else:
-                required.append(param)
+                required.append(addressed)
             continue
-        category = _categorize_param(param, edge_produced, all_bound, active_nodes)
+        category = _categorize_addressed_param(addressed, original, edge_produced, all_bound, active_nodes)
         if category == "required":
-            required.append(param)
+            required.append(addressed)
         elif category == "optional":
-            optional.append(param)
+            optional.append(addressed)
 
     return InputSpec(
         required=tuple(required),
@@ -164,6 +165,54 @@ def _unique_params(nodes: dict[str, HyperNode]) -> Iterator[str]:
                 yield param
 
 
+def _names_declared_at_scope(nodes: dict[str, HyperNode]) -> set[str]:
+    """Names declared directly at this graph's scope.
+
+    A name is declared at this scope if a leaf (non-GraphNode) node here
+    consumes or produces it. Sibling GraphNodes happening to share an input
+    name does NOT count as declaration at the parent scope -- under lexical
+    scope, each GraphNode is its own subscope, and an unshared inner input
+    stays private.
+    """
+    from hypergraph.nodes.graph_node import GraphNode
+
+    names: set[str] = set()
+    for node in nodes.values():
+        if isinstance(node, GraphNode):
+            continue
+        names.update(node.inputs)
+        names.update(node.outputs)
+    return names
+
+
+def _addressed_params(
+    nodes: dict[str, HyperNode],
+    declared: set[str],
+) -> Iterator[tuple[str, str, str | None]]:
+    """Yield (addressed_name, original_name, source_node_name_or_None) per input.
+
+    Inputs declared at this scope are emitted once with their flat name and no
+    source. Inputs private to a GraphNode subscope are emitted as dot-paths.
+    """
+    from hypergraph.nodes.graph_node import GraphNode
+
+    seen_flat: set[str] = set()
+    for node_name, node in nodes.items():
+        if isinstance(node, GraphNode):
+            for param in node.inputs:
+                if param in declared:
+                    if param not in seen_flat:
+                        seen_flat.add(param)
+                        yield (param, param, None)
+                else:
+                    yield (f"{node_name}.{param}", param, node_name)
+        else:
+            for param in node.inputs:
+                if param not in seen_flat:
+                    seen_flat.add(param)
+                    yield (param, param, None)
+
+
 def _categorize_param(
     param: str,
     edge_produced: set[str],
@@ -175,6 +224,27 @@ def _categorize_param(
         return None  # Produced by an edge, not a user input
 
     if param in bound or _all_consumers_have_default(param, nodes):
+        return "optional"
+
+    return "required"
+
+
+def _categorize_addressed_param(
+    addressed: str,
+    original: str,
+    edge_produced: set[str],
+    bound: dict[str, Any],
+    nodes: dict[str, HyperNode],
+) -> str | None:
+    """Categorize an addressed parameter: 'required', 'optional', or None (edge-produced)."""
+    # Edge-produced is checked against the original name, since edges act in scope.
+    if original in edge_produced and addressed == original:
+        return None
+
+    if addressed in bound:
+        return "optional"
+
+    if addressed == original and _all_consumers_have_default(original, nodes):
         return "optional"
 
     return "required"
@@ -335,12 +405,12 @@ def _collect_bound_values(
     nodes: dict[str, HyperNode],
     bound: dict[str, Any],
 ) -> dict[str, Any]:
-    """Collect all bound values from graph and nested GraphNodes.
+    """Collect all bound values from graph and nested GraphNodes under lexical scope.
 
-    When a graph contains GraphNodes with bound values, those values need to be
-    accessible at runtime for parameter resolution. This function merges:
-    1. The graph's own bound values
-    2. Bound values from all nested GraphNodes (recursively)
+    Inner binds whose public name is declared at this scope (consumed/produced by a
+    leaf node here) auto-link upward and surface as a flat key on the outer bound
+    dict. Inner binds whose public name is private to the subgraph surface as
+    dot-pathed keys (``"<graphnode_name>.<public_name>"``).
 
     Args:
         nodes: Map of node name -> HyperNode
@@ -351,27 +421,22 @@ def _collect_bound_values(
     """
     from hypergraph.nodes.graph_node import GraphNode
 
-    # Start with current graph's bound values
     all_bound = dict(bound)
-    nested_candidates: dict[str, list[Any]] = {}
+    declared = _names_declared_at_scope(nodes)
 
-    # Merge bound values from nested GraphNodes
-    for node in nodes.values():
-        if isinstance(node, GraphNode):
-            # Get bound values from the inner graph
-            inner_bound = node.graph.inputs.bound
-            # Merge unique nested bindings only. If sibling nested graphs bind
-            # the same key to different values, that key is ambiguous at the
-            # outer graph level and should stay out of graph.inputs.bound.
-            for key, value in inner_bound.items():
-                public_key = node.map_input_name_from_original(key)
-                if public_key in all_bound:
-                    continue
-                nested_candidates.setdefault(public_key, []).append(value)
-
-    for key, candidates in nested_candidates.items():
-        if len(candidates) == 1 or _all_values_equal(candidates):
-            all_bound[key] = candidates[0]
+    for node_name, node in nodes.items():
+        if not isinstance(node, GraphNode):
+            continue
+        for inner_key, value in node.graph.inputs.bound.items():
+            public_key = node.map_input_name_from_original(inner_key)
+            if public_key in declared:
+                # Auto-link to ancestor: set as flat default if not already set.
+                all_bound.setdefault(public_key, value)
+            else:
+                # Private to subgraph: dot-path it. The leaf label is the public
+                # name as seen on the GraphNode (post with_inputs rename), so a
+                # rename only changes the leaf without moving scope.
+                all_bound[f"{node_name}.{public_key}"] = value
 
     return all_bound
 

--- a/src/hypergraph/graph/validation.py
+++ b/src/hypergraph/graph/validation.py
@@ -165,10 +165,23 @@ def _collect_param_default_info(
     Only checks actual function signature defaults, not bound values from
     graph.bind(). This ensures validation only checks for consistent defaults
     in function signatures, not configuration values.
+
+    Under lexical scope, a GraphNode's input that is NOT declared at this
+    scope is private to its subgraph and lives in a different namespace from
+    a sibling GraphNode's same-named input. Such private inputs are excluded
+    from the cross-node consistency check -- their defaults are validated
+    inside the owning inner graph at its own construction time.
     """
+    from hypergraph.graph.input_spec import _names_declared_at_scope
+    from hypergraph.nodes.graph_node import GraphNode
+
+    declared = _names_declared_at_scope(nodes)
     param_info: dict[str, list[tuple[bool, Any, str]]] = defaultdict(list)
     for node in nodes.values():
         for param in node.inputs:
+            if isinstance(node, GraphNode) and param not in declared:
+                # Private to the subgraph -- different namespace from this scope.
+                continue
             # Check for signature defaults only (excludes bound values)
             has_default = node.has_signature_default_for(param)
             if has_default:

--- a/src/hypergraph/runners/_shared/AGENTS.md
+++ b/src/hypergraph/runners/_shared/AGENTS.md
@@ -54,8 +54,51 @@ InterruptNode execution has three paths:
 
 The `is_resuming` flag prevents false auto-resolve on fresh runs when provided_values happen to match interrupt output names.
 
+## Lexical-Scope Addressing (`address_for_node_input`)
+
+Under lexical scope (issue #94), a `GraphNode`'s private input is addressed at
+the parent scope as `"<node.name>.<param>"` — the dotted form. Auto-linked
+inputs (a leaf at this scope declares the same name) stay flat.
+
+State, provided values, and bound values all use this canonical form, so any
+code that looks up a node-input value against one of those dicts MUST resolve
+through the helper instead of using the bare param name:
+
+```python
+from hypergraph.runners._shared.helpers import address_for_node_input
+
+addr = address_for_node_input(node, param, state.values, graph.inputs.bound)
+if addr in state.values:
+    ...
+```
+
+`namespaces` (the variadic) are checked in order; the first one containing the
+dotted form wins, otherwise the flat name is the auto-link fallback. Pass the
+dicts you intend to look up in — the resolver matches whichever one actually
+holds the value.
+
+**Sites that already use it (canonical examples):**
+- `_has_input` (readiness check, helpers.py)
+- `get_value_source` (PROVIDED + BOUND + EDGE branches, helpers.py)
+- `_is_stale` (read side, helpers.py)
+- sync/async `superstep.py` (recording `input_versions` under the same key the
+  staleness check reads — record-key MUST equal read-key)
+- `runners/daft/operations.py` (DataFrame column resolution at `apply()` time)
+
+**Trap:** flat-only lookups (`state.values[param]`, `param in graph.inputs.bound`,
+`param in provided_values`) silently miss dot-pathed addresses. Both sides of a
+record/read pair must agree on the address — otherwise consumed-version
+defaults to 0 on read while being recorded as 0, and "not stale" silently
+classifies as fresh forever. PR #95 had exactly this bug at the staleness path
+(see commit `a3d3277` for the fix).
+
+When the column / dict namespace is only known at run time (e.g. daft
+`apply()`), defer the resolution to that point — pass the actual column names
+as the namespace.
+
 ## Common Pitfalls
 
 - **Shared params + cycles**: a node that both consumes and produces `messages` triggers the Sole Producer Rule. Split into separate consume/produce nodes if the node is NOT gate-controlled.
 - **Inputless gate targets**: without `_has_pending_activation`, they never re-fire after first execution because `_is_stale` iterates over zero inputs.
 - **Control edges vs ordering edges**: control edges are excluded from `startup_predecessors`. If you need ordering, use `wait_for` or data edges. Gates handle control flow separately.
+- **Flat-name input lookups**: see "Lexical-Scope Addressing" above. If you're touching `helpers.py` / `superstep.py` / an executor and writing `state.values[param]` or `param in node_bound`, route through `address_for_node_input` instead — flat-only matching silently misses dot-pathed private GraphNode inputs.

--- a/src/hypergraph/runners/_shared/helpers.py
+++ b/src/hypergraph/runners/_shared/helpers.py
@@ -299,8 +299,11 @@ def warn_on_bind_overrides(graph: Graph, provided_values: dict[str, Any]) -> Non
     Fires uniformly regardless of whether the override address is flat or
     dotted -- both surfaces share the same canonical form on graph.inputs.bound
     and provided_values. For primitive bound/provided pairs the warning shows
-    both values; otherwise it stays generic.
+    both values; otherwise it stays generic. Dot-pathed addresses are annotated
+    with their owning subgraph for clarity.
     """
+    from hypergraph.graph._helpers import describe_addressed_input
+
     bound = graph.inputs.bound
     for key, new_value in provided_values.items():
         if key not in bound:
@@ -308,12 +311,13 @@ def warn_on_bind_overrides(graph: Graph, provided_values: dict[str, Any]) -> Non
         old_value = bound[key]
         if old_value is new_value:
             continue
+        described = describe_addressed_input(key)
         old_repr = short_value_repr(old_value)
         new_repr = short_value_repr(new_value)
         if old_repr is not None and new_repr is not None:
-            msg = f"Run value overrides bound value for {key!r}: {old_repr} -> {new_repr}"
+            msg = f"Run value overrides bound value for {described} (address {key!r}): {old_repr} -> {new_repr}"
         else:
-            msg = f"Run value overrides bound value for {key!r}"
+            msg = f"Run value overrides bound value for {described} (address {key!r})"
         warnings.warn(msg, UserWarning, stacklevel=4)
 
 

--- a/src/hypergraph/runners/_shared/helpers.py
+++ b/src/hypergraph/runners/_shared/helpers.py
@@ -403,9 +403,12 @@ def get_value_source(
     """
     from hypergraph.nodes.graph_node import GraphNode
 
-    # 1. Edge value (from upstream node output)
-    if param in state.values:
-        return (ValueSource.EDGE, state.values[param])
+    # 1. Edge / restored-state value. For a GraphNode, a checkpoint may have
+    # restored its private input under the dot-pathed address; resolve to the
+    # canonical key so the lookup matches the readiness/staleness checks.
+    state_addr = address_for_node_input(node, param, state.values)
+    if state_addr in state.values:
+        return (ValueSource.EDGE, state.values[state_addr])
 
     # 2. Input value (from run() call). The address may be dot-pathed when
     # this is a GraphNode's private input.

--- a/src/hypergraph/runners/_shared/helpers.py
+++ b/src/hypergraph/runners/_shared/helpers.py
@@ -275,6 +275,31 @@ class ValueSource(Enum):
     DEFAULT = "default"  # From function signature - MUST copy
 
 
+def address_for_node_input(
+    node: HyperNode,
+    param: str,
+    *namespaces: dict[str, Any],
+) -> str:
+    """Resolve which key (dotted or flat) addresses ``param`` of ``node``.
+
+    Under lexical scope, a GraphNode's private input may be addressed at the
+    parent scope as ``"<node.name>.<param>"`` (state.values, state.versions,
+    provided_values, graph.inputs.bound, and per-execution input_versions all
+    share this convention). When the dotted key is present in any provided
+    namespace, it wins; otherwise the flat name is the auto-link fallback.
+
+    Used both for reading (find-the-key) and recording (consistent-key) so
+    that whatever key gets written must be the same key that gets read.
+    """
+    from hypergraph.nodes.graph_node import GraphNode
+
+    if isinstance(node, GraphNode):
+        dotted = f"{node.name}.{param}"
+        if any(dotted in ns for ns in namespaces):
+            return dotted
+    return param
+
+
 _SHORT_REPR_MAX_LEN = 40
 
 
@@ -382,27 +407,17 @@ def get_value_source(
     if param in state.values:
         return (ValueSource.EDGE, state.values[param])
 
-    # 2. Input value (from run() call). For GraphNodes, a dot-pathed entry
-    # ("<node_name>.<param>") addresses a private input of the subgraph and
-    # takes precedence over a bare flat name (which only auto-links when the
-    # name is declared at this scope).
-    if isinstance(node, GraphNode):
-        dotted = f"{node.name}.{param}"
-        if dotted in provided_values:
-            return (ValueSource.PROVIDED, provided_values[dotted])
-    if param in provided_values:
-        return (ValueSource.PROVIDED, provided_values[param])
+    # 2. Input value (from run() call). The address may be dot-pathed when
+    # this is a GraphNode's private input.
+    provided_addr = address_for_node_input(node, param, provided_values)
+    if provided_addr in provided_values:
+        return (ValueSource.PROVIDED, provided_values[provided_addr])
 
-    # 3. Bound value resolved at this graph boundary. Under lexical scope,
-    # graph.inputs.bound holds either flat keys (auto-linked at this scope) or
-    # dot-pathed keys for inputs private to a child subgraph. For GraphNode
-    # children we look up the dot-pathed key first.
-    if isinstance(node, GraphNode):
-        dotted = f"{node.name}.{param}"
-        if dotted in graph.inputs.bound:
-            return (ValueSource.BOUND, graph.inputs.bound[dotted])
-    if param in graph.inputs.bound:
-        return (ValueSource.BOUND, graph.inputs.bound[param])
+    # 3. Bound value resolved at this graph boundary. Same addressing applies
+    # for graph.inputs.bound (dot-pathed for private subgraph inputs).
+    bound_addr = address_for_node_input(node, param, graph.inputs.bound)
+    if bound_addr in graph.inputs.bound:
+        return (ValueSource.BOUND, graph.inputs.bound[bound_addr])
 
     # 3b. For GraphNode: check if inner graph has it bound
     if isinstance(node, GraphNode):
@@ -878,23 +893,9 @@ def _has_all_inputs(node: HyperNode, graph: Graph, state: GraphState) -> bool:
 
 def _has_input(param: str, node: HyperNode, graph: Graph, state: GraphState) -> bool:
     """Check if a single input parameter is available."""
-    from hypergraph.nodes.graph_node import GraphNode
-
-    # Value in state (from edge or initial input)
-    if param in state.values:
+    addr = address_for_node_input(node, param, state.values, graph.inputs.bound)
+    if addr in state.values or addr in graph.inputs.bound:
         return True
-
-    # Bound value in graph
-    if param in graph.inputs.bound:
-        return True
-
-    # GraphNode private input addressed by dot-path at this scope
-    if isinstance(node, GraphNode):
-        dotted = f"{node.name}.{param}"
-        if dotted in state.values or dotted in graph.inputs.bound:
-            return True
-
-    # Node has default for this parameter
     return bool(node.has_default_for(param))
 
 
@@ -965,8 +966,11 @@ def _is_stale(
             # Descendant Producer Rule: all producers are downstream (DAGs only)
             if param in downstream:
                 continue
-        current_version = state.get_version(param)
-        consumed_version = last_exec.input_versions.get(param, 0)
+        # Resolve the key the same way it was recorded -- dotted for a
+        # GraphNode's private input, flat otherwise.
+        addr = address_for_node_input(node, param, state.versions, last_exec.input_versions)
+        current_version = state.versions.get(addr, 0)
+        consumed_version = last_exec.input_versions.get(addr, 0)
         if current_version == consumed_version:
             continue
 

--- a/src/hypergraph/runners/_shared/helpers.py
+++ b/src/hypergraph/runners/_shared/helpers.py
@@ -335,14 +335,25 @@ def get_value_source(
     if param in state.values:
         return (ValueSource.EDGE, state.values[param])
 
-    # 2. Input value (from run() call)
+    # 2. Input value (from run() call). For GraphNodes, a dot-pathed entry
+    # ("<node_name>.<param>") addresses a private input of the subgraph and
+    # takes precedence over a bare flat name (which only auto-links when the
+    # name is declared at this scope).
+    if isinstance(node, GraphNode):
+        dotted = f"{node.name}.{param}"
+        if dotted in provided_values:
+            return (ValueSource.PROVIDED, provided_values[dotted])
     if param in provided_values:
         return (ValueSource.PROVIDED, provided_values[param])
 
-    # 3. Bound value resolved at this graph boundary.
-    # graph.inputs.bound includes this graph's own bindings plus any unique,
-    # non-ambiguous nested GraphNode bindings that are intentionally exposed as
-    # outer defaults.
+    # 3. Bound value resolved at this graph boundary. Under lexical scope,
+    # graph.inputs.bound holds either flat keys (auto-linked at this scope) or
+    # dot-pathed keys for inputs private to a child subgraph. For GraphNode
+    # children we look up the dot-pathed key first.
+    if isinstance(node, GraphNode):
+        dotted = f"{node.name}.{param}"
+        if dotted in graph.inputs.bound:
+            return (ValueSource.BOUND, graph.inputs.bound[dotted])
     if param in graph.inputs.bound:
         return (ValueSource.BOUND, graph.inputs.bound[param])
 
@@ -820,6 +831,8 @@ def _has_all_inputs(node: HyperNode, graph: Graph, state: GraphState) -> bool:
 
 def _has_input(param: str, node: HyperNode, graph: Graph, state: GraphState) -> bool:
     """Check if a single input parameter is available."""
+    from hypergraph.nodes.graph_node import GraphNode
+
     # Value in state (from edge or initial input)
     if param in state.values:
         return True
@@ -827,6 +840,12 @@ def _has_input(param: str, node: HyperNode, graph: Graph, state: GraphState) -> 
     # Bound value in graph
     if param in graph.inputs.bound:
         return True
+
+    # GraphNode private input addressed by dot-path at this scope
+    if isinstance(node, GraphNode):
+        dotted = f"{node.name}.{param}"
+        if dotted in state.values or dotted in graph.inputs.bound:
+            return True
 
     # Node has default for this parameter
     return bool(node.has_default_for(param))

--- a/src/hypergraph/runners/_shared/helpers.py
+++ b/src/hypergraph/runners/_shared/helpers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 import uuid
+import warnings
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
@@ -272,6 +273,48 @@ class ValueSource(Enum):
     PROVIDED = "provided"  # From run() call
     BOUND = "bound"  # From graph.bind() - NEVER copy
     DEFAULT = "default"  # From function signature - MUST copy
+
+
+_SHORT_REPR_MAX_LEN = 40
+
+
+def short_value_repr(value: Any, max_len: int = _SHORT_REPR_MAX_LEN) -> str | None:
+    """Short repr for primitive values; None for everything else.
+
+    Single source of truth for inlining user-supplied values into error and
+    warning text. Returns a length-capped repr for bool/int/float/str/bytes/None,
+    and None for everything else (DataFrames, numpy arrays, custom classes) so
+    callers can fall back to a generic message rather than dumping or hitting an
+    expensive __repr__.
+    """
+    if value is None or isinstance(value, (bool, int, float, bytes, str)):
+        rep = repr(value)
+        return rep if len(rep) <= max_len else None
+    return None
+
+
+def warn_on_bind_overrides(graph: Graph, provided_values: dict[str, Any]) -> None:
+    """Emit a UserWarning for each provided value that overrides a bound value.
+
+    Fires uniformly regardless of whether the override address is flat or
+    dotted -- both surfaces share the same canonical form on graph.inputs.bound
+    and provided_values. For primitive bound/provided pairs the warning shows
+    both values; otherwise it stays generic.
+    """
+    bound = graph.inputs.bound
+    for key, new_value in provided_values.items():
+        if key not in bound:
+            continue
+        old_value = bound[key]
+        if old_value is new_value:
+            continue
+        old_repr = short_value_repr(old_value)
+        new_repr = short_value_repr(new_value)
+        if old_repr is not None and new_repr is not None:
+            msg = f"Run value overrides bound value for {key!r}: {old_repr} -> {new_repr}"
+        else:
+            msg = f"Run value overrides bound value for {key!r}"
+        warnings.warn(msg, UserWarning, stacklevel=4)
 
 
 def _safe_deepcopy(value: Any, param_name: str = "<unknown>") -> Any:

--- a/src/hypergraph/runners/_shared/input_normalization.py
+++ b/src/hypergraph/runners/_shared/input_normalization.py
@@ -89,24 +89,6 @@ def normalize_inputs(
 
     if graph is None:
         return merged
-    return _flatten_subgraph_dicts(merged, graph)
+    from hypergraph.graph._helpers import flatten_subgraph_addressing
 
-
-def _flatten_subgraph_dicts(values: dict[str, Any], graph: Graph) -> dict[str, Any]:
-    """Flatten dict values whose key names a GraphNode child into dot-paths."""
-    from hypergraph.nodes.graph_node import GraphNode
-
-    flat: dict[str, Any] = {}
-    for key, value in values.items():
-        child = graph._nodes.get(key) if isinstance(graph._nodes.get(key), GraphNode) else None
-        if isinstance(value, dict) and child is not None:
-            for sub_key, sub_value in _flatten_subgraph_dicts(value, child.graph).items():
-                full_key = f"{key}.{sub_key}"
-                if full_key in flat:
-                    raise ValueError(f"Input key {full_key!r} provided twice (mixed dot-path and nested-dict).")
-                flat[full_key] = sub_value
-        else:
-            if key in flat:
-                raise ValueError(f"Input key {key!r} provided twice (mixed dot-path and nested-dict).")
-            flat[key] = value
-    return flat
+    return flatten_subgraph_addressing(merged, graph)

--- a/src/hypergraph/runners/_shared/input_normalization.py
+++ b/src/hypergraph/runners/_shared/input_normalization.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from hypergraph.graph.core import Graph
 
 RUN_RESERVED_OPTION_NAMES = frozenset(
     {
@@ -63,8 +66,17 @@ def normalize_inputs(
     input_kwargs: dict[str, Any],
     *,
     reserved_option_names: frozenset[str] | None = None,
+    graph: Graph | None = None,
 ) -> dict[str, Any]:
-    """Normalize inputs from values dict + kwargs shorthand."""
+    """Normalize inputs from values dict + kwargs shorthand.
+
+    When ``graph`` is provided, nested-dict entries whose top-level keys match a
+    GraphNode in the graph (or any descendant addressable via further nested
+    dicts) are flattened to dot-paths (``{"A": {"overwrite": True}}`` becomes
+    ``{"A.overwrite": True}``). This makes nested-dict and dot-path forms two
+    equivalent surfaces over the same canonical address form. Dict values whose
+    top-level key is not a subgraph name are passed through unchanged.
+    """
     base_values = dict(values) if values is not None else {}
 
     if reserved_option_names:
@@ -73,6 +85,28 @@ def normalize_inputs(
             conflicts_str = ", ".join(repr(name) for name in conflicts)
             raise ValueError(f"Input keys are reserved runner options: {conflicts_str}. Pass these keys via values={{...}}.")
 
-    if not input_kwargs:
-        return base_values
-    return merge_with_duplicate_check(base_values, input_kwargs)
+    merged = base_values if not input_kwargs else merge_with_duplicate_check(base_values, input_kwargs)
+
+    if graph is None:
+        return merged
+    return _flatten_subgraph_dicts(merged, graph)
+
+
+def _flatten_subgraph_dicts(values: dict[str, Any], graph: Graph) -> dict[str, Any]:
+    """Flatten dict values whose key names a GraphNode child into dot-paths."""
+    from hypergraph.nodes.graph_node import GraphNode
+
+    flat: dict[str, Any] = {}
+    for key, value in values.items():
+        child = graph._nodes.get(key) if isinstance(graph._nodes.get(key), GraphNode) else None
+        if isinstance(value, dict) and child is not None:
+            for sub_key, sub_value in _flatten_subgraph_dicts(value, child.graph).items():
+                full_key = f"{key}.{sub_key}"
+                if full_key in flat:
+                    raise ValueError(f"Input key {full_key!r} provided twice (mixed dot-path and nested-dict).")
+                flat[full_key] = sub_value
+        else:
+            if key in flat:
+                raise ValueError(f"Input key {key!r} provided twice (mixed dot-path and nested-dict).")
+            flat[key] = value
+    return flat

--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -39,6 +39,7 @@ from hypergraph.runners._shared.helpers import (
     get_ready_nodes,
     initialize_state,
     is_interrupt_resume_payload,
+    warn_on_bind_overrides,
 )
 from hypergraph.runners._shared.input_normalization import (
     ASYNC_MAP_RESERVED_OPTION_NAMES,
@@ -217,6 +218,10 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
             reserved_option_names=ASYNC_RUN_RESERVED_OPTION_NAMES,
             graph=graph,
         )
+        # Only fire override warning at the user-initiated outer run; nested
+        # GraphNode delegations propagate the same value and would re-warn.
+        if _parent_span_id is None and _parent_run_id is None:
+            warn_on_bind_overrides(graph, normalized_values)
 
         # Structural validation (doesn't depend on values)
         if _validation_ctx is None:

--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -594,6 +594,10 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
             reserved_option_names=ASYNC_MAP_RESERVED_OPTION_NAMES,
             graph=graph,
         )
+        # Same parity as run(): only fire override warning at the user-initiated
+        # outer call; nested delegations would re-warn for the propagated value.
+        if _parent_span_id is None and _parent_run_id is None:
+            warn_on_bind_overrides(graph, normalized_values)
 
         # Resolve show_progress and merge processors
         effective_show_progress = show_progress if show_progress is not None else getattr(self, "_show_progress", False)

--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -215,6 +215,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
             values,
             input_values,
             reserved_option_names=ASYNC_RUN_RESERVED_OPTION_NAMES,
+            graph=graph,
         )
 
         # Structural validation (doesn't depend on values)
@@ -586,6 +587,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
             values,
             input_values,
             reserved_option_names=ASYNC_MAP_RESERVED_OPTION_NAMES,
+            graph=graph,
         )
 
         # Resolve show_progress and merge processors

--- a/src/hypergraph/runners/_shared/template_sync.py
+++ b/src/hypergraph/runners/_shared/template_sync.py
@@ -38,6 +38,7 @@ from hypergraph.runners._shared.helpers import (
     get_ready_nodes,
     initialize_state,
     is_interrupt_resume_payload,
+    warn_on_bind_overrides,
 )
 from hypergraph.runners._shared.input_normalization import (
     ASYNC_MAP_RESERVED_OPTION_NAMES,
@@ -211,6 +212,10 @@ class SyncRunnerTemplate(BaseRunner, ABC):
             reserved_option_names=ASYNC_RUN_RESERVED_OPTION_NAMES,
             graph=graph,
         )
+        # Only fire override warning at the user-initiated outer run; nested
+        # GraphNode delegations propagate the same value and would re-warn.
+        if _parent_span_id is None and _parent_run_id is None:
+            warn_on_bind_overrides(graph, normalized_values)
 
         # Structural validation (doesn't depend on values)
         if _validation_ctx is None:

--- a/src/hypergraph/runners/_shared/template_sync.py
+++ b/src/hypergraph/runners/_shared/template_sync.py
@@ -567,6 +567,10 @@ class SyncRunnerTemplate(BaseRunner, ABC):
             reserved_option_names=ASYNC_MAP_RESERVED_OPTION_NAMES,
             graph=graph,
         )
+        # Same parity as run(): only fire override warning at the user-initiated
+        # outer call; nested delegations would re-warn for the propagated value.
+        if _parent_span_id is None and _parent_run_id is None:
+            warn_on_bind_overrides(graph, normalized_values)
 
         # Resolve show_progress and merge processors
         effective_show_progress = show_progress if show_progress is not None else getattr(self, "_show_progress", False)

--- a/src/hypergraph/runners/_shared/template_sync.py
+++ b/src/hypergraph/runners/_shared/template_sync.py
@@ -209,6 +209,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
             values,
             input_values,
             reserved_option_names=ASYNC_RUN_RESERVED_OPTION_NAMES,
+            graph=graph,
         )
 
         # Structural validation (doesn't depend on values)
@@ -559,6 +560,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
             values,
             input_values,
             reserved_option_names=ASYNC_MAP_RESERVED_OPTION_NAMES,
+            graph=graph,
         )
 
         # Resolve show_progress and merge processors

--- a/src/hypergraph/runners/_shared/validation.py
+++ b/src/hypergraph/runners/_shared/validation.py
@@ -403,6 +403,13 @@ def _find_internal_override_conflicts(
 
 def _node_is_runnable_from_seed_values(node: HyperNode, provided: set[str]) -> bool:
     """True when node can run from provided/bound/default values before execution."""
+    # NOTE: this iterates the node's flat input names against `provided`. For a
+    # GraphNode whose input is addressed dot-pathed at this scope, `provided`
+    # contains "<node.name>.<param>" -- so flat-only matching can miss it. Only
+    # triggers when the user simultaneously provides a downstream node's outputs
+    # (compute+inject conflict path), and isn't currently exercised by any test
+    # with a dot-pathed bind. Use address_for_node_input here when this case is
+    # ever observed in the wild.
     return all(param in provided or node.has_default_for(param) for param in node.inputs)
 
 

--- a/src/hypergraph/runners/_shared/validation.py
+++ b/src/hypergraph/runners/_shared/validation.py
@@ -195,8 +195,18 @@ def _build_missing_input_message(
     entrypoints: dict[str, tuple[str, ...]] | None = None,
 ) -> str:
     """Build a helpful error message for missing inputs."""
-    missing_str = ", ".join(f"'{m}'" for m in sorted(missing))
-    msg = f"Missing required inputs: {missing_str}"
+    from hypergraph.graph._helpers import describe_addressed_input
+
+    sorted_missing = sorted(missing)
+    any_dotted = any("." in m for m in sorted_missing)
+
+    if any_dotted:
+        # Show each missing input with its subgraph annotation, one per line.
+        lines = [f"  - {describe_addressed_input(m)}  (address as {m!r})" for m in sorted_missing]
+        msg = "Missing required inputs:\n" + "\n".join(lines)
+    else:
+        missing_str = ", ".join(f"'{m}'" for m in sorted_missing)
+        msg = f"Missing required inputs: {missing_str}"
 
     if provided:
         msg += f"\n\nProvided: {', '.join(f'{p!r}' for p in sorted(provided))}"
@@ -212,9 +222,13 @@ def _build_missing_input_message(
         for m, sugg in suggestions.items():
             msg += f"\n  - '{m}' -> '{sugg[0]}'?"
 
-    msg += "\n\nHint: If you used graph.bind(), remember it returns a NEW graph."
-    msg += "\n  ❌ graph.bind(x=10)           # Result discarded!"
-    msg += "\n  ✅ graph = graph.bind(x=10)   # Correct"
+    if not any_dotted:
+        # The bind()-returns-new-graph hint applies when the user is wrestling
+        # with bind() chaining. For dot-pathed lexical-scope misses it's a
+        # distraction -- the actual fix is to use the right address form.
+        msg += "\n\nHint: If you used graph.bind(), remember it returns a NEW graph."
+        msg += "\n  ❌ graph.bind(x=10)           # Result discarded!"
+        msg += "\n  ✅ graph = graph.bind(x=10)   # Correct"
 
     return msg
 

--- a/src/hypergraph/runners/_shared/validation.py
+++ b/src/hypergraph/runners/_shared/validation.py
@@ -402,15 +402,15 @@ def _find_internal_override_conflicts(
 
 
 def _node_is_runnable_from_seed_values(node: HyperNode, provided: set[str]) -> bool:
-    """True when node can run from provided/bound/default values before execution."""
-    # NOTE: this iterates the node's flat input names against `provided`. For a
-    # GraphNode whose input is addressed dot-pathed at this scope, `provided`
-    # contains "<node.name>.<param>" -- so flat-only matching can miss it. Only
-    # triggers when the user simultaneously provides a downstream node's outputs
-    # (compute+inject conflict path), and isn't currently exercised by any test
-    # with a dot-pathed bind. Use address_for_node_input here when this case is
-    # ever observed in the wild.
-    return all(param in provided or node.has_default_for(param) for param in node.inputs)
+    """True when node can run from provided/bound/default values before execution.
+
+    Resolves each input via the canonical address so a GraphNode's private
+    input addressed as ``"<node.name>.<param>"`` in ``provided`` is matched
+    correctly under lexical scope (matches sync/async runners' get_value_source).
+    """
+    from hypergraph.runners._shared.helpers import address_for_node_input
+
+    return all(address_for_node_input(node, param, provided) in provided or node.has_default_for(param) for param in node.inputs)
 
 
 def _warn_on_unrecognized_inputs(

--- a/src/hypergraph/runners/async_/executors/graph_node.py
+++ b/src/hypergraph/runners/async_/executors/graph_node.py
@@ -69,8 +69,16 @@ class AsyncGraphNodeExecutor:
             child_fork_from: str | None = None
             child_retry_from: str | None = None
             prefix = f"{node.name}."
+            # Resume-values are interrupt outputs prefixed with the GraphNode's
+            # name. Skip suffixes that match this node's public inputs -- those
+            # are dot-pathed user-provided inputs already routed via inner_inputs.
+            node_input_set = set(node.inputs)
             resume_values = {
-                node.resolve_original_output_name(key[len(prefix) :]): value for key, value in state.values.items() if key.startswith(prefix)
+                node.resolve_original_output_name(suffix): value
+                for key, value in state.values.items()
+                if key.startswith(prefix)
+                for suffix in [key[len(prefix) :]]
+                if suffix not in node_input_set
             }
 
             if map_config is None and child_workflow_id is not None and self.runner._checkpointer is not None:

--- a/src/hypergraph/runners/async_/superstep.py
+++ b/src/hypergraph/runners/async_/superstep.py
@@ -22,7 +22,7 @@ from hypergraph.runners._shared.event_helpers import (
     build_node_start_event,
     build_route_decision_event,
 )
-from hypergraph.runners._shared.helpers import apply_node_result, collect_inputs_for_node
+from hypergraph.runners._shared.helpers import address_for_node_input, apply_node_result, collect_inputs_for_node
 from hypergraph.runners._shared.types import ExecutionContext, GraphState, PauseExecution
 
 if TYPE_CHECKING:
@@ -102,7 +102,11 @@ async def run_superstep_async(
     ) -> tuple[HyperNode, dict[str, Any], dict[str, int], dict[str, int], float, bool]:
         """Execute a single node with event emission."""
         inputs = collect_inputs_for_node(node, graph, state, provided_values)
-        input_versions = {param: state.get_version(param) for param in node.inputs}
+        # Record input versions under the same addressed key the staleness
+        # check reads -- dotted for a GraphNode's private input, flat otherwise.
+        input_versions = {
+            (addr := address_for_node_input(node, param, state.versions)): state.versions.get(addr, 0) for param in node.inputs
+        }
         wait_for_versions = {name: state.get_version(name) for name in node.wait_for}
 
         # Check cache before execution

--- a/src/hypergraph/runners/async_/superstep.py
+++ b/src/hypergraph/runners/async_/superstep.py
@@ -104,9 +104,7 @@ async def run_superstep_async(
         inputs = collect_inputs_for_node(node, graph, state, provided_values)
         # Record input versions under the same addressed key the staleness
         # check reads -- dotted for a GraphNode's private input, flat otherwise.
-        input_versions = {
-            (addr := address_for_node_input(node, param, state.versions)): state.versions.get(addr, 0) for param in node.inputs
-        }
+        input_versions = {(addr := address_for_node_input(node, param, state.versions)): state.versions.get(addr, 0) for param in node.inputs}
         wait_for_versions = {name: state.get_version(name) for name in node.wait_for}
 
         # Check cache before execution

--- a/src/hypergraph/runners/daft/operations.py
+++ b/src/hypergraph/runners/daft/operations.py
@@ -246,8 +246,18 @@ class GraphNodeOperation(DaftOperation):
     def apply(self, df: daft.DataFrame) -> daft.DataFrame:
         import daft as daft_mod
 
+        from hypergraph.runners._shared.helpers import address_for_node_input
+
         node = self.node
-        input_cols = self.input_columns
+        # Resolve each public input to the actual DataFrame column. Under
+        # lexical scope a private GraphNode input may arrive under its
+        # dot-pathed address; address_for_node_input picks whichever column
+        # the schema actually has.
+        df_columns = {name: None for name in df.column_names}
+        param_to_col = {p: address_for_node_input(node, p, df_columns) for p in self.input_columns}
+        col_names_for_df = list(param_to_col.values())
+        col_names_for_inner = list(param_to_col.keys())
+
         output_col = self.output_columns[0] if len(self.output_columns) == 1 else f"_pack_{node.name}"
         multi_output = len(self.output_columns) > 1
         cache = self.cache
@@ -256,7 +266,11 @@ class GraphNodeOperation(DaftOperation):
         inner_graph = node.graph
         # map_config is (params, mode, error_handling) or None
         map_config = node.map_config
-        col_names = input_cols  # capture for closure
+
+        # Capture for the closure: build inner_inputs from positional args
+        # using the GraphNode's public input names (not the DataFrame column
+        # names, which may be dot-pathed).
+        inner_param_names = col_names_for_inner
 
         @daft_mod.func(return_dtype=daft_mod.DataType.python())
         def execute_graph(*args: Any) -> Any:
@@ -266,7 +280,7 @@ class GraphNodeOperation(DaftOperation):
             )
             from hypergraph.runners.sync.runner import SyncRunner
 
-            raw_inputs = {**bound, **dict(zip(col_names, args, strict=True))}
+            raw_inputs = {**bound, **dict(zip(inner_param_names, args, strict=True))}
             # Translate renamed input keys back to original inner graph names
             inner_inputs = map_inputs_to_func_params(node, raw_inputs)
             runner = SyncRunner(cache=cache)
@@ -299,7 +313,7 @@ class GraphNodeOperation(DaftOperation):
                     return result.values
                 return next(iter(result.values.values()))
 
-        col_refs = [df[c] for c in input_cols]
+        col_refs = [df[c] for c in col_names_for_df]
         df = df.with_column(output_col, execute_graph(*col_refs))
 
         if multi_output:
@@ -335,7 +349,10 @@ def create_operation(
         if addr in bound_values:
             node_bound[param] = bound_values[addr]
 
-    # Determine input columns (those not provided by bound values)
+    # Determine input columns (those not provided by bound values). For
+    # GraphNode private inputs the actual DataFrame column may be either flat
+    # or dot-pathed depending on how the user addressed the input -- the
+    # GraphNodeOperation resolves at apply() time once the schema is known.
     input_cols = [p for p in node.inputs if p not in node_bound]
     output_cols = list(node.data_outputs)
 

--- a/src/hypergraph/runners/daft/operations.py
+++ b/src/hypergraph/runners/daft/operations.py
@@ -323,14 +323,17 @@ def create_operation(
     """Route a node to the appropriate DaftOperation class."""
     from hypergraph.nodes.function import FunctionNode
     from hypergraph.nodes.graph_node import GraphNode
+    from hypergraph.runners._shared.helpers import address_for_node_input
 
-    # Determine which bound values apply to this node
-    # NOTE: under lexical scope `bound_values` may be keyed by dot-paths for a
-    # GraphNode's private inputs. This flat-name match misses those. No daft
-    # test currently exercises a GraphNode with dot-pathed binds; see
-    # address_for_node_input in runners/_shared/helpers.py for the canonical
-    # resolver if this is ever observed in the wild.
-    node_bound = {k: v for k, v in bound_values.items() if k in node.inputs}
+    # Determine which bound values apply to this node. For a GraphNode private
+    # input, bound_values may be keyed by dot-path; resolve to the canonical
+    # address (matching the sync/async runners) and store under the flat param
+    # name the inner node expects.
+    node_bound: dict[str, Any] = {}
+    for param in node.inputs:
+        addr = address_for_node_input(node, param, bound_values)
+        if addr in bound_values:
+            node_bound[param] = bound_values[addr]
 
     # Determine input columns (those not provided by bound values)
     input_cols = [p for p in node.inputs if p not in node_bound]

--- a/src/hypergraph/runners/daft/operations.py
+++ b/src/hypergraph/runners/daft/operations.py
@@ -325,6 +325,11 @@ def create_operation(
     from hypergraph.nodes.graph_node import GraphNode
 
     # Determine which bound values apply to this node
+    # NOTE: under lexical scope `bound_values` may be keyed by dot-paths for a
+    # GraphNode's private inputs. This flat-name match misses those. No daft
+    # test currently exercises a GraphNode with dot-pathed binds; see
+    # address_for_node_input in runners/_shared/helpers.py for the canonical
+    # resolver if this is ever observed in the wild.
     node_bound = {k: v for k, v in bound_values.items() if k in node.inputs}
 
     # Determine input columns (those not provided by bound values)

--- a/src/hypergraph/runners/sync/executors/graph_node.py
+++ b/src/hypergraph/runners/sync/executors/graph_node.py
@@ -60,8 +60,16 @@ class SyncGraphNodeExecutor:
         # executed so the inner interrupt should fire again, not skip.
         if node.name not in state.node_executions:
             prefix = f"{node.name}."
+            # Resume-values are interrupt outputs prefixed with the GraphNode's
+            # name. Skip suffixes that match this node's public inputs -- those
+            # are dot-pathed user-provided inputs already routed via inner_inputs.
+            node_input_set = set(node.inputs)
             resume_values = {
-                node.resolve_original_output_name(key[len(prefix) :]): value for key, value in state.values.items() if key.startswith(prefix)
+                node.resolve_original_output_name(suffix): value
+                for key, value in state.values.items()
+                if key.startswith(prefix)
+                for suffix in [key[len(prefix) :]]
+                if suffix not in node_input_set
             }
             child_fork_from: str | None = None
             child_retry_from: str | None = None

--- a/src/hypergraph/runners/sync/superstep.py
+++ b/src/hypergraph/runners/sync/superstep.py
@@ -72,9 +72,7 @@ def run_superstep_sync(
 
         # Record input versions under the same addressed key the staleness
         # check reads -- dotted for a GraphNode's private input, flat otherwise.
-        input_versions = {
-            (addr := address_for_node_input(node, param, state.versions)): state.versions.get(addr, 0) for param in node.inputs
-        }
+        input_versions = {(addr := address_for_node_input(node, param, state.versions)): state.versions.get(addr, 0) for param in node.inputs}
 
         # Check cache before execution
         cache_key, cached_outputs = ("", None)

--- a/src/hypergraph/runners/sync/superstep.py
+++ b/src/hypergraph/runners/sync/superstep.py
@@ -20,7 +20,7 @@ from hypergraph.runners._shared.event_helpers import (
     build_node_start_event,
     build_route_decision_event,
 )
-from hypergraph.runners._shared.helpers import apply_node_result, collect_inputs_for_node
+from hypergraph.runners._shared.helpers import address_for_node_input, apply_node_result, collect_inputs_for_node
 from hypergraph.runners._shared.types import ExecutionContext, GraphState, PauseExecution
 
 if TYPE_CHECKING:
@@ -70,8 +70,11 @@ def run_superstep_sync(
         # in this superstep see the same values (deterministic execution order)
         inputs = collect_inputs_for_node(node, graph, state, provided_values)
 
-        # Record input versions from the snapshot we used
-        input_versions = {param: state.get_version(param) for param in node.inputs}
+        # Record input versions under the same addressed key the staleness
+        # check reads -- dotted for a GraphNode's private input, flat otherwise.
+        input_versions = {
+            (addr := address_for_node_input(node, param, state.versions)): state.versions.get(addr, 0) for param in node.inputs
+        }
 
         # Check cache before execution
         cache_key, cached_outputs = ("", None)

--- a/src/hypergraph/viz/_common.py
+++ b/src/hypergraph/viz/_common.py
@@ -263,7 +263,7 @@ def resolve_dot_path_consumers(
         attrs = flat_graph.nodes.get(candidate)
         if attrs is None or attrs.get("node_type") != "GRAPH":
             return []  # unresolvable: malformed path
-        rest_local = ".".join(parts[idx + 1:])
+        rest_local = ".".join(parts[idx + 1 :])
         if rest_local not in attrs.get("inputs", ()):
             return []  # container does not declare this scope-local input
         consumers.append(candidate)
@@ -277,9 +277,7 @@ def resolve_dot_path_consumers(
     for node_id, attrs in flat_graph.nodes(data=True):
         if leaf not in attrs.get("inputs", ()):
             continue
-        if current_scope is None:
-            consumers.append(node_id)
-        elif is_descendant_of(node_id, current_scope, flat_graph):
+        if current_scope is None or is_descendant_of(node_id, current_scope, flat_graph):
             consumers.append(node_id)
 
     # Deduplicate while preserving order.

--- a/src/hypergraph/viz/_common.py
+++ b/src/hypergraph/viz/_common.py
@@ -191,6 +191,107 @@ def enumerate_valid_expansion_states(
 # =============================================================================
 
 
+def external_input_display_name(param: str) -> str:
+    """Return the leaf segment of a dot-pathed external-input name.
+
+    Synthetic INPUT-node IDs (``input_<name>``) and visible labels use the
+    leaf segment so users see ``x`` rather than ``middle.inner.x``. The
+    full dot path is an implementation detail of input addressing.
+    """
+    if not param:
+        return param
+    return param.rsplit(".", 1)[-1]
+
+
+def disambiguate_external_input_ids(
+    params_by_group: list[list[str]],
+) -> dict[str, str]:
+    """Map each dot-pathed external-input name to a unique synthetic id.
+
+    Returns ``{full_param: id_safe_name}``. When two groups would otherwise
+    collide on the leaf segment (e.g. ``A.x`` and ``B.x`` both map to
+    ``x``), each colliding name keeps its full dot-path so the synthetic
+    ``input_*`` node IDs stay unique.
+    """
+    leaf_counts: dict[str, int] = {}
+    for params in params_by_group:
+        for p in params:
+            leaf = external_input_display_name(p)
+            leaf_counts[leaf] = leaf_counts.get(leaf, 0) + 1
+
+    mapping: dict[str, str] = {}
+    for params in params_by_group:
+        for p in params:
+            leaf = external_input_display_name(p)
+            mapping[p] = leaf if leaf_counts.get(leaf, 0) == 1 else p
+    return mapping
+
+
+def resolve_dot_path_consumers(
+    param: str,
+    flat_graph: nx.DiGraph,
+) -> list[str]:
+    """Resolve a dot-pathed external-input name to its consumer chain.
+
+    External inputs surface in ``input_spec.required`` as dot paths like
+    ``"middle.inner.x"`` — meaning the GraphNode named ``middle`` (a child
+    of the current scope) has a subscope where ``inner.x`` is the further
+    address. This walks the chain and returns every consumer along it,
+    from outermost to innermost.
+
+    For a path ``head.rest`` at scope ``S``:
+    - the child of ``S`` named ``head`` (a GraphNode whose scope-local
+      inputs include ``rest``) is a consumer.
+    - recurse into that container with ``rest``.
+
+    At the leaf (no remaining dots), every descendant of the current
+    scope whose ``inputs`` contains the leaf name is added as a consumer.
+    Plain (non-dotted) params fall through to the same flat-graph
+    descendant scan, preserving legacy behavior.
+
+    Returns ``[]`` if the path cannot be resolved against the flat graph.
+    """
+    parts = param.split(".") if param else []
+    if not parts:
+        return []
+
+    # Walk down GraphNode chain for all but the final segment.
+    consumers: list[str] = []
+    current_scope: str | None = None  # None = root
+    for idx, head in enumerate(parts[:-1]):
+        candidate = f"{current_scope}/{head}" if current_scope is not None else head
+        attrs = flat_graph.nodes.get(candidate)
+        if attrs is None or attrs.get("node_type") != "GRAPH":
+            return []  # unresolvable: malformed path
+        rest_local = ".".join(parts[idx + 1:])
+        if rest_local not in attrs.get("inputs", ()):
+            return []  # container does not declare this scope-local input
+        consumers.append(candidate)
+        current_scope = candidate
+
+    leaf = parts[-1]
+    # All descendants of current_scope (or all root nodes when None) whose
+    # inputs declare the leaf name are also consumers. For a single-segment
+    # plain param, current_scope is None and this becomes the legacy
+    # descendant scan.
+    for node_id, attrs in flat_graph.nodes(data=True):
+        if leaf not in attrs.get("inputs", ()):
+            continue
+        if current_scope is None:
+            consumers.append(node_id)
+        elif is_descendant_of(node_id, current_scope, flat_graph):
+            consumers.append(node_id)
+
+    # Deduplicate while preserving order.
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for c in consumers:
+        if c not in seen:
+            seen.add(c)
+            deduped.append(c)
+    return deduped
+
+
 def build_param_to_consumer_map(
     flat_graph: nx.DiGraph,
     expansion_state: dict[str, bool],
@@ -217,6 +318,22 @@ def build_param_to_consumer_map(
             if param not in param_to_consumers:
                 param_to_consumers[param] = []
             param_to_consumers[param].append(node_id)
+
+    # External inputs surface as dot-pathed lexical addresses (issue #94).
+    # Resolve each one against the flat-graph hierarchy so the consumer
+    # chain (container -> ... -> leaf) is available for visibility-aware
+    # filtering below. Plain (non-dotted) params already match by exact
+    # name in the loop above and are skipped here.
+    input_spec = flat_graph.graph.get("input_spec", {})
+    for param in tuple(input_spec.get("required", ())) + tuple(input_spec.get("optional", ())):
+        if "." not in param:
+            continue
+        chain = resolve_dot_path_consumers(param, flat_graph)
+        if not chain:
+            continue
+        if not use_deepest:
+            chain = [c for c in chain if is_node_visible(c, flat_graph, expansion_state)]
+        param_to_consumers[param] = chain
 
     # Filter out containers that have deeper visible consumers
     for param, consumers in param_to_consumers.items():

--- a/src/hypergraph/viz/assets/scene_builder.js
+++ b/src/hypergraph/viz/assets/scene_builder.js
@@ -123,7 +123,11 @@
       var params = ext.params || [];
       var typeHints = ext.type_hints || [];
       var isGroup = params.length > 1;
-      var inputId = isGroup ? 'input_group_' + params.join('_') : 'input_' + params[0];
+      // ``id_segments`` falls back to ``params`` (leaf names) and mirrors
+      // the Python disambiguator that swaps in the full dot-path when
+      // leaf names collide between sibling subgraphs (issue #94).
+      var idSegments = (ext.id_segments && ext.id_segments.length === params.length) ? ext.id_segments : params;
+      var inputId = isGroup ? 'input_group_' + idSegments.join('_') : 'input_' + idSegments[0];
       var data = isGroup
         ? {
             nodeType: 'INPUT_GROUP',
@@ -280,9 +284,10 @@
       if (ext2.is_bound && !showBoundedInputs) continue;
       if (!showInputs) continue;
       var ext2Params = ext2.params || [];
+      var ext2Ids = (ext2.id_segments && ext2.id_segments.length === ext2Params.length) ? ext2.id_segments : ext2Params;
       var inputNodeId = ext2Params.length > 1
-        ? 'input_group_' + ext2Params.join('_')
-        : 'input_' + ext2Params[0];
+        ? 'input_group_' + ext2Ids.join('_')
+        : 'input_' + ext2Ids[0];
       var consumers = ext2.consumers || [];
       for (var r = 0; r < consumers.length; r++) {
         var consumer = consumers[r];

--- a/src/hypergraph/viz/ir_schema.py
+++ b/src/hypergraph/viz/ir_schema.py
@@ -56,13 +56,21 @@ class IRExternalInput:
     """An external-input group. Single-param groups render as INPUT;
     multi-param groups (e.g. one consumer takes both `alpha` and
     `beta`) render as INPUT_GROUP with a stable id like
-    `input_group_alpha_beta`."""
+    `input_group_alpha_beta`.
 
-    params: tuple[str, ...]  # one or more param names
+    ``params`` stores the user-visible leaf names (the lexical-scope leaf
+    of dot-pathed external inputs from issue #94). ``id_segments`` are
+    the corresponding identifier-safe segments used to construct the
+    synthetic ``input_*`` node id; they are equal to ``params`` except
+    when colliding leaf names force a fallback to the full dot-path.
+    """
+
+    params: tuple[str, ...]  # display labels (leaf segments)
     deepest_owner: str | None = None
     consumers: tuple[str, ...] = ()
     type_hints: tuple[str | None, ...] = ()  # one per param
     is_bound: bool = False
+    id_segments: tuple[str, ...] = ()  # one per param; falls back to params if empty
 
     @property
     def name(self) -> str:
@@ -72,6 +80,14 @@ class IRExternalInput:
     @property
     def is_group(self) -> bool:
         return len(self.params) > 1
+
+    @property
+    def synthetic_id(self) -> str:
+        """Stable scene-graph id of the INPUT/INPUT_GROUP node."""
+        segs = self.id_segments or self.params
+        if len(segs) == 1:
+            return f"input_{segs[0]}"
+        return f"input_group_{'_'.join(segs)}"
 
 
 # Bump when the IR shape changes in a way old scene_builders can't read.

--- a/src/hypergraph/viz/ir_schema.py
+++ b/src/hypergraph/viz/ir_schema.py
@@ -83,8 +83,15 @@ class IRExternalInput:
 
     @property
     def synthetic_id(self) -> str:
-        """Stable scene-graph id of the INPUT/INPUT_GROUP node."""
-        segs = self.id_segments or self.params
+        """Stable scene-graph id of the INPUT/INPUT_GROUP node.
+
+        Uses ``id_segments`` only when its length matches ``params`` -- mirrors
+        the JS twin (assets/scene_builder.js) which guards on the same length
+        check. Without this guard, a Python/JS payload with ``id_segments`` of
+        a different length would diverge: Python would use ``id_segments``
+        while JS falls back to ``params``, producing mismatched scene IDs.
+        """
+        segs = self.id_segments if self.id_segments and len(self.id_segments) == len(self.params) else self.params
         if len(segs) == 1:
             return f"input_{segs[0]}"
         return f"input_group_{'_'.join(segs)}"

--- a/src/hypergraph/viz/mermaid.py
+++ b/src/hypergraph/viz/mermaid.py
@@ -23,6 +23,8 @@ from hypergraph.viz._common import (
     build_output_to_producer_map,
     build_param_to_consumer_map,
     compute_exclusive_data_edges,
+    disambiguate_external_input_ids,
+    external_input_display_name,
     is_descendant_of,
     is_node_visible,
 )
@@ -769,18 +771,23 @@ def to_mermaid(
         set(shared_params),
         False,
     )
+    id_for_param = disambiguate_external_input_ids([list(g["params"]) for g in input_groups])
     if input_groups:
         lines.append("    %% Inputs")
     for group in input_groups:
         params = group["params"]
-        param_types = [format_type(_get_param_type(p, flat_graph)) for p in params]
-        label = _build_input_label(params, param_types, show_types)
+        # Display labels are scope-local leaf names; type lookup falls
+        # back to the leaf if the dot-pathed key has no entry.
+        display_params = [external_input_display_name(p) for p in params]
+        param_types = [format_type(_get_param_type(p, flat_graph) or _get_param_type(external_input_display_name(p), flat_graph)) for p in params]
+        label = _build_input_label(display_params, param_types, show_types)
 
         if len(params) == 1:
-            node_id = f"input_{params[0]}"
+            node_id = f"input_{id_for_param.get(params[0], display_params[0])}"
             node_type = "INPUT"
         else:
-            node_id = f"input_group_{'_'.join(params)}"
+            id_segs = [id_for_param.get(p, external_input_display_name(p)) for p in params]
+            node_id = f"input_group_{'_'.join(id_segs)}"
             node_type = "INPUT_GROUP"
 
         lines.append(_format_node(_sanitize_id(node_id), label, node_type))
@@ -856,7 +863,11 @@ def to_mermaid(
 
     for group in input_groups:
         params = group["params"]
-        input_node_id = f"input_{params[0]}" if len(params) == 1 else f"input_group_{'_'.join(params)}"
+        if len(params) == 1:
+            input_node_id = f"input_{id_for_param.get(params[0], external_input_display_name(params[0]))}"
+        else:
+            id_segs = [id_for_param.get(p, external_input_display_name(p)) for p in params]
+            input_node_id = f"input_group_{'_'.join(id_segs)}"
 
         targets = _get_input_targets(params, flat_graph, param_to_consumers, expansion_state)
         for tgt in targets:

--- a/src/hypergraph/viz/renderer/instructions.py
+++ b/src/hypergraph/viz/renderer/instructions.py
@@ -13,8 +13,10 @@ from typing import TYPE_CHECKING, Any
 from hypergraph.viz._common import (
     build_expansion_state,
     build_param_to_consumer_map,
+    disambiguate_external_input_ids,
     enumerate_valid_expansion_states,
     expansion_state_to_key,
+    external_input_display_name,
     get_expandable_nodes,
     get_nesting_depth,
     is_node_visible,
@@ -254,11 +256,12 @@ def _compute_edges_for_state(
     input_spec = flat_graph.graph.get("input_spec", {})
     required = input_spec.get("required", ())
     optional = input_spec.get("optional", ())
-    external_inputs = set(required) | set(optional)
+    external_inputs = list(required) + list(optional)
+    id_for_param = disambiguate_external_input_ids([[p] for p in external_inputs])
 
     # 1. Add edges from INPUT nodes to their actual consumers
     for param in external_inputs:
-        input_node_id = f"input_{param}"
+        input_node_id = f"input_{id_for_param[param]}"
         actual_target = _pick_primary_consumer(param_to_consumers.get(param, []), flat_graph)
 
         if actual_target:
@@ -344,20 +347,29 @@ def _add_input_nodes(
     required = input_spec.get("required", ())
     optional = input_spec.get("optional", ())
     external_inputs = list(required) + list(optional)
+    id_for_param = disambiguate_external_input_ids([[p] for p in external_inputs])
 
     for param in external_inputs:
+        # Dot-pathed external inputs (issue #94) carry the lexical scope
+        # in their name (``middle.inner.x``); the param's *type* lives
+        # under its scope-local leaf name on the leaf consumer's
+        # ``input_types``.
+        leaf = external_input_display_name(param)
         param_type = None
         for _node_id, attrs in flat_graph.nodes(data=True):
-            if param in attrs.get("inputs", ()):
+            inputs = attrs.get("inputs", ())
+            if param in inputs:
                 param_type = attrs.get("input_types", {}).get(param)
-                if param_type is not None:
-                    break
+            elif leaf in inputs:
+                param_type = attrs.get("input_types", {}).get(leaf)
+            if param_type is not None:
+                break
 
         instructions.add_node(
             VizNode(
-                id=f"input_{param}",
+                id=f"input_{id_for_param[param]}",
                 type=NodeType.INPUT,
-                label=param,
+                label=leaf,
                 type_hint=_format_type(param_type),
                 theme=theme,
                 show_types=show_types,
@@ -415,11 +427,12 @@ def _add_edges(
     input_spec = flat_graph.graph.get("input_spec", {})
     required = input_spec.get("required", ())
     optional = input_spec.get("optional", ())
-    external_inputs = set(required) | set(optional)
+    external_inputs = list(required) + list(optional)
+    id_for_param = disambiguate_external_input_ids([[p] for p in external_inputs])
 
     # 1. Add edges from INPUT nodes to their actual consumers
     for param in external_inputs:
-        input_node_id = f"input_{param}"
+        input_node_id = f"input_{id_for_param[param]}"
         actual_target = _pick_primary_consumer(param_to_consumers.get(param, []), flat_graph)
 
         if actual_target:

--- a/src/hypergraph/viz/renderer/ir_builder.py
+++ b/src/hypergraph/viz/renderer/ir_builder.py
@@ -13,6 +13,8 @@ import networkx as nx
 from hypergraph.viz._common import (
     build_param_to_consumer_map,
     compute_exclusive_data_edges,
+    disambiguate_external_input_ids,
+    external_input_display_name,
     get_expandable_nodes,
 )
 from hypergraph.viz.ir_schema import GraphIR, IREdge, IRExternalInput, IRNode
@@ -56,7 +58,10 @@ def build_graph_ir(flat_graph: nx.DiGraph) -> GraphIR:
         shared_params=shared_params,
         show_bounded_inputs=True,
     )
-    external_inputs = [_build_input_group(group, flat_graph) for group in groups]
+    # Pre-compute the synthetic-id mapping so colliding leaf names
+    # (e.g. ``A.x`` and ``B.x``) get unique ``input_<id>`` ids.
+    id_for_param = disambiguate_external_input_ids([list(group["params"]) for group in groups])
+    external_inputs = [_build_input_group(group, flat_graph, id_for_param) for group in groups]
 
     configured_entrypoints = tuple(flat_graph.graph.get("configured_entrypoints") or ())
     visibility = build_graph_output_visibility(flat_graph)
@@ -72,28 +77,47 @@ def build_graph_ir(flat_graph: nx.DiGraph) -> GraphIR:
     )
 
 
-def _build_input_group(group: dict, flat_graph: nx.DiGraph) -> IRExternalInput:
+def _build_input_group(
+    group: dict,
+    flat_graph: nx.DiGraph,
+    id_for_param: dict[str, str] | None = None,
+) -> IRExternalInput:
     """Convert a build_input_groups dict into an IRExternalInput.
 
     Multi-param groups (e.g. one consumer takes both alpha and beta)
     become a single IRExternalInput with len(params) > 1, which
     scene_builder renders as INPUT_GROUP."""
-    params = tuple(group["params"])
+    raw_params = tuple(group["params"])
     consumers: list[str] = []
     seen: set[str] = set()
-    for param in params:
+    for param in raw_params:
+        # Resolve consumers using the (possibly dot-pathed) full name so
+        # the dot-path walk in get_deepest_consumers can address nested
+        # subgraphs (issue #94). Deduplicate while preserving order.
         for consumer in get_deepest_consumers(param, flat_graph):
             if consumer not in seen:
                 seen.add(consumer)
                 consumers.append(consumer)
-    deepest_owner = compute_deepest_input_scope(params[0], flat_graph)
-    type_hints = tuple(format_type(get_param_type(p, flat_graph)) for p in params)
+    deepest_owner = compute_deepest_input_scope(raw_params[0], flat_graph)
+    # Type hints are looked up by the dot-pathed name first, then by the
+    # leaf — leaf consumers carry the type under their scope-local name.
+    type_hints: list[str | None] = []
+    for p in raw_params:
+        param_type = get_param_type(p, flat_graph)
+        if param_type is None:
+            param_type = get_param_type(external_input_display_name(p), flat_graph)
+        type_hints.append(format_type(param_type))
+    # Display labels are the leaf segments; synthetic ids fall back to
+    # the full dot-path when leaf names collide.
+    display_params = tuple(external_input_display_name(p) for p in raw_params)
+    id_segments = tuple((id_for_param or {}).get(p, external_input_display_name(p)) for p in raw_params)
     return IRExternalInput(
-        params=params,
+        params=display_params,
         deepest_owner=deepest_owner,
         consumers=tuple(consumers),
-        type_hints=type_hints,
+        type_hints=tuple(type_hints),
         is_bound=bool(group.get("is_bound", False)),
+        id_segments=id_segments,
     )
 
 

--- a/src/hypergraph/viz/renderer/ir_builder.py
+++ b/src/hypergraph/viz/renderer/ir_builder.py
@@ -99,13 +99,21 @@ def _build_input_group(
                 seen.add(consumer)
                 consumers.append(consumer)
     deepest_owner = compute_deepest_input_scope(raw_params[0], flat_graph)
-    # Type hints are looked up by the dot-pathed name first, then by the
-    # leaf — leaf consumers carry the type under their scope-local name.
+    # Type hints are looked up by the dot-pathed name first. If that misses
+    # (collapsed view, leaf consumer carries the type under its scope-local
+    # name), fall back to the leaf name -- but only when at least one of the
+    # param's actual consumers exposes that type, to avoid grabbing an
+    # unrelated sibling's annotation when two private inputs share a leaf name.
     type_hints: list[str | None] = []
     for p in raw_params:
         param_type = get_param_type(p, flat_graph)
         if param_type is None:
-            param_type = get_param_type(external_input_display_name(p), flat_graph)
+            leaf = external_input_display_name(p)
+            for consumer in get_deepest_consumers(p, flat_graph):
+                consumer_type = flat_graph.nodes[consumer].get("input_types", {}).get(leaf)
+                if consumer_type is not None:
+                    param_type = consumer_type
+                    break
         type_hints.append(format_type(param_type))
     # Display labels are the leaf segments; synthetic ids fall back to
     # the full dot-path when leaf names collide.

--- a/src/hypergraph/viz/renderer/nodes.py
+++ b/src/hypergraph/viz/renderer/nodes.py
@@ -224,13 +224,25 @@ def create_input_nodes(
             show_bounded_inputs,
         )
 
+    id_for_param = disambiguate_external_input_ids([list(g["params"]) for g in input_groups])
+
+    def _typed(param: str) -> type | None:
+        # Dot-pathed external inputs (issue #94) carry the lexical scope
+        # in their name; the type lives under the scope-local leaf on the
+        # leaf consumer's ``input_types``.
+        param_type = get_param_type(param, flat_graph)
+        if param_type is None:
+            param_type = get_param_type(external_input_display_name(param), flat_graph)
+        return param_type
+
     for group in input_groups:
         params = group["params"]
         is_bound = group["is_bound"]
         if len(params) == 1:
             param = params[0]
-            input_node_id = f"input_{param}"
-            param_type = get_param_type(param, flat_graph)
+            display = external_input_display_name(param)
+            input_node_id = f"input_{id_for_param.get(param, display)}"
+            param_type = _typed(param)
             actual_targets = get_group_targets([param], flat_graph, param_to_consumers)
             owner_container = compute_input_scope(param, flat_graph, expansion_state)
             deepest_owner = compute_deepest_input_scope(param, flat_graph)
@@ -241,7 +253,7 @@ def create_input_nodes(
                 "position": {"x": 0, "y": 0},
                 "data": {
                     "nodeType": "INPUT",
-                    "label": param,
+                    "label": display,
                     "typeHint": format_type(param_type),
                     "isBound": is_bound,
                     "actualTargets": actual_targets,
@@ -255,8 +267,10 @@ def create_input_nodes(
             }
             nodes.append(input_node)
         else:
-            group_id = f"input_group_{'_'.join(params)}"
-            param_types = [format_type(get_param_type(p, flat_graph)) for p in params]
+            id_segs = [id_for_param.get(p, external_input_display_name(p)) for p in params]
+            group_id = f"input_group_{'_'.join(id_segs)}"
+            display_params = [external_input_display_name(p) for p in params]
+            param_types = [format_type(_typed(p)) for p in params]
             actual_targets = get_group_targets(params, flat_graph, param_to_consumers)
 
             owner_container = compute_input_scope(params[0], flat_graph, expansion_state)
@@ -268,7 +282,7 @@ def create_input_nodes(
                 "position": {"x": 0, "y": 0},
                 "data": {
                     "nodeType": "INPUT_GROUP",
-                    "params": params,
+                    "params": display_params,
                     "paramTypes": param_types,
                     "isBound": is_bound,
                     "actualTargets": actual_targets,

--- a/src/hypergraph/viz/renderer/nodes.py
+++ b/src/hypergraph/viz/renderer/nodes.py
@@ -11,6 +11,8 @@ from typing import Any
 import networkx as nx
 
 from hypergraph.viz._common import (
+    disambiguate_external_input_ids,
+    external_input_display_name,
     get_root_ancestor,
     is_node_visible,
 )

--- a/src/hypergraph/viz/renderer/scope.py
+++ b/src/hypergraph/viz/renderer/scope.py
@@ -13,6 +13,7 @@ from hypergraph.viz._common import (
     get_parent,
     is_descendant_of,
     is_node_visible,
+    resolve_dot_path_consumers,
 )
 
 if TYPE_CHECKING:
@@ -25,11 +26,15 @@ def get_deepest_consumers(param: str, flat_graph: nx.DiGraph) -> list[str]:
     When a container (GRAPH node) and its internal nodes both list a parameter
     as an input, we return only the internal nodes - they are the "actual"
     consumers.
+
+    Dot-pathed external-input names (e.g. ``"middle.inner.x"``) are
+    resolved through the GraphNode chain — see
+    :func:`resolve_dot_path_consumers`.
     """
-    all_consumers = []
-    for node_id, attrs in flat_graph.nodes(data=True):
-        if param in attrs.get("inputs", ()):
-            all_consumers.append(node_id)
+    if "." in param:
+        all_consumers = resolve_dot_path_consumers(param, flat_graph)
+    else:
+        all_consumers = [node_id for node_id, attrs in flat_graph.nodes(data=True) if param in attrs.get("inputs", ())]
 
     if len(all_consumers) <= 1:
         return all_consumers

--- a/src/hypergraph/viz/scene_builder.py
+++ b/src/hypergraph/viz/scene_builder.py
@@ -95,10 +95,11 @@ def build_initial_scene(
         # deepestOwnerContainer is the state-independent fact (always the
         # deepest scope); ownerContainer is per-render.
         owner_container = _visible_owner(ext.deepest_owner, parent_map, expansion_state)
+        input_node_id = ext.synthetic_id
         if ext.is_group:
             scene_nodes.append(
                 {
-                    "id": f"input_group_{'_'.join(ext.params)}",
+                    "id": input_node_id,
                     "type": "custom",
                     "position": {"x": 0, "y": 0},
                     "data": {
@@ -118,7 +119,7 @@ def build_initial_scene(
         else:
             scene_nodes.append(
                 {
-                    "id": f"input_{ext.params[0]}",
+                    "id": input_node_id,
                     "type": "custom",
                     "position": {"x": 0, "y": 0},
                     "data": {
@@ -250,7 +251,7 @@ def build_initial_scene(
             continue
         if not show_inputs:
             continue
-        input_node_id = f"input_group_{'_'.join(ext.params)}" if ext.is_group else f"input_{ext.params[0]}"
+        input_node_id = ext.synthetic_id
         for consumer in ext.consumers:
             scene_edges.append(
                 {

--- a/tests/capabilities/builders.py
+++ b/tests/capabilities/builders.py
@@ -346,10 +346,22 @@ def _apply_renaming(graph: Graph, renaming: Renaming) -> Graph:
 def _apply_binding(graph: Graph, binding: Binding, topology: Topology) -> Graph:
     """Apply binding to the graph based on the binding mode.
 
-    Returns a new graph with bound values.
+    Returns a new graph with bound values. Under lexical scope, private inner
+    inputs surface as dot-paths on the outer graph, so we look up the actual
+    addressable name in graph.inputs.all rather than assuming flat names.
     """
     if binding == Binding.NONE:
         return graph
+
+    def _resolve_addressable(graph: Graph, target: str) -> str | None:
+        """Find the addressable input name (dot-path or flat) ending in `target`."""
+        all_inputs = graph.inputs.all
+        if target in all_inputs:
+            return target
+        for name in all_inputs:
+            if name == target or name.endswith(f".{target}"):
+                return name
+        return None
 
     # Find an optional input to bind (one with a default or that we can provide)
     # For cyclic graphs, we can bind the 'limit' parameter
@@ -357,12 +369,14 @@ def _apply_binding(graph: Graph, binding: Binding, topology: Topology) -> Graph:
     if topology == Topology.CYCLIC:
         # Bind the limit parameter which has a default
         # Use limit=3 so it stabilizes quickly (within 5 iterations)
-        if "limit" in graph.inputs.all:
-            return graph.bind(limit=3)
+        addr = _resolve_addressable(graph, "limit")
+        if addr is not None:
+            return graph.bind(**{addr: 3})
     elif topology == Topology.CONVERGING:
         # For converging, bind one of the inputs
-        if "y" in graph.inputs.all:
-            return graph.bind(y=100)
+        addr = _resolve_addressable(graph, "y")
+        if addr is not None:
+            return graph.bind(**{addr: 100})
     else:
         # For other topologies, we need to be careful not to bind required inputs
         # that don't have defaults. Check if x has a default or is optional
@@ -427,6 +441,31 @@ def _get_map_input_for_topology(topology: Topology) -> str | None:
         Topology.CONVERGING: "x",  # Map over first input
     }
     return topology_map_inputs.get(topology)
+
+
+def remap_inputs_to_addressable(inputs: dict, graph: Graph) -> dict:
+    """Remap flat input names to their addressable form (dot-path or flat).
+
+    Under lexical scope, an input that is private to a nested GraphNode appears
+    on the outer graph as ``"<graphnode>.<name>"``. This helper looks up each
+    flat key in graph.inputs.all and rewrites it to whatever addressable form
+    the graph exposes (matching by suffix when no flat key is found).
+    """
+    all_inputs = set(graph.inputs.all)
+    remapped: dict = {}
+    for key, value in inputs.items():
+        if key in all_inputs:
+            remapped[key] = value
+            continue
+        # Find a dot-pathed equivalent ending in `.{key}`
+        candidates = [name for name in all_inputs if name.endswith(f".{key}")]
+        if len(candidates) == 1:
+            remapped[candidates[0]] = value
+        else:
+            # No unique mapping (or zero) — leave the original key; the runner
+            # will surface a clear MissingInputError if it really matters.
+            remapped[key] = value
+    return remapped
 
 
 def get_test_inputs(cap: Capability) -> dict:

--- a/tests/capabilities/builders.py
+++ b/tests/capabilities/builders.py
@@ -354,14 +354,16 @@ def _apply_binding(graph: Graph, binding: Binding, topology: Topology) -> Graph:
         return graph
 
     def _resolve_addressable(graph: Graph, target: str) -> str | None:
-        """Find the addressable input name (dot-path or flat) ending in `target`."""
+        """Find the addressable input name (dot-path or flat) ending in `target`.
+
+        Returns None when no match exists OR when multiple dot-paths share the
+        same leaf -- ambiguous targets must be addressed by their full path.
+        """
         all_inputs = graph.inputs.all
         if target in all_inputs:
             return target
-        for name in all_inputs:
-            if name == target or name.endswith(f".{target}"):
-                return name
-        return None
+        candidates = [name for name in all_inputs if name.endswith(f".{target}")]
+        return candidates[0] if len(candidates) == 1 else None
 
     # Find an optional input to bind (one with a default or that we can provide)
     # For cyclic graphs, we can bind the 'limit' parameter

--- a/tests/capabilities/test_matrix.py
+++ b/tests/capabilities/test_matrix.py
@@ -15,7 +15,7 @@ import pytest
 from hypergraph import InMemoryCache
 from hypergraph.runners import AsyncRunner, RunStatus, SyncRunner
 
-from .builders import build_graph_for_capability, get_test_inputs
+from .builders import build_graph_for_capability, get_test_inputs, remap_inputs_to_addressable
 from .matrix import (
     Binding,
     Caching,
@@ -47,7 +47,7 @@ def _make_cache(cap: Capability):
 def run_capability_sync(cap: Capability) -> None:
     """Run a capability test with SyncRunner."""
     graph = build_graph_for_capability(cap)
-    inputs = get_test_inputs(cap)
+    inputs = remap_inputs_to_addressable(get_test_inputs(cap), graph)
 
     runner = SyncRunner(cache=_make_cache(cap))
     kwargs = {"max_iterations": 10} if cap.topology == Topology.CYCLIC else {}
@@ -59,7 +59,7 @@ def run_capability_sync(cap: Capability) -> None:
 async def run_capability_async(cap: Capability) -> None:
     """Run a capability test with AsyncRunner."""
     graph = build_graph_for_capability(cap)
-    inputs = get_test_inputs(cap)
+    inputs = remap_inputs_to_addressable(get_test_inputs(cap), graph)
 
     runner = AsyncRunner(cache=_make_cache(cap))
     kwargs = {"max_iterations": 10} if cap.topology == Topology.CYCLIC else {}
@@ -194,7 +194,7 @@ class TestMapOverBehavior:
     def test_zip_mode_produces_equal_length_outputs(self, cap: Capability):
         """Zip mode should produce outputs matching input length."""
         graph = build_graph_for_capability(cap)
-        inputs = get_test_inputs(cap)
+        inputs = remap_inputs_to_addressable(get_test_inputs(cap), graph)
 
         runner = SyncRunner()
         result = runner.run(graph, inputs)

--- a/tests/events/test_async_events.py
+++ b/tests/events/test_async_events.py
@@ -382,7 +382,8 @@ class TestNestedGraphEvents:
         runner = AsyncRunner()
         lp = ListProcessor()
 
-        result = await runner.run(outer, {"x": 5}, event_processors=[lp])
+        # x is private to inner GraphNode → addressed via dot-path
+        result = await runner.run(outer, {"inner.x": 5}, event_processors=[lp])
 
         assert result["final"] == 11
 
@@ -407,7 +408,8 @@ class TestNestedGraphEvents:
         runner = AsyncRunner()
         lp = ListProcessor()
 
-        await runner.run(outer, {"x": 5}, event_processors=[lp])
+        # x is private to inner GraphNode → addressed via dot-path
+        await runner.run(outer, {"inner.x": 5}, event_processors=[lp])
 
         run_starts = lp.of_type(RunStartEvent)
         assert len(run_starts) == 2

--- a/tests/events/test_sync_events.py
+++ b/tests/events/test_sync_events.py
@@ -285,7 +285,8 @@ class TestNestedGraphEvents:
         runner = SyncRunner()
         lp = ListProcessor()
 
-        result = runner.run(outer, {"x": 5}, event_processors=[lp])
+        # x is private to inner GraphNode → addressed via dot-path
+        result = runner.run(outer, {"inner.x": 5}, event_processors=[lp])
 
         assert result["final"] == 11
 
@@ -309,7 +310,8 @@ class TestNestedGraphEvents:
         runner = SyncRunner()
         lp = ListProcessor()
 
-        runner.run(outer, {"x": 5}, event_processors=[lp])
+        # x is private to inner GraphNode → addressed via dot-path
+        runner.run(outer, {"inner.x": 5}, event_processors=[lp])
 
         run_starts = lp.of_type(RunStartEvent)
         assert len(run_starts) == 2
@@ -503,7 +505,8 @@ class TestDeeplyNestedGraph:
         runner = SyncRunner()
         lp = ListProcessor()
 
-        result = runner.run(outer, {"x": 3}, event_processors=[lp])
+        # x is private through middle.inner GraphNode chain
+        result = runner.run(outer, {"middle.inner.x": 3}, event_processors=[lp])
 
         assert result["final"] == 7  # 3 * 2 + 1
 
@@ -528,7 +531,8 @@ class TestDeeplyNestedGraph:
         runner = SyncRunner()
         lp = ListProcessor()
 
-        runner.run(outer, {"x": 3}, event_processors=[lp])
+        # x is private through middle.inner GraphNode chain
+        runner.run(outer, {"middle.inner.x": 3}, event_processors=[lp])
 
         run_starts = lp.of_type(RunStartEvent)
         run_ids = [s.run_id for s in run_starts]
@@ -550,7 +554,14 @@ class TestMapWithNestedError:
         runner = SyncRunner()
         lp = ListProcessor()
 
-        results = runner.map(graph, {"x": [1, 2, 3]}, map_over="x", error_handling="continue", event_processors=[lp])
+        # x is private to inner GraphNode → addressed via dot-path; map_over uses that name
+        results = runner.map(
+            graph,
+            {"inner.x": [1, 2, 3]},
+            map_over="inner.x",
+            error_handling="continue",
+            event_processors=[lp],
+        )
 
         # run() catches exceptions and returns RunResult(status=FAILED)
         # so map completes but some results are failed

--- a/tests/test_bind_defaults.py
+++ b/tests/test_bind_defaults.py
@@ -42,12 +42,13 @@ def test_bound_params_not_treated_as_defaults():
 
     # config is now optional because the GraphNode has it bound (has_default_for returns True)
     # This allows the outer graph to optionally provide config for outer_func
-    assert set(outer_graph.inputs.required) == {"x"}
+    # x is private to inner GraphNode → addressed as inner.x
+    assert set(outer_graph.inputs.required) == {"inner.x"}
     assert set(outer_graph.inputs.optional) == {"config"}
 
     # If we bind config at the outer level, it's still in bound dict
     outer_bound = outer_graph.bind(config="outer_config")
-    assert set(outer_bound.inputs.required) == {"x"}
+    assert set(outer_bound.inputs.required) == {"inner.x"}
     assert "config" in outer_bound.inputs.bound
 
 
@@ -83,8 +84,8 @@ def test_nested_graph_with_bound_and_defaults():
 
     # Should work: y has consistent defaults, x is bound (not a default)
     graph = Graph([inner.as_node(), outer_func])
-    # Both x and y are optional: x is bound in inner, y has defaults
-    assert set(graph.inputs.optional) == {"x", "y"}
+    # Both x and y are optional: x is bound in inner (private → inner.x), y has defaults
+    assert set(graph.inputs.optional) == {"inner.x", "y"}
     assert set(graph.inputs.required) == set()
 
 
@@ -266,20 +267,24 @@ def test_three_level_nested_binding():
     assert "vector_store" in retrieval_graph.inputs.bound
 
     # Key assertion: bound values from retrieval_graph must appear in rag_graph
-    assert "embedder" in rag_graph.inputs.bound
-    assert "vector_store" in rag_graph.inputs.bound
+    # embedder/vector_store are private to retrieval GraphNode → addressed as retrieval.X
+    assert "retrieval.embedder" in rag_graph.inputs.bound
+    assert "retrieval.vector_store" in rag_graph.inputs.bound
     assert "llm" in rag_graph.inputs.bound
 
     # Key assertion: bound values must propagate to eval_graph
-    assert "embedder" in eval_graph.inputs.bound
-    assert "vector_store" in eval_graph.inputs.bound
+    # embedder/vector_store are private through rag.retrieval.X
+    assert "rag.retrieval.embedder" in eval_graph.inputs.bound
+    assert "rag.retrieval.vector_store" in eval_graph.inputs.bound
     assert "llm" in eval_graph.inputs.bound
 
     # Runtime execution should work
+    # text is private at rag.retrieval (consumed by leaf 'embed' inside retrieval graph,
+    # which is a GraphNode at rag scope and a sub-GraphNode at eval scope)
     runner = SyncRunner()
     result = runner.run(
         eval_graph,
-        {"text": "test query", "query": "test query", "expected_answer": "expected"},
+        {"rag.retrieval.text": "test query", "query": "test query", "expected_answer": "expected"},
     )
 
     assert result["judgment"] == "Judged: Answer: test query"
@@ -302,7 +307,8 @@ def test_sibling_nested_bindings_do_not_leak():
 
     assert "cfg" not in graph.inputs.bound
 
-    result = SyncRunner().run(graph, {"x": 1})
+    # x is private to each inner GraphNode → addressed by dot-path
+    result = SyncRunner().run(graph, {"inner_a.x": 1, "inner_b.x": 1})
     assert result["out_a"] == "A:1:CFG_A"
     assert result["out_b"] == "B:1:CFG_B"
 
@@ -318,6 +324,7 @@ def test_nested_bound_values_use_graphnode_public_input_names():
     nested = inner.as_node().with_inputs(cfg="public_cfg")
     outer = Graph([nested], name="outer")
 
-    assert "public_cfg" in outer.inputs.bound
+    # public_cfg is private to inner GraphNode → addressed as inner.public_cfg
+    assert "inner.public_cfg" in outer.inputs.bound
     assert "cfg" not in outer.inputs.bound
-    assert outer.inputs.bound["public_cfg"] == "inner-cfg"
+    assert outer.inputs.bound["inner.public_cfg"] == "inner-cfg"

--- a/tests/test_bind_defaults.py
+++ b/tests/test_bind_defaults.py
@@ -23,33 +23,25 @@ def test_bound_params_not_treated_as_defaults():
     so it shouldn't trigger the "inconsistent defaults" validation error.
     """
 
-    # Inner graph with bound parameter
+    # Inner graph (no bind on config -- under lexical scope, an inner bind on a
+    # name the outer declares would be shadowed and is a build-time error).
     @node(output_name="result")
     def inner_func(x: int, config: str) -> str:
         return f"{x}:{config}"
 
-    inner_graph = Graph([inner_func], name="inner").bind(config="bound_value")
+    inner_graph = Graph([inner_func], name="inner")
 
     # Outer function with same param but NO default
     @node(output_name="final")
     def outer_func(result: str, config: str) -> str:
         return f"{result}:{config}"
 
-    # Should NOT raise GraphConfigError about inconsistent defaults
-    # config is bound in inner_graph, but that's not a "default"
-    # This is the main test - it should not raise during graph construction
-    outer_graph = Graph([inner_graph.as_node(), outer_func], name="outer")
+    # Outer binds config at the scope where it's declared (auto-links into inner).
+    outer_graph = Graph([inner_graph.as_node(), outer_func], name="outer").bind(config="bound_value")
 
-    # config is now optional because the GraphNode has it bound (has_default_for returns True)
-    # This allows the outer graph to optionally provide config for outer_func
-    # x is private to inner GraphNode → addressed as inner.x
+    # x is private to inner GraphNode -> addressed as inner.x
     assert set(outer_graph.inputs.required) == {"inner.x"}
-    assert set(outer_graph.inputs.optional) == {"config"}
-
-    # If we bind config at the outer level, it's still in bound dict
-    outer_bound = outer_graph.bind(config="outer_config")
-    assert set(outer_bound.inputs.required) == {"inner.x"}
-    assert "config" in outer_bound.inputs.bound
+    assert "config" in outer_graph.inputs.bound
 
 
 def test_actual_defaults_still_validated():
@@ -101,19 +93,19 @@ def test_user_rag_example():
     def judge_answer(query: str, answer: str, expected_answer: str, llm) -> dict:
         return {"judgment": "good"}
 
-    # RAG graph with bound llm
-    rag_graph = Graph([rag_func], name="rag").bind(llm="llm_instance")
+    # RAG graph (no bind on llm -- judge_answer at eval also consumes llm, so a
+    # bind here would be shadowed at the outer scope).
+    rag_graph = Graph([rag_func], name="rag")
 
-    # Evaluation graph - should NOT raise error
-    # llm is bound in rag_graph (not a default), and judge_answer has no default for llm
+    # Bind llm once at eval scope where it's declared by both judge_answer and
+    # (transitively) rag_func.
     eval_graph = Graph(
         [rag_graph.as_node(name="rag"), judge_answer],
         name="evaluation",
-    )
+    ).bind(llm="llm_instance")
 
-    # llm is optional because the rag GraphNode has it bound
-    # The user can provide llm to override both nodes, or omit it to use rag's binding
-    assert "llm" in eval_graph.inputs.optional
+    # llm is now in bound (optional) at eval; required set excludes it.
+    assert "llm" in eval_graph.inputs.bound
     assert "llm" not in eval_graph.inputs.required
 
 
@@ -250,13 +242,16 @@ def test_three_level_nested_binding():
         name="retrieval",
     ).bind(embedder=embedder, vector_store=vector_store)
 
-    # Level 2: RAG graph using retrieval as nested node
+    # Level 2: RAG graph using retrieval as nested node. llm is declared at
+    # rag (generate consumes it). We don't bind it here -- judge at eval also
+    # consumes llm, so a bind here would be shadowed at the outer scope.
     rag_graph = Graph(
         [retrieval_graph.as_node(name="retrieval"), generate],
         name="rag",
-    ).bind(llm=llm)
+    )
 
-    # Level 3: evaluation graph using RAG as nested node
+    # Level 3: evaluation graph binds llm once at the outermost scope where
+    # both judge and (transitively) generate need it.
     eval_graph = Graph(
         [rag_graph.as_node(name="rag"), judge],
         name="evaluation",
@@ -270,12 +265,12 @@ def test_three_level_nested_binding():
     # embedder/vector_store are private to retrieval GraphNode → addressed as retrieval.X
     assert "retrieval.embedder" in rag_graph.inputs.bound
     assert "retrieval.vector_store" in rag_graph.inputs.bound
-    assert "llm" in rag_graph.inputs.bound
 
     # Key assertion: bound values must propagate to eval_graph
     # embedder/vector_store are private through rag.retrieval.X
     assert "rag.retrieval.embedder" in eval_graph.inputs.bound
     assert "rag.retrieval.vector_store" in eval_graph.inputs.bound
+    # llm bound at eval scope; auto-links to both judge.llm and rag.generate.llm.
     assert "llm" in eval_graph.inputs.bound
 
     # Runtime execution should work

--- a/tests/test_bind_edge_cases.py
+++ b/tests/test_bind_edge_cases.py
@@ -573,8 +573,9 @@ class TestBindWithGraphNode:
         result = runner.run(outer, {"inner.x": 5})
         assert result["result"] == 10
 
-        # Override with runtime value
-        result = runner.run(outer, {"inner.x": 5, "inner.factor": 3})
+        # Override with runtime value (warning expected for the bind override)
+        with pytest.warns(UserWarning, match="(?i)override.*inner\\.factor"):
+            result = runner.run(outer, {"inner.x": 5, "inner.factor": 3})
         assert result["result"] == 15
 
 

--- a/tests/test_bind_edge_cases.py
+++ b/tests/test_bind_edge_cases.py
@@ -530,7 +530,8 @@ class TestBindWithGraphNode:
         inner = Graph([double], name="inner")
         outer = Graph([inner.as_node()])
 
-        outer_bound = outer.bind(x=5)
+        # x is private to inner GraphNode → bind via dot-path
+        outer_bound = outer.bind(**{"inner.x": 5})
 
         runner = SyncRunner()
         result = runner.run(outer_bound, {})
@@ -549,7 +550,8 @@ class TestBindWithGraphNode:
         outer = Graph([inner_bound.as_node()])
 
         runner = SyncRunner()
-        result = runner.run(outer, {"x": 5})
+        # x is private to inner GraphNode → addressed via dot-path
+        result = runner.run(outer, {"inner.x": 5})
         assert result["result"] == 15
 
     def test_outer_bind_overrides_inner(self):
@@ -566,12 +568,13 @@ class TestBindWithGraphNode:
 
         runner = SyncRunner()
 
+        # x and factor are private to inner GraphNode → addressed via dot-path
         # Run with inner's binding
-        result = runner.run(outer, {"x": 5})
+        result = runner.run(outer, {"inner.x": 5})
         assert result["result"] == 10
 
         # Override with runtime value
-        result = runner.run(outer, {"x": 5, "factor": 3})
+        result = runner.run(outer, {"inner.x": 5, "inner.factor": 3})
         assert result["result"] == 15
 
 

--- a/tests/test_cache_behavior.py
+++ b/tests/test_cache_behavior.py
@@ -208,7 +208,8 @@ class TestCacheWithNestedGraph:
         outer = Graph([inner.as_node()])
         runner = SyncRunner(cache=InMemoryCache())
 
-        result = runner.run(outer, {"x": 5})
+        # x is private to inner GraphNode → addressed via dot-path
+        result = runner.run(outer, {"inner.x": 5})
 
         assert result.status == RunStatus.COMPLETED
         assert result["doubled"] == 10
@@ -337,7 +338,8 @@ class TestCacheWithMapOver:
         outer = Graph([inner.as_node().map_over("x")])
         runner = SyncRunner(cache=InMemoryCache())
 
-        result = runner.run(outer, {"x": [1, 2, 3]})
+        # x is private to inner GraphNode → addressed via dot-path
+        result = runner.run(outer, {"inner.x": [1, 2, 3]})
 
         assert result.status == RunStatus.COMPLETED
         assert result["doubled"] == [2, 4, 6]
@@ -357,7 +359,8 @@ class TestCacheWithMapOver:
         runner = SyncRunner(cache=InMemoryCache())
 
         # Same value repeated — cache should deduplicate
-        result = runner.run(outer, {"x": [5, 5, 5]})
+        # x is private to inner GraphNode → addressed via dot-path
+        result = runner.run(outer, {"inner.x": [5, 5, 5]})
 
         assert result.status == RunStatus.COMPLETED
         assert result["doubled"] == [10, 10, 10]

--- a/tests/test_checkpointer/test_hierarchical_checkpointing.py
+++ b/tests/test_checkpointer/test_hierarchical_checkpointing.py
@@ -145,7 +145,7 @@ class TestNestedGraphCheckpointing:
         inner = Graph([double], name="inner")
         outer = Graph([inner.as_node(name="embed"), triple], name="outer")
 
-        result = await runner.run(outer, {"x": 5}, workflow_id="nested")
+        result = await runner.run(outer, {"embed.x": 5}, workflow_id="nested")
 
         assert result["tripled"] == 30
 
@@ -162,7 +162,7 @@ class TestNestedGraphCheckpointing:
         inner = Graph([double], name="inner")
         outer = Graph([inner.as_node(name="embed"), triple], name="outer")
 
-        await runner.run(outer, {"x": 5}, workflow_id="nested-step")
+        await runner.run(outer, {"embed.x": 5}, workflow_id="nested-step")
 
         steps = async_cp.steps("nested-step")
         embed_step = next(s for s in steps if s.node_name == "embed")
@@ -178,7 +178,8 @@ class TestNestedGraphCheckpointing:
         embed = inner.as_node(name="embed").map_over("x")
         outer = Graph([embed], name="outer")
 
-        await runner.run(outer, {"x": [1, 2]}, workflow_id="nested-map")
+        # x is private to "embed" GraphNode → addressed via dot-path
+        await runner.run(outer, {"embed.x": [1, 2]}, workflow_id="nested-map")
 
         runs = async_cp.runs()
         run_ids = {r.id for r in runs}
@@ -203,7 +204,8 @@ class TestNestedGraphCheckpointing:
         outer_node = mid.as_node(name="A")
         outer = Graph([outer_node], name="outer")
 
-        result = await runner.run(outer, {"x": 5}, workflow_id="deep")
+        # x is private through A.B GraphNode chain (mid_node B wraps inner C)
+        result = await runner.run(outer, {"A.B.x": 5}, workflow_id="deep")
         assert result["result"] == 6
 
         runs = async_cp.runs()
@@ -218,7 +220,8 @@ class TestNestedGraphCheckpointing:
         inner = Graph([double], name="inner")
         outer = Graph([inner.as_node(name="embed"), triple], name="outer")
 
-        result = await runner.run(outer, {"x": 5})
+        # x is private to "embed" GraphNode → addressed via dot-path
+        result = await runner.run(outer, {"embed.x": 5})
         assert result["tripled"] == 30
         assert result.workflow_id is not None
 
@@ -233,9 +236,10 @@ class TestNestedGraphCheckpointing:
         inner = Graph([double], name="inner")
         outer = Graph([inner.as_node(name="embed"), triple], name="outer")
 
-        await runner.run(outer, {"x": 5}, workflow_id="nested-root")
+        await runner.run(outer, {"embed.x": 5}, workflow_id="nested-root")
         fork_id, fork_cp = async_cp.fork_workflow("nested-root", workflow_id="nested-root-fork")
-        await runner.run(outer, {"x": 10}, checkpoint=fork_cp, workflow_id=fork_id)
+        # x is private to "embed" GraphNode → use nested-dict form (alternative to dot-path)
+        await runner.run(outer, {"embed": {"x": 10}}, checkpoint=fork_cp, workflow_id=fork_id)
 
         fork_run = async_cp.get_run("nested-root-fork")
         assert fork_run is not None
@@ -309,7 +313,7 @@ class TestSyncNestedCheckpointing:
         inner = Graph([double], name="inner")
         outer = Graph([inner.as_node(name="embed"), triple], name="outer")
 
-        result = runner.run(outer, {"x": 5}, workflow_id="sync-nested")
+        result = runner.run(outer, {"embed.x": 5}, workflow_id="sync-nested")
         assert result["tripled"] == 30
 
         db = sync_cp._sync_db()
@@ -325,7 +329,7 @@ class TestSyncNestedCheckpointing:
         inner = Graph([double], name="inner")
         outer = Graph([inner.as_node(name="embed"), triple], name="outer")
 
-        runner.run(outer, {"x": 5}, workflow_id="sync-step")
+        runner.run(outer, {"embed.x": 5}, workflow_id="sync-step")
 
         db = sync_cp._sync_db()
         step = db.execute(
@@ -341,7 +345,8 @@ class TestSyncNestedCheckpointing:
         embed = inner.as_node(name="embed").map_over("x")
         outer = Graph([embed], name="outer")
 
-        runner.run(outer, {"x": [1, 2]}, workflow_id="sync-map-nest")
+        # x is private to "embed" GraphNode → addressed via dot-path
+        runner.run(outer, {"embed.x": [1, 2]}, workflow_id="sync-map-nest")
 
         db = sync_cp._sync_db()
         runs = db.execute("SELECT id FROM runs ORDER BY id").fetchall()

--- a/tests/test_checkpointer/test_lineage_semantics.py
+++ b/tests/test_checkpointer/test_lineage_semantics.py
@@ -352,7 +352,8 @@ class TestLineageSemantics:
         outer_v2 = Graph([Graph([inner_v2_mid, inner_v2_end], name="inner").as_node(name="nested"), finalize])
 
         runner = AsyncRunner(checkpointer=checkpointer)
-        await runner.run(outer_v1, {"x": 5}, workflow_id="wf-nested-hash")
+        # x is private to "nested" GraphNode → addressed via dot-path
+        await runner.run(outer_v1, {"nested.x": 5}, workflow_id="wf-nested-hash")
 
         with pytest.raises(GraphChangedError):
             await runner.run(outer_v2, workflow_id="wf-nested-hash")

--- a/tests/test_checkpointer/test_memory.py
+++ b/tests/test_checkpointer/test_memory.py
@@ -47,7 +47,8 @@ class TestMemoryCheckpointer:
         inner = Graph([double], name="inner")
         outer = Graph([inner.as_node(name="embed"), triple], name="outer")
 
-        result = await runner.run(outer, {"x": 5}, workflow_id="nested-memory")
+        # x is private to "embed" GraphNode → addressed via dot-path
+        result = await runner.run(outer, {"embed.x": 5}, workflow_id="nested-memory")
 
         assert result["tripled"] == 30
 

--- a/tests/test_daft_examples.py
+++ b/tests/test_daft_examples.py
@@ -17,7 +17,7 @@ def test_quickstart_orders_example():
     result = runner.run(
         graph,
         {
-            "orders": [
+            "process_orders.orders": [
                 {"order_id": "A-1", "customer": " ada ", "country": "us", "unit_price": 25, "quantity": 2},
                 {"order_id": "B-2", "customer": "grace", "country": "uk", "unit_price": 80, "quantity": 2},
                 {"order_id": "C-3", "customer": "linus", "country": "de", "unit_price": 10, "quantity": 1, "rush": True},
@@ -40,7 +40,7 @@ def test_document_processing_example():
     result = runner.run(
         graph,
         {
-            "documents": [
+            "process_documents.documents": [
                 "Hypergraph composes graphs into larger workflows. Daft scales dataset fan-out.",
                 "This background note talks about deployment plans and rollout windows.",
             ]
@@ -59,15 +59,17 @@ def test_scenario_sweep_example():
     graph = build_scenario_sweep_graph()
     runner = DaftRunner()
 
+    # `weights` and `candidates` are private to the `evaluate_candidates`
+    # GraphNode under lexical scope; `scenario_id` is consumed at outer.
     results = runner.map(
         graph,
         {
             "scenario_id": ["latency_sensitive", "quality_first"],
-            "weights": [
+            "evaluate_candidates.weights": [
                 {"accuracy": 1.0, "latency": 0.01, "cost": 0.5},
                 {"accuracy": 2.5, "latency": 0.002, "cost": 0.2},
             ],
-            "candidates": [
+            "evaluate_candidates.candidates": [
                 [
                     {"name": "fast-small", "accuracy": 0.81, "latency_ms": 40, "cost": 0.01},
                     {"name": "balanced", "accuracy": 0.9, "latency_ms": 85, "cost": 0.03},
@@ -78,7 +80,7 @@ def test_scenario_sweep_example():
                 ],
             ],
         },
-        map_over=["scenario_id", "weights", "candidates"],
+        map_over=["scenario_id", "evaluate_candidates.weights", "evaluate_candidates.candidates"],
     )
 
     assert results["best_candidate"] == [

--- a/tests/test_deep_nesting_issues.py
+++ b/tests/test_deep_nesting_issues.py
@@ -67,7 +67,9 @@ class TestFourLevelNestingSync:
         g1 = Graph(nodes=[g2.as_node(), level1], name="g1")
 
         runner = SyncRunner()
-        result = runner.run(g1, {"x": 0})
+        # x is consumed only by leaf level4 inside g4 (innermost), and is private
+        # at every level it bubbles through → addressed as g2.g3.g4.x
+        result = runner.run(g1, {"g2.g3.g4.x": 0})
 
         assert result["l4"] == 1
         assert result["l3"] == 2
@@ -89,7 +91,8 @@ class TestSameInnerGraphTwice:
 
         outer = Graph(nodes=[node_a, node_b])
         runner = SyncRunner()
-        result = runner.run(outer, {"a": 3, "b": 5})
+        # a/b are private to inner_a/inner_b GraphNodes → addressed via dot-path
+        result = runner.run(outer, {"inner_a.a": 3, "inner_b.b": 5})
 
         assert result["res_a"] == 6
         assert result["res_b"] == 10

--- a/tests/test_empty_collections.py
+++ b/tests/test_empty_collections.py
@@ -181,7 +181,8 @@ class TestEmptyListToMapOver:
         outer = Graph([inner.as_node().map_over("x")])
         runner = SyncRunner()
 
-        result = runner.run(outer, {"x": []})
+        # x is private to inner GraphNode → addressed via dot-path
+        result = runner.run(outer, {"inner.x": []})
 
         assert result.status == RunStatus.COMPLETED
         assert result["doubled"] == []
@@ -200,7 +201,8 @@ class TestEmptyListToMapOver:
         outer = Graph([inner.as_node().map_over("x")])
         runner = SyncRunner()
 
-        result = runner.run(outer, {"x": []})
+        # x is private to inner GraphNode → addressed via dot-path
+        result = runner.run(outer, {"inner.x": []})
 
         assert result.status == RunStatus.COMPLETED
         assert call_count == 0
@@ -216,7 +218,8 @@ class TestNestedGraphWithEmptyInput:
         outer = Graph([inner.as_node()])
         runner = SyncRunner()
 
-        result = runner.run(outer, {"items": []})
+        # items is private to inner GraphNode → addressed via dot-path
+        result = runner.run(outer, {"inner.items": []})
 
         assert result.status == RunStatus.COMPLETED
         assert result["processed"] == []
@@ -227,7 +230,8 @@ class TestNestedGraphWithEmptyInput:
         outer = Graph([inner.as_node()])
         runner = SyncRunner()
 
-        result = runner.run(outer, {"items": []})
+        # items is private to inner GraphNode → addressed via dot-path
+        result = runner.run(outer, {"inner.items": []})
 
         assert result.status == RunStatus.COMPLETED
         assert result["length"] == 0

--- a/tests/test_error_handling_edge_cases.py
+++ b/tests/test_error_handling_edge_cases.py
@@ -237,7 +237,8 @@ class TestMapOverAllFail:
         gn = inner.as_node().map_over("x", error_handling="continue")
         outer = Graph([gn, passthrough])
         runner = SyncRunner()
-        result = runner.run(outer, {"x": [1, 2, 3]})
+        # x is private to inner GraphNode → addressed via dot-path
+        result = runner.run(outer, {"inner.x": [1, 2, 3]})
         assert result.status == RunStatus.COMPLETED
         assert result["result"] == [None, None, None]
 
@@ -247,7 +248,8 @@ class TestMapOverAllFail:
         gn = inner.as_node().map_over("x", error_handling="continue")
         outer = Graph([gn, passthrough])
         runner = AsyncRunner()
-        result = await runner.run(outer, {"x": [1, 2, 3]})
+        # x is private to inner GraphNode → addressed via dot-path
+        result = await runner.run(outer, {"inner.x": [1, 2, 3]})
         assert result.status == RunStatus.COMPLETED
         assert result["result"] == [None, None, None]
 
@@ -260,7 +262,8 @@ class TestMapOverMultipleFailures:
         gn = inner.as_node().map_over("x", error_handling="continue")
         outer = Graph([gn, passthrough])
         runner = SyncRunner()
-        result = runner.run(outer, {"x": [1, 2, 3, 4, 5]})
+        # x is private to inner GraphNode → addressed via dot-path
+        result = runner.run(outer, {"inner.x": [1, 2, 3, 4, 5]})
         assert result.status == RunStatus.COMPLETED
         assert result["result"] == [None, 4, None, 8, None]
 
@@ -273,7 +276,8 @@ class TestMapOverSingleItem:
         gn = inner.as_node().map_over("x", error_handling="continue")
         outer = Graph([gn, passthrough])
         runner = SyncRunner()
-        result = runner.run(outer, {"x": [1]})
+        # x is private to inner GraphNode → addressed via dot-path
+        result = runner.run(outer, {"inner.x": [1]})
         assert result.status == RunStatus.COMPLETED
         assert result["result"] == [None]
 
@@ -283,7 +287,8 @@ class TestMapOverSingleItem:
         outer = Graph([gn, passthrough])
         runner = SyncRunner()
         with pytest.raises(FailError):
-            runner.run(outer, {"x": [1]})
+            # x is private to inner GraphNode → addressed via dot-path
+            runner.run(outer, {"inner.x": [1]})
 
 
 class TestMapOverWithRenamedOutputs:
@@ -299,7 +304,8 @@ class TestMapOverWithRenamedOutputs:
 
         outer = Graph([gn, consume])
         runner = SyncRunner()
-        result = runner.run(outer, {"x": [1, 2, 3, 4]})
+        # x is private to inner GraphNode → addressed via dot-path
+        result = runner.run(outer, {"inner.x": [1, 2, 3, 4]})
         assert result.status == RunStatus.COMPLETED
         assert result["final"] == [None, 4, None, 8]
 
@@ -312,7 +318,8 @@ class TestMapOverEmptyInput:
         gn = inner.as_node().map_over("x", error_handling="continue")
         outer = Graph([gn, passthrough])
         runner = SyncRunner()
-        result = runner.run(outer, {"x": []})
+        # x is private to inner GraphNode → addressed via dot-path
+        result = runner.run(outer, {"inner.x": []})
         assert result.status == RunStatus.COMPLETED
         assert result["result"] == []
 
@@ -327,4 +334,5 @@ class TestMapOverRaisePartialValues:
         outer = Graph([gn, passthrough])
         runner = SyncRunner()
         with pytest.raises(FailError):
-            runner.run(outer, {"x": [1, 2]})
+            # x is private to inner GraphNode → addressed via dot-path
+            runner.run(outer, {"inner.x": [1, 2]})

--- a/tests/test_exception_propagation.py
+++ b/tests/test_exception_propagation.py
@@ -115,7 +115,8 @@ class TestExceptionInNestedGraphNode:
 
         runner = SyncRunner()
         with pytest.raises(CustomError, match="inner graph failed"):
-            runner.run(outer, {"x": 5})
+            # x is private to inner GraphNode → addressed via dot-path
+            runner.run(outer, {"inner.x": 5})
 
     def test_exception_in_deeply_nested_graph(self):
         """Exception in deeply nested graph propagates."""
@@ -130,7 +131,8 @@ class TestExceptionInNestedGraphNode:
 
         runner = SyncRunner()
         with pytest.raises(CustomError, match="deep failure"):
-            runner.run(level1, {"x": 5})
+            # x is private all the way down → level2.level3.x
+            runner.run(level1, {"level2.level3.x": 5})
 
     def test_exception_after_successful_nested_graph(self):
         """Exception after nested graph completes successfully."""
@@ -149,7 +151,8 @@ class TestExceptionInNestedGraphNode:
 
         runner = SyncRunner()
         with pytest.raises(CustomError, match="outer failed after inner success"):
-            runner.run(outer, {"x": 5})
+            # x is private to inner GraphNode → addressed via dot-path
+            runner.run(outer, {"inner.x": 5})
 
 
 class TestExceptionInCycle:
@@ -214,7 +217,8 @@ class TestExceptionInMapOver:
 
         runner = SyncRunner()
         with pytest.raises(CustomError, match="failed on x=3"):
-            runner.run(outer, {"x": [1, 2, 3, 4, 5]})
+            # x is private to inner GraphNode → addressed via dot-path
+            runner.run(outer, {"inner.x": [1, 2, 3, 4, 5]})
 
     def test_exception_in_first_map_iteration(self):
         """Exception in first iteration of map_over."""
@@ -228,7 +232,8 @@ class TestExceptionInMapOver:
 
         runner = SyncRunner()
         with pytest.raises(CustomError, match="always fails"):
-            runner.run(outer, {"x": [1, 2, 3]})
+            # x is private to inner GraphNode → addressed via dot-path
+            runner.run(outer, {"inner.x": [1, 2, 3]})
 
 
 class TestExceptionPreservesPartialResults:
@@ -347,7 +352,8 @@ class TestAsyncExceptionHandling:
 
         runner = AsyncRunner()
         with pytest.raises(CustomError, match="async inner failure"):
-            await runner.run(outer, {"x": 5})
+            # x is private to inner GraphNode → addressed via dot-path
+            await runner.run(outer, {"inner.x": 5})
 
     async def test_async_partial_values_on_failure(self):
         """Async runner returns partial values when a node fails."""

--- a/tests/test_framework_ports.py
+++ b/tests/test_framework_ports.py
@@ -29,11 +29,13 @@ def test_agentic_rag_routes_latest_questions_to_web():
         graph,
         {
             "question": "What changed in the latest release for interrupts?",
-            "local_documents": [
+            # `local_documents` and `web_documents` are private to the
+            # `retrieve_context` GraphNode at outer scope.
+            "retrieve_context.local_documents": [
                 "Hypergraph supports interrupt nodes for human review.",
                 "Nested graphs make composition natural.",
             ],
-            "web_documents": [
+            "retrieve_context.web_documents": [
                 "Latest release notes mention better interrupt resume semantics.",
                 "Recent release adds richer run logs for nested graphs.",
             ],
@@ -58,10 +60,12 @@ async def test_support_inbox_nested_interrupt_propagates_pause():
                 "issue": "refund API timeout after release",
             }
         },
-        "knowledge_base": [
+        # `knowledge_base` is private to `customer_support`; `release_notes` is
+        # private to `technical_support`.
+        "customer_support.knowledge_base": [
             "General account changes are applied within one hour.",
         ],
-        "release_notes": [
+        "technical_support.release_notes": [
             "Refund API timeout fixed in patch 2026.03.",
             "Release 2026.03 improves webhook retries.",
         ],
@@ -83,8 +87,9 @@ def test_ml_model_selection_uses_mapped_trials_to_pick_best_model():
         graph,
         {
             "dataset_name": "toy_flowers",
-            "feature_names": ("length", "width"),
-            "model_types": ["threshold", "centroid"],
+            # `feature_names` and `model_types` are private to the `trial` GraphNode.
+            "trial.feature_names": ("length", "width"),
+            "trial.model_types": ["threshold", "centroid"],
         },
     )
 
@@ -101,7 +106,8 @@ def test_document_batch_pipeline_maps_one_document_graph_over_many_inputs():
     result = runner.run(
         graph,
         {
-            "documents": [
+            # `documents` is private to the `process_document` GraphNode at outer scope.
+            "process_document.documents": [
                 "Hypergraph composes graphs into larger workflows. It keeps nodes testable.",
                 "Mapped graph nodes let one document pipeline scale across a batch. Automatic wiring keeps the graph readable.",
             ]

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1801,16 +1801,18 @@ class TestGraphNodeCapabilities:
         outer_gn = outer_graph.as_node()
 
         # Types should flow correctly: inner produces str, outer consumes str
+        # The bare name resolves to int via inner_gn (which still exposes flat names)
         assert outer_gn.get_input_type("a") is int
         assert outer_gn.get_output_type("intermediate") is str
         assert outer_gn.get_output_type("final") is int
 
-        # Both a and b appear in outer's inputs (b is optional due to binding)
-        assert "a" in outer_gn.inputs
-        assert "b" in outer_gn.inputs
-        # b has a default (the bound value)
-        assert outer_gn.has_default_for("b") is True
-        assert outer_gn.get_default_for("b") == 10
+        # Both a and b are private to the nested inner GraphNode at outer's scope,
+        # so they appear under the dot-path "inner.a" / "inner.b"
+        assert "inner.a" in outer_gn.inputs
+        assert "inner.b" in outer_gn.inputs
+        # b has a default (the bound value), addressed via dot-path
+        assert outer_gn.has_default_for("inner.b") is True
+        assert outer_gn.get_default_for("inner.b") == 10
 
 
 class TestStrictTypesWithNestedGraphNode:

--- a/tests/test_graph_topologies.py
+++ b/tests/test_graph_topologies.py
@@ -433,7 +433,8 @@ class TestDeeplyNestedGraphs:
 
         # No exception raised
         assert "middle" in outer.nodes
-        assert outer.inputs.required == ("x",)
+        # x is private to middle.inner_inner GraphNode chain
+        assert outer.inputs.required == ("middle.inner_inner.x",)
         assert outer.outputs == ("z",)
 
     def test_three_level_inputs_propagate(self):
@@ -460,11 +461,11 @@ class TestDeeplyNestedGraphs:
         # Level 1: contains level 2 + its own node
         outer = Graph([middle.as_node(), level1_node], name="outer")
 
-        # All external inputs propagate
+        # All external inputs propagate (private inputs surface as dot-paths)
         all_inputs = outer.inputs.all
-        assert "x" in all_inputs  # from level 3
-        assert "y" in all_inputs  # from level 2
-        assert "z" in all_inputs  # from level 1
+        assert "middle.inner_inner.x" in all_inputs  # from level 3 (private through middle.inner_inner)
+        assert "middle.y" in all_inputs  # from level 2 (private through middle)
+        assert "z" in all_inputs  # from level 1 (consumed by leaf at outer)
 
     def test_three_level_outputs_visible(self):
         """Outputs from all levels are visible from outermost graph."""

--- a/tests/test_lexical_scope.py
+++ b/tests/test_lexical_scope.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import pytest
 
 from hypergraph import Graph, node
+from hypergraph.exceptions import MissingInputError
 from hypergraph.graph.validation import GraphConfigError
 from hypergraph.runners import SyncRunner
 
@@ -190,3 +191,101 @@ def test_run_value_overriding_dot_pathed_bind_emits_warning():
         result = SyncRunner().run(outer, {"inner.x": 99})
 
     assert result["out"] == 99
+
+
+def test_with_inputs_renames_leaf_label_only_not_scope():
+    """with_inputs(...) changes only the leaf label of an input's path; it
+    does not move the input out of the subgraph's scope.
+
+    Before: a bare-name with_inputs implicitly "lifted" the input. Under
+    lexical scope the renamed input stays under the subgraph (the path is
+    still ``<graphnode>.<new_label>``), and a same-named ancestor input
+    remains independent.
+    """
+
+    @node(output_name="inner_out")
+    def consume_x(x: int) -> int:
+        return x
+
+    @node(output_name="outer_out")
+    def consume_x_outer(x: int) -> int:  # outer also has x; declared at outer
+        return x + 1000
+
+    inner_graph = Graph([consume_x], name="inner")
+    # Rename inner's "x" -> "inner_x" via with_inputs on the GraphNode.
+    inner_node = inner_graph.as_node().with_inputs(x="inner_x")
+
+    outer = Graph([inner_node, consume_x_outer], name="outer")
+
+    # The renamed input stays under the subgraph -- new leaf label only.
+    assert "inner.inner_x" in outer.inputs.required
+    # Outer's own x is still an independent flat input.
+    assert "x" in outer.inputs.required
+    # Bare "inner_x" at outer is NOT auto-linked: rename didn't move scope.
+    assert "inner_x" not in outer.inputs.required
+
+
+def test_no_warning_or_error_on_silent_bind_with_no_ancestor_declaration():
+    """A bind on a name no ancestor declares is a normal default and is silent."""
+    import warnings as _warnings
+
+    @node(output_name="out")
+    def use_x(x: int) -> int:
+        return x
+
+    inner = Graph([use_x], name="inner").bind(x=10)
+
+    with _warnings.catch_warnings():
+        _warnings.simplefilter("error")
+        outer = Graph([inner.as_node()], name="outer")
+        # Building the graph emits no warnings/errors -- bind is private and silent.
+        assert outer.inputs.bound == {"inner.x": 10}
+
+
+def test_bare_name_at_outer_resolving_only_to_private_input_errors():
+    """Strict mode: a bare name passed to runner.run() that doesn't resolve at
+    the call's scope errors instead of silently smart-routing to a deeper
+    private input. The error names the actual expected dot-path."""
+
+    @node(output_name="out")
+    def use_x(x: int) -> int:
+        return x
+
+    inner = Graph([use_x], name="inner")
+    outer = Graph([inner.as_node()], name="outer")
+
+    # x is private to inner (no leaf at outer declares it). Bare 'x' must
+    # error -- the user has to address it as 'inner.x' (or via nested-dict).
+    # The validator emits a warning naming the expected path AND raises a
+    # MissingInputError; both surface the same fact.
+    with pytest.warns(UserWarning, match=r"inner\.x"), pytest.raises(MissingInputError, match=r"inner\.x"):
+        SyncRunner().run(outer, {"x": 5})
+
+    # And the legitimate dot-path works.
+    result = SyncRunner().run(outer, {"inner.x": 5})
+    assert result["out"] == 5
+
+
+def test_bind_conflict_walks_descendants_fires_at_outermost():
+    """A deeply-nested bind whose leaf name matches an ancestor declaration
+    triggers a build-time error at the outermost graph that surfaces it."""
+
+    @node(output_name="out")
+    def use_x(x: int) -> int:
+        return x
+
+    @node(output_name="root_out")
+    def consume_x_at_root(x: int) -> int:
+        return x
+
+    # Three-level nest: bind x at the innermost.
+    inner = Graph([use_x], name="inner").bind(x=10)
+    middle = Graph([inner.as_node()], name="middle")  # builds clean -- no x at middle
+
+    # Sanity: middle holds the bind dot-pathed and didn't error.
+    assert middle.inputs.bound == {"inner.x": 10}
+
+    # Outermost scope declares x via a leaf -- the bind's leaf name `x` is
+    # shadowed even though the addressing chain is `inner.x`.
+    with pytest.raises(GraphConfigError, match=r"(?i)bind.*shadow|shadow.*bind|bind.*conflict"):
+        Graph([middle.as_node(), consume_x_at_root], name="root")

--- a/tests/test_lexical_scope.py
+++ b/tests/test_lexical_scope.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import pytest
 
 from hypergraph import Graph, node
+from hypergraph.graph.validation import GraphConfigError
 from hypergraph.runners import SyncRunner
 
 
@@ -71,3 +72,44 @@ def test_run_addresses_private_inputs_by_dot_path_or_nested_dict(values):
 
     assert result["out_a"] == "A:True"
     assert result["out_b"] == "B:False"
+
+
+def test_bind_shadowed_by_ancestor_leaf_consumer_is_build_time_error():
+    """A bind inside a subgraph errors at build time when an ancestor scope
+    declares the same name.
+
+    Without the check, the parent's value would silently override the bind at
+    run time -- the bind would look like a lock but be one. The validator
+    fires at the outermost graph that surfaces the conflict and reports both
+    the bind path and the ancestor scope that shadowed it.
+    """
+
+    @node(output_name="inner_out")
+    def consume_x_inner(x: int) -> int:
+        return x * 2
+
+    @node(output_name="outer_out")
+    def consume_x_outer(x: int) -> int:
+        return x + 1
+
+    inner = Graph([consume_x_inner], name="inner").bind(x=10)
+    with pytest.raises(GraphConfigError, match="(?i)bind.*shadow|shadow.*bind|bind.*conflict"):
+        Graph([consume_x_outer, inner.as_node()], name="outer")
+
+
+def test_bind_with_no_ancestor_declaration_builds_cleanly():
+    """A bind on a name nobody else declares is just a normal default and is
+    silent (no warning, no error)."""
+
+    @node(output_name="inner_out")
+    def consume_x(x: int) -> int:
+        return x * 2
+
+    @node(output_name="outer_out")
+    def consume_y(y: int) -> int:  # outer leaf consumes y, NOT x -- no conflict
+        return y + 1
+
+    inner = Graph([consume_x], name="inner").bind(x=10)
+    outer = Graph([consume_y, inner.as_node()], name="outer")
+
+    assert outer.inputs.bound == {"inner.x": 10}

--- a/tests/test_lexical_scope.py
+++ b/tests/test_lexical_scope.py
@@ -80,7 +80,7 @@ def test_bind_shadowed_by_ancestor_leaf_consumer_is_build_time_error():
     declares the same name.
 
     Without the check, the parent's value would silently override the bind at
-    run time -- the bind would look like a lock but be one. The validator
+    run time -- the bind would look like a lock but NOT be one. The validator
     fires at the outermost graph that surfaces the conflict and reports both
     the bind path and the ancestor scope that shadowed it.
     """
@@ -191,6 +191,55 @@ def test_run_value_overriding_dot_pathed_bind_emits_warning():
         result = SyncRunner().run(outer, {"inner.x": 99})
 
     assert result["out"] == 99
+
+
+def test_private_input_with_signature_default_is_optional_not_required():
+    """A private subgraph input whose inner function has a signature default
+    must be classified as optional at the outer scope, not required.
+
+    Regression for #95 review feedback: before this test, the addressed-param
+    categorizer dropped the `source` GraphNode and only checked
+    _all_consumers_have_default with the original (flat) name. For a single
+    GraphNode whose inner has a default, that worked; for siblings where only
+    one inner declares a default, it incorrectly returned False (required).
+    """
+
+    @node(output_name="out")
+    def use_x(x: int = 5) -> int:
+        return x * 2
+
+    inner = Graph([use_x], name="inner")
+    outer = Graph([inner.as_node()], name="outer")
+
+    assert "inner.x" in outer.inputs.optional
+    assert "inner.x" not in outer.inputs.required
+
+    # Run without providing inner.x: the inner function's default fires.
+    assert SyncRunner().run(outer)["out"] == 10
+
+
+def test_sibling_private_inputs_with_only_one_default_classified_per_source():
+    """Each private input is classified per its OWNING GraphNode's defaults.
+
+    A's inner has a default for x; B's inner does not. Outer should report
+    A.x as optional and B.x as required, not both as required.
+    """
+
+    @node(output_name="out_a")
+    def use_a(x: int = 7) -> int:
+        return x
+
+    @node(output_name="out_b")
+    def use_b(x: int) -> int:
+        return x
+
+    inner_a = Graph([use_a], name="A")
+    inner_b = Graph([use_b], name="B")
+    outer = Graph([inner_a.as_node(), inner_b.as_node()], name="outer")
+
+    assert "A.x" in outer.inputs.optional
+    assert "B.x" in outer.inputs.required
+    assert "A.x" not in outer.inputs.required
 
 
 def test_with_inputs_renames_leaf_label_only_not_scope():

--- a/tests/test_lexical_scope.py
+++ b/tests/test_lexical_scope.py
@@ -1,0 +1,38 @@
+"""Lexical scope semantics for nested subgraph inputs (issue #94).
+
+Under lexical scope, an input name that no ancestor scope declares is private
+to its subgraph; outer addresses it via the dot-path ``subgraph.name``.
+
+Each test in this module exercises one observable behavior end-to-end through
+the public Graph / Runner API. Implementation details (the scope tree, the
+old lift/promote machinery) are not asserted here.
+"""
+
+from __future__ import annotations
+
+from hypergraph import Graph, node
+
+
+def test_sibling_subgraphs_private_inputs_appear_as_dot_paths():
+    """Two siblings sharing an input name are private to each subgraph.
+
+    A bind on one sibling does not leak into the other's required set, and the
+    outer ``inputs.required`` / ``inputs.bound`` address each via dot-path.
+    """
+
+    @node(output_name="out_a")
+    def use_a(overwrite: bool) -> bool:
+        return overwrite
+
+    @node(output_name="out_b")
+    def use_b(overwrite: bool) -> bool:
+        return overwrite
+
+    inner_a = Graph([use_a], name="A").bind(overwrite=True)
+    inner_b = Graph([use_b], name="B")
+    outer = Graph([inner_a.as_node(), inner_b.as_node()], name="outer")
+
+    assert outer.inputs.required == ("B.overwrite",)
+    assert outer.inputs.bound == {"A.overwrite": True}
+    assert "overwrite" not in outer.inputs.required
+    assert "overwrite" not in outer.inputs.bound

--- a/tests/test_lexical_scope.py
+++ b/tests/test_lexical_scope.py
@@ -307,6 +307,48 @@ def test_override_warning_annotates_subgraph_for_dot_pathed_address():
     assert any("'x' of subgraph 'inner'" in m for m in msgs), msgs
 
 
+def test_changed_dot_pathed_input_marks_graphnode_as_stale_on_replay():
+    """A GraphNode whose private dot-pathed input changed must be seen as stale
+    against its previous execution record.
+
+    This locks in the invariant that the version recorded for a GraphNode
+    input at execution time uses the same key the staleness check reads.
+    Without alignment, _is_stale silently classifies a changed dot-pathed
+    input as unchanged (both record and read default to 0).
+    """
+    from hypergraph.runners._shared.helpers import _is_stale
+    from hypergraph.runners._shared.types import GraphState, NodeExecution
+
+    @node(output_name="doubled")
+    def double(x: int) -> int:
+        return x * 2
+
+    inner = Graph([double], name="inner")
+    outer = Graph([inner.as_node(name="embed")], name="outer")
+    embed_node = outer._nodes["embed"]
+
+    # Simulate a prior run that consumed embed.x=5 (state v1, recorded v1).
+    state = GraphState()
+    state.update_value("embed.x", 5)
+    # Record what an aligned superstep WOULD record for embed's prior exec.
+    # The address used here must match the staleness-check lookup.
+    prior_exec = NodeExecution(
+        node_name="embed",
+        input_versions={"embed.x": 1},  # aligned key
+        outputs={"doubled": 10},
+        output_versions={"doubled": 1},
+        wait_for_versions={},
+    )
+    state.node_executions["embed"] = prior_exec
+
+    # User provides a new value -- state version advances for the dotted key.
+    state.update_value("embed.x", 10)
+    assert state.versions["embed.x"] == 2
+
+    # The staleness check must see embed's prior input as stale (consumed v1, current v2).
+    assert _is_stale(embed_node, outer, state, prior_exec) is True
+
+
 def test_bare_name_at_outer_resolving_only_to_private_input_errors():
     """Strict mode: a bare name passed to runner.run() that doesn't resolve at
     the call's scope errors instead of silently smart-routing to a deeper

--- a/tests/test_lexical_scope.py
+++ b/tests/test_lexical_scope.py
@@ -242,6 +242,71 @@ def test_no_warning_or_error_on_silent_bind_with_no_ancestor_declaration():
         assert outer.inputs.bound == {"inner.x": 10}
 
 
+def test_missing_input_error_names_subgraph_for_dot_pathed_inputs():
+    """MissingInputError text annotates each dot-pathed missing input with
+    its owning subgraph, so the user knows where the input belongs."""
+
+    @node(output_name="out")
+    def use_x(x: int) -> int:
+        return x
+
+    inner = Graph([use_x], name="inner")
+    outer = Graph([inner.as_node()], name="outer")
+
+    with pytest.raises(MissingInputError) as exc_info:
+        SyncRunner().run(outer, {})
+
+    msg = str(exc_info.value)
+    # The new annotation: "input 'x' of subgraph 'inner'".
+    assert "'x' of subgraph 'inner'" in msg
+    # The bind() hint, irrelevant to a lexical-scope miss, is gone.
+    assert "graph.bind(x=10)" not in msg
+
+
+def test_bind_conflict_error_names_scope_and_shadowing_node():
+    """The bind-conflict GraphConfigError names the scope (graph) and the
+    specific shadowing node (a leaf at this scope) -- not just the bare
+    leaf name -- so the user can navigate to the source of the conflict."""
+
+    @node(output_name="inner_out")
+    def consume_x(x: int) -> int:
+        return x
+
+    @node(output_name="judge_out")
+    def judge_consumes_x(x: int) -> int:  # leaf at outer that shadows the bind
+        return x
+
+    inner = Graph([consume_x], name="inner").bind(x=10)
+    with pytest.raises(GraphConfigError) as exc_info:
+        Graph([inner.as_node(), judge_consumes_x], name="evaluation")
+
+    msg = str(exc_info.value)
+    # Scope (graph name) named explicitly.
+    assert "evaluation" in msg
+    # Shadowing leaf node named explicitly.
+    assert "judge_consumes_x" in msg
+    # Original bind path still present.
+    assert "inner.x" in msg
+
+
+def test_override_warning_annotates_subgraph_for_dot_pathed_address():
+    """The override UserWarning annotates the dot-pathed override target with
+    its owning subgraph, matching the missing-input message style."""
+
+    @node(output_name="out")
+    def use_x(x: int) -> int:
+        return x
+
+    inner = Graph([use_x], name="inner").bind(x=10)
+    outer = Graph([inner.as_node()], name="outer")
+
+    with pytest.warns(UserWarning) as records:
+        SyncRunner().run(outer, {"inner.x": 99})
+
+    msgs = [str(w.message) for w in records]
+    assert any("'x' of subgraph 'inner'" in m for m in msgs), msgs
+
+
 def test_bare_name_at_outer_resolving_only_to_private_input_errors():
     """Strict mode: a bare name passed to runner.run() that doesn't resolve at
     the call's scope errors instead of silently smart-routing to a deeper

--- a/tests/test_lexical_scope.py
+++ b/tests/test_lexical_scope.py
@@ -113,3 +113,80 @@ def test_bind_with_no_ancestor_declaration_builds_cleanly():
     outer = Graph([consume_y, inner.as_node()], name="outer")
 
     assert outer.inputs.bound == {"inner.x": 10}
+
+
+def test_run_value_overriding_primitive_bind_emits_warning_with_values():
+    """A run value that overrides a bound primitive emits a warning showing
+    both the bound and the new value."""
+
+    @node(output_name="out")
+    def use_x(x: int) -> int:
+        return x
+
+    graph = Graph([use_x], name="g").bind(x=10)
+
+    with pytest.warns(UserWarning, match=r"(?i)override.*x.*10.*42|override.*x.*42.*10"):
+        result = SyncRunner().run(graph, {"x": 42})
+
+    assert result["out"] == 42
+
+
+def test_run_value_overriding_opaque_bind_emits_generic_warning():
+    """A run value that overrides a bound non-primitive value emits a generic
+    warning without dumping the value text."""
+
+    class Opaque:
+        def __repr__(self) -> str:
+            return "<should-not-appear-in-warning>"
+
+    @node(output_name="out")
+    def use_x(x) -> str:
+        return "ok"
+
+    graph = Graph([use_x], name="g").bind(x=Opaque())
+
+    with pytest.warns(UserWarning) as records:
+        SyncRunner().run(graph, {"x": Opaque()})
+
+    msgs = [str(w.message) for w in records]
+    assert any("override" in m.lower() and "x" in m for m in msgs)
+    assert not any("should-not-appear-in-warning" in m for m in msgs)
+
+
+def test_run_with_no_override_emits_no_warning():
+    """A run that doesn't override anything emits no warnings."""
+
+    @node(output_name="out")
+    def use_x(x: int) -> int:
+        return x
+
+    graph = Graph([use_x], name="g").bind(x=10)
+
+    import warnings as _warnings
+
+    with _warnings.catch_warnings():
+        _warnings.simplefilter("error")
+        result = SyncRunner().run(graph)
+
+    assert result["out"] == 10
+
+
+def test_run_value_overriding_dot_pathed_bind_emits_warning():
+    """Override warning fires uniformly for dot-path overrides (not just flat)."""
+
+    @node(output_name="out")
+    def use_x(x: int) -> int:
+        return x
+
+    inner = Graph([use_x], name="inner").bind(x=10)
+
+    @node(output_name="other_out")
+    def consume_unrelated(y: int = 0) -> int:
+        return y
+
+    outer = Graph([inner.as_node(), consume_unrelated], name="outer")
+
+    with pytest.warns(UserWarning, match=r"(?i)override.*inner\.x"):
+        result = SyncRunner().run(outer, {"inner.x": 99})
+
+    assert result["out"] == 99

--- a/tests/test_lexical_scope.py
+++ b/tests/test_lexical_scope.py
@@ -307,6 +307,46 @@ def test_override_warning_annotates_subgraph_for_dot_pathed_address():
     assert any("'x' of subgraph 'inner'" in m for m in msgs), msgs
 
 
+@pytest.mark.parametrize(
+    "bind_call",
+    [
+        pytest.param(lambda outer, value: outer.bind(A={"x": value}), id="nested-dict-kwarg"),
+        pytest.param(lambda outer, value: outer.bind({"A.x": value}), id="dot-path-positional-dict"),
+    ],
+)
+def test_bind_addresses_private_subgraph_input_via_nested_dict_or_dot_path(bind_call):
+    """A user can bind a private subgraph input using either form, mirroring
+    the run() addressing surfaces. Both produce the same canonical entry on
+    inputs.bound and the same runtime behavior.
+    """
+
+    @node(output_name="out")
+    def use_x(x: int) -> int:
+        return x
+
+    inner = Graph([use_x], name="A")
+    outer = Graph([inner.as_node()], name="outer")
+
+    bound = bind_call(outer, 42)
+
+    assert bound.inputs.bound == {"A.x": 42}
+    assert SyncRunner().run(bound)["out"] == 42
+
+
+def test_bind_with_dict_value_for_non_subgraph_key_passes_through_as_value():
+    """When the outer key isn't a GraphNode name, a dict value is just an
+    opaque value -- not addressing. Mirrors normalize_inputs's rule."""
+
+    @node(output_name="out")
+    def use_config(config: dict) -> dict:
+        return config
+
+    graph = Graph([use_config], name="g")
+    bound = graph.bind(config={"key": "value"})  # config is a flat input, value IS a dict
+
+    assert bound.inputs.bound == {"config": {"key": "value"}}
+
+
 def test_changed_dot_pathed_input_marks_graphnode_as_stale_on_replay():
     """A GraphNode whose private dot-pathed input changed must be seen as stale
     against its previous execution record.

--- a/tests/test_lexical_scope.py
+++ b/tests/test_lexical_scope.py
@@ -10,7 +10,10 @@ old lift/promote machinery) are not asserted here.
 
 from __future__ import annotations
 
+import pytest
+
 from hypergraph import Graph, node
+from hypergraph.runners import SyncRunner
 
 
 def test_sibling_subgraphs_private_inputs_appear_as_dot_paths():
@@ -36,3 +39,35 @@ def test_sibling_subgraphs_private_inputs_appear_as_dot_paths():
     assert outer.inputs.bound == {"A.overwrite": True}
     assert "overwrite" not in outer.inputs.required
     assert "overwrite" not in outer.inputs.bound
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        pytest.param({"A.overwrite": True, "B.overwrite": False}, id="dot-path"),
+        pytest.param({"A": {"overwrite": True}, "B": {"overwrite": False}}, id="nested-dict"),
+    ],
+)
+def test_run_addresses_private_inputs_by_dot_path_or_nested_dict(values):
+    """Dot-path and nested-dict forms route a value to the right subgraph.
+
+    Both forms must produce identical results -- they are two surfaces over the
+    same canonical addressing.
+    """
+
+    @node(output_name="out_a")
+    def use_a(overwrite: bool) -> str:
+        return f"A:{overwrite}"
+
+    @node(output_name="out_b")
+    def use_b(overwrite: bool) -> str:
+        return f"B:{overwrite}"
+
+    inner_a = Graph([use_a], name="A")
+    inner_b = Graph([use_b], name="B")
+    outer = Graph([inner_a.as_node(), inner_b.as_node()], name="outer")
+
+    result = SyncRunner().run(outer, values)
+
+    assert result["out_a"] == "A:True"
+    assert result["out_b"] == "B:False"

--- a/tests/test_map_over_error_handling.py
+++ b/tests/test_map_over_error_handling.py
@@ -39,7 +39,7 @@ class TestSyncMapOverErrorHandling:
         outer = Graph([inner.as_node().map_over("x"), passthrough])
         runner = SyncRunner()
         with pytest.raises(CustomMapError):
-            runner.run(outer, {"x": [1, 2, 3, 4, 5]})
+            runner.run(outer, {"inner.x": [1, 2, 3, 4, 5]})
 
     def test_continue_mode_returns_none_placeholders(self):
         """error_handling='continue' uses None for failed items, preserving list length."""
@@ -47,7 +47,7 @@ class TestSyncMapOverErrorHandling:
         gn = inner.as_node().map_over("x", error_handling="continue")
         outer = Graph([gn, passthrough])
         runner = SyncRunner()
-        result = runner.run(outer, {"x": [1, 2, 3, 4, 5]})
+        result = runner.run(outer, {"inner.x": [1, 2, 3, 4, 5]})
         assert result.status == RunStatus.COMPLETED
         # List length preserved: 5 items in, 5 items out
         assert result["result"] == [2, 4, None, 8, 10]
@@ -58,7 +58,7 @@ class TestSyncMapOverErrorHandling:
         gn = inner.as_node().map_over("x", error_handling="continue")
         outer = Graph([gn, passthrough])
         runner = SyncRunner()
-        result = runner.run(outer, {"x": [1, 2, 4, 5]})
+        result = runner.run(outer, {"inner.x": [1, 2, 4, 5]})
         assert result.status == RunStatus.COMPLETED
         assert result["result"] == [2, 4, 8, 10]
 
@@ -88,7 +88,7 @@ class TestAsyncMapOverErrorHandling:
         outer = Graph([inner.as_node().map_over("x"), passthrough])
         runner = AsyncRunner()
         with pytest.raises(CustomMapError):
-            await runner.run(outer, {"x": [1, 2, 3, 4, 5]})
+            await runner.run(outer, {"inner.x": [1, 2, 3, 4, 5]})
 
     @pytest.mark.asyncio
     async def test_continue_mode_returns_none_placeholders(self):
@@ -96,7 +96,7 @@ class TestAsyncMapOverErrorHandling:
         gn = inner.as_node().map_over("x", error_handling="continue")
         outer = Graph([gn, passthrough])
         runner = AsyncRunner()
-        result = await runner.run(outer, {"x": [1, 2, 3, 4, 5]})
+        result = await runner.run(outer, {"inner.x": [1, 2, 3, 4, 5]})
         assert result.status == RunStatus.COMPLETED
         assert result["result"] == [2, 4, None, 8, 10]
 
@@ -106,6 +106,6 @@ class TestAsyncMapOverErrorHandling:
         gn = inner.as_node().map_over("x", error_handling="continue")
         outer = Graph([gn, passthrough])
         runner = AsyncRunner()
-        result = await runner.run(outer, {"x": [1, 2, 4, 5]})
+        result = await runner.run(outer, {"inner.x": [1, 2, 4, 5]})
         assert result.status == RunStatus.COMPLETED
         assert result["result"] == [2, 4, 8, 10]

--- a/tests/test_multi_output_graphnode.py
+++ b/tests/test_multi_output_graphnode.py
@@ -60,7 +60,7 @@ class TestMultiOutputGraphNode:
         inner = Graph([compute_a, compute_b], name="inner")
         outer = Graph([inner.as_node(), consume_both])
         runner = SyncRunner()
-        result = runner.run(outer, {"x": 5})
+        result = runner.run(outer, {"inner.x": 5})
         assert result.status == RunStatus.COMPLETED
         assert result["final"] == {"a": 6, "b": 50}
 
@@ -69,7 +69,7 @@ class TestMultiOutputGraphNode:
         inner = Graph([async_compute_a, async_compute_b], name="inner")
         outer = Graph([inner.as_node(), consume_both])
         runner = AsyncRunner()
-        result = await runner.run(outer, {"x": 5})
+        result = await runner.run(outer, {"inner.x": 5})
         assert result.status == RunStatus.COMPLETED
         assert result["final"] == {"a": 6, "b": 50}
 
@@ -80,7 +80,8 @@ class TestMultiOutputGraphNode:
         # 'a' and 'b' should NOT be in required inputs — they come from inner
         assert "a" not in outer.inputs.required
         assert "b" not in outer.inputs.required
-        assert "x" in outer.inputs.required
+        # x is private to inner GraphNode → addressed as inner.x
+        assert "inner.x" in outer.inputs.required
 
 
 # ============================================================
@@ -96,7 +97,7 @@ class TestMultiOutputGraphNodeMapOver:
         gn = inner.as_node().map_over("x")
         outer = Graph([gn, consume_both_lists])
         runner = SyncRunner()
-        result = runner.run(outer, {"x": [1, 2, 3]})
+        result = runner.run(outer, {"inner.x": [1, 2, 3]})
         assert result.status == RunStatus.COMPLETED
         assert result["final"] == {"a": [2, 3, 4], "b": [10, 20, 30]}
 
@@ -120,7 +121,7 @@ class TestMultiOutputGraphNodeMapOver:
         gn = inner.as_node().map_over("x", error_handling="continue")
         outer = Graph([gn, consume_both_lists])
         runner = SyncRunner()
-        result = runner.run(outer, {"x": [-1, 2, 3]})
+        result = runner.run(outer, {"inner.x": [-1, 2, 3]})
         assert result.status == RunStatus.COMPLETED
         assert result["final"] == {"a": [None, 3, 4], "b": [None, 20, 30]}
 
@@ -143,7 +144,7 @@ class TestMultiOutputPartialConsumption:
         inner = Graph([compute_a, compute_b], name="inner")
         outer = Graph([inner.as_node(), use_a])
         runner = SyncRunner()
-        result = runner.run(outer, {"x": 5})
+        result = runner.run(outer, {"inner.x": 5})
         assert result.status == RunStatus.COMPLETED
         assert result["result"] == 600
 
@@ -161,7 +162,7 @@ class TestMultiOutputPartialConsumption:
         inner = Graph([compute_a, compute_b], name="inner")
         outer = Graph([inner.as_node(), use_a, use_b])
         runner = SyncRunner()
-        result = runner.run(outer, {"x": 5})
+        result = runner.run(outer, {"inner.x": 5})
         assert result.status == RunStatus.COMPLETED
         assert result["ra"] == 600
         assert result["rb"] == 51

--- a/tests/test_nested_cycle_topologies.py
+++ b/tests/test_nested_cycle_topologies.py
@@ -52,7 +52,8 @@ class TestThreeLevelNestedWithInnerCycle:
         outer = Graph([middle.as_node()], entrypoint="middle")
 
         runner = SyncRunner()
-        result = runner.run(outer, {"count": 0, "limit": 3})
+        # count/limit are private to middle.inner GraphNode chain
+        result = runner.run(outer, {"middle.inner.count": 0, "middle.inner.limit": 3})
 
         assert result.status == RunStatus.COMPLETED
         assert result["count"] == 3
@@ -77,7 +78,10 @@ class TestThreeLevelNestedWithInnerCycle:
         outer = Graph([middle.as_node(), finalize], entrypoint="middle")
 
         runner = SyncRunner()
-        result = runner.run(outer, {"count": 0, "limit": 2})
+        # count is consumed by leaf process_count inside middle, declared at middle scope.
+        # At outer, no leaf consumes count → count is private to middle → middle.count
+        # limit is private at every level → middle.inner.limit
+        result = runner.run(outer, {"middle.count": 0, "middle.inner.limit": 2})
 
         # count goes 0->1->2, then 2*10=20, then 20+1=21
         assert result.status == RunStatus.COMPLETED
@@ -154,13 +158,15 @@ class TestParallelNestedGraphsWithCycles:
         outer = Graph([inner_a.as_node(), inner_b.as_node(), combine], entrypoint=["inner_a", "inner_b"])
 
         runner = SyncRunner()
+        # count_a/count_b consumed by leaf combine at outer → declared, stay flat.
+        # limit_a/limit_b only consumed inside inner_a/inner_b → private dot-paths.
         result = runner.run(
             outer,
             {
                 "count_a": 0,
-                "limit_a": 3,
+                "inner_a.limit_a": 3,
                 "count_b": 0,
-                "limit_b": 5,
+                "inner_b.limit_b": 5,
             },
         )
 
@@ -229,7 +235,15 @@ class TestDeeplyNestedConvergence:
         outer = Graph([level2.as_node()], entrypoint="level2")
 
         runner = SyncRunner()
-        result = runner.run(outer, {"approx": 0.0, "target": 10.0, "rate": 0.5})
+        # No leaves at outer/level2 declare these → private through level2.level3
+        result = runner.run(
+            outer,
+            {
+                "level2.level3.approx": 0.0,
+                "level2.level3.target": 10.0,
+                "level2.level3.rate": 0.5,
+            },
+        )
 
         assert result.status == RunStatus.COMPLETED
         # Should converge close to 10.0
@@ -261,11 +275,13 @@ class TestNestedCyclesWithDifferentSeeds:
         outer = Graph([inner.as_node(), process_inner], entrypoint="inner")
 
         runner = SyncRunner()
+        # inner_count/multiplier consumed by leaf process_inner → declared, stay flat.
+        # inner_limit only inside inner GraphNode → private dot-path.
         result = runner.run(
             outer,
             {
                 "inner_count": 0,
-                "inner_limit": 3,
+                "inner.inner_limit": 3,
                 "multiplier": 10,
             },
         )
@@ -307,13 +323,15 @@ class TestNestedCyclesWithDifferentSeeds:
         outer = Graph([inner_a.as_node(), inner_b.as_node(), combine], entrypoint=["inner_a", "inner_b"])
 
         runner = SyncRunner()
+        # a/b consumed by leaf combine → declared, stay flat.
+        # limit_a/limit_b private to inner_a/inner_b GraphNodes.
         result = runner.run(
             outer,
             {
                 "a": 0,
-                "limit_a": 3,
+                "inner_a.limit_a": 3,
                 "b": 0,
-                "limit_b": 5,
+                "inner_b.limit_b": 5,
             },
         )
 
@@ -332,7 +350,8 @@ class TestNestedCyclesAsync:
         outer = Graph([inner.as_node()], entrypoint="inner")
 
         runner = AsyncRunner()
-        result = await runner.run(outer, {"count": 0, "limit": 3})
+        # count/limit are private to inner GraphNode → addressed via dot-path
+        result = await runner.run(outer, {"inner.count": 0, "inner.limit": 3})
 
         assert result.status == RunStatus.COMPLETED
         assert result["count"] == 3
@@ -354,7 +373,8 @@ class TestNestedCyclesAsync:
         outer = Graph([middle.as_node()], entrypoint="middle")
 
         runner = AsyncRunner()
-        result = await runner.run(outer, {"count": 0, "limit": 3})
+        # count/limit are private through middle.inner GraphNode chain
+        result = await runner.run(outer, {"middle.inner.count": 0, "middle.inner.limit": 3})
 
         assert result.status == RunStatus.COMPLETED
         assert result["count"] == 3
@@ -372,11 +392,12 @@ class TestCycleWithMapOver:
         outer = Graph([inner.as_node().map_over("count")], entrypoint="inner")
 
         runner = SyncRunner()
+        # count/limit are private to inner GraphNode → addressed via dot-path
         result = runner.run(
             outer,
             {
-                "count": [0, 1, 2],
-                "limit": 5,
+                "inner.count": [0, 1, 2],
+                "inner.limit": 5,
             },
         )
 
@@ -390,11 +411,12 @@ class TestCycleWithMapOver:
         outer = Graph([inner.as_node().map_over("count", "limit", mode="zip")], entrypoint="inner")
 
         runner = SyncRunner()
+        # count/limit are private to inner GraphNode → addressed via dot-path
         result = runner.run(
             outer,
             {
-                "count": [0, 0, 0],
-                "limit": [2, 3, 4],
+                "inner.count": [0, 0, 0],
+                "inner.limit": [2, 3, 4],
             },
         )
 

--- a/tests/test_nested_cycle_topologies.py
+++ b/tests/test_nested_cycle_topologies.py
@@ -52,8 +52,9 @@ class TestThreeLevelNestedWithInnerCycle:
         outer = Graph([middle.as_node()], entrypoint="middle")
 
         runner = SyncRunner()
-        # count/limit are private to middle.inner GraphNode chain
-        result = runner.run(outer, {"middle.inner.count": 0, "middle.inner.limit": 3})
+        # count auto-links upward via each GraphNode's output. limit stays
+        # private to the innermost subgraph.
+        result = runner.run(outer, {"count": 0, "middle.inner.limit": 3})
 
         assert result.status == RunStatus.COMPLETED
         assert result["count"] == 3
@@ -78,10 +79,9 @@ class TestThreeLevelNestedWithInnerCycle:
         outer = Graph([middle.as_node(), finalize], entrypoint="middle")
 
         runner = SyncRunner()
-        # count is consumed by leaf process_count inside middle, declared at middle scope.
-        # At outer, no leaf consumes count → count is private to middle → middle.count
-        # limit is private at every level → middle.inner.limit
-        result = runner.run(outer, {"middle.count": 0, "middle.inner.limit": 2})
+        # count auto-links across every level (GraphNode outputs declare it at the
+        # parent scope). limit is private at every level.
+        result = runner.run(outer, {"count": 0, "middle.inner.limit": 2})
 
         # count goes 0->1->2, then 2*10=20, then 20+1=21
         assert result.status == RunStatus.COMPLETED
@@ -235,11 +235,12 @@ class TestDeeplyNestedConvergence:
         outer = Graph([level2.as_node()], entrypoint="level2")
 
         runner = SyncRunner()
-        # No leaves at outer/level2 declare these → private through level2.level3
+        # approx auto-links through level2.level3 (GraphNode outputs declare it at
+        # each parent scope). target and rate stay private to level3.
         result = runner.run(
             outer,
             {
-                "level2.level3.approx": 0.0,
+                "approx": 0.0,
                 "level2.level3.target": 10.0,
                 "level2.level3.rate": 0.5,
             },
@@ -350,8 +351,8 @@ class TestNestedCyclesAsync:
         outer = Graph([inner.as_node()], entrypoint="inner")
 
         runner = AsyncRunner()
-        # count/limit are private to inner GraphNode → addressed via dot-path
-        result = await runner.run(outer, {"inner.count": 0, "inner.limit": 3})
+        # count auto-links via inner's output. limit is private to inner.
+        result = await runner.run(outer, {"count": 0, "inner.limit": 3})
 
         assert result.status == RunStatus.COMPLETED
         assert result["count"] == 3
@@ -373,8 +374,8 @@ class TestNestedCyclesAsync:
         outer = Graph([middle.as_node()], entrypoint="middle")
 
         runner = AsyncRunner()
-        # count/limit are private through middle.inner GraphNode chain
-        result = await runner.run(outer, {"middle.inner.count": 0, "middle.inner.limit": 3})
+        # count auto-links through middle.inner. limit is private to inner.
+        result = await runner.run(outer, {"count": 0, "middle.inner.limit": 3})
 
         assert result.status == RunStatus.COMPLETED
         assert result["count"] == 3
@@ -392,11 +393,11 @@ class TestCycleWithMapOver:
         outer = Graph([inner.as_node().map_over("count")], entrypoint="inner")
 
         runner = SyncRunner()
-        # count/limit are private to inner GraphNode → addressed via dot-path
+        # count auto-links via inner's output (mapped). limit is private to inner.
         result = runner.run(
             outer,
             {
-                "inner.count": [0, 1, 2],
+                "count": [0, 1, 2],
                 "inner.limit": 5,
             },
         )
@@ -411,11 +412,11 @@ class TestCycleWithMapOver:
         outer = Graph([inner.as_node().map_over("count", "limit", mode="zip")], entrypoint="inner")
 
         runner = SyncRunner()
-        # count/limit are private to inner GraphNode → addressed via dot-path
+        # count auto-links via inner's output (mapped). limit is private to inner.
         result = runner.run(
             outer,
             {
-                "inner.count": [0, 0, 0],
+                "count": [0, 0, 0],
                 "inner.limit": [2, 3, 4],
             },
         )

--- a/tests/test_pr32_review_bugs.py
+++ b/tests/test_pr32_review_bugs.py
@@ -61,7 +61,7 @@ class TestCollectAsListsLengthConsistency:
         gn = inner.as_node().map_over("x")
         outer = Graph([gn, combine])
         runner = SyncRunner()
-        result = runner.run(outer, {"x": [1, 2, 3]})
+        result = runner.run(outer, {"inner.x": [1, 2, 3]})
         assert result["combined"]["a"] == [2, 3, 4]
         assert result["combined"]["b"] == [10, 20, 30]
 
@@ -75,7 +75,7 @@ class TestCollectAsListsLengthConsistency:
         gn = inner.as_node().map_over("x", error_handling="continue")
         outer = Graph([gn, combine])
         runner = SyncRunner()
-        result = runner.run(outer, {"x": [1, 2, 3, 4]})
+        result = runner.run(outer, {"inner.x": [1, 2, 3, 4]})
         a_list = result["combined"]["a"]
         b_list = result["combined"]["b"]
         # Both lists must be same length (4 items)
@@ -95,7 +95,7 @@ class TestCollectAsListsLengthConsistency:
 
         outer = Graph([gn, use_renamed])
         runner = SyncRunner()
-        result = runner.run(outer, {"x": [1, 2, 3]})
+        result = runner.run(outer, {"inner.x": [1, 2, 3]})
         assert len(result["result"]["alpha"]) == len(result["result"]["beta"]) == 3
 
     def test_runner_map_continue_multi_output_graph(self):

--- a/tests/test_red_team_fixes.py
+++ b/tests/test_red_team_fixes.py
@@ -347,6 +347,7 @@ class TestOutputRenamePropagation:
 
         outer_graph = Graph(nodes=[graph_node, outer_step])
         runner = SyncRunner()
-        result = runner.run(outer_graph, {"x": 5})
+        # x is private to inner GraphNode → addressed via dot-path
+        result = runner.run(outer_graph, {"inner.x": 5})
 
         assert result["final"] == 11, f"Expected 11 (5*2+1), got {result['final']}"

--- a/tests/test_run_log/test_run_log.py
+++ b/tests/test_run_log/test_run_log.py
@@ -334,7 +334,8 @@ class TestInnerLogs:
         """A nested GraphNode step.log returns a single RunLog."""
         inner = Graph([_double], name="inner")
         outer = Graph([inner.as_node()])
-        result = SyncRunner().run(outer, {"x": 5})
+        # x is private to inner GraphNode → addressed via dot-path
+        result = SyncRunner().run(outer, {"inner.x": 5})
 
         assert result["doubled"] == 10
         assert result.log is not None
@@ -354,7 +355,8 @@ class TestInnerLogs:
         """A map_over GraphNode step.log returns a MapLog when N inner."""
         inner = Graph([_double], name="inner")
         outer = Graph([inner.as_node().map_over("x")])
-        result = SyncRunner().run(outer, {"x": [1, 2, 3]})
+        # x is private to inner GraphNode → addressed via dot-path
+        result = SyncRunner().run(outer, {"inner.x": [1, 2, 3]})
 
         step = result.log.steps[0]
 
@@ -384,7 +386,8 @@ class TestInnerLogs:
             name="middle",
         )
         outer = Graph([middle.as_node()])
-        result = SyncRunner().run(outer, {"x": 5})
+        # x is private through middle.innermost GraphNode chain
+        result = SyncRunner().run(outer, {"middle.innermost.x": 5})
 
         assert result["incremented"] == 11
         # Outer step → middle RunLog
@@ -399,7 +402,8 @@ class TestInnerLogs:
         """to_dict() serializes inner_log via .log accessor."""
         inner = Graph([_double], name="inner")
         outer = Graph([inner.as_node()])
-        result = SyncRunner().run(outer, {"x": 5})
+        # x is private to inner GraphNode → addressed via dot-path
+        result = SyncRunner().run(outer, {"inner.x": 5})
 
         d = result.log.to_dict()
         step_dict = d["steps"][0]
@@ -417,7 +421,8 @@ class TestInnerLogs:
         """__str__() shows '(N inner)' for steps with inner logs."""
         inner = Graph([_double], name="inner")
         outer = Graph([inner.as_node()])
-        result = SyncRunner().run(outer, {"x": 5})
+        # x is private to inner GraphNode → addressed via dot-path
+        result = SyncRunner().run(outer, {"inner.x": 5})
 
         output = str(result.log)
         assert "(1 inner)" in output
@@ -426,7 +431,8 @@ class TestInnerLogs:
         """__str__() footer has .steps[i].log drill-down hint."""
         inner = Graph([_double], name="inner")
         outer = Graph([inner.as_node()])
-        result = SyncRunner().run(outer, {"x": 5})
+        # x is private to inner GraphNode → addressed via dot-path
+        result = SyncRunner().run(outer, {"inner.x": 5})
 
         output = str(result.log)
         assert ".steps[0].log" in output
@@ -436,7 +442,8 @@ class TestInnerLogs:
         """Async runner also surfaces inner RunLogs via .log."""
         inner = Graph([_double], name="inner")
         outer = Graph([inner.as_node()])
-        result = await AsyncRunner().run(outer, {"x": 5})
+        # x is private to inner GraphNode → addressed via dot-path
+        result = await AsyncRunner().run(outer, {"inner.x": 5})
 
         assert result["doubled"] == 10
         step = result.log.steps[0]
@@ -451,7 +458,8 @@ class TestInnerLogs:
         """Async runner step.log returns MapLog for map_over."""
         inner = Graph([_double], name="inner")
         outer = Graph([inner.as_node().map_over("x")])
-        result = await AsyncRunner().run(outer, {"x": [1, 2, 3]})
+        # x is private to inner GraphNode → addressed via dot-path
+        result = await AsyncRunner().run(outer, {"inner.x": [1, 2, 3]})
 
         step = result.log.steps[0]
 

--- a/tests/test_runners/test_async_runner.py
+++ b/tests/test_runners/test_async_runner.py
@@ -409,7 +409,7 @@ class TestAsyncRunnerRun:
         outer = Graph([inner.as_node()])
         runner = AsyncRunner()
 
-        result = await runner.run(outer, {"x": 5})
+        result = await runner.run(outer, {"inner.x": 5})
 
         assert result["doubled"] == 10
 
@@ -419,7 +419,7 @@ class TestAsyncRunnerRun:
         outer = Graph([inner.as_node(), async_add.with_inputs(a="doubled")])
         runner = AsyncRunner()
 
-        result = await runner.run(outer, {"x": 5, "b": 3})
+        result = await runner.run(outer, {"inner.x": 5, "b": 3})
 
         assert result["sum"] == 13
 

--- a/tests/test_runners/test_async_runner.py
+++ b/tests/test_runners/test_async_runner.py
@@ -733,7 +733,9 @@ class TestDisconnectedSubgraphs:
         level1 = Graph([level2.as_node(), level1_node])
 
         runner = AsyncRunner()
-        result = await runner.run(level1, {"a": 5})
+        # a is consumed only by leaf level3_node inside level3 GraphNode (private),
+        # which is wrapped by level2 GraphNode → addressed as level2.level3.a
+        result = await runner.run(level1, {"level2.level3.a": 5})
 
         # a=5 -> x=10 -> y=11 -> z=33
         assert result.status == RunStatus.COMPLETED
@@ -821,7 +823,8 @@ class TestDisconnectedSubgraphs:
         outer = Graph([inner.as_node(), other_node])
         runner = AsyncRunner()
 
-        result = await runner.run(outer, {"a": 5, "b": 3})
+        # a is private to inner GraphNode → dot-path; b is declared at outer (consumed by other_node)
+        result = await runner.run(outer, {"inner.a": 5, "b": 3})
 
         assert result.status == RunStatus.COMPLETED
         assert result["inner_result"] == 10
@@ -859,7 +862,8 @@ class TestDeeplyNestedAsync:
         l1_graph = Graph([l2_graph.as_node(), level1])
 
         runner = AsyncRunner()
-        result = await runner.run(l1_graph, {"x": 0})
+        # x is private through l2.l3.l4 GraphNode chain
+        result = await runner.run(l1_graph, {"l2.l3.l4.x": 0})
 
         # 0 -> 1 -> 2 -> 3 -> 4
         assert result.status == RunStatus.COMPLETED
@@ -889,7 +893,8 @@ class TestDeeplyNestedAsync:
         outer = Graph([inner.as_node()])
 
         runner = AsyncRunner()
-        result = await runner.run(outer, {"x": 5})
+        # x is private to inner GraphNode → addressed via dot-path
+        result = await runner.run(outer, {"inner.x": 5})
 
         # a=10, b=15, sum=25
         assert result.status == RunStatus.COMPLETED
@@ -942,7 +947,8 @@ class TestGlobalConcurrencyLimit:
         outer = Graph([inner.as_node(), outer_slow])
         runner = AsyncRunner()
 
-        result = await runner.run(outer, {"x": 5, "y": 10}, max_concurrency=1)
+        # x is private to inner GraphNode; y is declared at outer (consumed by outer_slow)
+        result = await runner.run(outer, {"inner.x": 5, "y": 10}, max_concurrency=1)
 
         assert result.status == RunStatus.COMPLETED
         # With max_concurrency=1, only one operation should run at a time
@@ -1014,9 +1020,10 @@ class TestGlobalConcurrencyLimit:
         outer = Graph([inner_mapped, outer_tracked])
         runner = AsyncRunner()
 
+        # item is private to inner GraphNode; x declared at outer (consumed by outer_tracked)
         result = await runner.run(
             outer,
-            {"item": [1, 2, 3], "x": 5},
+            {"inner.item": [1, 2, 3], "x": 5},
             max_concurrency=2,
         )
 
@@ -1070,7 +1077,8 @@ class TestGlobalConcurrencyLimit:
         l1_graph = Graph([l2_graph.as_node(), level1])
 
         runner = AsyncRunner()
-        result = await runner.run(l1_graph, {"a": 5}, max_concurrency=1)
+        # a is private through l2.l3 GraphNode chain
+        result = await runner.run(l1_graph, {"l2.l3.a": 5}, max_concurrency=1)
 
         assert result.status == RunStatus.COMPLETED
         # All three levels share max_concurrency=1
@@ -1098,11 +1106,12 @@ class TestGlobalConcurrencyLimit:
 
         runner = AsyncRunner()
 
-        # 4 map items, each with a nested graph
+        # 4 map items, each with a nested graph.
+        # x is private to inner GraphNode → addressed via dot-path; map_over uses that name.
         results = await runner.map(
             outer,
-            {"x": [1, 2, 3, 4]},
-            map_over="x",
+            {"inner.x": [1, 2, 3, 4]},
+            map_over="inner.x",
             max_concurrency=2,
         )
 

--- a/tests/test_runners/test_daft_runner.py
+++ b/tests/test_runners/test_daft_runner.py
@@ -47,7 +47,8 @@ def test_daft_runner_run_nested_graphnode_with_map_over():
     outer = Graph([inner.as_node(name="mapper").with_inputs(x="items").map_over("items")], name="outer")
 
     runner = DaftRunner()
-    result = runner.run(outer, {"items": [2, 4, 6]})
+    # `items` is private to the `mapper` GraphNode at outer scope.
+    result = runner.run(outer, {"mapper.items": [2, 4, 6]})
 
     assert result["doubled"] == [4, 8, 12]
 
@@ -60,7 +61,8 @@ def test_daft_runner_handles_bound_inputs_inside_nested_map_over():
     scorer = Graph([score], name="scorer").bind(multiplier=3)
     batch_graph = Graph([scorer.as_node(name="score_many").with_inputs(text="texts").map_over("texts")], name="batch_graph")
 
-    result = DaftRunner().run(batch_graph, {"texts": ["a", "tool", "hypergraph"]})
+    # `texts` is private to the `score_many` GraphNode at batch_graph scope.
+    result = DaftRunner().run(batch_graph, {"score_many.texts": ["a", "tool", "hypergraph"]})
 
     assert result["scored"] == [3, 12, 30]
 
@@ -111,7 +113,7 @@ def test_daft_runner_rejects_nested_graph_with_async_nodes():
     outer = Graph([inner.as_node(name="sub").with_inputs(x="val")], name="outer")
 
     with pytest.raises(IncompatibleRunnerError, match="async nodes"):
-        DaftRunner().run(outer, {"val": 1})
+        DaftRunner().run(outer, {"sub.val": 1})
 
 
 def test_daft_runner_rejects_with_runner_override():

--- a/tests/test_runners/test_delegation.py
+++ b/tests/test_runners/test_delegation.py
@@ -106,7 +106,8 @@ class TestDelegationExecution:
         outer = Graph([gn])
 
         parent_runner = SyncRunner()
-        result = parent_runner.run(outer, x=5)
+        # x is private to inner GraphNode → addressed via dot-path (use dict form)
+        result = parent_runner.run(outer, {"inner.x": 5})
         assert result.values["doubled"] == 10
 
     def test_sync_delegation_with_map_over(self):
@@ -117,7 +118,8 @@ class TestDelegationExecution:
         outer = Graph([mapped])
 
         parent_runner = SyncRunner()
-        result = parent_runner.run(outer, x=[1, 2, 3])
+        # x is private to inner GraphNode → addressed via dot-path
+        result = parent_runner.run(outer, {"inner.x": [1, 2, 3]})
         assert result.values["doubled"] == [2, 4, 6]
 
     @pytest.mark.asyncio
@@ -129,7 +131,8 @@ class TestDelegationExecution:
         outer = Graph([gn])
 
         parent_runner = AsyncRunner()
-        result = await parent_runner.run(outer, x=5)
+        # x is private to inner GraphNode → addressed via dot-path
+        result = await parent_runner.run(outer, {"inner.x": 5})
         assert result.values["doubled"] == 10
 
     def test_delegation_with_renamed_inputs(self):
@@ -138,7 +141,8 @@ class TestDelegationExecution:
         gn = inner.as_node(runner=SyncRunner()).with_inputs(x="val")
         outer = Graph([gn])
 
-        result = SyncRunner().run(outer, val=7)
+        # val (renamed from x) is private to inner GraphNode → dot-path
+        result = SyncRunner().run(outer, {"inner.val": 7})
         assert result.values["doubled"] == 14
 
     def test_delegation_in_multi_node_graph(self):
@@ -147,6 +151,7 @@ class TestDelegationExecution:
         gn = inner.as_node(runner=SyncRunner())
         outer = Graph([gn, add.with_inputs(a="doubled")])
 
-        result = SyncRunner().run(outer, x=3, b=10)
+        # x is private to inner GraphNode; b is declared at outer (consumed by add)
+        result = SyncRunner().run(outer, {"inner.x": 3, "b": 10})
         assert result.values["doubled"] == 6
         assert result.values["sum"] == 16

--- a/tests/test_runners/test_graphnode_map_over.py
+++ b/tests/test_runners/test_graphnode_map_over.py
@@ -165,7 +165,8 @@ class TestMapOverRenameExecution:
         inner = Graph(nodes=[process_item], name="inner")
         mapped_node = inner.as_node(name="process_all").with_inputs(item="items").map_over("items")
 
-        outer = Graph(nodes=[produce_items, mapped_node]).bind(multiplier=2)
+        # multiplier is private to mapped_node (process_all) → bind via dot-path
+        outer = Graph(nodes=[produce_items, mapped_node]).bind(**{"process_all.multiplier": 2})
         runner = SyncRunner()
 
         result = runner.run(outer, {"count": 3})
@@ -269,8 +270,8 @@ class TestMapOverRenameExecution:
         outer = Graph(nodes=[produce, mapped_node])
         runner = SyncRunner()
 
-        # "factor" is broadcast to all iterations
-        result = runner.run(outer, {"factor": 10})
+        # factor is private to mapped GraphNode (multiplier) → addressed via dot-path
+        result = runner.run(outer, {"multiplier.factor": 10})
 
         assert result.status == RunStatus.COMPLETED
         assert result["result"] == [10, 20, 30]
@@ -350,7 +351,8 @@ class TestMapOverExecution:
         outer = Graph([inner.as_node().map_over("x")])
         runner = SyncRunner()
 
-        result = runner.run(outer, {"x": [1, 2, 3]})
+        # x is private to inner GraphNode → addressed via dot-path
+        result = runner.run(outer, {"inner.x": [1, 2, 3]})
 
         assert result.status == RunStatus.COMPLETED
         assert result["doubled"] == [2, 4, 6]
@@ -361,7 +363,8 @@ class TestMapOverExecution:
         outer = Graph([inner.as_node().map_over("a", "b", mode="zip")])
         runner = SyncRunner()
 
-        result = runner.run(outer, {"a": [1, 2, 3], "b": [10, 20, 30]})
+        # a, b are private to inner GraphNode → addressed via dot-path
+        result = runner.run(outer, {"inner.a": [1, 2, 3], "inner.b": [10, 20, 30]})
 
         assert result["sum"] == [11, 22, 33]
 
@@ -371,7 +374,8 @@ class TestMapOverExecution:
         outer = Graph([inner.as_node().map_over("a", "b", mode="product")])
         runner = SyncRunner()
 
-        result = runner.run(outer, {"a": [1, 2], "b": [10, 20]})
+        # a, b are private to inner GraphNode → addressed via dot-path
+        result = runner.run(outer, {"inner.a": [1, 2], "inner.b": [10, 20]})
 
         # 2 * 2 = 4 results
         assert len(result["sum"]) == 4
@@ -392,7 +396,8 @@ class TestMapOverExecution:
         # This test documents current behavior — may succeed or raise
         # depending on how the downstream node handles list input
         try:
-            result = runner.run(outer, {"x": [1, 2], "b": 0})
+            # x is private to inner GraphNode; b is declared at outer (consumed by add)
+            result = runner.run(outer, {"inner.x": [1, 2], "b": 0})
             assert result.status == RunStatus.COMPLETED
         except Exception:
             pass  # Also acceptable — type mismatch in downstream node
@@ -403,7 +408,8 @@ class TestMapOverExecution:
         outer = Graph([inner.as_node().map_over("x")])
         runner = AsyncRunner()
 
-        result = await runner.run(outer, {"x": [1, 2, 3]})
+        # x is private to inner GraphNode → addressed via dot-path
+        result = await runner.run(outer, {"inner.x": [1, 2, 3]})
 
         assert result.status == RunStatus.COMPLETED
         assert result["doubled"] == [2, 4, 6]
@@ -414,7 +420,8 @@ class TestMapOverExecution:
         outer = Graph([inner.as_node().map_over("x")])
         runner = SyncRunner()
 
-        result = runner.run(outer, {"x": []})
+        # x is private to inner GraphNode → addressed via dot-path
+        result = runner.run(outer, {"inner.x": []})
 
         assert result["doubled"] == []
 
@@ -424,7 +431,8 @@ class TestMapOverExecution:
         outer = Graph([inner.as_node().map_over("a")])
         runner = SyncRunner()
 
-        result = runner.run(outer, {"a": [1, 2, 3], "b": 10})
+        # a, b are private to inner GraphNode → addressed via dot-path
+        result = runner.run(outer, {"inner.a": [1, 2, 3], "inner.b": 10})
 
         assert result["sum"] == [11, 12, 13]
 
@@ -448,8 +456,8 @@ class TestConcurrentNestedMaps:
         outer = Graph([middle.as_node(), collect])
         runner = SyncRunner()
 
-        # Pass list to inner map_over
-        result = runner.run(outer, {"x": [1, 2, 3]})
+        # x is private through middle.inner GraphNode chain
+        result = runner.run(outer, {"middle.inner.x": [1, 2, 3]})
 
         assert result.status == RunStatus.COMPLETED
         assert result["doubled"] == [2, 4, 6]
@@ -470,7 +478,8 @@ class TestConcurrentNestedMaps:
         runner = AsyncRunner()
 
         # Multiple items should process concurrently
-        result = await runner.run(outer, {"x": [1, 2, 3, 4, 5]})
+        # x is private to inner GraphNode → addressed via dot-path
+        result = await runner.run(outer, {"inner.x": [1, 2, 3, 4, 5]})
 
         assert result.status == RunStatus.COMPLETED
         assert result["value"] == [2, 4, 6, 8, 10]
@@ -492,8 +501,9 @@ class TestConcurrentNestedMaps:
 
         # With max_concurrency=1 on outer, nested map should still work (no deadlock)
         # Nested executions don't inherit outer concurrency limits
+        # x is private to inner GraphNode → addressed via dot-path
         start = time.time()
-        result = await runner.run(outer, {"x": [1, 2, 3]}, max_concurrency=1)
+        result = await runner.run(outer, {"inner.x": [1, 2, 3]}, max_concurrency=1)
         elapsed = time.time() - start
 
         assert result.status == RunStatus.COMPLETED
@@ -517,8 +527,9 @@ class TestConcurrentNestedMaps:
         runner = AsyncRunner()
 
         # With default concurrency (unlimited), should run in parallel
+        # x is private to inner GraphNode → addressed via dot-path
         start = time.time()
-        result = await runner.run(outer, {"x": [1, 2, 3, 4, 5]})
+        result = await runner.run(outer, {"inner.x": [1, 2, 3, 4, 5]})
         elapsed = time.time() - start
 
         assert result.status == RunStatus.COMPLETED
@@ -537,7 +548,8 @@ class TestConcurrentNestedMaps:
         outer = Graph([inner.as_node().map_over("x")])
 
         runner = AsyncRunner()
-        result = await runner.run(outer, {"x": [1, 2, 3]})
+        # x is private to inner GraphNode → addressed via dot-path
+        result = await runner.run(outer, {"inner.x": [1, 2, 3]})
 
         assert result.status == RunStatus.COMPLETED
         assert result["value"] == [2, 4, 6]
@@ -557,7 +569,8 @@ class TestConcurrentNestedMaps:
         outer = Graph([inner.as_node().map_over("x")])
 
         runner = AsyncRunner()
-        result = await runner.run(outer, {"x": [1, 2, 3]})
+        # x is private to inner GraphNode → addressed via dot-path
+        result = await runner.run(outer, {"inner.x": [1, 2, 3]})
 
         assert result.status == RunStatus.COMPLETED
         # (1+1)*2=4, (2+1)*2=6, (3+1)*2=8
@@ -575,7 +588,8 @@ class TestConcurrentNestedMaps:
         outer = Graph([middle.as_node()])
 
         runner = SyncRunner()
-        result = runner.run(outer, {"x": [1, 2, 3]})
+        # x is private through middle.innermost GraphNode chain
+        result = runner.run(outer, {"middle.innermost.x": [1, 2, 3]})
 
         assert result.status == RunStatus.COMPLETED
         assert result["doubled"] == [2, 4, 6]
@@ -609,7 +623,8 @@ class TestConcurrentNestedMaps:
         )
 
         runner = SyncRunner()
-        result = runner.run(outer, {"vals_a": [1, 2], "vals_b": [10, 20]})
+        # vals_a private to inner_a, vals_b private to inner_b → dot-paths
+        result = runner.run(outer, {"inner_a.vals_a": [1, 2], "inner_b.vals_b": [10, 20]})
 
         assert result.status == RunStatus.COMPLETED
         assert result["a"] == [2, 4]
@@ -792,10 +807,11 @@ class TestMaxConcurrency:
 
         # With max_concurrency=1 on outer, the two GraphNodes run sequentially
         # But their inner maps run concurrently (nested execution is independent)
+        # x private to inner_a, y private to inner_b → dot-paths
         start = time.time()
         result = await runner.run(
             outer,
-            {"x": [1, 2], "y": [10, 20]},
+            {"inner_a.x": [1, 2], "inner_b.y": [10, 20]},
             max_concurrency=1,
         )
         elapsed = time.time() - start
@@ -819,14 +835,16 @@ class TestMaxConcurrency:
         # Three levels of nesting
         level1 = Graph([async_double], name="level1")
         level2 = Graph([level1.as_node()], name="level2")
-        level3 = Graph([level2.as_node().map_over("x")])
+        # level2 exposes its inner private input as "level1.x"; map_over uses that name.
+        level3 = Graph([level2.as_node().map_over("level1.x")])
 
         runner = AsyncRunner()
 
         # Should work even with max_concurrency=1
+        # x is private through level2.level1 GraphNode chain at level3 scope
         result = await runner.run(
             level3,
-            {"x": [1, 2, 3]},
+            {"level2.level1.x": [1, 2, 3]},
             max_concurrency=1,
         )
 
@@ -849,8 +867,9 @@ class TestMaxConcurrency:
         runner = AsyncRunner()
 
         # Product of [1,2] x [10,20] = 4 combinations
+        # a, b are private to inner GraphNode → addressed via dot-path
         start = time.time()
-        result = await runner.run(outer, {"a": [1, 2], "b": [10, 20]})
+        result = await runner.run(outer, {"inner.a": [1, 2], "inner.b": [10, 20]})
         elapsed = time.time() - start
 
         assert result.status == RunStatus.COMPLETED
@@ -874,9 +893,10 @@ class TestMaxConcurrency:
         runner = AsyncRunner()
 
         with pytest.raises(ValueError, match="x cannot be 2"):
+            # x is private to inner GraphNode → addressed via dot-path
             await runner.run(
                 outer,
-                {"x": [1, 2, 3]},
+                {"inner.x": [1, 2, 3]},
                 max_concurrency=1,
             )
 
@@ -892,9 +912,10 @@ class TestMaxConcurrency:
 
         runner = AsyncRunner()
 
+        # x is private to inner GraphNode → addressed via dot-path
         result = await runner.run(
             outer,
-            {"x": []},
+            {"inner.x": []},
             max_concurrency=1,
         )
 
@@ -915,9 +936,10 @@ class TestMaxConcurrency:
 
         runner = AsyncRunner()
 
+        # x is private to inner GraphNode → addressed via dot-path
         result = await runner.run(
             outer,
-            {"x": [42]},
+            {"inner.x": [42]},
             max_concurrency=1,
         )
 
@@ -987,7 +1009,8 @@ class TestCloneExecution:
         runner = SyncRunner()
 
         config = {"key": "value"}
-        result = runner.run(outer, {"x": [1, 2, 3], "config": config})
+        # x and config are private to inner GraphNode → addressed via dot-path
+        result = runner.run(outer, {"inner.x": [1, 2, 3], "inner.config": config})
 
         assert result.status == RunStatus.COMPLETED
         # All iterations should see the same object
@@ -1006,7 +1029,8 @@ class TestCloneExecution:
         runner = SyncRunner()
 
         config = {"key": "value"}
-        result = runner.run(outer, {"x": [1, 2, 3], "config": config})
+        # x and config are private to inner GraphNode → addressed via dot-path
+        result = runner.run(outer, {"inner.x": [1, 2, 3], "inner.config": config})
 
         assert result.status == RunStatus.COMPLETED
         ids = result["item_id"]
@@ -1024,7 +1048,8 @@ class TestCloneExecution:
         outer = Graph([inner.as_node().map_over("x", clone=["config"])])
         runner = SyncRunner()
 
-        result = runner.run(outer, {"x": [1, 2, 3], "config": {"k": "v"}, "factor": 10})
+        # x, config, factor are private to inner GraphNode → addressed via dot-path
+        result = runner.run(outer, {"inner.x": [1, 2, 3], "inner.config": {"k": "v"}, "inner.factor": 10})
 
         assert result.status == RunStatus.COMPLETED
         # config should be cloned (different ids)
@@ -1048,7 +1073,8 @@ class TestCloneExecution:
         outer = Graph([inner.as_node().map_over("x", clone=True)])
         runner = SyncRunner()
 
-        result = runner.run(outer, {"x": [1, 2, 3], "config": {"count": 0}})
+        # x and config are private to inner GraphNode → addressed via dot-path
+        result = runner.run(outer, {"inner.x": [1, 2, 3], "inner.config": {"count": 0}})
 
         assert result.status == RunStatus.COMPLETED
         # With clone=True, each iteration gets a fresh copy with count=0
@@ -1070,7 +1096,8 @@ class TestCloneExecution:
         runner = SyncRunner()
 
         with pytest.raises(GraphConfigError, match="cannot be deep-copied for clone"):
-            runner.run(outer, {"x": [1, 2], "lock": threading.Lock()})
+            # x and lock are private to inner GraphNode → addressed via dot-path
+            runner.run(outer, {"inner.x": [1, 2], "inner.lock": threading.Lock()})
 
     async def test_clone_with_async_runner(self):
         """Clone works with AsyncRunner."""
@@ -1084,7 +1111,8 @@ class TestCloneExecution:
         outer = Graph([inner.as_node().map_over("x", clone=True)])
         runner = AsyncRunner()
 
-        result = await runner.run(outer, {"x": [1, 2, 3], "config": {"count": 0}})
+        # x and config are private to inner GraphNode → addressed via dot-path
+        result = await runner.run(outer, {"inner.x": [1, 2, 3], "inner.config": {"count": 0}})
 
         assert result.status == RunStatus.COMPLETED
         # Each iteration sees a fresh config with count=0
@@ -1102,7 +1130,8 @@ class TestCloneExecution:
         outer = Graph([inner.as_node().map_over("a", "b", mode="product", clone=True)])
         runner = SyncRunner()
 
-        result = runner.run(outer, {"a": [1, 2], "b": [10, 20], "state": {}})
+        # a, b, state are private to inner GraphNode → addressed via dot-path
+        result = runner.run(outer, {"inner.a": [1, 2], "inner.b": [10, 20], "inner.state": {}})
 
         assert result.status == RunStatus.COMPLETED
         # Product: (1,10), (1,20), (2,10), (2,20) → sums: 11, 21, 12, 22
@@ -1121,7 +1150,8 @@ class TestCloneExecution:
         outer = Graph([inner.as_node().map_over("x", clone=True)])
         runner = SyncRunner()
 
-        result = runner.run(outer, {"x": [1, 2, 3]})
+        # x is private to inner GraphNode → addressed via dot-path
+        result = runner.run(outer, {"inner.x": [1, 2, 3]})
 
         assert result.status == RunStatus.COMPLETED
         # Inner-bound config is resolved inside each inner run, not through clone
@@ -1144,7 +1174,8 @@ class TestCloneExecution:
         outer = Graph([mapped_node])
         runner = SyncRunner()
 
-        result = runner.run(outer, {"x": [1, 2, 3], "config": {"count": 0}})
+        # x and config (renamed from cfg) are private to inner GraphNode → dot-paths
+        result = runner.run(outer, {"inner.x": [1, 2, 3], "inner.config": {"count": 0}})
 
         assert result.status == RunStatus.COMPLETED
         # Each iteration sees fresh config
@@ -1162,8 +1193,10 @@ class TestCloneExecution:
 
         inner = Graph([use_lock], name="inner")
         # Outer bind — values DO pass through generate_map_inputs
-        outer = Graph([inner.as_node().map_over("x", clone=True)]).bind(lock=threading.Lock())
+        # lock is private to inner GraphNode → bind via dot-path key
+        outer = Graph([inner.as_node().map_over("x", clone=True)]).bind(**{"inner.lock": threading.Lock()})
         runner = SyncRunner()
 
         with pytest.raises(GraphConfigError, match="cannot be deep-copied for clone"):
-            runner.run(outer, {"x": [1, 2]})
+            # x is private to inner GraphNode → addressed via dot-path
+            runner.run(outer, {"inner.x": [1, 2]})

--- a/tests/test_runners/test_sync_runner.py
+++ b/tests/test_runners/test_sync_runner.py
@@ -424,11 +424,10 @@ class TestSyncRunnerRun:
         outer = Graph([middle.as_node()])
         runner = SyncRunner()
 
-        # x is private at innermost (consumed by GraphNode middle), and middle has a leaf
-        # increment that consumes x → x is declared at middle scope (via increment.x).
-        # Wait: increment.with_inputs(x="doubled") renames x to doubled, so increment
-        # consumes "doubled", not "x". The innermost GraphNode consumes "x" privately.
-        # At outer, middle is GraphNode and has private "x" → outer.x = "middle.innermost.x"
+        # `increment.with_inputs(x="doubled")` renames increment's parameter, so it
+        # consumes the output of `double` rather than an external "x". `double`
+        # (inside `innermost`) is the only consumer of external "x", so "x" is private
+        # to `innermost` within `middle`, and addressed from outer as "middle.innermost.x".
         result = runner.run(outer, {"middle.innermost.x": 5})
 
         assert result["incremented"] == 11  # (5*2) + 1

--- a/tests/test_runners/test_sync_runner.py
+++ b/tests/test_runners/test_sync_runner.py
@@ -397,7 +397,7 @@ class TestSyncRunnerRun:
         outer = Graph([inner.as_node()])
         runner = SyncRunner()
 
-        result = runner.run(outer, {"x": 5})
+        result = runner.run(outer, {"inner.x": 5})
 
         assert result["doubled"] == 10
 
@@ -412,7 +412,7 @@ class TestSyncRunnerRun:
         )
         runner = SyncRunner()
 
-        result = runner.run(outer, {"x": 5, "b": 3})
+        result = runner.run(outer, {"inner.x": 5, "b": 3})
 
         assert result["sum"] == 13
 
@@ -423,7 +423,12 @@ class TestSyncRunnerRun:
         outer = Graph([middle.as_node()])
         runner = SyncRunner()
 
-        result = runner.run(outer, {"x": 5})
+        # x is private at innermost (consumed by GraphNode middle), and middle has a leaf
+        # increment that consumes x → x is declared at middle scope (via increment.x).
+        # Wait: increment.with_inputs(x="doubled") renames x to doubled, so increment
+        # consumes "doubled", not "x". The innermost GraphNode consumes "x" privately.
+        # At outer, middle is GraphNode and has private "x" → outer.x = "middle.innermost.x"
+        result = runner.run(outer, {"middle.innermost.x": 5})
 
         assert result["incremented"] == 11  # (5*2) + 1
 

--- a/tests/test_runners/test_sync_runner.py
+++ b/tests/test_runners/test_sync_runner.py
@@ -295,7 +295,8 @@ class TestSyncRunnerRun:
         graph = Graph([add]).bind(a=5, b=10)
         runner = SyncRunner()
 
-        result = runner.run(graph, {"a": 100, "b": 200})
+        with pytest.warns(UserWarning, match="(?i)override"):
+            result = runner.run(graph, {"a": 100, "b": 200})
 
         assert result["sum"] == 300
 

--- a/tests/test_runners/test_value_resolution.py
+++ b/tests/test_runners/test_value_resolution.py
@@ -102,9 +102,10 @@ class TestNonCopyableBoundValues:
         # Use as node in outer graph
         outer_graph = Graph([inner_graph.as_node()], name="outer")
 
-        # Should NOT raise error about deep-copy failure
+        # Should NOT raise error about deep-copy failure.
+        # query is private to inner GraphNode → addressed via dot-path
         runner = SyncRunner()
-        result = runner.run(outer_graph, {"query": "test"})
+        result = runner.run(outer_graph, {"inner.query": "test"})
 
         assert result["result"] == "Used test"
 

--- a/tests/test_runners/test_value_resolution.py
+++ b/tests/test_runners/test_value_resolution.py
@@ -39,8 +39,9 @@ class TestValueSourceDetection:
         graph = Graph([process]).bind(x=99)
         runner = SyncRunner()
 
-        # Provided value should override both binding and default
-        result = runner.run(graph, {"x": 42})
+        # Provided value should override both binding and default (warning expected).
+        with pytest.warns(UserWarning, match="(?i)override"):
+            result = runner.run(graph, {"x": 42})
         assert result["result"] == 42
 
     def test_bound_value_source(self):

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -105,7 +105,8 @@ class TestSelectNested:
             return f"val={sum}"
 
         outer = Graph([inner.as_node(), fmt])
-        result = SyncRunner().run(outer, {"x": 5, "b": 3})
+        # x and b are private to inner GraphNode → addressed via dot-path
+        result = SyncRunner().run(outer, {"inner.x": 5, "inner.b": 3})
         assert result.values["formatted"] == "val=13"
 
     def test_nested_graph_hides_unselected_from_parent(self):


### PR DESCRIPTION
Closes #94.

## Problem / Bug / Challenge

Previously, inputs declared only inside nested `GraphNode` subgraphs would "auto-lift" to the outermost scope, silently surfacing at the parent level. This created a refactor hazard: two sibling subgraphs sharing an input name would collide, and renaming or rewiring inputs inside one subgraph could silently affect siblings.

This implements **lexical scope** semantics: an input name not declared at a graph's scope (no leaf node consumes/produces it, and no nested `GraphNode` exposes it as an output) is now **private** to its subgraph and addressed via dot-path (`"inner.x"`) or nested dict (`{"inner": {"x": ...}}`).

## Before / After

**Before:**
```python
@node(output_name="out")
def use_x(x: int) -> int:
    return x * 2

inner = Graph([use_x], name="inner")
outer = Graph([inner.as_node()], name="outer")

# x silently surfaced at outer scope
print(outer.inputs.required)  # ('x',)
runner.run(outer, {"x": 5})
```

**After:**
```python
@node(output_name="out")
def use_x(x: int) -> int:
    return x * 2

inner = Graph([use_x], name="inner")
outer = Graph([inner.as_node()], name="outer")

# x is private to inner — addressed via dot-path
print(outer.inputs.required)  # ('inner.x',)
runner.run(outer, {"inner.x": 5})  # or {"inner": {"x": 5}}
```

**Sibling isolation:**
```python
inner_a = Graph([use_a], name="A")
inner_b = Graph([use_b], name="B")
outer = Graph([inner_a.as_node(), inner_b.as_node()], name="outer")

# Two independent inputs, no collision
print(outer.inputs.required)  # ('A.x', 'B.x')
```

**Auto-linking when declared at parent scope:**
```python
@node(output_name="outer_out")
def consume_x_outer(x: int) -> int:
    return x + 1

inner = Graph([use_x], name="inner")
outer = Graph([inner.as_node(), consume_x_outer], name="outer")

# x is now declared at outer scope (leaf consumes it) → auto-links, no dot-path
print(outer.inputs.required)  # ('x',)
runner.run(outer, {"x": 5})  # single flat input feeds both
```

## Key Changes

1. **Input addressing:** `InputSpec` now uses dot-paths for private subgraph inputs. Both `inputs.required` and `inputs.bound` reflect the new addressing.

2. **Scope declaration:** A name is "declared" at a scope if any leaf node consumes/produces it, or if a `GraphNode` exposes it as an output. `GraphNode` inputs alone do not declare a name.

3. **Bind validation:** A `bind()` on a name shadowed by an ancestor-scope leaf is now a build-time `GraphConfigError` (prevents silent override).

4. **Override warnings:** Running with a value that overrides a bound value now emits a `UserWarning` (uniform for both flat and dot-pathed inputs).

5. **Runner input normalization:** Both dot-path (`{"A.x": v}`) and nested-dict (`{"A": {"x": v}}`) forms are supported and canonicalized internally.

6. **Visualization:** External input nodes in Mermaid/scene graphs now disambiguate colliding leaf names (e.g., `A.x` and `B.x` both map to `x` visually, but get unique synthetic IDs).

7. **Error messages:** `MissingInputError` now annotates dot-pathed inputs with their owning subgraph; bind-conflict errors name both the scope and the shadowing node.

## Test Plan

- New `tests/test_lexical_scope.py` (22+ tests) covers the full spec: sibling isolation, dot-path/nested-dict run parity, GraphNode-output auto-link, bind-conflict, override warning, `with_inputs` scope semantics, bare-name error, deep bind-conflict walk, dict-form bind, state-key alignment for fork-with-changed-input, defaults-on-private-inputs, ambiguity-checked addressing.
- 146 existing tests migrated to dot-paths in one mechanical sweep (`f956904`).
- 13 viz tests + 10 daft / framework-port tests + 2 example scripts also migrated.
- CI-equivalent gate (`uv run pytest -W error -W 'ignore::pytest.PytestUnraisableExceptionWarning'` with daft + playwright installed): **2558 pass / 0 skip / 0 fail**.
- Lint (`ruff check`) and format (`ruff format --check`) clean.
- Structural sweeps from `dev/REVIEW-CHECKLIST.md` (mirror, parity sync↔async, consumer, validation-runtime alignment) all clean.
- Docs added/updated: `changelog.md`, `06-api-reference/inputspec.md`, `06-api-reference/graph.md`, `03-patterns/04-hierarchical.md`. Two stale doc examples corrected inline.

## Notes

- **Breaking change.** Anywhere a flat name previously addressed a nested subgraph input via auto-lift, the new addressing is required. Migration is mechanical (`{"x": 5}` → `{"inner.x": 5}` or `{"inner": {"x": 5}}`); see the changelog.
- **No deprecation flag.** Per the issue's "Out of Scope" note, phase-1 warning and phase-2 default-flip ship together.
- **No fuzzy suggester.** Issue #90 (smart-suggester redirect) is out of scope; the new error messages name the expected dot-path explicitly but don't fuzzy-match.

https://claude.ai/code/session_01P2KujFRdPrq7zsSr8f3DVA

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Nested subgraph inputs now support lexical scoping—inputs private to nested graphs are addressable via dot-paths (e.g., `"inner.x"`), with support for both dot-path and nested-dict addressing formats.

* **Behavior Changes**
  * Runtime input values now emit a `UserWarning` when overriding previously bound values.
  * Build-time validation now detects bind conflicts where inner binds would be shadowed by ancestor declarations, raising `GraphConfigError`.

* **API Updates**
  * `Graph.bind()` now accepts optional positional dict plus kwargs for flexible nested input addressing.

* **Documentation**
  * Added new sections explaining private subgraph input scoping, dot-path addressing, and build-time validation behavior.
