### PR TITLE
[codex] add GraphNode boundary projection

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -78,10 +78,10 @@ _Avoid_: Start node, root node
 
 > **Dev:** "If `chat.messages` is both an input and output, does exposing `messages` only expose the input?"
 > **Domain expert:** "No. An **Exposed port** opens the matching child port into the parent flat flow; if the child has both input and output ports named `messages`, both are exposed."
-
+>
 > **Dev:** "Can I expose `response` as `research_answer` and then use `with_outputs(research_answer='answer')`?"
 > **Domain expert:** "No. `research_answer` is the parent-facing **Port address**, not a **Local port name**. Rename the local name first, or choose the final exposed name in `expose(...)`."
-
+>
 > **Dev:** "After `namespaced=True`, does `GraphNode.outputs` contain `response` or `researcher.response`?"
 > **Domain expert:** "`GraphNode.outputs` contains the resolved parent-facing **Port address**, so the value is `researcher.response`."
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,96 @@
+# Hypergraph
+
+Hypergraph is a workflow orchestration framework where users compose nodes and nested graphs through named values.
+
+## Language
+
+**Port**:
+A named input or output on a node or graph boundary.
+_Avoid_: Argument, field
+
+**Local port name**:
+The local port name before any graph-node namespace prefix is applied.
+_Avoid_: Suffix, internal name
+
+**Port address**:
+A parent-facing port name, optionally qualified by graph-node path segments such as `retrieval.query`.
+_Avoid_: Port name
+
+**Flat port**:
+A port that participates directly in its parent graph's shared name flow.
+_Avoid_: Public port, global port
+
+**Namespaced port**:
+A port addressed through its child node name, such as `retrieval.query`.
+_Avoid_: Private port, hidden port
+
+**Exposed port**:
+A child port whose parent-facing address is intentionally renamed into the parent graph's flat name flow.
+_Avoid_: Unscoped port, leaked port
+
+**Selected output**:
+An output included in a graph's configured output surface.
+_Avoid_: Exposed output
+
+**Graph-node surface**:
+The ports a graph presents after graph-level scoping such as selected outputs and entrypoints are applied.
+_Avoid_: Graph internals, raw graph ports
+
+**Shared parameter**:
+A value intentionally held in one graph's state across cyclic execution rather than carried by ordinary data edges.
+_Avoid_: Shared input, shared output
+
+**Entrypoint**:
+A node where execution is configured to start, excluding upstream nodes from the active graph.
+_Avoid_: Start node, root node
+
+## Relationships
+
+- A **Port** is either a **Flat port** or a **Namespaced port** from the parent graph's point of view.
+- Renaming changes a **Local port name** and is agnostic to boundary addressing.
+- A **Port address** may contain `.` only as a namespace separator inserted by Hypergraph, not inside a user-authored port name.
+- Boundary addressing is resolved before graph semantics: flat mode, namespaced mode, and expose only define parent-facing **Port addresses**.
+- `GraphNode.inputs` and `GraphNode.outputs` are resolved parent-facing **Port addresses** after boundary projection, not raw child **Local port names**.
+- The same **Port address** may appear in both `GraphNode.inputs` and `GraphNode.outputs`; cyclic values such as `messages` need both an input seed and a produced output.
+- A **Selected output** controls which outputs a graph makes available to callers or parent graphs before graph-node boundary transforms are applied.
+- `with_inputs(...)` and `with_outputs(...)` rename **Local port names** only; they do not connect values and do not rename exposed parent-facing addresses.
+- An **Exposed port** replaces the child port's namespaced parent-facing address for both inputs and outputs; callers use the exposed flat name, not both names.
+- An `expose(...)` alias is the final flat parent-facing **Port address** at that graph-node boundary, not a renamed **Local port name** that is later namespaced.
+- An **Exposed port** defines the final parent-facing flat address for that port; rename the **Local port name** before exposing it, or expose directly with an alias.
+- An **Exposed port** is local to the graph-node boundary where it is declared; ancestors may namespace that flat surface again.
+- Exposing a name applies to matching input and output ports on the current **Graph-node surface**; graph validation decides whether the resulting flat graph semantics are valid.
+- `expose(...)` targets **Local port names** on the current **Graph-node surface**, not already-projected **Port addresses**.
+- Direction-specific expose operations are out of scope for the MVP; when a **Local port name** exists as both input and output, exposing it exposes both directions.
+- Exposing a name is valid when at least one matching input or output port exists on the current **Graph-node surface**.
+- Multiple GraphNodes may expose input ports to the same flat address and share one parent input; duplicate aliases inside one GraphNode are rejected. Multiple exposed outputs with the same flat address follow the ordinary duplicate-output conflict rules.
+- An **Exposed port** may only target ports that exist on the current **Graph-node surface** after graph-level scoping such as selected outputs and entrypoints.
+- Only **Namespaced ports** can become **Exposed ports**; exposing an already **Flat port** is an error.
+- After boundary addressing is resolved, an **Exposed port** is an ordinary **Flat port** for graph semantics such as auto-wiring, default consistency, type validation, and duplicate-output conflict checks.
+- Visualization must render the same **Port addresses** that graph construction and execution use, including renames, selected outputs, exposed ports, and whether a shared input belongs at the parent or child boundary.
+- For the MVP, expose is a graph-node boundary operation, not a graph-level operation.
+- For the MVP, namespacing is a graph-node boundary operation declared when a graph is used as a node, not an intrinsic graph property.
+- A namespaced graph-node namespaces both inputs and outputs; expose is the only MVP mechanism for returning selected names to the parent flat flow.
+- A graph-node always has a resolved name from either the wrapped graph or the `as_node(name=...)` call; namespacing is orthogonal and uses that resolved graph-node name as the namespace prefix.
+- A **Shared parameter** is scoped to the graph that declares it; it does not automatically become shared in parent or child graphs.
+- An **Entrypoint** can turn an upstream output into a required input at the graph boundary.
+
+## Example Dialogue
+
+> **Dev:** "If `chat.messages` is both an input and output, does exposing `messages` only expose the input?"
+> **Domain expert:** "No. An **Exposed port** opens the matching child port into the parent flat flow; if the child has both input and output ports named `messages`, both are exposed."
+
+> **Dev:** "Can I expose `response` as `research_answer` and then use `with_outputs(research_answer='answer')`?"
+> **Domain expert:** "No. `research_answer` is the parent-facing **Port address**, not a **Local port name**. Rename the local name first, or choose the final exposed name in `expose(...)`."
+
+> **Dev:** "After `namespaced=True`, does `GraphNode.outputs` contain `response` or `researcher.response`?"
+> **Domain expert:** "`GraphNode.outputs` contains the resolved parent-facing **Port address**, so the value is `researcher.response`."
+
+## Flagged Ambiguities
+
+- "private" was used for namespaced ports, but **Namespaced port** is the canonical term because the port remains addressable.
+- "shared input" and "shared output" were used for cyclic state, but **Shared parameter** is the canonical term because the value is stateful rather than an ordinary one-way port.
+- "expose" was considered as adding an extra alias, but **Exposed port** is now resolved as a parent-facing rename: the exposed flat name replaces the namespaced address at that boundary.
+- Existing docs sometimes say `select()` controls which outputs are "exposed" when nested; use **Selected output** for that concept to avoid confusing it with `.expose(...)`.
+- `with_inputs(...)` and `with_outputs(...)` were sometimes used as wiring language, but they are canonical **Local port name** renames only.
+- `link_inputs` was considered for shared input fan-out, but the MVP keeps **Exposed port** as the single boundary-flattening concept; `link_inputs` may be added later as direct-child input-only sugar.
+- Direction-specific expose was considered, but the MVP keeps **Exposed port** name-based across matching input and output directions.

--- a/docs/03-patterns/03-agentic-loops.md
+++ b/docs/03-patterns/03-agentic-loops.md
@@ -261,12 +261,13 @@ def should_continue(messages: list) -> str:
 - `emit="turn_done"` declares an ordering-only output. A sentinel value is auto-produced when `accumulate` runs — your function doesn't return it.
 - `wait_for="turn_done"` declares an ordering-only input. `should_continue` won't run until `turn_done` exists and is fresh (produced since `should_continue` last ran).
 - `emit` names appear in `node.outputs` but not in `node.data_outputs`. They're filtered from the final result.
+- In a parent graph, `wait_for` references the resolved port address. For a namespaced GraphNode emit, that can be a generated address such as `retrieval.done`; user-authored `emit` names themselves remain local names and cannot contain `.` or `/`.
 
 **When to use emit/wait_for vs data edges**:
 - If node B needs node A's output value → use a data edge (parameter matching)
 - If node B just needs to run after node A → use `emit`/`wait_for`
 
-**Validation**: emit names must not overlap with `output_name`, and wait_for names must not overlap with function parameters. Referencing a nonexistent emit/output in `wait_for` raises `GraphConfigError` at build time.
+**Validation**: emit names must not overlap with `output_name`, and wait_for names must not overlap with function parameters. Referencing a nonexistent emit/output address in `wait_for` raises `GraphConfigError` at build time.
 
 ## Entry Points
 

--- a/docs/03-patterns/04-hierarchical.md
+++ b/docs/03-patterns/04-hierarchical.md
@@ -151,13 +151,12 @@ evaluation = Graph([
 ], name="evaluation")
 
 # Run evaluation: the cyclic conversation runs inside the DAG.
-# `query` is consumed only inside the nested `conversation` graph, so at the
-# evaluation scope it is private to that GraphNode — address it via the
-# dot-path. `history` is declared by `score_responses` here, so it stays flat.
+# Flat GraphNodes keep inputs in the parent flow, so both `query` and
+# `history` are parent-facing values here.
 runner = AsyncRunner()
 report = await runner.run(evaluation, {
     "dataset_path": "test_conversations.json",
-    "conversation.query": "initial query",  # First query for each test case
+    "query": "initial query",  # First query for each test case
     "history": [],
 })
 ```
@@ -352,11 +351,11 @@ graph_node = my_graph.as_node().map_over("items")
 
 ---
 
-## Addressing private subgraph inputs
+## GraphNode boundary addresses
 
-Each subgraph is its own scope. An input that's only declared inside a nested `GraphNode` — not consumed or produced by any leaf at the parent scope, and not exposed as a `GraphNode` output there — stays **private** to that subgraph. The parent addresses it under the `GraphNode`'s name.
+By default, `Graph.as_node()` keeps the wrapped graph's ports flat in the parent graph. This makes common values such as `query`, `messages`, and `config` easy to share across parent and child graphs.
 
-This keeps composed graphs **refactor-safe**: renaming or rewiring inputs inside one subgraph never silently affects a sibling.
+Use `as_node(namespaced=True)` when a subgraph needs its own independent namespace, then use `.expose(...)` to intentionally bring selected ports back into the parent flat flow.
 
 ### The mental model
 
@@ -370,15 +369,18 @@ def double(x: int) -> int:
 inner = Graph([double], name="inner")
 outer = Graph([inner.as_node()], name="outer")
 
-# 'x' is only declared inside `inner` — at the outer scope it's private
-print(outer.inputs.required)  # ('inner.x',)
+# Default: the GraphNode is flat at the parent boundary.
+print(outer.inputs.required)  # ('x',)
+
+namespaced = Graph([inner.as_node(namespaced=True)], name="outer")
+print(namespaced.inputs.required)  # ('inner.x',)
 ```
 
-If a leaf at the outer scope also declares `x` (consumes or produces it), the inner `x` auto-links to it and the dot-path goes away. Lexical scope is doing exactly what local variable scoping does in Python.
+If a leaf at the outer scope also declares `x` (consumes or produces it), a flat GraphNode's `x` auto-links to the same parent value.
 
 ### Sibling isolation
 
-Two sibling subgraphs that share an input name remain independent:
+Two sibling flat subgraphs that share an input name intentionally share one parent value. Opt into namespacing when they should be independent:
 
 ```python
 @node(output_name="out_a")
@@ -391,8 +393,11 @@ def use_b(x: int) -> int:
 
 inner_a = Graph([use_a], name="A")
 inner_b = Graph([use_b], name="B")
-outer = Graph([inner_a.as_node(), inner_b.as_node()], name="outer")
+flat = Graph([inner_a.as_node(), inner_b.as_node()], name="outer")
 
+print(flat.inputs.required)  # ('x',)
+
+outer = Graph([inner_a.as_node(namespaced=True), inner_b.as_node(namespaced=True)], name="outer")
 print(outer.inputs.required)  # ('A.x', 'B.x')
 
 # A bind on A's input does NOT leak into B
@@ -401,9 +406,9 @@ print(configured.inputs.required)  # ('B.x',)
 print(configured.inputs.bound)     # {'A.x': 1}
 ```
 
-### Four equivalent addressing forms
+### Equivalent namespaced addressing forms
 
-For an input `x` private to a `GraphNode` named `inner`, all four forms below are equivalent:
+For an input `x` on a namespaced `GraphNode` named `inner`, all four forms below are equivalent:
 
 ```python
 @node(output_name="result")
@@ -411,16 +416,16 @@ def double(x: int) -> int:
     return x * 2
 
 inner = Graph([double], name="inner")
-outer = Graph([inner.as_node()], name="outer")
+outer = Graph([inner.as_node(namespaced=True)], name="outer")
 runner = SyncRunner()
 
-# 1. Run-time dot-path
+# 1. Run-time resolved address
 runner.run(outer, {"inner.x": 5})
 
 # 2. Run-time nested-dict
 runner.run(outer, {"inner": {"x": 5}})
 
-# 3. Build-time dot-path
+# 3. Build-time resolved address
 configured = outer.bind({"inner.x": 5})
 runner.run(configured, {})
 
@@ -429,31 +434,23 @@ configured = outer.bind(inner={"x": 5})
 runner.run(configured, {})
 ```
 
-Binding directly on the inner graph (`Graph([inner.bind(x=5).as_node()], name="outer")`) before composing is also valid and produces the same `outer.inputs.bound == {"inner.x": 5}`.
+Binding directly on the inner graph (`Graph([inner.bind(x=5).as_node(namespaced=True)], name="outer")`) before composing is also valid and produces the same `outer.inputs.bound == {"inner.x": 5}`.
 
-Use the dot-path form for single-key addressing; reach for the nested-dict form when you're grouping several private inputs of the same `GraphNode`.
+Use the resolved-address form for single-key addressing; reach for the nested-dict form when you're grouping several inputs of the same namespaced `GraphNode`.
 
-### Bind-conflict is caught at build time
+### Exposing selected ports
 
-If you bind an input on an inner subgraph whose leaf name is also declared at any ancestor scope, graph construction raises `GraphConfigError` immediately:
+`expose(...)` replaces the namespaced address at that boundary with a flat parent-facing address. It targets local port names before projection:
 
 ```python
-@node(output_name="result")
-def inner_func(x: int) -> int:
-    return x * 2
+retrieval = retrieval_graph.as_node(namespaced=True).expose("query")
+generation = generation_graph.as_node(namespaced=True).expose("query")
+outer = Graph([retrieval, generation])
 
-@node(output_name="final")
-def outer_func(result: int, x: int) -> int:  # outer also consumes 'x'
-    return result + x
-
-inner = Graph([inner_func], name="inner").bind(x=5)
-Graph([inner.as_node(), outer_func], name="outer")
-# GraphConfigError: Bind on 'inner.x' is shadowed at scope 'outer' by node
-# 'outer_func' (consumes 'x'). At run time the parent's value would silently
-# override the bind. ...
+print(outer.inputs.required)  # ('query',)
 ```
 
-The error names both the bind's full dot-path and the shadowing leaf so you can navigate straight to the source. Fix it by removing the inner bind, or by renaming the inner input via `with_inputs(...)` so it no longer collides.
+When a local name exists as both input and output, exposing it exposes both directions. That is useful for cyclic values such as `messages`, which need an initial input and also produce the next value. Duplicate aliases inside one GraphNode are rejected; different GraphNodes may still expose inputs to the same parent address.
 
 ## When to Use Hierarchical Composition
 

--- a/docs/03-patterns/05-multi-agent.md
+++ b/docs/03-patterns/05-multi-agent.md
@@ -146,11 +146,10 @@ research_team = Graph([
     review_gate,
 ], name="research_team")
 
-# Run the team
-# `topic` is consumed only inside `researcher`, so at the outer scope it is
-# private to that GraphNode — address it via the dot-path.
+# Run the team. Flat GraphNodes keep common inputs in the parent flow, so the
+# researcher's `topic` is addressed as `topic`.
 runner = SyncRunner()
-result = runner.run(research_team, {"researcher.topic": "Quantum Computing in 2024"})
+result = runner.run(research_team, {"topic": "Quantum Computing in 2024"})
 print(result["report"])
 ```
 
@@ -253,8 +252,7 @@ def test_writer():
 
 def test_team():
     runner = SyncRunner()
-    # `topic` is private to the inner `researcher` GraphNode at this scope.
-    result = runner.run(research_team, {"researcher.topic": "test topic"})
+    result = runner.run(research_team, {"topic": "test topic"})
 
     assert result["review_score"] >= 0.7
 ```

--- a/docs/03-patterns/07-human-in-the-loop.md
+++ b/docs/03-patterns/07-human-in-the-loop.md
@@ -412,10 +412,10 @@ result = await runner.run(outer, {"query": "hello"})
 
 assert result.paused
 assert result.pause.node_name == "inner/approval"
-assert result.pause.response_key == "inner.y"
+assert result.pause.response_key == "y"
 ```
 
-The `response_key` uses dot-separated paths for nested interrupts: `"inner.y"` means the output `y` inside the graph node `inner`.
+The `response_key` uses the parent-facing GraphNode boundary address. For the default flat boundary, that can stay as `"y"`; for `inner.as_node(namespaced=True)`, it would be `"inner.y"`.
 
 Think of `response_key` as a **resume slot identifier**. It is precise and stable, but it is primarily a runtime-facing detail. In user-facing applications, you will often wrap it behind your own inbox, form, or webhook layer.
 
@@ -510,8 +510,8 @@ def approval(draft: str) -> str | None:
 | `output_name` | `str \| tuple[str, ...]` | Name(s) for output value(s) — **required** |
 | `rename_inputs` | `dict[str, str] \| None` | Mapping to rename inputs {old: new} |
 | `cache` | `bool` | Enable result caching (default: `False`) |
-| `emit` | `str \| tuple[str, ...] \| None` | Ordering-only output name(s) |
-| `wait_for` | `str \| tuple[str, ...] \| None` | Ordering-only input name(s) |
+| `emit` | `str \| tuple[str, ...] \| None` | Ordering-only local output name(s) |
+| `wait_for` | `str \| tuple[str, ...] \| None` | Ordering-only graph-scope output/emit address(es) |
 | `hide` | `bool` | Whether to hide from visualization |
 
 ### InterruptNode Constructor
@@ -538,7 +538,7 @@ InterruptNode(my_func, name="review", output_name="decision",
 | `is_interrupt` | `bool` | Always `True` |
 | `cache` | `bool` | Whether caching is enabled (default: `False`) |
 | `hide` | `bool` | Whether hidden from visualization |
-| `wait_for` | `tuple[str, ...]` | Ordering-only inputs |
+| `wait_for` | `tuple[str, ...]` | Ordering-only graph-scope output/emit addresses |
 | `is_async` | `bool` | True if handler is async |
 | `is_generator` | `bool` | True if handler yields |
 | `definition_hash` | `str` | SHA256 hash of function source |
@@ -567,5 +567,5 @@ class PauseInfo:
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `response_key` | `str` | Key to use when resuming (first output). Top-level: `output_param`. Nested: dot-separated path (e.g., `"inner.decision"`) |
+| `response_key` | `str` | Key to use when resuming (first output). Uses the resolved graph-scope address after GraphNode projection. |
 | `response_keys` | `dict[str, str]` | Map of all output names to resume keys (for multi-output interrupts) |

--- a/docs/06-api-reference/gates.md
+++ b/docs/06-api-reference/gates.md
@@ -41,8 +41,8 @@ def ifelse(
 | `default_open` | `bool` | `True` | If True, targets may execute before the gate runs. If False, targets are blocked until the gate executes. |
 | `name` | `str \| None` | `None` | Node name (default: function name) |
 | `rename_inputs` | `dict \| None` | `None` | Mapping to rename inputs `{old: new}` |
-| `emit` | `str \| tuple \| None` | `None` | Ordering-only output(s). Auto-produced when the gate runs |
-| `wait_for` | `str \| tuple \| None` | `None` | Ordering-only input(s). Gate waits until these values are fresh |
+| `emit` | `str \| tuple \| None` | `None` | Ordering-only local output(s). Auto-produced when the gate runs |
+| `wait_for` | `str \| tuple \| None` | `None` | Ordering-only graph-scope output/emit address(es). Gate waits until these values are fresh |
 
 ### Return Value
 
@@ -224,8 +224,8 @@ def route(
 | `default_open` | `bool` | `True` | If True, targets may execute before the gate runs. If False, targets are blocked until the gate executes. |
 | `name` | `str \| None` | `None` | Node name (default: function name) |
 | `rename_inputs` | `dict \| None` | `None` | Mapping to rename inputs `{old: new}` |
-| `emit` | `str \| tuple \| None` | `None` | Ordering-only output(s). Auto-produced when the gate runs |
-| `wait_for` | `str \| tuple \| None` | `None` | Ordering-only input(s). Gate waits until these values are fresh |
+| `emit` | `str \| tuple \| None` | `None` | Ordering-only local output(s). Auto-produced when the gate runs |
+| `wait_for` | `str \| tuple \| None` | `None` | Ordering-only graph-scope output/emit address(es). Gate waits until these values are fresh |
 
 ### Return Value
 

--- a/docs/06-api-reference/graph.md
+++ b/docs/06-api-reference/graph.md
@@ -308,18 +308,18 @@ print(g.inputs.required)  # ('x',)
 ```
 
 **Args:**
-- `values` (dict, positional-only): Optional mapping of input names to values. Supports dot-paths for nested subgraph inputs.
-- `**kwargs`: Named values to bind. Keys must be graph inputs in the current scope. A nested-dict value addresses a nested `GraphNode`'s private inputs.
+- `values` (dict, positional-only): Optional mapping of graph input names to values. Keys use the resolved parent-facing port addresses shown by `graph.inputs.all`.
+- `**kwargs`: Named values to bind. Keys must be graph inputs in the current scope. Nested-dict values are accepted for currently namespaced `GraphNode` inputs.
 
 **Returns:** New Graph with bindings applied
 
 **Raises:**
 - `ValueError` - If binding a name not recognized as a graph input in the current scope, or if the same key is provided in both the positional dict and as a kwarg.
-- `GraphConfigError` - At graph-construction time, if an inner subgraph's bind is shadowed by a leaf declared at an ancestor scope (see below).
+- `GraphConfigError` - If graph construction detects an invalid binding for the configured graph scope.
 
-#### Addressing nested subgraph inputs
+#### Addressing GraphNode inputs
 
-A nested `GraphNode`'s private inputs (inputs not declared at the parent scope) are addressed under the `GraphNode`'s name. `bind()` accepts three equivalent forms:
+By default, `Graph.as_node()` is flat: the wrapped graph's input names appear directly in the parent graph. Use `as_node(namespaced=True)` when sibling subgraphs need separate inputs with the same local name.
 
 ```python
 @node(output_name="result")
@@ -329,23 +329,32 @@ def inner_func(x: int) -> int:
 inner = Graph([inner_func], name="inner")
 outer = Graph([inner.as_node()], name="outer")
 
-# 1. Positional dict, dot-path
+print(outer.inputs.required)  # ('x',)
+outer.bind(x=5)
+```
+
+With a namespaced GraphNode, the parent-facing address is prefixed by the resolved GraphNode name. `bind()` accepts the resolved address, an equivalent nested dict, or a bind on the inner graph before composition:
+
+```python
+outer = Graph([inner.as_node(namespaced=True)], name="outer")
+
+# 1. Positional dict, resolved address
 outer.bind({"inner.x": 5})
 
 # 2. Kwarg, nested-dict
 outer.bind(inner={"x": 5})
 
 # 3. Bind on the inner graph before composing
-Graph([inner.bind(x=5).as_node()], name="outer")
+Graph([inner.bind(x=5).as_node(namespaced=True)], name="outer")
 ```
 
 All three produce the same `outer.inputs.bound == {"inner.x": 5}`.
 
-For multi-level nesting, dot-paths chain (`"middle.inner.x"`) and nested-dicts nest (`{"middle": {"inner": {"x": 5}}}`).
+For multi-level namespaced nesting, addresses chain (`"middle.inner.x"`) and nested-dicts nest (`{"middle": {"inner": {"x": 5}}}`).
 
-#### Bind-conflict validation
+#### Shared flat inputs
 
-If you bind an inner subgraph input whose leaf name is also declared at any ancestor scope, graph construction raises `GraphConfigError`. At run time, the parent scope's value would silently override the bind, so the conflict is reported up front:
+Flat GraphNodes participate in the same parent flow as any other node. If a parent node and a nested GraphNode both consume `x`, one `x` value feeds both. This is often what you want for common parameters such as `query`.
 
 ```python
 @node(output_name="result")
@@ -357,12 +366,13 @@ def outer_func(result: int, x: int) -> int:  # outer also consumes 'x'
     return result + x
 
 inner = Graph([inner_func], name="inner").bind(x=5)
-Graph([inner.as_node(), outer_func], name="outer")
-# GraphConfigError: Bind on 'inner.x' is shadowed at scope 'outer' by node
-# 'outer_func' (consumes 'x'). At run time the parent's value would silently
-# override the bind. Fix: either remove the bind on the inner subgraph, or
-# rename the input via with_inputs(...) so it no longer matches the ancestor.
+outer = Graph([inner.as_node(), outer_func], name="outer")
+
+print(outer.inputs.bound)     # {'x': 5}
+print(outer.inputs.required)  # ()
 ```
+
+Use `as_node(namespaced=True)` when sibling GraphNodes need independent values for the same local input name. Use `.expose("x")` on a namespaced GraphNode to intentionally join a specific local port back into the parent flat flow.
 
 #### Shared State and Non-Copyable Objects
 
@@ -445,7 +455,7 @@ print(partial.inputs.bound)  # {'y': 10}
 
 Set a default output selection. Returns a new Graph (immutable pattern).
 
-This controls which outputs are returned by `runner.run()` and which outputs are exposed when the graph is used as a nested node via `as_node()`.
+This controls which outputs are returned by `runner.run()` and which outputs are visible when the graph is used as a nested node via `as_node()`.
 
 `select` also narrows `graph.inputs` to only the parameters needed to produce the selected outputs. Nodes that don't contribute to those outputs are excluded from input computation.
 
@@ -497,7 +507,7 @@ When a graph with `select` is used as a nested node, only the selected outputs a
 ```python
 inner = Graph([embed, retrieve, generate], name="rag").select("answer")
 gn = inner.as_node()
-print(gn.outputs)  # ('answer',) — only "answer" is exposed
+print(gn.outputs)  # ('answer',) — only "answer" is visible
 
 # Parent graph can only use "answer" from the nested graph
 outer = Graph([gn, postprocess])  # postprocess must consume "answer", not "docs"
@@ -597,7 +607,7 @@ result = runner.run(g2, {"embedding": [0.1, 0.2], "query": "hello"})
 # Only retrieve and generate execute
 ```
 
-### `as_node(*, name=None) -> GraphNode`
+### `as_node(*, name=None, namespaced=False) -> GraphNode`
 
 Wrap graph as a node for composition. Returns a new GraphNode.
 
@@ -611,6 +621,7 @@ outer = Graph([gn, add_one])
 
 **Args:**
 - `name` (str | None): Node name. If not provided, uses `graph.name`.
+- `namespaced` (bool): When `False` (default), the GraphNode's inputs and outputs stay flat in the parent graph. When `True`, inputs and outputs are projected under the resolved GraphNode name, e.g. `retrieval.query` and `retrieval.docs`.
 
 **Returns:** GraphNode wrapping this graph
 

--- a/docs/06-api-reference/inputspec.md
+++ b/docs/06-api-reference/inputspec.md
@@ -158,11 +158,11 @@ print(g.inputs.required)    # ('state', 'input')
 print(g.inputs.entrypoints) # {}
 ```
 
-### Nested Subgraph Inputs
+### GraphNode Boundary Inputs
 
-When a graph contains nested `GraphNode`s, each subgraph is its own scope. An input name not declared at a graph's scope — meaning no leaf node consumes or produces it, and no nested `GraphNode` exposes it as an output — is **private** to its subgraph and surfaces in the outer `InputSpec` under a dot-path: `"<graphnode_name>.<input>"`.
+`InputSpec` reports the resolved parent-facing port addresses for nested `GraphNode`s.
 
-This applies to both `inputs.required` and `inputs.bound`.
+By default, `Graph.as_node()` is flat: a wrapped graph input appears in the parent graph under the same name. Use `as_node(namespaced=True)` when a nested graph needs its own namespace.
 
 ```python
 from hypergraph import Graph, node
@@ -174,10 +174,13 @@ def inner_func(x: int) -> int:
 inner = Graph([inner_func], name="inner")
 outer = Graph([inner.as_node()], name="outer")
 
-print(outer.inputs.required)  # ('inner.x',)
+print(outer.inputs.required)  # ('x',)
+
+namespaced = Graph([inner.as_node(namespaced=True)], name="outer")
+print(namespaced.inputs.required)  # ('inner.x',)
 ```
 
-Sibling subgraphs that share an input name stay independent — there is no merge:
+Sibling flat subgraphs that share an input name intentionally share one parent input:
 
 ```python
 @node(output_name="out_a")
@@ -192,10 +195,18 @@ inner_a = Graph([use_a], name="A")
 inner_b = Graph([use_b], name="B")
 outer = Graph([inner_a.as_node(), inner_b.as_node()], name="outer")
 
+print(outer.inputs.required)  # ('x',)
+```
+
+Use `namespaced=True` when those sibling inputs should be independent:
+
+```python
+outer = Graph([inner_a.as_node(namespaced=True), inner_b.as_node(namespaced=True)], name="outer")
+
 print(outer.inputs.required)  # ('A.x', 'B.x')
 ```
 
-Adding a leaf node at the outer scope that declares the same name links the two together — the inner `GraphNode`'s input auto-wires to the outer-scope name, and the dot-path goes away:
+Adding a leaf node at the outer scope that declares the same name links flat GraphNode inputs to the same parent name:
 
 ```python
 @node(output_name="result")
@@ -212,17 +223,20 @@ outer = Graph([inner.as_node(), outer_func], name="outer")
 print(outer.inputs.required)  # ('x',) — outer 'x' feeds both leaves
 ```
 
-A bound value on an inner subgraph surfaces under the same dot-path:
+A bound value on an inner subgraph surfaces under the boundary's resolved parent-facing address:
 
 ```python
 inner = Graph([inner_func], name="inner").bind(x=5)
 outer = Graph([inner.as_node()], name="outer")
 
-print(outer.inputs.bound)     # {'inner.x': 5}
+print(outer.inputs.bound)     # {'x': 5}
 print(outer.inputs.required)  # ()
+
+namespaced = Graph([inner.as_node(namespaced=True)], name="outer")
+print(namespaced.inputs.bound)  # {'inner.x': 5}
 ```
 
-If a `bind` on an inner subgraph would be shadowed by a leaf at any ancestor scope, graph construction fails with `GraphConfigError` at build time. See [Graph.bind](graph.md) for the addressing forms accepted by `bind()`.
+For namespaced GraphNodes, `.expose("x")` replaces `inner.x` with the flat parent-facing address `x`. This is how a graph can keep most ports namespaced while intentionally sharing common parameters such as `query`.
 
 ### Scope Narrowing (Entrypoint and Select)
 

--- a/docs/06-api-reference/nodes.md
+++ b/docs/06-api-reference/nodes.md
@@ -171,8 +171,8 @@ def __init__(
 - `rename_inputs`: Optional dict `{old_param: new_param}` for input renaming
 - `cache`: Whether to cache results (default: False)
 - `hide`: Whether to hide this node from visualization (default: False)
-- `emit`: Ordering-only output name(s). Auto-produced when the node runs
-- `wait_for`: Ordering-only input name(s). Node waits until these values exist and are fresh
+- `emit`: Ordering-only local output name(s). Auto-produced when the node runs
+- `wait_for`: Ordering-only graph-scope output/emit address(es). Node waits until these values exist and are fresh
 
 **Returns:** FunctionNode instance
 
@@ -303,7 +303,7 @@ print(producer.data_outputs)  # ("result",)
 
 ### `wait_for: tuple[str, ...]`
 
-Ordering-only inputs. Empty tuple when not set.
+Ordering-only graph-scope output/emit addresses. Empty tuple when not set.
 
 ```python
 @node(output_name="result", wait_for="signal")
@@ -480,8 +480,8 @@ def node(
 - `rename_inputs`: Optional dict to rename inputs
 - `cache`: Enable result caching for this node. Requires a cache backend on the runner. See [Caching](../03-patterns/08-caching.md). Not allowed on GraphNode
 - `hide`: Whether to hide this node from visualization (default: False)
-- `emit`: Ordering-only output name(s). Auto-produced when the node runs. Used with `wait_for` to enforce execution order without data dependency. See [Ordering](../03-patterns/03-agentic-loops.md#ordering-with-emitwait_for)
-- `wait_for`: Ordering-only input name(s). Node won't run until these values exist and are fresh. Must reference an `emit` or `output_name` of another node
+- `emit`: Ordering-only local output name(s). Auto-produced when the node runs. Used with `wait_for` to enforce execution order without data dependency. See [Ordering](../03-patterns/03-agentic-loops.md#ordering-with-emitwait_for)
+- `wait_for`: Ordering-only graph-scope output/emit address(es). Node won't run until these values exist and are fresh. Must reference an `emit` or `output_name` of another node at the current graph scope
 
 **Returns:**
 - FunctionNode if source provided (decorator without parens)
@@ -730,6 +730,25 @@ print(gn.inputs)   # ('x',)
 print(gn.outputs)  # ('doubled',)
 ```
 
+By default the GraphNode surface is flat in the parent graph. Use
+`as_node(namespaced=True)` when the parent-facing ports should be prefixed by
+the resolved GraphNode name:
+
+```python
+gn = inner.as_node(namespaced=True)
+print(gn.inputs)   # ('doubler.x',)
+print(gn.outputs)  # ('doubler.doubled',)
+```
+
+On a namespaced GraphNode, `.expose(...)` replaces selected namespaced ports
+with flat parent-facing addresses:
+
+```python
+gn = inner.as_node(namespaced=True).expose("x", doubled="result")
+print(gn.inputs)   # ('x',)
+print(gn.outputs)  # ('result',)
+```
+
 ### Overriding the Name
 
 You can override the name when calling `as_node()`:
@@ -749,7 +768,7 @@ The node name. Either from `graph.name` or explicitly provided to `as_node()`.
 
 #### `inputs: tuple[str, ...]`
 
-All inputs of the wrapped graph (required + optional + entry point params).
+Resolved parent-facing input addresses after boundary projection.
 
 ```python
 gn = inner.as_node()
@@ -758,7 +777,7 @@ print(gn.inputs)  # ('x',)
 
 #### `outputs: tuple[str, ...]`
 
-All outputs of the wrapped graph.
+Resolved parent-facing output addresses after boundary projection.
 
 ```python
 gn = inner.as_node()
@@ -790,11 +809,12 @@ print(gn.is_async)  # True
 
 #### `definition_hash: str`
 
-Delegates to the wrapped graph's `definition_hash`.
+Includes the wrapped graph and the GraphNode boundary surface, including
+`namespaced`, local renames, exposed ports, and map settings.
 
 ```python
 gn = inner.as_node()
-print(gn.definition_hash == inner.definition_hash)  # True
+print(gn.definition_hash == inner.definition_hash)  # False
 ```
 
 ### Type Annotation Forwarding
@@ -847,6 +867,10 @@ def finalize(tripled: int) -> str:
 outer = Graph([inner.as_node(), finalize])
 print(outer.inputs.required)  # ('x',)
 print(outer.outputs)          # ('doubled', 'tripled', 'final')
+
+outer_ns = Graph([inner.as_node(namespaced=True)])
+print(outer_ns.inputs.required)  # ('multiply.x',)
+print(outer_ns.outputs)          # ('multiply.doubled', 'multiply.tripled')
 ```
 
 ### Rename Methods
@@ -868,6 +892,21 @@ print(adapted.outputs)  # ('result',)
 adapted = gn.with_name("my_processor")
 print(adapted.name)  # "my_processor"
 ```
+
+For namespaced GraphNodes, `with_inputs(...)`, `with_outputs(...)`, `map_over(...)`, and `clone` names target the current local port names before namespace projection. The projected parent-facing addresses are recomputed afterward.
+
+### expose()
+
+Expose selected local ports from a namespaced GraphNode as flat parent-facing addresses.
+
+```python
+gn = inner.as_node(namespaced=True).expose("query", answer="final_answer")
+
+print(gn.inputs)   # ('query',)
+print(gn.outputs)  # ('final_answer',)
+```
+
+`expose(...)` is only valid on namespaced GraphNodes. It replaces the namespaced address at that boundary rather than adding a second alias. If a local name exists as both an input and output, exposing that name exposes both directions. Duplicate aliases inside one GraphNode are rejected; different GraphNodes may still expose inputs to the same parent address.
 
 ### map_over()
 
@@ -1140,8 +1179,8 @@ def approval(draft: str) -> str | None:
 - `output_name` (required): Output name(s)
 - `rename_inputs`: Optional dict to rename inputs
 - `cache`: Enable result caching (default: `False`)
-- `emit`: Ordering-only output name(s) (see [emit/wait_for](../03-patterns/03-agentic-loops.md#ordering-with-emitwait_for))
-- `wait_for`: Ordering-only input name(s)
+- `emit`: Ordering-only local output name(s) (see [emit/wait_for](../03-patterns/03-agentic-loops.md#ordering-with-emitwait_for))
+- `wait_for`: Ordering-only graph-scope output/emit address(es)
 - `hide`: Whether to hide from visualization
 
 ### Constructor
@@ -1175,7 +1214,7 @@ approval = InterruptNode(
 | `is_interrupt` | `bool` | Always `True` |
 | `cache` | `bool` | Whether caching is enabled (default: `False`) |
 | `hide` | `bool` | Whether hidden from visualization |
-| `wait_for` | `tuple[str, ...]` | Ordering-only inputs |
+| `wait_for` | `tuple[str, ...]` | Ordering-only graph-scope output/emit addresses |
 | `is_async` | `bool` | True if handler is async |
 | `is_generator` | `bool` | True if handler yields |
 | `definition_hash` | `str` | SHA256 hash of function source |

--- a/docs/06-api-reference/nodes.md
+++ b/docs/06-api-reference/nodes.md
@@ -893,7 +893,7 @@ adapted = gn.with_name("my_processor")
 print(adapted.name)  # "my_processor"
 ```
 
-For namespaced GraphNodes, `with_inputs(...)`, `with_outputs(...)`, `map_over(...)`, and `clone` names target the current local port names before namespace projection. The projected parent-facing addresses are recomputed afterward.
+For namespaced GraphNodes, `with_inputs(...)` and `with_outputs(...)` names target the current local port names before namespace projection. `map_over(...)` and `clone` accept either current local names or projected parent-facing input addresses, then normalize to local names internally.
 
 ### expose()
 
@@ -922,7 +922,7 @@ def map_over(
 ```
 
 **Args:**
-- `*params` - Input parameter names to iterate over
+- `*params` - Input parameter names to iterate over. Use current local names or projected parent-facing input addresses.
 - `mode` - How to combine multiple parameters:
   - `"zip"` (default): Parallel iteration, equal-length lists required
   - `"product"`: Cartesian product, all combinations

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -46,9 +46,9 @@
 
 - **Run-time override of a bound value emits a `UserWarning`** — Passing a value at `runner.run(...)` for a key already present in `inputs.bound` is allowed but warned. The warning shows the old and new value for primitive types and a generic message for opaque types, so accidental overrides surface in test logs.
 
-- **Bind precedence is parent-first at a projected address** — If an inner graph bind and an outer graph bind project to the same parent-facing address, the outer bind wins. If sibling inner graph binds project different values to the same flat address, graph construction errors instead of choosing one silently. Runtime values can still override the effective bind and emit the warning above.
+- **Bind precedence is parent-first at a projected address** — If an inner graph bind and an outer graph bind project to the same parent-facing address, the outer bind wins and emits a warning when the effective bound inputs are computed. If sibling inner graph binds project different values to the same flat address, graph construction errors instead of choosing one silently. Runtime values can still override the effective bind and emit the warning above.
 
-- **`with_inputs(...)`, `with_outputs(...)`, `map_over(...)`, and `clone` target local names** — These GraphNode methods operate on the current local port names before boundary projection. Changing the GraphNode name recomputes namespaced addresses; exposed aliases stay flat.
+- **`with_inputs(...)` and `with_outputs(...)` target local names** — GraphNode renames operate on the current local port names before boundary projection. `map_over(...)` and `clone` accept either current local names or projected parent-facing input addresses, then normalize to local names internally. Changing the GraphNode name recomputes namespaced addresses; exposed aliases stay flat.
 
 - **GraphNode boundary hashes include the projected surface** — `definition_hash` / `structural_hash` now include boundary namespacing, exposed-port mappings, projected inputs/outputs, and local renames. Existing checkpoint compatibility and cache keys may change after upgrading graphs that use nested composition.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,35 +4,55 @@
 
 ### Changed
 
-- **Lexical scope for nested subgraph inputs (breaking)** — An input name not declared at a graph's scope (no leaf node consumes or produces it, and no nested `GraphNode` exposes it as an output) is now **private** to its subgraph. Outer code addresses a private input via a dot-path (`"inner.x"`) or an equivalent nested dict (`{"inner": {"x": ...}}`). The previous "auto-lift" behavior — where an inner input silently surfaced at the outermost scope — has been removed. ([#94](https://github.com/gilad-rubin/hypergraph/issues/94))
+- **GraphNode boundary projection (breaking refinement)** — `Graph.as_node()` is flat by default again: a wrapped graph's inputs and outputs appear in the parent graph under their local names. Use `Graph.as_node(namespaced=True)` to project a boundary under the resolved GraphNode name, e.g. `retrieval.query` and `retrieval.docs`. ([#97](https://github.com/gilad-rubin/hypergraph/issues/97))
 
-  **Why:** auto-lift was a silent-leak hazard. Two sibling subgraphs that happened to share an input name would collide at the outer scope, and a `bind` on the outer graph could silently flow into a deeply nested input the user didn't intend to reach. Lexical scope makes addressing explicit and refactor-safe.
+  **Why:** common parameters such as `query`, `messages`, and `config` often intentionally belong to the parent flow. Namespacing is still available when sibling subgraphs need independent parameters with the same local name.
 
-  **Migration.** Anywhere you previously passed a flat name that belonged to a nested subgraph, address it under its owning `GraphNode`. The four equivalent forms for an input `x` private to a `GraphNode` named `inner`:
+  **Migration.** Code that was updated for the earlier namespaced-by-default behavior can usually remove the prefix:
 
   ```python
-  # Run-time (positional dict, dot-path):
+  # Before
   runner.run(outer, {"inner.x": 5})
 
-  # Run-time (positional dict, nested-dict):
-  runner.run(outer, {"inner": {"x": 5}})
-
-  # Build-time (positional dict, dot-path):
-  outer.bind({"inner.x": 5})
-
-  # Build-time (kwarg, nested-dict):
-  outer.bind(inner={"x": 5})
+  # After, for the default flat boundary
+  runner.run(outer, {"x": 5})
   ```
 
-  Binding directly on the inner graph (`inner.bind(x=5)`) before composing it is also valid and equivalent in result.
+  Keep the prefix by opting into a namespaced boundary:
 
-- **Bind-conflict is a build-time error** — A `bind` on an inner subgraph input whose leaf name is also declared at any ancestor scope now raises `GraphConfigError` at construction time. The error names the bind's full dot-path and the shadowing leaf node so you can fix the source directly. Previously this case silently overrode the bind at run time.
+  ```python
+  outer = Graph([inner.as_node(namespaced=True)])
+  runner.run(outer, {"inner.x": 5})
+  ```
+
+  Namespaced inputs also accept nested-dict sugar:
+
+  ```python
+  runner.run(outer, {"inner": {"x": 5}})
+  ```
+
+  Use `.expose(...)` to bring selected namespaced ports back into the parent flat flow:
+
+  ```python
+  retrieval = retrieval_graph.as_node(namespaced=True).expose("query")
+  generation = generation_graph.as_node(namespaced=True).expose("query")
+  outer = Graph([retrieval, generation])
+  runner.run(outer, {"query": "what is hypergraph?"})
+  ```
+
+- **Resolved GraphNode port addresses everywhere** — `GraphNode.inputs`, `GraphNode.outputs`, `GraphNode.data_outputs`, `graph.inputs`, runtime values, bind keys, checkpoint step values, `wait_for`, visualization, and Mermaid all use the same parent-facing port addresses. A cyclic value such as `messages` may appear in both a GraphNode's inputs and outputs.
+
+- **Expose replaces, not aliases** — On a namespaced GraphNode, `.expose("query", answer="final_answer")` replaces `retrieval.query` / `retrieval.answer` at that boundary with `query` / `final_answer`. Expose targets current local port names, not already-projected addresses. Multiple GraphNodes may expose inputs to the same parent input; duplicate aliases inside one GraphNode are a build-time error. A single GraphNode may use the same address as both input and output only when it is the same local cyclic seed/update port.
 
 - **Run-time override of a bound value emits a `UserWarning`** — Passing a value at `runner.run(...)` for a key already present in `inputs.bound` is allowed but warned. The warning shows the old and new value for primitive types and a generic message for opaque types, so accidental overrides surface in test logs.
 
-- **`with_inputs(...)` only renames the leaf label** — It no longer moves an input out of its subgraph's scope. Combined with lexical scope, this means renaming an inner input does not promote it to the outer namespace.
+- **Bind precedence is parent-first at a projected address** — If an inner graph bind and an outer graph bind project to the same parent-facing address, the outer bind wins. If sibling inner graph binds project different values to the same flat address, graph construction errors instead of choosing one silently. Runtime values can still override the effective bind and emit the warning above.
 
-- **`inputs.required` and `inputs.bound` use dot-paths** — When a graph has nested `GraphNode`s with private inputs, the outer graph's `InputSpec` now reports those inputs as dot-pathed entries (e.g. `"inner.x"`). See [InputSpec API Reference](06-api-reference/inputspec.md#nested-subgraph-inputs).
+- **`with_inputs(...)`, `with_outputs(...)`, `map_over(...)`, and `clone` target local names** — These GraphNode methods operate on the current local port names before boundary projection. Changing the GraphNode name recomputes namespaced addresses; exposed aliases stay flat.
+
+- **GraphNode boundary hashes include the projected surface** — `definition_hash` / `structural_hash` now include boundary namespacing, exposed-port mappings, projected inputs/outputs, and local renames. Existing checkpoint compatibility and cache keys may change after upgrading graphs that use nested composition.
+
+- **Nested dict input sugar is only for namespaced addresses** — Flat GraphNodes no longer accept `{"inner": {"x": ...}}` as a way to address child inputs. Pass the flat key directly (`{"x": ...}`), or opt into `as_node(namespaced=True)`.
 
 ## March 2026
 

--- a/examples/daft/nested_review_objects.py
+++ b/examples/daft/nested_review_objects.py
@@ -70,9 +70,9 @@ def main() -> None:
     runner = DaftRunner()
     result = runner.run(
         workflow,
-        # `reviews` is private to the `assess_reviews` GraphNode at outer scope.
+        # `reviews` is projected flat from the `assess_reviews` GraphNode.
         {
-            "assess_reviews.reviews": [
+            "reviews": [
                 Review("Ava", 9, "Loved it"),
                 Review("Ben", 4, "It broke during setup"),
                 Review("Chen", 6, "Good, but not great"),

--- a/examples/daft/scenario_sweeps.py
+++ b/examples/daft/scenario_sweeps.py
@@ -56,18 +56,18 @@ def build_scenario_sweep_graph() -> Graph:
 def main() -> None:
     graph = build_scenario_sweep_graph()
     runner = DaftRunner()
-    # `weights` and `candidates` are private to the `evaluate_candidates`
-    # GraphNode at outer scope; address via dot-path. `scenario_id` is
-    # consumed at the outer scope by `choose_best` so it stays flat.
+    # `weights` and `candidates` are projected flat from the
+    # `evaluate_candidates` GraphNode. `scenario_id` is consumed at the outer
+    # scope by `choose_best` so it is flat too.
     results = runner.map(
         graph,
         {
             "scenario_id": ["latency_sensitive", "quality_first"],
-            "evaluate_candidates.weights": [
+            "weights": [
                 {"accuracy": 1.0, "latency": 0.01, "cost": 0.5},
                 {"accuracy": 2.5, "latency": 0.002, "cost": 0.2},
             ],
-            "evaluate_candidates.candidates": [
+            "candidates": [
                 [
                     {"name": "fast-small", "accuracy": 0.81, "latency_ms": 40, "cost": 0.01},
                     {"name": "balanced", "accuracy": 0.9, "latency_ms": 85, "cost": 0.03},
@@ -78,7 +78,7 @@ def main() -> None:
                 ],
             ],
         },
-        map_over=["scenario_id", "evaluate_candidates.weights", "evaluate_candidates.candidates"],
+        map_over=["scenario_id", "weights", "candidates"],
     )
 
     print(results["best_candidate"])

--- a/specs/reviewed/durability.md
+++ b/specs/reviewed/durability.md
@@ -240,11 +240,11 @@ There are two boundaries people want:
   - Current reviewed default: `GraphNode.outputs = graph.outputs` (all inner outputs).
   - Use `.with_outputs()` to rename lifted output names.
 
-- **Return surface (nested RunResult):** the nested graph can still be returned as a nested `RunResult` under `result[graphnode.name][...]` (subject to `select=` filtering).
+- **Return surface (projected values):** the nested graph's selected outputs are returned under the GraphNode's projected output addresses.
 
 These are intentionally different:
 - wiring surface controls dependency/value-resolution in the parent graph,
-- return surface controls what the caller sees in the run result.
+- return surface controls what the caller sees in the flat run result.
 
 ### Practical consequence of the current default
 

--- a/specs/reviewed/durable-execution.md
+++ b/specs/reviewed/durable-execution.md
@@ -515,12 +515,11 @@ outer = Graph([
 ]).as_node(complete_on_stop=True)  # Outer also completes
 ```
 
-If `complete_on_stop=True` on outer, then all nested GraphNodes must also have `complete_on_stop=True`. This is validated at graph construction time:
+There is no graph-wide inheritance rule: each GraphNode boundary decides independently. If an outer GraphNode has `complete_on_stop=True` but an inner GraphNode does not, the inner boundary may still propagate stop before its own remaining nodes run.
 
 ```python
-# This raises ValueError at construction time
 inner = Graph([...]).as_node(complete_on_stop=False)
-outer = Graph([inner]).as_node(complete_on_stop=True)  # ❌ Error!
+outer = Graph([inner]).as_node(complete_on_stop=True)
 ```
 
 **Default Behavior:**
@@ -534,7 +533,7 @@ By default, `complete_on_stop=False` — stop propagates immediately. This is pr
 | Partial output | Saved in stopped node's step | Accumulated into state |
 
 **See also:**
-- [GraphNode.complete_on_stop](node-types.md#graphnode-specific-properties) - Property definition
+- [Graph.as_node(..., complete_on_stop=...)](graph.md#as_node) - Boundary option
 - [StepStatus.STOPPED](execution-types.md#stepstatus) - Step status enum
 
 ### Checkpointer Interface

--- a/specs/reviewed/execution-types.md
+++ b/specs/reviewed/execution-types.md
@@ -218,7 +218,7 @@ This ensures at-least-once semantics per node, not per superstep.
 | [Status Enums](#status-enums) | Execution state values | RunStatus, PauseReason |
 | [GraphState](#graphstate) | Runtime value storage | Internal to runners (not user-facing) |
 | [PauseInfo](#pauseinfo) | Pause details | Nested in `RunResult.pause` |
-| [RunResult](#runresult) | Execution result | Returned by `runner.run()`, supports nesting |
+| [RunResult](#runresult) | Execution result | Returned by `runner.run()`, with nested graph outputs projected into `values` |
 | [RunHandle](#runhandle) | Streaming execution handle | Returned by `AsyncRunner.iter()` |
 | [Event Types](#event-types) | Streaming events | Yielded during iteration |
 | [Persistence Types](#persistence-types) | Checkpoint storage | Workflow, StepRecord, Checkpoint |
@@ -658,7 +658,7 @@ class RunResult:
     # === Dict-like access for convenience ===
 
     def __getitem__(self, key: str) -> Any:
-        """Dict-like access: result['answer'] or result['rag.response']"""
+        """Dict-like access: result['answer'] or namespaced result['rag.response']"""
         return self.values[key]
 
     def __contains__(self, key: str) -> bool:
@@ -1828,8 +1828,8 @@ result = await runner.run(
 
 ```
 User-Facing Types:
-├── RunResult (primary result type, supports nesting)
-│   ├── values: dict[str, Any | RunResult]  ← nested graphs are RunResult
+├── RunResult (primary result type, flat projected graph outputs)
+│   ├── values: dict[str, Any]  ← projected port address → value
 │   ├── status: RunStatus
 │   ├── pause: PauseInfo | None  ← only when PAUSED
 │   ├── error: str | None        ← only when FAILED
@@ -1911,7 +1911,8 @@ Observability:
 │  ├── workflow_id: str | None                                        │
 │  └── run_id: str                                                    │
 │                                                                     │
-│  Dict-like access: result["answer"], result["rag.docs"]             │
+│  Dict-like access: result["answer"] (flat mode),                    │
+│                    result["rag.docs"] (namespaced projection)       │
 │                                                                     │
 │  Nested graphs: GraphNode projects outputs into flat values.        │
 │  Pause/error propagate up: if nested fails/pauses, parent does too. │

--- a/specs/reviewed/execution-types.md
+++ b/specs/reviewed/execution-types.md
@@ -589,44 +589,37 @@ class PauseInfo:
     """
 
     response_param: str
-    """Local parameter name defined by the InterruptNode (e.g., "decision").
-
-    For the full namespaced key to use in values dict, use response_key property.
-    """
+    """Resolved graph-scope response key for values dict (e.g., "decision" or
+    "review.decision" after GraphNode boundary projection)."""
 
     value: Any
     """Value to show user (e.g., the draft for approval)."""
 
     @property
     def response_key(self) -> str:
-        """Namespaced key for the values dict when resuming.
-
-        Returns dot notation (e.g., "review.decision"), but since values=
-        accepts multiple formats, you can also use "/" or nested dict.
+        """Key for the values dict when resuming.
 
         For top-level interrupts: returns response_param as-is.
-        For nested interrupts: prefixes with GraphNode path.
+        For nested interrupts: returns the parent-facing address after the
+        containing GraphNode boundary has projected/renamed/exposed it.
 
         Examples:
             - Top-level: response_param="decision" → "decision"
-            - Nested: node_name="review/approval", response_param="decision" → "review.decision"
-            - Deeply nested: node_name="outer/inner/approval" → "outer.inner.decision"
+            - Flat GraphNode: node_name="review/approval" → "decision"
+            - Namespaced GraphNode: node_name="review/approval" → "review.decision"
 
         Usage:
             result = await runner.run(graph, values={...})
             if result.pause:
                 response = get_user_input(result.pause.value)
 
-                # All three are equivalent:
-                values={result.pause.response_key: response}  # "review.decision"
-                values={"review/decision": response}          # slash notation
-                values={"review": {"decision": response}}     # nested dict
+                # response_key is the resolved graph-scope key:
+                values={result.pause.response_key: response}
+
+                # For namespaced GraphNodes, nested dict sugar is equivalent:
+                values={"review": {"decision": response}}
         """
-        if "/" not in self.node_name:
-            return self.response_param
-        # Convert path separator "/" to value separator "."
-        namespace = self.node_name.rsplit("/", 1)[0].replace("/", ".")
-        return f"{namespace}.{self.response_param}"
+        return self.response_param
 ```
 
 ---
@@ -635,7 +628,7 @@ class PauseInfo:
 
 ### Purpose
 
-**The primary result type from graph execution.** Returned by `runner.run()`. Contains outputs, status, pause information, and supports nesting for composed graphs.
+**The primary result type from graph execution.** Returned by `runner.run()`. Contains projected graph outputs, status, and pause information. Nested graphs execute as child workflows internally, but their public values are projected through the `GraphNode` boundary into this flat result map.
 
 ### Class Definition
 
@@ -644,8 +637,8 @@ class PauseInfo:
 class RunResult:
     """Result from graph execution."""
 
-    values: dict[str, Any | "RunResult"]
-    """Output name → value mapping. For nested graphs, contains nested RunResult objects."""
+    values: dict[str, Any]
+    """Output port address → value mapping."""
 
     status: RunStatus
     """Execution status: COMPLETED, PAUSED, STOPPED, or FAILED."""
@@ -664,8 +657,8 @@ class RunResult:
 
     # === Dict-like access for convenience ===
 
-    def __getitem__(self, key: str) -> Any | "RunResult":
-        """Dict-like access: result['answer'] or result['nested_graph']['value']"""
+    def __getitem__(self, key: str) -> Any:
+        """Dict-like access: result['answer'] or result['rag.response']"""
         return self.values[key]
 
     def __contains__(self, key: str) -> bool:
@@ -688,11 +681,11 @@ class RunResult:
 
 ### Key Design Decisions
 
-- **Nested `RunResult` for nested graphs** - When a graph contains `GraphNode`s, their results are nested `RunResult` objects, preserving status and pause info per subgraph.
+- **Flat values for nested graphs** - When a graph contains `GraphNode`s, child outputs are projected through the GraphNode boundary. Flat GraphNodes expose local output names; `namespaced=True` prefixes unexposed outputs like `rag.response`.
 - **No `checkpoint: bytes`** - The checkpointer manages state internally by `workflow_id`. You don't pass checkpoint bytes around.
 - **`workflow_id` for resume** - Same `workflow_id` auto-resumes from where you left off (checkpointer detects paused state).
 - **Dict-like access** - `result["answer"]` is equivalent to `result.values["answer"]`.
-- **All values by default** - `values` contains all node outputs unless filtered with `select=`.
+- **Graph outputs by default** - `values` contains graph outputs present in state. `Graph.select(...)` changes the graph's output surface before runtime.
 
 ### Basic Example
 
@@ -716,9 +709,9 @@ if result.status == RunStatus.COMPLETED:
     print("Done!")
 ```
 
-### Nested Graph Results
+### GraphNode Result Surface
 
-When a graph contains nested graphs (via `GraphNode`), each nested graph's result is a nested `RunResult`:
+When a graph contains nested graphs (via `GraphNode`), each GraphNode projects its output ports into the parent graph:
 
 ```python
 # Define nested structure
@@ -734,16 +727,21 @@ outer = Graph(nodes=[
 
 result = await runner.run(outer, values={...}, workflow_id="order-123")
 
-# Access nested graph results
+# Access projected graph outputs
 result["final_output"]                    # Top-level output
-result["rag"]                             # RunResult for rag_pipeline
-result["rag"]["embedding"]                # Output from nested graph
-result["rag"].status                      # RunStatus.COMPLETED
-result["rag"].workflow_id                 # "order-123/rag"
+result["embedding"]                       # Flat GraphNode output from rag_pipeline
+result["draft"]                           # Flat GraphNode output from review_pipeline
 
-result["review"]                          # RunResult for review_pipeline
-result["review"].status                   # Could be PAUSED if interrupt hit
-result["review"]["draft"]                 # Output from nested graph
+outer_namespaced = Graph(nodes=[
+    preprocess,
+    rag_pipeline.as_node(namespaced=True),
+    review_pipeline.as_node(namespaced=True),
+    postprocess,
+])
+
+result = await runner.run(outer_namespaced, values={...}, workflow_id="order-123")
+result["rag.embedding"]                   # Namespaced GraphNode output
+result["review.draft"]                    # Namespaced GraphNode output
 ```
 
 ### Nested Graph Pauses
@@ -755,14 +753,9 @@ result = await runner.run(outer, values={...}, workflow_id="order-123")
 
 # Check overall status
 if result.status == RunStatus.PAUSED:
-    # Find which nested graph paused
-    if result["rag"].status == RunStatus.COMPLETED:
-        print("RAG completed")
-
-    if result["review"].status == RunStatus.PAUSED:
-        print(f"Review paused at: {result['review'].pause.node_name}")
-        print(f"Value to show user: {result['review'].pause.value}")
-        print(f"Nested workflow ID: {result['review'].workflow_id}")  # "order-123/review"
+    print(f"Paused at: {result.pause.node_name}")      # "review/approval"
+    print(f"Resume key: {result.pause.response_key}")  # Parent-facing input address
+    print(f"Value to show user: {result.pause.value}")
 
 # The top-level pause info points to the nested interrupt
 print(result.pause.node_name)  # "review/approval" (path to the interrupt)
@@ -778,19 +771,11 @@ print(result.pause.node_name)  # "review/approval" (path to the interrupt)
 To resume a paused nested graph:
 
 ```python
-# Option 1: Resume the outer graph (recommended)
-# response_key uses "." for nested: "review.decision"
+# Resume the outer graph using the parent-facing response key.
 result = await runner.run(
     outer,
     values={result.pause.response_key: user_response},
     workflow_id="order-123",
-)
-
-# Option 2: Resume the nested graph directly (advanced)
-result = await runner.run(
-    review_pipeline,
-    values={"decision": user_response},
-    workflow_id="order-123/review",  # Nested workflow ID uses "/"
 )
 ```
 
@@ -1132,7 +1117,7 @@ if result.pause:
     response = await get_user_response(prompt)
 
     # Resume using same workflow_id (checkpointer auto-detects paused state)
-    # Use response_key for namespaced value access (uses "." separator)
+    # response_key is already the resolved graph-scope key to provide.
     result = await runner.run(
         graph,
         values={result.pause.response_key: response},
@@ -1215,54 +1200,37 @@ Rationale: Each batch item would potentially pause at different points, making t
 
 ## Common Patterns
 
-### Working with Nested Results
+### Working with Projected Values
 
 ```python
-def extract_all_values(result: RunResult, prefix="") -> dict[str, Any]:
-    """Recursively extract all values from nested results."""
-    flat = {}
+def group_namespaced_values(result: RunResult) -> dict[str, dict[str, Any]]:
+    """Group dotted GraphNode outputs for display."""
+    groups: dict[str, dict[str, Any]] = {}
 
     for key, value in result.items():
-        full_key = f"{prefix}{key}" if prefix else key
+        if "." not in key:
+            groups.setdefault("", {})[key] = value
+            continue
 
-        if isinstance(value, RunResult):
-            # Recurse into nested result
-            nested = extract_all_values(value, f"{full_key}/")
-            flat.update(nested)
-        else:
-            flat[full_key] = value
+        prefix, suffix = key.split(".", 1)
+        groups.setdefault(prefix, {})[suffix] = value
 
-    return flat
+    return groups
 
 # Usage
 result = await runner.run(outer_graph, values={...})
-all_values = extract_all_values(result)
-# {"answer": "...", "rag/embedding": [...], "rag/docs": [...]}
+groups = group_namespaced_values(result)
+# {"": {"answer": "..."}, "rag": {"embedding": [...], "docs": [...]}}
 ```
 
-### Finding Paused Nested Graphs
+### Handling Nested Pauses
 
 ```python
-def find_paused_graphs(result: RunResult, path="") -> list[tuple[str, RunResult]]:
-    """Find all paused graphs in a nested result."""
-    paused = []
-
-    if result.status == RunStatus.PAUSED:
-        paused.append((path or "root", result))
-
-    for key, value in result.items():
-        if isinstance(value, RunResult):
-            nested_path = f"{path}/{key}" if path else key
-            paused.extend(find_paused_graphs(value, nested_path))
-
-    return paused
-
-# Usage
 result = await runner.run(outer_graph, values={...})
-for path, paused_result in find_paused_graphs(result):
-    print(f"Paused at: {path}")
-    print(f"  Waiting for: {paused_result.pause.response_param}")
-    print(f"  Value: {paused_result.pause.value}")
+if result.status == RunStatus.PAUSED and result.pause is not None:
+    print(f"Paused at: {result.pause.node_name}")
+    print(f"Waiting for: {result.pause.response_key}")
+    print(f"Value: {result.pause.value}")
 ```
 
 ### Event Filtering and Routing
@@ -1927,7 +1895,7 @@ Observability:
 │  └── history: in-memory execution log                               │
 │                                                                     │
 │  Nested graphs: Each GraphNode has its own GraphState.              │
-│  Parent GraphState stores child's RunResult as a value.             │
+│  Parent GraphState stores child's projected output values.          │
 └─────────────────────────────────────────────────────────────────────┘
                               │
                               │ Runner translates to user-facing types
@@ -1936,16 +1904,16 @@ Observability:
 │                     USER-FACING (API layer)                         │
 ├─────────────────────────────────────────────────────────────────────┤
 │  RunResult                                                          │
-│  ├── values: dict[str, Any | RunResult]  ← nested graphs here       │
+│  ├── values: dict[str, Any]  ← projected graph outputs              │
 │  ├── status: RunStatus (COMPLETED, FAILED, PAUSED, STOPPED)         │
 │  ├── pause: PauseInfo | None    ← only when PAUSED                  │
 │  ├── error: str | None          ← only when FAILED                  │
 │  ├── workflow_id: str | None                                        │
 │  └── run_id: str                                                    │
 │                                                                     │
-│  Dict-like access: result["answer"], result["rag"]["docs"]          │
+│  Dict-like access: result["answer"], result["rag.docs"]             │
 │                                                                     │
-│  Nested graphs: RunResult.values["rag"] returns nested RunResult.   │
+│  Nested graphs: GraphNode projects outputs into flat values.        │
 │  Pause/error propagate up: if nested fails/pauses, parent does too. │
 └─────────────────────────────────────────────────────────────────────┘
                               │
@@ -1993,7 +1961,7 @@ Observability:
 │  Later values overwrite earlier ones (same key).                    │
 │                                                                     │
 │  Nested graphs: Child workflow state is computed separately.        │
-│  Parent state includes child's RunResult as a value.                │
+│  Parent state includes child's projected output values.             │
 └─────────────────────────────────────────────────────────────────────┘
                               │
                               │ snapshot for forking
@@ -2004,7 +1972,7 @@ Observability:
 │  └── steps: list[StepRecord] ← step history (implicit cursor)       │
 │                                                                     │
 │  Used for: forking, manual resume, testing.                         │
-│  Nested graphs: Checkpoint includes nested RunResults in values.    │
+│  Nested graphs: Checkpoint values use projected output addresses.   │
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -2013,11 +1981,11 @@ Observability:
 | Layer | How nested graphs appear |
 |-------|-------------------------|
 | Events | Span hierarchy via `parent_span_id` linking child to parent |
-| GraphState | Child has own GraphState; parent stores child RunResult as value |
-| RunResult | `result.values["rag"]` returns nested `RunResult` object |
+| GraphState | Child has own GraphState; parent stores projected child outputs |
+| RunResult | `result.values` contains flat projected output addresses |
 | Workflow | GraphNode step has `child_workflow_id` (e.g., `"order-123/rag"`) |
 | StepRecord | Child workflow has its own independent step records |
-| Checkpoint | Nested RunResults included in `values` dict |
+| Checkpoint | Values use the same projected output addresses as runtime state |
 
 **See also:**
 - [Checkpointer API](checkpointer.md) - Full interface definition and custom implementations

--- a/specs/reviewed/graph.md
+++ b/specs/reviewed/graph.md
@@ -27,44 +27,29 @@ class Graph:
         self,
         nodes: list[HyperNode],
         *,
+        edges: list[tuple] | None = None,
+        entrypoint: str | HyperNode | list[str | HyperNode] | tuple[str | HyperNode, ...] | None = None,
         name: str | None = None,
         strict_types: bool = False,
-        complete_on_stop: bool = False,
-        hash_depth: int | None = 1,
+        shared: str | list[str] | tuple[str, ...] | None = None,
     ):
         """
         Create a graph from nodes.
 
         Args:
             nodes: List of HyperNode objects
+            edges: Explicit edge declarations. When provided, disables
+                implicit data-edge inference except where shared-state rules
+                intentionally keep ordering separate from data flow.
+            entrypoint: Convenience shortcut for with_entrypoint(...). Required
+                for cyclic graphs.
             name: Optional graph name. Used as default for as_node() when
                   nesting this graph. If not set here, must be provided
                   when calling as_node(name='...')
             strict_types: Validate type annotations between connected nodes (default: False)
-            hash_depth: How deep to follow local imports when computing definition_hash.
-                Controls the trade-off between hash sensitivity and performance.
-
-                - 0: Function source only (fastest, misses helper changes)
-                - 1: Function + direct local imports (default, good balance)
-                - 2+: Recursive up to N levels (thorough, slower)
-                - None: Full transitive closure within package (most thorough)
-
-                Only same-package imports are included; stdlib and pip packages
-                are excluded. See definition_hash property for details.
-
-            complete_on_stop: Behavior when a stop signal is received during execution.
-
-                True:
-                  - Streaming nodes: save partial output, mark step COMPLETED with partial=True
-                  - Regular nodes being stopped: mark step STOPPED (no output possible)
-                  - Continue executing remaining nodes in the graph
-
-                False (default):
-                  - All stopped nodes: mark step STOPPED (no output)
-                  - Stop graph immediately, skip remaining nodes
-
-                This setting can be overridden when using as_node(complete_on_stop=...).
-                See durable-execution.md for patterns and examples.
+            shared: Parameter names that are shared state across the graph.
+                Shared params are excluded from auto-wiring, allow multiple
+                producers, and require explicit ordering via edges or emit/wait_for.
 
         Example:
             # Basic graph
@@ -74,18 +59,18 @@ class Graph:
             rag = Graph(nodes=[embed, retrieve, generate], name="rag_pipeline")
             outer = Graph(nodes=[preprocess, rag.as_node(), postprocess])
 
-            # Graph that saves partial streaming output on stop
-            chat = Graph(
-                nodes=[generate, accumulate],
-                name="chat",
-                complete_on_stop=True,  # Partial responses saved to history
-            )
+            # Cyclic graph with explicit entrypoint
+            chat = Graph(nodes=[wait, add_user, respond], entrypoint="add_user")
         """
-        self._nodes = {n.name: n for n in nodes}
         self.name = name
-        self.complete_on_stop = complete_on_stop
-        self._nx_graph = self._build_graph(nodes)
+        self._strict_types = strict_types
+        self._shared = self._normalize_shared(shared)
         self._bound = {}
+        self._selected = None
+        self._nodes = self._build_nodes_dict(nodes)
+        self._entrypoints = self._normalize_constructor_entrypoints(entrypoint)
+        self._explicit_edges = self._normalize_edges(edges) if edges is not None else None
+        self._nx_graph = self._build_graph(nodes)
         self._validate()  # Build-time validation
 ```
 
@@ -193,7 +178,7 @@ def _compute_definition_hash(self) -> str:
 
 | Node Type | Hash includes |
 |-----------|---------------|
-| `FunctionNode` | Function source + local imports (up to `hash_depth`) |
+| `FunctionNode` | Function source when available, otherwise bytecode/qualified-name fallback |
 | `GraphNode` | Inner graph's `definition_hash` (recursive) |
 | `InterruptNode` | `input_param`, `response_param`, `response_type` |
 | `TypeRouteNode` | `input_param`, routes mapping |
@@ -205,16 +190,15 @@ def _compute_definition_hash(self) -> str:
 
 | Include in hash | Exclude from hash |
 |-----------------|-------------------|
-| Function source code | stdlib (`os`, `sys`, `json`) |
-| Same-package imports (up to `hash_depth`) | pip packages (`pydantic`, `numpy`) |
-| Graph structure (edges) | Runtime env vars |
+| Function source code | Runtime env vars |
+| Graph structure (edges) | Bound runtime values |
 | Node configuration | Dynamically loaded modules |
 
 **Trade-offs:**
 
 - Changing a comment invalidates the hash (aggressive but safe)
-- Updating pip packages does NOT invalidate (intentional - library updates are explicit via requirements.txt)
-- Deep transitive imports only go up to `hash_depth` levels
+- Updating helper code does not invalidate a function hash unless that helper's
+  source is part of the wrapped function body.
 
 ### Detailed Node Lists
 
@@ -416,8 +400,9 @@ def as_node(
     self,
     *,
     name: str | None = None,
-    runner: BaseRunner | None = None,
-    complete_on_stop: bool | None = None,
+    namespaced: bool = False,
+    runner: Any = None,
+    complete_on_stop: bool = False,
 ) -> GraphNode:
     """
     Wrap graph as a node for composition.
@@ -431,29 +416,21 @@ def as_node(
 
     Args:
         name: Override node name (default: use graph.name)
+        namespaced: When True, project inputs and outputs under the resolved
+            GraphNode name (e.g. "rag.query"). Default False keeps the
+            GraphNode flat in the parent graph.
         runner: Runner for nested execution (default: inherit from parent)
-        complete_on_stop: Override graph's complete_on_stop setting.
-            If None (default), inherits from Graph(..., complete_on_stop=).
-            See Graph constructor for behavior details.
+        complete_on_stop: When True, the inner graph finishes all remaining
+            supersteps after a stop signal instead of breaking immediately.
 
     Returns:
-        GraphNode with graph's outputs as default *lifted* outputs.
+        GraphNode whose inputs/outputs are resolved parent-facing port
+        addresses. By default those addresses are flat; with namespaced=True
+        they are prefixed by the resolved GraphNode name. Use .expose(...) on
+        a namespaced GraphNode to replace selected prefixed ports with flat
+        parent-facing addresses.
 
-        Important: there are two “surfaces” for nested graphs:
-        1. **Dataflow / wiring surface (lifted outputs)**:
-           GraphNode.outputs determines which inner values are lifted into
-           the parent graph’s value namespace and can be consumed by other
-           outer nodes via normal parameter names. By default, this is the
-           inner graph’s outputs (all node outputs).
-
-        2. **Return surface (nested RunResult)**:
-           The nested graph’s full outputs remain accessible inside the
-           nested RunResult (e.g. result["rag"]["embedding"]), subject to
-           `select=` filtering. Selecting nested outputs via paths like
-           "rag/embedding" does not imply that "embedding" is lifted into
-           the parent value namespace for wiring.
-
-        Use .with_outputs() to rename lifted output names.
+        Use .with_outputs() to rename local output names before projection.
         Use .map_over() to configure iteration.
 
     Raises:
@@ -466,6 +443,9 @@ def as_node(
         # Override name
         node = graph.as_node(name="custom")
 
+        # Opt into namespaced parent-facing ports
+        node = graph.as_node(namespaced=True)
+
         # Override complete_on_stop for this nested usage
         node = graph.as_node(complete_on_stop=True)
 
@@ -476,7 +456,11 @@ def as_node(
             .map_over("query")
         )
     """
-    return GraphNode(self, name=name, runner=runner, complete_on_stop=complete_on_stop)
+    node = GraphNode(self, name=name, namespaced=namespaced)
+    node._complete_on_stop = complete_on_stop
+    if runner is not None:
+        return node.with_runner(runner)
+    return node
 ```
 
 **Name resolution examples:**
@@ -757,7 +741,7 @@ def _validate_node_names(self):
                     f"The problem:\n"
                     f"  The '.' and '/' characters are reserved as separators:\n"
                     f"  - '.' for nested values: values={{'rag.query': 'hello'}}\n"
-                    f"  - '/' for paths: select=['rag/*'], node_name='review/approval'\n\n"
+                    f"  - '/' for structural paths: workflow_id='run-1/rag', node_name='review/approval'\n\n"
                     f"  If node names contained these, values would be ambiguous:\n\n"
                     f"    values={{'rag.query': 'hello'}} - Is this:\n"
                     f"      • A node named 'rag.query' at top level?\n"
@@ -781,60 +765,28 @@ def _validate_node_names(self):
                     )
 ```
 
-### 7. Namespace Collision Validation
+### 7. GraphNode Names And Port Addresses
 
-```python
-def _validate_no_namespace_collision(self):
-    """Output names cannot match GraphNode names (would create ambiguous paths)."""
-    graphnode_names = {
-        node.name for node in self._nodes.values()
-        if isinstance(node, GraphNode)
-    }
+GraphNode names identify nodes and, when `namespaced=True`, prefix projected port
+addresses. They do not create nested `RunResult` slots in `RunResult.values`.
 
-    for node in self._nodes.values():
-        output_name = getattr(node, 'output_name', node.name)
-        if output_name in graphnode_names and node.name != output_name:
-            raise GraphConfigError(
-                f"Namespace collision: output '{output_name}' matches GraphNode name\n\n"
-                f"  → Node '{node.name}' produces output '{output_name}'\n"
-                f"  → GraphNode '{output_name}' exists in this graph\n\n"
-                f"The problem:\n"
-                f"  RunResult.values stores both regular outputs and nested\n"
-                f"  RunResults from GraphNodes in the same dict:\n\n"
-                f"    result.values = {{\n"
-                f"      'answer': '...',           # Regular output\n"
-                f"      'rag_pipeline': RunResult  # Nested graph\n"
-                f"    }}\n\n"
-                f"  If an output name equals a GraphNode name, result['{output_name}']\n"
-                f"  is ambiguous - is it the output value or the nested RunResult?\n\n"
-                f"How to fix:\n"
-                f"  Rename one to avoid the collision:\n"
-                f"  • Change the output name: @node(output_name='...')\n"
-                f"  • Change the GraphNode name: graph.as_node(name='...')"
-            )
-```
-
-**Example error:**
+An output may therefore have the same string as a sibling GraphNode name:
 
 ```python
 @node(output_name="summary")
 def summarize(text: str) -> str:
     return text[:100]
 
-# Nested graph also named "summary"
 inner = Graph(nodes=[...], name="summary")
-
-# ❌ Error at Graph() construction time
 outer = Graph(nodes=[summarize, inner.as_node()])
-# → GraphConfigError: Namespace collision: output 'summary' matches GraphNode name
-#
-#   → Node 'summarize' produces output 'summary'
-#   → GraphNode 'summary' exists in this graph
-#
-#   The problem:
-#     RunResult.values stores both regular outputs and nested
-#     RunResults from GraphNodes in the same dict...
+
+result = runner.run(outer, values={...})
+result["summary"]  # the output value named "summary"
 ```
+
+Ordinary graph rules still apply to port addresses. Duplicate output addresses
+from multiple producers must be ordered, mutex, or otherwise rejected by the
+duplicate-output validator.
 
 ---
 
@@ -887,154 +839,45 @@ outer = Graph(nodes=[
 
 ---
 
-## Nested Graph Results
+## GraphNode Result Surface
 
-### Graph Names Are Mandatory for Nesting
+When a graph is used as a `GraphNode`, the parent result contains the child
+graph's projected output port addresses. There is no nested `RunResult` value
+under the GraphNode name.
 
-When nesting graphs, the nested graph **must** have a name to be addressable in results. You can provide the name either:
+Graph names are still useful because `as_node()` needs a resolved node name:
 
-1. **When constructing the Graph** (recommended):
 ```python
 rag = Graph(nodes=[...], name="rag_pipeline")
 outer = Graph(nodes=[preprocess, rag.as_node(), postprocess])
+
+also_ok = Graph(nodes=[preprocess, Graph(nodes=[...]).as_node(name="rag_pipeline")])
 ```
 
-2. **When calling .as_node()**:
-```python
-rag = Graph(nodes=[...])
-outer = Graph(nodes=[preprocess, rag.as_node(name="rag_pipeline"), postprocess])
-```
-
-**If you provide both, `.as_node(name=...)` overrides `Graph(..., name=...)`.**
-
-### Result Structure
-
-Results from nested graphs are returned as nested `RunResult` objects. This preserves the full execution context (status, pause info) for each subgraph:
+`Graph.select(...)` controls which outputs a graph makes visible before the
+GraphNode boundary projects those local output names:
 
 ```python
-result = await runner.run(outer_graph, values={...})
+rag = Graph([embed, retrieve, generate], name="rag").select("response")
+outer = Graph([rag.as_node(namespaced=True)])
 
-# Direct values
-result["answer"]                      # value
-result["cleaned"]                     # value
-
-# Nested graphs (by name) → RunResult objects
-result["rag_pipeline"]                # RunResult (with its own status, pause, etc.)
-result["rag_pipeline"]["embedding"]   # value inside nested result
-result["rag_pipeline"]["inner"]       # another nested RunResult
+result = runner.run(outer, {"rag.query": "what is RAG?"})
+result.keys()  # dict_keys(["rag.response"])
 ```
 
-Both output values and nested graph names share the same namespace:
-
-```python
-result.values = {
-    "answer": "...",                  # output value
-    "rag_pipeline": RunResult(...),   # nested graph by name
-}
-```
-
-### Why Nested RunResult?
-
-Using `RunResult` (not a simpler value container) for nested graphs enables:
-
-1. **Per-subgraph status:** Know if a subgraph completed, paused, or is running
-2. **Pause propagation:** When a nested graph pauses, you can identify which one
-3. **Consistent access:** Same dict-like API at every level
-
-```python
-# Example: Nested graph paused
-result = await runner.run(outer_graph, values={...})
-
-if result.status == RunStatus.PAUSED:
-    # Find which nested graph paused
-    if result["rag_pipeline"].status == RunStatus.PAUSED:
-        print(f"RAG paused: {result['rag_pipeline'].pause}")
-```
-
-### Filtering with select Parameter
-
-Use the `select` parameter in `.run()` to filter what's included in the result:
-
-```python
-# Default: everything accessible
-result = runner.run(graph, values={...})
-result.keys()  # ["answer", "cleaned", "rag_pipeline", "other_graph"]
-
-# Filtered: specific outputs only
-result = runner.run(graph, values={...}, select=["answer"])
-result.keys()  # ["answer"]
-
-# With patterns
-result = runner.run(
-    graph,
-    values={...},
-    select=["answer", "rag_pipeline/*"]
-)
-```
-
-### Pattern Syntax
-
-| Pattern | Meaning |
-|---------|---------|
-| `"answer"` | Specific output |
-| `"rag_pipeline"` | Nested graph as RunResult |
-| `"rag_pipeline/*"` | All direct outputs from rag_pipeline |
-| `"rag_pipeline/**"` | All outputs recursively |
-| `"**/embedding"` | Any "embedding" at any depth |
-| `"*/docs"` | "docs" from any direct child graph |
-
-### Examples
-
-**Full access (default):**
-
-```python
-result = runner.run(graph, values={...})
-result["rag_pipeline"]["embedding"]  # accessible
-```
-
-**Only top-level values:**
-
-```python
-result = runner.run(graph, values={...}, select=["answer", "cleaned"])
-result["rag_pipeline"]  # KeyError - not selected
-```
-
-**Specific nested outputs:**
-
-```python
-result = runner.run(
-    graph,
-    values={...},
-    select=["answer", "rag_pipeline/embedding"]
-)
-result["rag_pipeline"]["embedding"]  # accessible
-result["rag_pipeline"]["docs"]       # KeyError - not selected
-```
-
-**Everything from a nested graph:**
-
-```python
-result = runner.run(graph, values={...}, select=["rag_pipeline/**"])
-# All outputs from rag_pipeline and its nested graphs
-```
-
-### RunResult for Nested Graphs
-
-Nested graphs return `RunResult` objects, which provide:
-- `values`: Dict of output values (and nested `RunResult` for deeper nesting)
-- `status`: Execution status (`COMPLETED`, `PAUSED`, `STOPPED`, `FAILED`)
-- `pause`: Pause info if the nested graph paused
+Runtime `runner.run(..., select=...)` overrides are not supported; configure
+output scope on the graph with `graph.select(...)`.
 
 ```python
 @dataclass
 class RunResult:
-    values: dict[str, Any | "RunResult"]  # Supports nesting
+    values: dict[str, Any]
     status: RunStatus
     workflow_id: str | None
     run_id: str
     pause: PauseInfo | None = None
 
-    def __getitem__(self, key: str) -> Any | "RunResult":
+    def __getitem__(self, key: str) -> Any:
         return self.values[key]
 ```
 
@@ -1056,10 +899,7 @@ def retrieve(embedding: list[float]) -> list[str]:
 def generate(docs: list[str]) -> str:
     return llm.generate(docs)
 
-rag_pipeline = Graph(
-    nodes=[embed, retrieve, generate],
-    name="rag_pipeline"  # Name required for nesting
-)
+rag_pipeline = Graph(nodes=[embed, retrieve, generate], name="rag_pipeline")
 
 # Outer pipeline
 @node(output_name="cleaned")
@@ -1068,7 +908,7 @@ def clean(query: str) -> str:
 
 outer = Graph(nodes=[
     clean,
-    rag_pipeline.as_node(name="rag"),  # Nested
+    rag_pipeline.as_node(name="rag"),
 ])
 
 # Execute
@@ -1077,33 +917,29 @@ result = await runner.run(outer, values={"query": "  What is RAG?  "})
 # Access results
 result["cleaned"]                  # "what is rag?"
 result["response"]                 # Final answer
-result["rag"]                      # RunResult from nested pipeline
-result["rag"]["embedding"]         # Embedding from nested
-result["rag"]["docs"]              # Retrieved docs from nested
-result["rag"]["response"]          # Same as result["response"]
-result["rag"].status               # RunStatus.COMPLETED
 
-# Filtered execution
+selected = Graph(nodes=[
+    clean,
+    rag_pipeline.select("response").as_node(name="rag", namespaced=True),
+])
+
 result = await runner.run(
-    outer,
-    values={"query": "  What is RAG?  "},
-    select=["response", "rag/embedding"]  # Only these
+    selected,
+    values={"rag.query": "  What is RAG?  "},
 )
-result["response"]          # Available
-result["rag"]["embedding"]  # Available
-result["rag"]["docs"]       # KeyError - not selected
+result["rag.response"]              # Final answer from selected nested graph
 ```
 
-### Nested Graph Values
+### Namespaced GraphNode Values
 
-Provide values directly to nested graphs using **dot notation** in the `values` parameter:
+Provide values to namespaced GraphNode ports using their resolved parent-facing addresses:
 
 ```python
 result = await runner.run(outer, values={
-    "query": "hello",              # Top-level value
-    "rag.top_k": 5,                # Value for nested "rag" graph
-    "rag.model": "gpt-4",          # Another nested value
-    "rag.inner.threshold": 0.8,    # Deeply nested (rag → inner)
+    "query": "hello",              # Flat parent value
+    "rag.top_k": 5,                # Namespaced GraphNode value
+    "rag.model": "gpt-4",          # Another namespaced value
+    "rag.inner.threshold": 0.8,    # Multi-level namespaced value
 })
 ```
 
@@ -1111,15 +947,10 @@ result = await runner.run(outer, values={
 
 | Pattern | Example | Purpose |
 |---------|---------|---------|
-| Configure nested graph | `{"rag.top_k": 5}` | Override defaults |
-| Skip nested node | `{"rag.embedding": [...]}` | Provide output directly |
-| Resume nested interrupt | `{"review.decision": "approve"}` | Response for nested InterruptNode |
+| Configure namespaced GraphNode | `{"rag.top_k": 5}` | Override defaults |
+| Resume namespaced interrupt | `{"review.decision": "approve"}` | Response for interrupt inside namespaced GraphNode |
 
-**Routing behavior:**
-When the runner sees `"rag.query"` in values:
-1. Split on first `.` → `("rag", "query")`
-2. Find GraphNode named `"rag"`
-3. Pass `{"query": ...}` to the nested graph's values
+Flat GraphNodes use flat keys. Use `as_node(namespaced=True)` when you want the `rag.*` surface.
 
 **Deeply nested:**
 ```python
@@ -1128,33 +959,15 @@ values={"middle.inner.param": "value"}
 # Routes to: middle graph → inner graph → param
 ```
 
-### Separator Conventions
-
-hypergraph uses different separators for different contexts:
-
-| Context | Accepted Formats | Canonical | Rationale |
-|---------|------------------|-----------|-----------|
-| **`values=` parameter** | `.`, `/`, nested dict | nested dict | Flexible input, user's choice |
-| **All other paths** | `/` only | `/` | File system mental model |
-
-#### Values Parameter: Flexible Input
-
-The `values=` parameter in `.run()`, `.map()`, `.iter()` accepts three equivalent formats:
+#### Values Parameter
 
 ```python
-# All three are equivalent - use whichever you prefer:
-
-# 1. Nested dict (recommended - most Pythonic)
+# Namespaced GraphNode values can use nested-dict sugar:
 graph.run(values={"rag": {"query": "hello", "top_k": 5}})
 
-# 2. Dot notation (convenience)
+# Equivalent resolved-address form:
 graph.run(values={"rag.query": "hello", "rag.top_k": 5})
-
-# 3. Slash notation (convenience)
-graph.run(values={"rag/query": "hello", "rag/top_k": 5})
 ```
-
-**Why flexible?** The `values=` parameter is the most common user touchpoint. Users from different backgrounds prefer different styles (Python uses dicts, JS uses dots, file systems use slashes). All map unambiguously to the same thing.
 
 **Error: Conflicting formats in same call:**
 
@@ -1188,7 +1001,7 @@ Everything else uses `/` consistently:
 |-------|---------|
 | `node_name` in pause info | `"review/approval"` |
 | `workflow_id` for nested graphs | `"order-123/rag"` |
-| `select=` patterns | `["rag/*", "**/embedding"]` |
+| Graph output scope | `graph.select("answer")` |
 
 **The mental model:**
 - `values=` = "provide data" → flexible formats accepted
@@ -1224,7 +1037,7 @@ Graph (structure definition)
     └── Used by runners, not user-facing
 
 RunResult (user-facing result)
-├── values: dict[str, Any | RunResult]  # Nested graphs → nested RunResult
+├── values: dict[str, Any]  # Output port address → value
 ├── status: RunStatus
 ├── pause: PauseInfo | None
 └── workflow_id, run_id
@@ -1232,7 +1045,7 @@ RunResult (user-facing result)
 
 **See [Execution Types](execution-types.md)** for complete type definitions including:
 - `RunStatus`, `PauseReason` enums
-- `RunResult` with nested support and pause handling
+- `RunResult` status and pause handling
 - `Workflow`, `StepRecord`, `Checkpoint` for persistence
 - `GraphState` (internal runtime state)
 

--- a/specs/reviewed/node-types.md
+++ b/specs/reviewed/node-types.md
@@ -1216,8 +1216,8 @@ class GraphNode(HyperNode):
         self,
         graph: Graph,
         name: str | None = None,
-        runner: BaseRunner | None = None,
-        complete_on_stop: bool | None = None,
+        *,
+        namespaced: bool = False,
     ):
         """
         Wrap a graph as a node.
@@ -1225,28 +1225,18 @@ class GraphNode(HyperNode):
         Args:
             graph: The graph to wrap (reference, not copy)
             name: Node name (default: use graph.name if set)
-            runner: Runner for nested execution (default: inherit from parent)
-            complete_on_stop: Override graph's complete_on_stop setting.
-                If None (default), inherits from Graph(..., complete_on_stop=).
-
-                When True: run remaining nodes even when a streaming
-                node is stopped by the user. Streaming nodes save partial
-                output (marked partial=True). Ensures cleanup nodes execute.
-
-                When False: stop propagates immediately, skip remaining nodes.
+            namespaced: When True, project local ports under the resolved
+                GraphNode name at the parent boundary.
 
         Raises:
             ValueError: If name not provided and graph has no name.
-            ValueError: If complete_on_stop=True but any nested GraphNode has
-                complete_on_stop=False (inconsistent guarantees).
+            ValueError: If name contains reserved characters ('.' or '/').
 
         Note:
-            Use .with_outputs() to override output names (default: graph.outputs).
+            Use .with_outputs() to rename local output names before projection.
+            Use .expose() on namespaced GraphNodes to replace selected
+            namespaced addresses with flat parent-facing addresses.
             Use .map_over() to configure iteration.
-
-        See Also:
-            graph.md for Graph(..., complete_on_stop=) documentation.
-            durable-execution.md for stop handling patterns and examples.
         """
         resolved_name = name or graph.name
         if resolved_name is None:
@@ -1255,40 +1245,43 @@ class GraphNode(HyperNode):
                 "or pass name to GraphNode(graph, name='x')"
             )
 
-        # Resolve complete_on_stop: explicit override > graph default
-        resolved_complete_on_stop = (
-            complete_on_stop if complete_on_stop is not None
-            else graph.complete_on_stop
-        )
-
-        # Validate nested GraphNode consistency
-        if resolved_complete_on_stop:
-            for node in graph.nodes:
-                if isinstance(node, GraphNode) and not node.complete_on_stop:
-                    raise ValueError(
-                        f"complete_on_stop=True requires all nested GraphNodes "
-                        f"to also have complete_on_stop=True. "
-                        f"Node '{node.name}' has complete_on_stop=False."
-                    )
+        for char in self._RESERVED_CHARS:
+            if char in resolved_name:
+                raise ValueError(...)
 
         self._graph = graph
-        self._runner = runner
-        self._complete_on_stop = resolved_complete_on_stop
+        self._rename_history: list[RenameEntry] = []
+        self._namespaced = namespaced
+        self._exposed: dict[str, str] = {}
         self._map_over: list[str] | None = None
         self._map_mode: Literal["zip", "product"] = "zip"
-        self._rename_history: list[RenameEntry] = []
+        self._runner_override: Any = None
+        self._complete_on_stop: bool = False
 
         # Core HyperNode attributes
         self.name = resolved_name
-        self.inputs = graph.inputs.all  # Extract tuple from InputSpec
-        # Lifted outputs: the only inner values that become available to the
-        # *parent graph’s wiring/value resolution* under normal names.
-        #
-        # Note: this does not limit what the nested RunResult can contain.
-        # All inner outputs remain available under result[self.name][...]
-        # (subject to select= filtering), but only these lifted outputs can be
-        # consumed by other outer nodes without path syntax.
-        self.outputs = graph.outputs  # Use .with_outputs() to rename
+        self._local_inputs = graph.inputs.all
+        self._local_outputs = self._derive_outputs(graph)
+        self._local_data_outputs = self._derive_data_outputs(graph, self._local_outputs)
+        self._refresh_projected_ports()
+
+    def _refresh_projected_ports(self) -> None:
+        """Recompute parent-facing input/output addresses and boundary maps."""
+        self.inputs = tuple(self._project_address(name) for name in self._local_inputs)
+        self.outputs = tuple(self._project_address(name) for name in self._local_outputs)
+
+    def _project_address(self, local_name: str) -> str:
+        if self._namespaced:
+            return self._exposed.get(local_name, f"{self.name}.{local_name}")
+        return local_name
+```
+
+`Graph.as_node(..., runner=..., complete_on_stop=...)` creates the wrapper above, then applies execution options:
+
+```python
+node = GraphNode(graph, name=name, namespaced=namespaced)
+node._complete_on_stop = complete_on_stop
+return node.with_runner(runner) if runner is not None else node
 ```
 
 ### GraphNode-Specific Properties
@@ -1301,36 +1294,46 @@ def graph(self) -> Graph:
     """The wrapped graph (read-only reference)."""
 
 @property
-def complete_on_stop(self) -> bool:
-    """Whether to run remaining nodes when a streaming node is stopped.
+def namespaced(self) -> bool:
+    """Whether this boundary prefixes unexposed ports with the GraphNode name."""
 
-    When True: If a streaming node receives a stop signal, the graph
-    continues executing remaining nodes before returning STOPPED status.
-    This ensures cleanup/accumulation nodes run with partial output.
+@property
+def local_inputs(self) -> tuple[str, ...]:
+    """Current local input names before boundary projection."""
 
-    When False (default): Stop signal propagates immediately, skipping
-    remaining nodes in this graph.
+@property
+def local_outputs(self) -> tuple[str, ...]:
+    """Current local output names before boundary projection."""
 
-    See durable-execution.md for patterns and examples.
-    """
+@property
+def data_outputs(self) -> tuple[str, ...]:
+    """Projected data-carrying output addresses."""
+
+@property
+def runner_override(self) -> Any:
+    """Runner to delegate execution to, or None to inherit from parent."""
+
+@property
+def is_async(self) -> bool:
+    """Whether the wrapped graph contains async nodes."""
 ```
 
-**Note:** GraphNode intentionally has no `cache`, `is_async`, or `is_generator` properties:
-- **No `cache`**: Caching happens at individual node level inside the graph. Graph-level caching would override inner nodes' cache decisions and skip side effects.
-- **No `is_async`/`is_generator`**: The runner discovers these properties recursively when executing inner nodes.
+**Note:** GraphNode does not expose graph-level cache or generator controls:
+- **`cache` remains `False`**: Caching happens at individual node level inside the graph. Graph-level caching would override inner nodes' cache decisions and skip side effects.
+- **`is_async` delegates to the wrapped graph** so runner selection can see async work through composition.
+- **`is_generator` remains `False`**: streaming/generator behavior belongs to inner nodes.
 
-**GraphNode does have `definition_hash`** - it delegates to the inner graph:
+**GraphNode does have `definition_hash`** - it includes the inner graph and the configured boundary surface:
 
 ```python
 @property
 def definition_hash(self) -> str:
-    """Hash of the nested graph (delegates to inner graph)."""
-    return self.graph.definition_hash
+    """Hash of the nested graph plus namespacing, exposes, renames, and map config."""
 ```
 
-This ensures changes inside nested graphs bubble up to the parent graph's hash (Merkle tree).
+This ensures changes inside nested graphs and changes to the parent-facing GraphNode contract both bubble up to the parent graph's hash.
 
-GraphNode is a pure structural wrapper with no execution semantics of its own.
+GraphNode is primarily a structural boundary. Runners still give it execution behavior by delegating into the wrapped graph, optionally via `runner_override`.
 
 ### Methods
 
@@ -1343,7 +1346,7 @@ def map_over(
     """
     Configure this GraphNode for iteration (config setter, not execution).
 
-    The params must be current public input names at the time of calling.
+    The params must be current local input names at the time of calling.
     If you later call with_inputs() to rename a mapped param, the _map_over
     list is updated automatically to use the new name.
 

--- a/specs/reviewed/node-types.md
+++ b/specs/reviewed/node-types.md
@@ -275,7 +275,7 @@ node.with_inputs(text="final")  # ERROR!
 
 #### map_over() Error Messages
 
-Same principle applies to `map_over()` - use current public names:
+Same principle applies to `map_over()` - use current local names or projected parent-facing addresses:
 
 ```python
 # After renaming, map_over must use the new name
@@ -1346,9 +1346,10 @@ def map_over(
     """
     Configure this GraphNode for iteration (config setter, not execution).
 
-    The params must be current local input names at the time of calling.
-    If you later call with_inputs() to rename a mapped param, the _map_over
-    list is updated automatically to use the new name.
+    The params may be current local input names or projected parent-facing
+    input addresses at the time of calling. GraphNode stores map_over in local
+    names internally. If you later call with_inputs() to rename a mapped param,
+    the _map_over list is updated automatically to use the new local name.
 
     This is a CONFIGURATION method for nested graphs. It stores which
     parameters should be iterated over when this GraphNode is executed
@@ -1359,7 +1360,8 @@ def map_over(
 
     Args:
         *params: Input parameter name(s) to iterate over. REQUIRED (at least one).
-                 Must be CURRENT names at time of call.
+                 Must be current local names or projected parent-facing addresses
+                 at time of call.
         mode: How to combine multiple mapped parameters:
               - "zip": Iterate in parallel (requires same-length iterables)
               - "product": Cartesian product of all combinations
@@ -1400,10 +1402,14 @@ def map_over(
 
         # Both result in _map_over = ["user_question"]
 
+        # For a namespaced GraphNode, projected addresses are also accepted
+        # and normalized back to local names.
+        worker = graph.as_node(name="worker", namespaced=True).map_over("worker.user_question")
+
         # For direct execution - use runner.map() instead:
         results = runner.map(graph, values={...}, map_over=["query"])
     """
-    _validate_map_over(params, self.inputs, self._rename_history)
+    params = _normalize_map_over(params, local_inputs=self.local_inputs, projected_inputs=self.inputs)
     clone = self._copy()
     clone._map_over = list(params)
     clone._map_mode = mode
@@ -1430,9 +1436,7 @@ This ensures consistent behavior regardless of call order.
 
 ### Shared Validation
 
-The `_validate_map_over` helper is used by:
-- `GraphNode.map_over()`
-- `runner.map()`
+The `_validate_map_over` helper is used by `runner.map()`. `GraphNode.map_over()` first normalizes projected parent-facing addresses back to local names, then applies the same existence checks.
 
 ```python
 def _validate_map_over(

--- a/specs/reviewed/persistence.md
+++ b/specs/reviewed/persistence.md
@@ -295,12 +295,13 @@ class PauseInfo:
     node_name: str           # Path to InterruptNode (uses "/" separator)
     value: Any               # Value to show user (input_param)
     response_param: str      # Local parameter name from InterruptNode
-    response_key: str        # Namespaced key for values dict (uses "." separator)
+    response_key: str        # Resolved parent-facing key for values dict
 ```
 
-**For nested graphs:** `response_key` automatically namespaces the response.
+**For nested graphs:** `response_key` crosses GraphNode boundaries using the resolved parent-facing address.
 - Top-level: `response_key == response_param` (e.g., `"decision"`)
-- Nested: `response_key` adds graph path (e.g., `"review.decision"` for `node_name="review/approval"`)
+- Flat GraphNode: `response_key` may remain flat (e.g., `"decision"` for `node_name="review/approval"`)
+- Namespaced GraphNode: `response_key` uses the projected address (e.g., `"review.decision"`)
 
 ---
 
@@ -682,14 +683,15 @@ result = await runner.run(outer, values={...}, workflow_id="order-123")
 # Child:  "order-123/rag"
 ```
 
-### Accessing Nested Results
+### Accessing Nested Outputs
 
 ```python
 result["final_output"]          # Top-level output
-result["rag"]                   # Nested RunResult
-result["rag"]["embedding"]      # Output from nested graph
-result["rag"].status            # RunStatus.COMPLETED
-result["rag"].workflow_id       # "order-123/rag"
+result["embedding"]             # Flat GraphNode output from nested graph
+
+namespaced = Graph(nodes=[preprocess, rag.as_node(namespaced=True), postprocess])
+result = await runner.run(namespaced, values={...}, workflow_id="order-123")
+result["rag.embedding"]         # Namespaced GraphNode output
 ```
 
 ### Nested Pauses
@@ -698,9 +700,8 @@ If a nested graph pauses, the parent pauses too:
 
 ```python
 if result.status == RunStatus.PAUSED:
-    # Check which graph paused
-    if result["review"].status == RunStatus.PAUSED:
-        print(f"Review waiting for: {result['review'].pause.response_param}")
+    print(f"Paused at: {result.pause.node_name}")
+    print(f"Waiting for: {result.pause.response_key}")
 ```
 
 ---

--- a/specs/reviewed/persistence.md
+++ b/specs/reviewed/persistence.md
@@ -865,7 +865,7 @@ match result.status:
     case RunStatus.PAUSED:
         # Store for later, notify user
         await save_pending(result.workflow_id, result.pause)
-        return {"status": "pending", "waiting_for": result.pause.response_param}
+        return {"status": "pending", "waiting_for": result.pause.response_key}
     case RunStatus.FAILED:
         # Log and handle error
         logger.error(f"Workflow failed: {result.error}")

--- a/specs/reviewed/runners-api-reference.md
+++ b/specs/reviewed/runners-api-reference.md
@@ -234,11 +234,11 @@ async def run(
     Args:
         graph: Graph to execute.
         values: Input values. Merged with checkpoint state if workflow_id exists.
-            Use "." separator to provide values to nested graphs:
-            - {"query": "hello"} → top-level value
-            - {"rag.top_k": 5} → value for nested "rag" GraphNode
-            - {"rag.inner.threshold": 0.8} → deeply nested value
-            See graph.md "Nested Graph Values" for details.
+            Keys use resolved graph-scope port addresses:
+            - {"query": "hello"} → flat parent value
+            - {"rag.top_k": 5} → value for a namespaced "rag" GraphNode
+            - {"rag.inner.threshold": 0.8} → multi-level namespaced value
+            See graph.md "Namespaced GraphNode Values" for details.
         select: Outputs to return.
         session_id: Session identifier.
         max_iterations: Max iterations before InfiniteLoopError.
@@ -572,11 +572,12 @@ class PauseInfo:
 
     @property
     def response_key(self) -> str:
-        """Namespaced key for values dict (uses "." separator).
+        """Resolved graph-scope key for values dict.
 
         Examples:
             - Top-level: "decision"
-            - Nested: "review.decision" (from node_name="review/approval")
+            - Flat GraphNode: "decision" (from node_name="review/approval")
+            - Namespaced GraphNode: "review.decision"
         """
 ```
 
@@ -584,10 +585,10 @@ class PauseInfo:
 ```python
 if result.pause:
     response = get_user_input(result.pause.value)
-    # values= accepts ".", "/", or nested dict - all equivalent:
+    # response_key is already the key this graph expects:
     result = await runner.run(
         graph,
-        values={result.pause.response_key: response},  # e.g., "review.decision"
+        values={result.pause.response_key: response},
         workflow_id=result.workflow_id,
     )
 ```
@@ -601,7 +602,7 @@ Returned by `AsyncRunner.run()`:
 ```python
 @dataclass
 class RunResult:
-    values: dict[str, Any | "RunResult"]  # Output name → value (or nested RunResult)
+    values: dict[str, Any]          # Output port address → value
     status: RunStatus             # COMPLETED, PAUSED, STOPPED, or FAILED
     workflow_id: str | None       # For persistence/resume (if checkpointer configured)
     run_id: str                   # Unique run identifier

--- a/specs/reviewed/state-model.md
+++ b/specs/reviewed/state-model.md
@@ -266,9 +266,9 @@ approval = InterruptNode(
 ┌─────────────────────────────────────────────────────────────────┐
 │  Returned State (RunResult) - USER-FACING                       │
 │                                                                  │
-│  All outputs returned to the user (or filtered with select=).  │
-│  Nested graphs return nested RunResult objects.                 │
-│  Dict-like access: result["answer"], result["rag"]["docs"]     │
+│  Graph outputs returned to the user.                            │
+│  Nested graphs project outputs through GraphNode boundaries.     │
+│  Dict-like access: result["answer"], result["rag.docs"]         │
 └─────────────────────────────────────────────────────────────────┘
 ```
 

--- a/specs/reviewed/state-model.md
+++ b/specs/reviewed/state-model.md
@@ -268,7 +268,8 @@ approval = InterruptNode(
 │                                                                  │
 │  Graph outputs returned to the user.                            │
 │  Nested graphs project outputs through GraphNode boundaries.     │
-│  Dict-like access: result["answer"], result["rag.docs"]         │
+│  Dict-like access: result["answer"] (flat mode),                │
+│                    result["rag.docs"] (namespaced projection)   │
 └─────────────────────────────────────────────────────────────────┘
 ```
 

--- a/src/hypergraph/graph/_helpers.py
+++ b/src/hypergraph/graph/_helpers.py
@@ -33,23 +33,21 @@ def sources_of(output: str, nodes: dict[str, HyperNode]) -> list[str]:
 
 
 def flatten_subgraph_addressing(values: dict[str, Any], graph: Graph) -> dict[str, Any]:
-    """Canonicalize nested-dict addressing into dot-paths for a graph's inputs.
+    """Canonicalize nested-dict sugar for valid namespaced graph-node inputs.
 
-    A user can address a GraphNode's private input either as a dot-path
-    (``{"A.x": v}``) or as a nested dict (``{"A": {"x": v}}``). This walks
-    the graph's child GraphNodes recursively and flattens nested-dict entries
-    whose outer key names a child into dot-paths. Dict values whose outer key
-    is NOT a child GraphNode pass through unchanged (the dict IS the value).
+    A user can address a namespaced GraphNode input either as a resolved port
+    address (``{"A.x": v}``) or as nested-dict sugar
+    (``{"A": {"x": v}}``). Flat GraphNodes do not create this nested-dict
+    surface; a dict under their node name remains an ordinary dict value.
 
     Single source of truth used by both the runner boundary
     (``normalize_inputs``) and ``Graph.bind`` so the two surfaces stay in
     lockstep.
 
     Raises:
-        ValueError: when the same leaf is addressed both as dot-path and
-            as nested-dict in the same call, OR when a key is ambiguous
-            because it names BOTH a child GraphNode AND a flat input
-            declared at this scope.
+        ValueError: when the same address is provided twice, when a nested
+            dict targets an exposed/stale address, or when the nested key does
+            not resolve to a current namespaced input address.
     """
     from hypergraph.nodes.graph_node import GraphNode
 
@@ -57,30 +55,40 @@ def flatten_subgraph_addressing(values: dict[str, Any], graph: Graph) -> dict[st
     flat: dict[str, Any] = {}
     for key, value in values.items():
         child = graph._nodes.get(key) if isinstance(graph._nodes.get(key), GraphNode) else None
-        if isinstance(value, dict) and child is not None:
+        if isinstance(value, dict) and child is not None and child.namespaced:
             if key in flat_input_names:
                 raise ValueError(
                     f"Ambiguous addressing: {key!r} is both a flat input of this graph and the "
-                    f"name of a child GraphNode. Pass a flat dict value via the dot-path form "
+                    f"name of a child GraphNode. Pass a flat dict value via the resolved address "
                     f"(e.g., {{{key + '.<inner>'!r}: ...}}) to disambiguate."
                 )
             for sub_key, sub_value in flatten_subgraph_addressing(value, child.graph).items():
-                full_key = f"{key}.{sub_key}"
+                candidate = f"{key}.{sub_key}"
+                if candidate in child.inputs:
+                    full_key = candidate
+                else:
+                    replacement = child.replacement_for_stale_input_address(candidate)
+                    if replacement is not None:
+                        raise ValueError(f"Input address {candidate!r} is no longer valid. Use {replacement!r}.")
+                    valid_namespaced = sorted(address for address in child.inputs if address.startswith(f"{key}."))
+                    raise ValueError(
+                        f"Nested input {candidate!r} is not a valid namespaced input address. Valid namespaced inputs: {valid_namespaced}"
+                    )
                 if full_key in flat:
-                    raise ValueError(f"Input key {full_key!r} provided twice (mixed dot-path and nested-dict).")
+                    raise ValueError(f"Input key {full_key!r} provided twice (mixed resolved-address and nested-dict forms).")
                 flat[full_key] = sub_value
         else:
             if key in flat:
-                raise ValueError(f"Input key {key!r} provided twice (mixed dot-path and nested-dict).")
+                raise ValueError(f"Input key {key!r} provided twice (mixed resolved-address and nested-dict forms).")
             flat[key] = value
     return flat
 
 
 def describe_addressed_input(path: str) -> str:
-    """Render a human-readable description of a (possibly dot-pathed) input.
+    """Render a human-readable description of a possibly namespaced input.
 
     Single source of truth for inlining input addresses into error / warning
-    text. A flat name renders as ``"'x'"``; a dot-pathed name renders as
+    text. A flat name renders as ``"'x'"``; a namespaced name renders as
     ``"'x' of subgraph 'inner'"`` (one level) or
     ``"'x' of subgraph 'middle.inner'"`` (multi-level chain).
 

--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -357,7 +357,6 @@ class Graph:
             self._bound,
             entrypoints=self._entrypoints,
             selected=self._selected,
-            graph_name=self.name,
         )
 
     @functools.cached_property
@@ -949,11 +948,12 @@ class Graph:
     def bind(self, _values: dict[str, Any] | None = None, /, **values: Any) -> Graph:
         """Bind default values. Returns new Graph (immutable).
 
-        Accepts graph input names in the current configured scope. A private
-        subgraph input may be addressed three equivalent ways:
+        Accepts graph input names in the current configured scope. A namespaced
+        GraphNode input may be addressed with either its resolved address or a
+        nested dict:
 
             graph.bind(A={"x": v})       # nested-dict kwarg (recommended)
-            graph.bind({"A.x": v})       # positional dict with dot-path
+            graph.bind({"A.x": v})       # positional dict with resolved address
             inner.bind(x=v)              # bind on the inner Graph itself
 
         Bound values act as pre-filled run() values -- overridable at run time
@@ -1008,7 +1008,7 @@ class Graph:
         """Set default output selection. Returns new Graph (immutable).
 
         Controls which outputs are returned by runner.run() and which outputs
-        are exposed when this graph is used as a nested node via as_node().
+        are visible when this graph is used as a nested node via as_node().
 
         Also narrows ``graph.inputs`` to only parameters needed to produce
         the selected outputs. Nodes that don't contribute are excluded from
@@ -1241,6 +1241,14 @@ class Graph:
                     parts.append(f"when_false={wf if wf is not END else 'END'}")
             if isinstance(node, GraphNode):
                 parts.append(f"nested_struct={node.graph.structural_hash}")
+                parts.append(f"namespaced={node.namespaced}")
+                parts.append("local_inputs=" + ",".join(node.local_inputs))
+                parts.append("local_outputs=" + ",".join(node.local_outputs))
+                parts.append("data_outputs=" + ",".join(node.data_outputs))
+                exposed = getattr(node, "_exposed", {})
+                if exposed:
+                    exposed_str = ",".join(f"{local}->{address}" for local, address in sorted(exposed.items()))
+                    parts.append(f"exposed={exposed_str}")
                 if getattr(node, "_complete_on_stop", False):
                     parts.append("complete_on_stop=True")
                 map_config = node.map_config
@@ -1290,11 +1298,20 @@ class Graph:
                 "  # or Graph(..., entrypoint='<node_name>')"
             )
 
-    def as_node(self, *, name: str | None = None, runner: Any = None, complete_on_stop: bool = False) -> GraphNode:
+    def as_node(
+        self,
+        *,
+        name: str | None = None,
+        namespaced: bool = False,
+        runner: Any = None,
+        complete_on_stop: bool = False,
+    ) -> GraphNode:
         """Wrap graph as node for composition. Returns new GraphNode.
 
         Args:
             name: Optional node name. If not provided, uses graph.name.
+            namespaced: When True, project this graph-node boundary's inputs
+                and outputs under the resolved graph-node name.
             runner: Optional runner to delegate execution to. When set,
                 the parent runner's GraphNode executor uses this runner
                 instead of itself for this subgraph.
@@ -1311,7 +1328,7 @@ class Graph:
         """
         from hypergraph.nodes.graph_node import GraphNode
 
-        node = GraphNode(self, name=name)
+        node = GraphNode(self, name=name, namespaced=namespaced)
         node._complete_on_stop = complete_on_stop
         if runner is not None:
             return node.with_runner(runner)

--- a/src/hypergraph/graph/input_spec.py
+++ b/src/hypergraph/graph/input_spec.py
@@ -373,6 +373,13 @@ def _collect_bound_values(
         for inner_key, value in node.graph.inputs.bound.items():
             address = node.map_input_name_from_original(inner_key)
             if address in bound:
+                import warnings
+
+                warnings.warn(
+                    f"Parent bind for {address!r} overrides nested bind from GraphNode {node_name!r}.",
+                    UserWarning,
+                    stacklevel=4,
+                )
                 continue
             if address in all_bound:
                 from hypergraph.graph.validation import GraphConfigError, _values_equal

--- a/src/hypergraph/graph/input_spec.py
+++ b/src/hypergraph/graph/input_spec.py
@@ -54,7 +54,6 @@ def compute_input_spec(
     entrypoints: tuple[str, ...] | None = None,
     selected: tuple[str, ...] | None = None,
     _active_scope: tuple[dict[str, HyperNode], nx.DiGraph] | None = None,
-    graph_name: str | None = None,
 ) -> InputSpec:
     """Compute input specification for a graph.
 
@@ -88,7 +87,7 @@ def compute_input_spec(
 
     data_subgraph = _data_only_subgraph(active_subgraph)
     edge_produced = get_edge_produced_values(active_subgraph)
-    all_bound = _collect_bound_values(active_nodes, bound, graph_name=graph_name)
+    all_bound = _collect_bound_values(active_nodes, bound)
     cycle_seed_params = _compute_cycle_seed_params(
         active_nodes,
         data_subgraph,
@@ -98,20 +97,18 @@ def compute_input_spec(
     )
 
     required, optional = [], []
-    declared = _names_declared_at_scope(active_nodes)
-
-    for addressed, original, source in _addressed_params(active_nodes, declared):
-        if original in cycle_seed_params:
-            if addressed in all_bound:
-                optional.append(addressed)
+    for address in _input_addresses(active_nodes):
+        if address in cycle_seed_params:
+            if address in all_bound:
+                optional.append(address)
             else:
-                required.append(addressed)
+                required.append(address)
             continue
-        category = _categorize_addressed_param(addressed, original, source, edge_produced, all_bound, active_nodes)
+        category = _categorize_input_address(address, edge_produced, all_bound, active_nodes)
         if category == "required":
-            required.append(addressed)
+            required.append(address)
         elif category == "optional":
-            optional.append(addressed)
+            optional.append(address)
 
     return InputSpec(
         required=tuple(required),
@@ -156,87 +153,41 @@ def _compute_cycle_seed_params(
     return required
 
 
-def _names_declared_at_scope(nodes: dict[str, HyperNode]) -> set[str]:
-    """Names declared directly at this graph's scope.
+def _input_addresses(nodes: dict[str, HyperNode]) -> Iterator[str]:
+    """Yield each graph-scope input port address once.
 
-    A name is declared at this scope if any node here can produce it (leaf
-    output OR GraphNode output, since both surface at this scope) or if a
-    leaf node here consumes it. GraphNode inputs do NOT count -- they are
-    private to the subscope unless declared by something else here.
-
-    Two siblings GraphNodes that happen to share an input name therefore stay
-    private to each. But a GraphNode whose output flows (via edge) to a sibling
-    GraphNode's same-named input auto-links, because the producer's output is
-    declared at this scope.
+    Inputs are emitted once by their parent-facing address. GraphNode boundary
+    projection owns flat/namespaced/exposed addressing; InputSpec does not
+    synthesize or parse addresses.
     """
-    from hypergraph.nodes.graph_node import GraphNode
 
-    names: set[str] = set()
+    seen: set[str] = set()
     for node in nodes.values():
-        if isinstance(node, GraphNode):
-            names.update(node.outputs)
-        else:
-            names.update(node.inputs)
-            names.update(node.outputs)
-    return names
+        for address in node.inputs:
+            if address in seen:
+                continue
+            seen.add(address)
+            yield address
 
 
-def _addressed_params(
-    nodes: dict[str, HyperNode],
-    declared: set[str],
-) -> Iterator[tuple[str, str, str | None]]:
-    """Yield (addressed_name, original_name, source_node_name_or_None) per input.
-
-    Inputs declared at this scope are emitted once with their flat name and no
-    source. Inputs private to a GraphNode subscope are emitted as dot-paths.
-    """
-    from hypergraph.nodes.graph_node import GraphNode
-
-    seen_flat: set[str] = set()
-    for node_name, node in nodes.items():
-        if isinstance(node, GraphNode):
-            for param in node.inputs:
-                if param in declared:
-                    if param not in seen_flat:
-                        seen_flat.add(param)
-                        yield (param, param, None)
-                else:
-                    yield (f"{node_name}.{param}", param, node_name)
-        else:
-            for param in node.inputs:
-                if param not in seen_flat:
-                    seen_flat.add(param)
-                    yield (param, param, None)
-
-
-def _categorize_addressed_param(
-    addressed: str,
-    original: str,
-    source: str | None,
+def _categorize_input_address(
+    address: str,
     edge_produced: set[str],
     bound: dict[str, Any],
     nodes: dict[str, HyperNode],
 ) -> str | None:
-    """Categorize an addressed parameter: 'required', 'optional', or None (edge-produced).
+    """Categorize an input address: 'required', 'optional', or None.
 
-    For a flat (declared-at-scope) param, ``source`` is None and optionality
-    is decided by ``_all_consumers_have_default(original, nodes)``. For a
-    private dot-pathed param, ``source`` names the owning GraphNode and
-    optionality is decided by THAT node's defaults specifically -- siblings'
-    defaults don't influence each other.
+    ``None`` means the address is edge-produced and should not appear as a
+    graph input.
     """
-    # Edge-produced is checked against the original name, since edges act in scope.
-    if original in edge_produced and addressed == original:
+    if address in edge_produced:
         return None
 
-    if addressed in bound:
+    if address in bound:
         return "optional"
 
-    if source is not None and nodes[source].has_default_for(original):
-        # Private dot-pathed input whose owning GraphNode supplies a default.
-        return "optional"
-
-    if addressed == original and _all_consumers_have_default(original, nodes):
+    if _all_consumers_have_default(address, nodes):
         return "optional"
 
     return "required"
@@ -396,16 +347,12 @@ def _active_from_selection(
 def _collect_bound_values(
     nodes: dict[str, HyperNode],
     bound: dict[str, Any],
-    *,
-    graph_name: str | None = None,
 ) -> dict[str, Any]:
-    """Collect all bound values from graph and nested GraphNodes under lexical scope.
+    """Collect all bound values from graph and nested GraphNodes.
 
-    Inner binds surface as dot-pathed keys (``"<graphnode_name>.<public_name>"``)
-    on the outer bound dict. If an inner bind's public name is declared at this
-    scope (would auto-link to an ancestor's same-named input), the bind would be
-    silently overridden by the ancestor's value at run time -- so this is a
-    build-time error pointing to both the bind site and the ancestor scope.
+    Inner binds surface under the GraphNode boundary's projected parent-facing
+    address: flat for flat graph nodes, namespaced for namespaced graph nodes,
+    or exposed alias for exposed ports.
 
     Args:
         nodes: Map of node name -> HyperNode
@@ -414,58 +361,32 @@ def _collect_bound_values(
     Returns:
         Merged dict of all bound values (current graph + nested graphs)
 
-    Raises:
-        GraphConfigError: when a nested bind is shadowed by an ancestor-declared name.
     """
-    from hypergraph.graph.validation import GraphConfigError
     from hypergraph.nodes.graph_node import GraphNode
 
     all_bound = dict(bound)
-    declared = _names_declared_at_scope(nodes)
+    inner_bound_sources: dict[str, str] = {}
 
     for node_name, node in nodes.items():
         if not isinstance(node, GraphNode):
             continue
         for inner_key, value in node.graph.inputs.bound.items():
-            public_key = node.map_input_name_from_original(inner_key)
-            full_path = f"{node_name}.{public_key}"
-            # Conflict surfaces at the OUTERMOST scope that declares the bind's
-            # leaf name. For a deeply-nested bind addressed `a.b.c` reaching
-            # this scope, the leaf is `c`; if a leaf at this scope consumes or
-            # produces `c`, the bind would be silently overridden.
-            leaf = public_key.rsplit(".", 1)[-1]
-            if leaf in declared:
-                raise GraphConfigError(_bind_conflict_message(full_path, leaf, nodes, graph_name))
-            all_bound[full_path] = value
+            address = node.map_input_name_from_original(inner_key)
+            if address in bound:
+                continue
+            if address in all_bound:
+                from hypergraph.graph.validation import GraphConfigError, _values_equal
+
+                if not _values_equal(all_bound[address], value):
+                    first = inner_bound_sources.get(address, "another GraphNode")
+                    raise GraphConfigError(
+                        f"Conflicting nested binds for {address!r}\n\n"
+                        f"  -> GraphNode {first!r} and GraphNode {node_name!r} both bind this parent-facing address.\n\n"
+                        f"How to fix:\n"
+                        f"  Bind {address!r} on the parent graph, or use namespaced/exposed aliases so the binds have distinct addresses."
+                    )
+                continue
+            all_bound[address] = value
+            inner_bound_sources[address] = node_name
 
     return all_bound
-
-
-def _bind_conflict_message(
-    full_path: str,
-    leaf: str,
-    nodes: dict[str, HyperNode],
-    graph_name: str | None,
-) -> str:
-    """Compose a build-time bind-conflict error naming the scope and the
-    specific shadowing node so the user can navigate straight to the source."""
-    from hypergraph.nodes.graph_node import GraphNode
-
-    shadowers: list[str] = []
-    for n_name, n in nodes.items():
-        if isinstance(n, GraphNode):
-            continue
-        if leaf in n.inputs:
-            shadowers.append(f"{n_name!r} (consumes {leaf!r})")
-        elif leaf in n.outputs:
-            shadowers.append(f"{n_name!r} (produces {leaf!r})")
-
-    scope_text = f" at scope {graph_name!r}" if graph_name else " at this scope"
-    shadow_text = f"by node {' / '.join(shadowers)}" if shadowers else f"by '{leaf}' declared at this scope"
-
-    return (
-        f"Bind on {full_path!r} is shadowed{scope_text} {shadow_text}. "
-        f"At run time the parent's value would silently override the bind. "
-        f"Fix: either remove the bind on the inner subgraph, or rename "
-        f"the input via with_inputs(...) so it no longer matches the ancestor."
-    )

--- a/src/hypergraph/graph/validation.py
+++ b/src/hypergraph/graph/validation.py
@@ -40,7 +40,6 @@ def validate_graph(
     _validate_graph_name(graph_name)
     _validate_reserved_names(nodes)
     _validate_valid_identifiers(nodes)
-    _validate_no_namespace_collision(nodes)
     _validate_consistent_defaults(nodes)
     _validate_gate_targets(nodes)
     _validate_no_gate_self_loop(nodes)
@@ -112,41 +111,6 @@ def _validate_valid_identifiers(nodes: dict[str, HyperNode]) -> None:
                     )
 
 
-def _validate_no_namespace_collision(nodes: dict[str, HyperNode]) -> None:
-    """Ensure GraphNode names don't collide with output names.
-
-    GraphNode names are used for path-based result access (e.g., results['subgraph.output']).
-    If a GraphNode name matches an output name, it creates ambiguity.
-    """
-    from hypergraph.nodes.graph_node import GraphNode
-
-    graph_node_names = {node.name for node in nodes.values() if isinstance(node, GraphNode)}
-
-    if not graph_node_names:
-        return  # No GraphNodes, nothing to validate
-
-    # Collect ALL outputs (including from other GraphNodes)
-    all_outputs: dict[str, str] = {}  # output_name -> source_node_name
-    for node in nodes.values():
-        for output in node.outputs:
-            all_outputs[output] = node.name
-
-    # Check for collision between GraphNode names and any output
-    for gn_name in graph_node_names:
-        if gn_name in all_outputs:
-            source_node = all_outputs[gn_name]
-            # Skip if the GraphNode's own output matches its name (that's fine)
-            if source_node == gn_name:
-                continue
-            raise GraphConfigError(
-                f"GraphNode name '{gn_name}' collides with output name\n\n"
-                f"  -> GraphNode '{gn_name}' exists\n"
-                f"  -> Node '{source_node}' outputs '{gn_name}'\n\n"
-                f"How to fix:\n"
-                f"  Rename the GraphNode: graph.as_node(name='other_name')"
-            )
-
-
 def _validate_consistent_defaults(nodes: dict[str, HyperNode]) -> None:
     """Shared input parameters must have ALL-or-NONE consistent defaults."""
     param_info = _collect_param_default_info(nodes)
@@ -166,22 +130,12 @@ def _collect_param_default_info(
     graph.bind(). This ensures validation only checks for consistent defaults
     in function signatures, not configuration values.
 
-    Under lexical scope, a GraphNode's input that is NOT declared at this
-    scope is private to its subgraph and lives in a different namespace from
-    a sibling GraphNode's same-named input. Such private inputs are excluded
-    from the cross-node consistency check -- their defaults are validated
-    inside the owning inner graph at its own construction time.
+    GraphNode inputs are already projected into parent-facing addresses by the
+    GraphNode boundary, so they participate in this scope using those names.
     """
-    from hypergraph.graph.input_spec import _names_declared_at_scope
-    from hypergraph.nodes.graph_node import GraphNode
-
-    declared = _names_declared_at_scope(nodes)
     param_info: dict[str, list[tuple[bool, Any, str]]] = defaultdict(list)
     for node in nodes.values():
         for param in node.inputs:
-            if isinstance(node, GraphNode) and param not in declared:
-                # Private to the subgraph -- different namespace from this scope.
-                continue
             # Check for signature defaults only (excludes bound values)
             has_default = node.has_signature_default_for(param)
             if has_default:

--- a/src/hypergraph/nodes/base.py
+++ b/src/hypergraph/nodes/base.py
@@ -67,8 +67,8 @@ class HyperNode(ABC):
 
     Defines the minimal interface that all nodes share:
     - name: Public node name
-    - inputs: Input parameter names
-    - outputs: Output value names
+    - inputs: Parent-facing input names or addresses
+    - outputs: Parent-facing output names or addresses
     - _rename_history: Tracks renames for error messages
 
     All with_* methods return new instances (immutable pattern).
@@ -164,7 +164,7 @@ class HyperNode(ABC):
 
     @property
     def wait_for(self) -> tuple[str, ...]:
-        """Ordering-only inputs: node won't run until these values exist and are fresh.
+        """Ordering-only graph-scope addresses this node waits for.
 
         Default: empty tuple. Override in subclasses that support wait_for.
         """

--- a/src/hypergraph/nodes/function.py
+++ b/src/hypergraph/nodes/function.py
@@ -125,11 +125,10 @@ class FunctionNode(CallableMixin, HyperNode):
             rename_inputs: Mapping to rename inputs {old: new}
             cache: Whether to cache results (default: False)
             hide: Whether to hide from visualization (default: False)
-            emit: Ordering-only output name(s). Auto-produced with sentinel value
+            emit: Ordering-only local output name(s). Auto-produced with sentinel value
                   when node runs. Participates in edge inference like output_name.
-            wait_for: Ordering-only input name(s). Node won't run until these
-                      values exist and are fresh. Participates in edge inference
-                      like function parameters.
+            wait_for: Ordering-only graph-scope output/emit address(es). Node
+                      won't run until these values exist and are fresh.
             batch: If True, DaftRunner uses vectorized batch UDF execution
                    (receives ``daft.Series`` instead of scalars).
 
@@ -202,7 +201,7 @@ class FunctionNode(CallableMixin, HyperNode):
 
     @property
     def wait_for(self) -> tuple[str, ...]:
-        """Ordering-only inputs this node waits for."""
+        """Ordering-only graph-scope addresses this node waits for."""
         return self._wait_for
 
     @property
@@ -327,10 +326,10 @@ def node(
         rename_inputs: Mapping to rename inputs {old: new}
         cache: Whether to cache results (default: False)
         hide: Whether to hide from visualization (default: False)
-        emit: Ordering-only output name(s). Auto-produced with sentinel value
+        emit: Ordering-only local output name(s). Auto-produced with sentinel value
               when node runs. Participates in edge inference like output_name.
-        wait_for: Ordering-only input name(s). Node won't run until these
-                  values exist and are fresh.
+        wait_for: Ordering-only graph-scope output/emit address(es). Node
+                  won't run until these values exist and are fresh.
         batch: If True, DaftRunner uses vectorized batch UDF execution
                (receives ``daft.Series`` instead of scalars).
 

--- a/src/hypergraph/nodes/gate.py
+++ b/src/hypergraph/nodes/gate.py
@@ -124,7 +124,7 @@ class GateNode(CallableMixin, HyperNode):
 
     @property
     def wait_for(self) -> tuple[str, ...]:
-        """Ordering-only inputs this gate waits for."""
+        """Ordering-only graph-scope addresses this gate waits for."""
         return self._wait_for
 
     @property
@@ -225,9 +225,9 @@ class RouteNode(GateNode):
             hide: Whether to hide from visualization (default: False)
             name: Node name (default: func.__name__)
             rename_inputs: Mapping to rename inputs {old: new}
-            emit: Ordering-only output name(s). Auto-produced when gate runs.
-            wait_for: Ordering-only input name(s). Gate won't run until these
-                      values exist and are fresh.
+            emit: Ordering-only local output name(s). Auto-produced when gate runs.
+            wait_for: Ordering-only graph-scope output/emit address(es). Gate
+                      won't run until these values exist and are fresh.
 
         Raises:
             TypeError: If func is async or generator
@@ -363,9 +363,9 @@ def route(
             and records a decision.
         name: Node name (default: func.__name__)
         rename_inputs: Mapping to rename inputs {old: new}
-        emit: Ordering-only output name(s). Auto-produced when gate runs.
-        wait_for: Ordering-only input name(s). Gate won't run until these
-                  values exist and are fresh.
+        emit: Ordering-only local output name(s). Auto-produced when gate runs.
+        wait_for: Ordering-only graph-scope output/emit address(es). Gate
+                  won't run until these values exist and are fresh.
 
     Returns:
         Decorator that creates a RouteNode
@@ -457,9 +457,9 @@ class IfElseNode(GateNode):
                 executes and records a decision.
             name: Node name (default: func.__name__)
             rename_inputs: Mapping to rename inputs {old: new}
-            emit: Ordering-only output name(s). Auto-produced when gate runs.
-            wait_for: Ordering-only input name(s). Gate won't run until these
-                      values exist and are fresh.
+            emit: Ordering-only local output name(s). Auto-produced when gate runs.
+            wait_for: Ordering-only graph-scope output/emit address(es). Gate
+                      won't run until these values exist and are fresh.
 
         Raises:
             TypeError: If func is async or generator
@@ -568,9 +568,9 @@ def ifelse(
             and records a decision.
         name: Node name (default: func.__name__)
         rename_inputs: Mapping to rename inputs {old: new}
-        emit: Ordering-only output name(s). Auto-produced when gate runs.
-        wait_for: Ordering-only input name(s). Gate won't run until these
-                  values exist and are fresh.
+        emit: Ordering-only local output name(s). Auto-produced when gate runs.
+        wait_for: Ordering-only graph-scope output/emit address(es). Gate
+                  won't run until these values exist and are fresh.
 
     Returns:
         Decorator that creates an IfElseNode

--- a/src/hypergraph/nodes/graph_node.py
+++ b/src/hypergraph/nodes/graph_node.py
@@ -723,21 +723,39 @@ class GraphNode(HyperNode):
         if not params:
             raise ValueError("map_over requires at least one parameter")
 
-        # Validate all params exist in local inputs
-        for param in params:
-            if param not in self._local_inputs:
-                raise ValueError(f"Parameter '{param}' is not an input of this GraphNode. Available local inputs: {self._local_inputs}")
+        normalized_params = tuple(self._normalize_map_input_param(param) for param in params)
+        normalized_clone: bool | list[str]
+        if not isinstance(clone, (bool, list)):
+            raise TypeError(f"clone must be bool or list[str], got {type(clone).__name__}")
+        if isinstance(clone, list):
+            for entry in clone:
+                if not isinstance(entry, str):
+                    raise TypeError(f"clone list entries must be strings, got {type(entry).__name__}: {entry!r}")
+            normalized_clone = [self._normalize_map_input_param(param) for param in clone]
+        else:
+            normalized_clone = clone
 
         # Validate clone parameter
-        _validate_clone(clone, params, self._local_inputs)
+        _validate_clone(normalized_clone, normalized_params, self._local_inputs)
 
         # Create copy with map_over configuration
         new = self._copy()
-        new._map_over = list(params)
+        new._map_over = list(normalized_params)
         new._map_mode = mode
         new._error_handling = error_handling
-        new._clone = list(clone) if isinstance(clone, list) else clone
+        new._clone = list(normalized_clone) if isinstance(normalized_clone, list) else normalized_clone
         return new
+
+    def _normalize_map_input_param(self, param: str) -> str:
+        if param in self._local_inputs:
+            return param
+        if param in self.inputs:
+            local_candidates = self._local_inputs_for_address(param)
+            if len(local_candidates) == 1 and local_candidates[0] in self._local_inputs:
+                return local_candidates[0]
+        raise ValueError(
+            f"Parameter '{param}' is not an input of this GraphNode. Available local inputs: {self._local_inputs}; projected inputs: {self.inputs}"
+        )
 
     def _copy(self: _GN) -> _GN:
         """Create a shallow copy preserving map_over and runner_override."""

--- a/src/hypergraph/nodes/graph_node.py
+++ b/src/hypergraph/nodes/graph_node.py
@@ -1,9 +1,10 @@
 """GraphNode - wrapper for using graphs as nodes."""
 
 import functools
+import hashlib
 from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
-from hypergraph.nodes._rename import build_reverse_rename_map
+from hypergraph.nodes._rename import RenameError, build_reverse_rename_map, get_next_batch_id
 from hypergraph.nodes.base import HyperNode, RenameEntry, _invalidate_cached_properties
 
 # TypeVar for self-referential return types (Python 3.10 compatible)
@@ -31,8 +32,8 @@ class GraphNode(HyperNode):
 
     Attributes:
         name: Node name (from graph.name or explicit override)
-        inputs: All graph inputs (required + optional + entry point params)
-        outputs: All graph outputs
+        inputs: Parent-facing input addresses after boundary projection
+        outputs: Parent-facing output addresses after boundary projection
         graph: The wrapped Graph instance
 
     Properties:
@@ -52,14 +53,16 @@ class GraphNode(HyperNode):
         ('y',)
     """
 
-    # Reserved characters that cannot appear in GraphNode names
-    # These are used as path separators in nested graph output access
+    # Reserved characters that cannot appear in GraphNode names.
+    # "." separates projected port addresses; "/" separates workflow paths.
     _RESERVED_CHARS = frozenset("./")
 
     def __init__(
         self,
         graph: "Graph",
         name: str | None = None,
+        *,
+        namespaced: bool = False,
     ):
         """Wrap a graph as a node.
 
@@ -82,6 +85,8 @@ class GraphNode(HyperNode):
 
         self._graph = graph
         self._rename_history: list[RenameEntry] = []
+        self._namespaced = namespaced
+        self._exposed: dict[str, str] = {}
 
         # map_over configuration (None = no mapping)
         self._map_over: list[str] | None = None
@@ -98,8 +103,10 @@ class GraphNode(HyperNode):
 
         # Core HyperNode attributes
         self.name = resolved_name
-        self.inputs = graph.inputs.all
-        self.outputs = self._derive_outputs(graph)
+        self._local_inputs = graph.inputs.all
+        self._local_outputs = self._derive_outputs(graph)
+        self._local_data_outputs = self._derive_data_outputs(graph, self._local_outputs)
+        self._refresh_projected_ports()
 
     @property
     def graph(self) -> "Graph":
@@ -108,8 +115,22 @@ class GraphNode(HyperNode):
 
     @property
     def definition_hash(self) -> str:
-        """Hash of the nested graph."""
-        return self._graph.definition_hash
+        """Hash of the nested graph plus this boundary's projected surface."""
+        content = repr(
+            (
+                self._graph.definition_hash,
+                self.name,
+                self._namespaced,
+                tuple(sorted(self._exposed.items())),
+                self._local_inputs,
+                self._local_outputs,
+                self._local_data_outputs,
+                self.inputs,
+                self.outputs,
+                self._data_outputs,
+            )
+        )
+        return hashlib.sha256(content.encode()).hexdigest()
 
     @property
     def is_async(self) -> bool:
@@ -130,6 +151,26 @@ class GraphNode(HyperNode):
         return self._runner_override
 
     @property
+    def namespaced(self) -> bool:
+        """Whether this graph-node boundary projects local ports with a prefix."""
+        return self._namespaced
+
+    @property
+    def local_inputs(self) -> tuple[str, ...]:
+        """Current local input names before boundary projection."""
+        return self._local_inputs
+
+    @property
+    def local_outputs(self) -> tuple[str, ...]:
+        """Current local output names before boundary projection."""
+        return self._local_outputs
+
+    @property
+    def data_outputs(self) -> tuple[str, ...]:
+        """Projected data-carrying output addresses."""
+        return self._data_outputs
+
+    @property
     def nested_graph(self) -> "Graph":
         """Returns the nested Graph."""
         return self._graph
@@ -139,7 +180,80 @@ class GraphNode(HyperNode):
         """Flattened attributes enriched with collapsed-view output metadata."""
         attrs = super().nx_attrs
         attrs["collapsed_outputs"] = self._derive_collapsed_outputs()
+        attrs["local_inputs"] = self._local_inputs
+        attrs["local_outputs"] = self._local_outputs
+        attrs["namespaced"] = self._namespaced
         return attrs
+
+    def _refresh_projected_ports(self) -> None:
+        """Recompute parent-facing addresses and boundary maps."""
+        input_address_to_local: dict[str, list[str]] = {}
+        projected_inputs: list[str] = []
+        for local in self._local_inputs:
+            address = self._project_address(local)
+            input_address_to_local.setdefault(address, []).append(local)
+            if address not in projected_inputs:
+                projected_inputs.append(address)
+
+        output_local_to_address: dict[str, str] = {}
+        projected_outputs: list[str] = []
+        for local in self._local_outputs:
+            address = self._project_address(local)
+            if address in projected_outputs:
+                raise ValueError(f"GraphNode '{self.name}' projects multiple outputs to {address!r}")
+            input_locals = input_address_to_local.get(address, ())
+            if input_locals and local not in input_locals:
+                raise ValueError(
+                    f"GraphNode '{self.name}' projects input(s) {input_locals!r} and output {local!r} "
+                    f"to the same address {address!r}. Use the same local name for cyclic seed/update "
+                    f"ports, or choose distinct aliases."
+                )
+            output_local_to_address[local] = address
+            projected_outputs.append(address)
+
+        self._input_address_to_local = {key: tuple(values) for key, values in input_address_to_local.items()}
+        self._output_local_to_address = output_local_to_address
+        self._output_address_to_local = {address: local for local, address in output_local_to_address.items()}
+        self.inputs = tuple(projected_inputs)
+        self.outputs = tuple(projected_outputs)
+        self._data_outputs = tuple(self._project_address(local) for local in self._local_data_outputs if local in output_local_to_address)
+
+    def _project_address(self, local_name: str) -> str:
+        if self._namespaced:
+            if local_name in self._exposed:
+                return self._exposed[local_name]
+            return f"{self.name}.{local_name}"
+        return local_name
+
+    def _local_inputs_for_address(self, address: str) -> tuple[str, ...]:
+        return self._input_address_to_local.get(address, (address,))
+
+    def _local_output_for_address(self, address: str) -> str:
+        return self._output_address_to_local.get(address, address)
+
+    def replacement_for_stale_input_address(self, address: str) -> str | None:
+        """Return the current parent-facing input address for a stale namespaced one."""
+        prefixes = [self.name, *(entry.old for entry in self._rename_history if entry.kind == "name")]
+        prefix = next((f"{name}." for name in prefixes if address.startswith(f"{name}.")), None)
+        if prefix is None:
+            return None
+        local_name = address[len(prefix) :]
+        if local_name not in self._local_inputs:
+            for current in self._local_inputs:
+                if self._resolve_original_input_name(current) == local_name:
+                    local_name = current
+                    break
+            else:
+                if local_name in self.inputs:
+                    return local_name
+                return None
+        current = self._project_address(local_name)
+        return current if current != address else None
+
+    def _validate_local_port_name(self, name: str, *, role: str) -> None:
+        for char in self._RESERVED_CHARS:
+            if char in name:
+                raise ValueError(f"{role} cannot contain '{char}': {name!r}. Reserved characters: {set(self._RESERVED_CHARS)}")
 
     def with_runner(self: _GN, runner: Any) -> _GN:
         """Return a new GraphNode that delegates execution to the given runner.
@@ -204,13 +318,15 @@ class GraphNode(HyperNode):
 
         # For each output of this GraphNode, get type from source node
         for output_name in self.outputs:
-            source_node = output_to_node.get(output_name)
+            local_output = self._local_output_for_address(output_name)
+            original_output = self.resolve_original_output_name(local_output)
+            source_node = output_to_node.get(original_output)
             if source_node is None:
                 result[output_name] = self._wrap_type_for_map_over(None)
                 continue
 
             # Use universal get_output_type method
-            output_type = source_node.get_output_type(output_name)
+            output_type = source_node.get_output_type(original_output)
             result[output_name] = self._wrap_type_for_map_over(output_type)
 
         return result
@@ -254,13 +370,12 @@ class GraphNode(HyperNode):
         Returns:
             The type annotation, or None if not annotated.
         """
-        # Resolve param back to original name if renamed
-        original_param = self._resolve_original_input_name(param)
-
-        # Find which node in inner graph has this as an input
-        for inner_node in self._graph.iter_nodes():
-            if original_param in inner_node.inputs:
-                return inner_node.get_input_type(original_param)
+        for local_param in self._local_inputs_for_address(param):
+            original_param = self._resolve_original_input_name(local_param)
+            # Find which node in inner graph has this as an input
+            for inner_node in self._graph.iter_nodes():
+                if original_param in inner_node.inputs:
+                    return inner_node.get_input_type(original_param)
         return None
 
     def _resolve_original_input_name(self, param: str) -> str:
@@ -296,10 +411,11 @@ class GraphNode(HyperNode):
             Dict with original inner graph parameter names as keys
         """
         reverse_map = build_reverse_rename_map(self._rename_history, "inputs")
-        if not reverse_map:
-            return inputs
-
-        return {reverse_map.get(key, key): value for key, value in inputs.items()}
+        mapped: dict[str, Any] = {}
+        for address, value in inputs.items():
+            for local_name in self._local_inputs_for_address(address):
+                mapped[reverse_map.get(local_name, local_name)] = value
+        return mapped
 
     def _original_map_params(self) -> list[str] | None:
         """Get map_over params translated to original inner graph names.
@@ -347,42 +463,52 @@ class GraphNode(HyperNode):
         Returns:
             Dict with renamed (external) output names as keys
         """
-        reverse_map = build_reverse_rename_map(self._rename_history, "outputs")
-        if not reverse_map:
-            return outputs
+        from hypergraph.nodes.base import _EMIT_SENTINEL
 
-        # Build forward map (original -> renamed) by inverting reverse map
+        reverse_map = build_reverse_rename_map(self._rename_history, "outputs")
         forward_map = {v: k for k, v in reverse_map.items()}
-        return {forward_map.get(key, key): value for key, value in outputs.items()}
+        mapped = {self._output_local_to_address.get(forward_map.get(key, key), forward_map.get(key, key)): value for key, value in outputs.items()}
+        for local_output in self._local_outputs:
+            if local_output in self._local_data_outputs:
+                continue
+            address = self._output_local_to_address.get(local_output)
+            if address is not None and address not in mapped:
+                mapped[address] = _EMIT_SENTINEL
+        return mapped
 
     def map_output_name_from_original(self, output_name: str) -> str:
         """Map a single inner output name to its external renamed name."""
         reverse_map = build_reverse_rename_map(self._rename_history, "outputs")
-        if not reverse_map:
-            return output_name
         forward_map = {v: k for k, v in reverse_map.items()}
-        return forward_map.get(output_name, output_name)
+        local_name = forward_map.get(output_name, output_name)
+        return self._output_local_to_address.get(local_name, local_name)
 
     def resolve_original_output_name(self, output_name: str) -> str:
         """Resolve an external output name back to the inner graph's name."""
         reverse_map = build_reverse_rename_map(self._rename_history, "outputs")
-        return reverse_map.get(output_name, output_name)
+        local_name = self._local_output_for_address(output_name)
+        return reverse_map.get(local_name, local_name)
 
     def map_input_name_from_original(self, input_name: str) -> str:
         """Map a single inner input name to its external renamed name."""
         reverse_map = build_reverse_rename_map(self._rename_history, "inputs")
-        if not reverse_map:
-            return input_name
         forward_map = {v: k for k, v in reverse_map.items()}
-        return forward_map.get(input_name, input_name)
+        local_name = forward_map.get(input_name, input_name)
+        return self._project_address(local_name)
 
     def map_resume_key_from_original(self, resume_key: str) -> str:
         """Map a nested resume key from inner names to external names.
+
+        If the key is on this graph-node's current local output surface, map
+        the whole key. This matters when a child namespaced GraphNode has
+        already produced a local output address such as ``inner.decision``.
 
         Only the first path component can be renamed by the GraphNode boundary.
         For example, ``decision`` may become ``verdict`` while
         ``review.decision`` remains unchanged because ``review`` is internal.
         """
+        if resume_key in self._local_outputs:
+            return self.map_output_name_from_original(resume_key)
         head, sep, tail = resume_key.partition(".")
         mapped_head = self.map_output_name_from_original(head)
         if not sep:
@@ -416,17 +542,16 @@ class GraphNode(HyperNode):
         if param not in self.inputs:
             return False
 
-        # Resolve to original name for inner graph lookup
-        original_param = self._resolve_original_input_name(param)
-
-        # Check if bound anywhere in the visible inner graph scope
-        if original_param in self._graph.inputs.bound:
-            return True
-        # Check if any inner node has a default
-        inner_nodes_with_param = [n for n in self._graph.iter_nodes() if original_param in n.inputs]
-        if not inner_nodes_with_param:
-            return False
-        return all(inner_node.has_default_for(original_param) for inner_node in inner_nodes_with_param)
+        for local_param in self._local_inputs_for_address(param):
+            original_param = self._resolve_original_input_name(local_param)
+            if original_param in self._graph.inputs.bound:
+                continue
+            inner_nodes_with_param = [n for n in self._graph.iter_nodes() if original_param in n.inputs]
+            if not inner_nodes_with_param:
+                return False
+            if not all(inner_node.has_default_for(original_param) for inner_node in inner_nodes_with_param):
+                return False
+        return True
 
     def get_default_for(self, param: str) -> Any:
         """Get the default or bound value for a parameter from the inner graph.
@@ -443,8 +568,8 @@ class GraphNode(HyperNode):
         Raises:
             KeyError: If no default or bound value exists for this parameter.
         """
-        # Resolve to original name for inner graph lookup
-        original_param = self._resolve_original_input_name(param)
+        local_param = self._local_inputs_for_address(param)[0]
+        original_param = self._resolve_original_input_name(local_param)
 
         # Check if bound in inner graph first
         if original_param in self._graph.inputs.bound:
@@ -471,20 +596,16 @@ class GraphNode(HyperNode):
         if param not in self.inputs:
             return False
 
-        # Resolve to original name for inner graph lookup
-        original_param = self._resolve_original_input_name(param)
-
-        # Bound parameters don't have signature defaults (they're configuration)
-        if original_param in self._graph.inputs.bound:
-            return False
-
-        # Check if ALL inner nodes using this param have signature defaults
-        inner_nodes_with_param = [n for n in self._graph.iter_nodes() if original_param in n.inputs]
-
-        if not inner_nodes_with_param:
-            return False
-
-        return all(n.has_signature_default_for(original_param) for n in inner_nodes_with_param)
+        for local_param in self._local_inputs_for_address(param):
+            original_param = self._resolve_original_input_name(local_param)
+            if original_param in self._graph.inputs.bound:
+                return False
+            inner_nodes_with_param = [n for n in self._graph.iter_nodes() if original_param in n.inputs]
+            if not inner_nodes_with_param:
+                return False
+            if not all(n.has_signature_default_for(original_param) for n in inner_nodes_with_param):
+                return False
+        return True
 
     def get_signature_default_for(self, param: str) -> Any:
         """Get the signature default value for a parameter.
@@ -501,8 +622,8 @@ class GraphNode(HyperNode):
         Raises:
             KeyError: If no signature default exists (bound values don't count).
         """
-        # Resolve to original name for inner graph lookup
-        original_param = self._resolve_original_input_name(param)
+        local_param = self._local_inputs_for_address(param)[0]
+        original_param = self._resolve_original_input_name(local_param)
 
         # Bound parameters don't have signature defaults
         if original_param in self._graph.inputs.bound:
@@ -602,13 +723,13 @@ class GraphNode(HyperNode):
         if not params:
             raise ValueError("map_over requires at least one parameter")
 
-        # Validate all params exist in inputs
+        # Validate all params exist in local inputs
         for param in params:
-            if param not in self.inputs:
-                raise ValueError(f"Parameter '{param}' is not an input of this GraphNode. Available inputs: {self.inputs}")
+            if param not in self._local_inputs:
+                raise ValueError(f"Parameter '{param}' is not an input of this GraphNode. Available local inputs: {self._local_inputs}")
 
         # Validate clone parameter
-        _validate_clone(clone, params, self.inputs)
+        _validate_clone(clone, params, self._local_inputs)
 
         # Create copy with map_over configuration
         new = self._copy()
@@ -624,6 +745,10 @@ class GraphNode(HyperNode):
 
         new = copy.copy(self)
         new._rename_history = list(self._rename_history)
+        new._exposed = dict(self._exposed)
+        new._local_inputs = tuple(self._local_inputs)
+        new._local_outputs = tuple(self._local_outputs)
+        new._local_data_outputs = tuple(self._local_data_outputs)
         # Preserve map_over as a new list if set
         if self._map_over is not None:
             new._map_over = list(self._map_over)
@@ -632,6 +757,18 @@ class GraphNode(HyperNode):
             new._clone = list(self._clone)
         # runner_override is preserved as-is (runner instances are shared)
         _invalidate_cached_properties(new)
+        return new
+
+    def with_name(self: _GN, name: str) -> _GN:
+        """Return new node with a different graph-node name."""
+        for char in self._RESERVED_CHARS:
+            if char in name:
+                raise ValueError(f"GraphNode name cannot contain '{char}': {name!r}. Reserved characters: {set(self._RESERVED_CHARS)}")
+        new = self._copy()
+        if new.name != name:
+            new._rename_history.append(RenameEntry("name", new.name, name, get_next_batch_id()))
+            new.name = name
+            new._refresh_projected_ports()
         return new
 
     def with_inputs(
@@ -648,8 +785,19 @@ class GraphNode(HyperNode):
         if not combined:
             return self._copy()
 
-        # Call base class rename
-        renamed = self._with_renamed("inputs", combined)
+        renamed = self._copy()
+        batch_id = get_next_batch_id()
+        current = renamed._local_inputs
+        for old, new_name in combined.items():
+            if old not in current:
+                raise renamed._make_rename_error(old, "inputs")
+            if old in renamed._exposed:
+                raise RenameError(f"Cannot rename exposed local input {old!r}; its parent-facing address is finalized.")
+            renamed._validate_local_port_name(new_name, role="Input name")
+            renamed._rename_history.append(RenameEntry("inputs", old, new_name, batch_id))
+        renamed._local_inputs = tuple(combined.get(value, value) for value in current)
+        if len(renamed._local_inputs) != len(set(renamed._local_inputs)):
+            raise RenameError("Rename produces duplicate inputs. Each name must be unique.")
 
         # Update map_over if any mapped params were renamed
         if renamed._map_over is not None:
@@ -659,7 +807,65 @@ class GraphNode(HyperNode):
         if isinstance(renamed._clone, list):
             renamed._clone = [combined.get(p, p) for p in renamed._clone]
 
+        renamed._refresh_projected_ports()
         return renamed
+
+    def with_outputs(
+        self: _GN,
+        mapping: dict[str, str] | None = None,
+        /,
+        **kwargs: str,
+    ) -> _GN:
+        """Return new node with renamed local outputs."""
+        combined = {**(mapping or {}), **kwargs}
+        if not combined:
+            return self._copy()
+
+        renamed = self._copy()
+        batch_id = get_next_batch_id()
+        current = renamed._local_outputs
+        for old, new_name in combined.items():
+            if old not in current:
+                raise renamed._make_rename_error(old, "outputs")
+            if old in renamed._exposed:
+                raise RenameError(f"Cannot rename exposed local output {old!r}; its parent-facing address is finalized.")
+            renamed._validate_local_port_name(new_name, role="Output name")
+            renamed._rename_history.append(RenameEntry("outputs", old, new_name, batch_id))
+        renamed._local_outputs = tuple(combined.get(value, value) for value in current)
+        renamed._local_data_outputs = tuple(combined.get(value, value) for value in renamed._local_data_outputs)
+        if len(renamed._local_outputs) != len(set(renamed._local_outputs)):
+            raise RenameError("Rename produces duplicate outputs. Each name must be unique.")
+
+        renamed._refresh_projected_ports()
+        return renamed
+
+    def expose(self: _GN, *names: str, **aliases: str) -> _GN:
+        """Expose local ports from a namespaced GraphNode as flat parent addresses."""
+        if not self._namespaced:
+            raise ValueError("expose(...) is only valid on namespaced GraphNodes")
+        if not names and not aliases:
+            return self._copy()
+
+        exposed = self._copy()
+        for name in names:
+            exposed._add_exposed_port(name, name)
+        for local_name, alias in aliases.items():
+            exposed._add_exposed_port(local_name, alias)
+        exposed._refresh_projected_ports()
+        return exposed
+
+    def _add_exposed_port(self, local_name: str, alias: str) -> None:
+        if any(char in local_name for char in self._RESERVED_CHARS):
+            raise ValueError(f"expose(...) targets Local port names, not projected addresses: {local_name!r}")
+        self._validate_local_port_name(local_name, role="Expose target")
+        self._validate_local_port_name(alias, role="Expose alias")
+        if local_name not in self._local_inputs and local_name not in self._local_outputs:
+            raise ValueError(
+                f"Cannot expose {local_name!r}: not on GraphNode surface. Available inputs: {self._local_inputs}; outputs: {self._local_outputs}"
+            )
+        if alias in self._exposed.values() and self._exposed.get(local_name) != alias:
+            raise ValueError(f"expose(...) alias {alias!r} is already used by another local port on GraphNode '{self.name}'")
+        self._exposed[local_name] = alias
 
     @staticmethod
     def _derive_outputs(graph: "Graph") -> tuple[str, ...]:
@@ -679,6 +885,12 @@ class GraphNode(HyperNode):
             selected=None,
         )
         return tuple(dict.fromkeys(output for node in active_nodes.values() for output in node.outputs))
+
+    @staticmethod
+    def _derive_data_outputs(graph: "Graph", outputs: tuple[str, ...]) -> tuple[str, ...]:
+        """Resolve data-carrying local outputs for the current graph scope."""
+        emit_only_outputs = graph._get_emit_only_outputs()
+        return tuple(output for output in outputs if output not in emit_only_outputs)
 
     def _derive_collapsed_outputs(self) -> tuple[str, ...]:
         """Resolve outputs a collapsed GraphNode should advertise.

--- a/src/hypergraph/nodes/interrupt.py
+++ b/src/hypergraph/nodes/interrupt.py
@@ -85,8 +85,8 @@ def interrupt(
         output_name: Name(s) for output value(s).
         rename_inputs: Mapping to rename inputs {old: new}.
         cache: Whether to cache results (default: False).
-        emit: Ordering-only output name(s).
-        wait_for: Ordering-only input name(s).
+        emit: Ordering-only local output name(s).
+        wait_for: Ordering-only graph-scope output/emit address(es).
         hide: Whether to hide from visualization (default: False).
 
     Examples::

--- a/src/hypergraph/runners/_shared/AGENTS.md
+++ b/src/hypergraph/runners/_shared/AGENTS.md
@@ -54,28 +54,27 @@ InterruptNode execution has three paths:
 
 The `is_resuming` flag prevents false auto-resolve on fresh runs when provided_values happen to match interrupt output names.
 
-## Lexical-Scope Addressing (`address_for_node_input`)
+## GraphNode Boundary Addressing (`address_for_node_input`)
 
-Under lexical scope (issue #94), a `GraphNode`'s private input is addressed at
-the parent scope as `"<node.name>.<param>"` — the dotted form. Auto-linked
-inputs (a leaf at this scope declares the same name) stay flat.
+A `GraphNode`'s inputs are already projected to the parent-facing address:
+flat by default, or `"<node.name>.<param>"` when the node was created with
+`as_node(namespaced=True)` unless that port was exposed back to a flat name.
 
 State, provided values, and bound values all use this canonical form, so any
-code that looks up a node-input value against one of those dicts MUST resolve
-through the helper instead of using the bare param name:
+code that looks up a node-input value should use that canonical address instead
+of guessing a bare or prefixed name:
 
 ```python
 from hypergraph.runners._shared.helpers import address_for_node_input
 
-addr = address_for_node_input(node, param, state.values, graph.inputs.bound)
+addr = address_for_node_input(node, param)
 if addr in state.values:
     ...
 ```
 
-`namespaces` (the variadic) are checked in order; the first one containing the
-dotted form wins, otherwise the flat name is the auto-link fallback. Pass the
-dicts you intend to look up in — the resolver matches whichever one actually
-holds the value.
+The helper is intentionally thin after boundary projection: `node.inputs`
+already contains the resolved parent-facing address, so the helper currently
+returns `param`. It remains useful as a readable assertion at record/read sites.
 
 **Sites that already use it (canonical examples):**
 - `_has_input` (readiness check, helpers.py)
@@ -83,22 +82,21 @@ holds the value.
 - `_is_stale` (read side, helpers.py)
 - sync/async `superstep.py` (recording `input_versions` under the same key the
   staleness check reads — record-key MUST equal read-key)
-- `runners/daft/operations.py` (DataFrame column resolution at `apply()` time)
+- `runners/daft/operations.py` (DataFrame column naming)
 
-**Trap:** flat-only lookups (`state.values[param]`, `param in graph.inputs.bound`,
-`param in provided_values`) silently miss dot-pathed addresses. Both sides of a
-record/read pair must agree on the address — otherwise consumed-version
-defaults to 0 on read while being recorded as 0, and "not stale" silently
-classifies as fresh forever. PR #95 had exactly this bug at the staleness path
-(see commit `a3d3277` for the fix).
+**Trap:** local-name lookups (`state.values[param]`, `param in graph.inputs.bound`,
+`param in provided_values`) silently miss namespaced or exposed parent-facing
+addresses. Both sides of a record/read pair must agree on the address —
+otherwise consumed-version defaults to 0 on read while being recorded as 0,
+and "not stale" silently classifies as fresh forever. PR #95 had exactly this
+bug at the staleness path (see commit `a3d3277` for the fix).
 
-When the column / dict namespace is only known at run time (e.g. daft
-`apply()`), defer the resolution to that point — pass the actual column names
-as the namespace.
+If you find yourself trying to pass a namespace dict into the helper, the
+caller is probably carrying an old pre-projection assumption.
 
 ## Common Pitfalls
 
 - **Shared params + cycles**: a node that both consumes and produces `messages` triggers the Sole Producer Rule. Split into separate consume/produce nodes if the node is NOT gate-controlled.
 - **Inputless gate targets**: without `_has_pending_activation`, they never re-fire after first execution because `_is_stale` iterates over zero inputs.
 - **Control edges vs ordering edges**: control edges are excluded from `startup_predecessors`. If you need ordering, use `wait_for` or data edges. Gates handle control flow separately.
-- **Flat-name input lookups**: see "Lexical-Scope Addressing" above. If you're touching `helpers.py` / `superstep.py` / an executor and writing `state.values[param]` or `param in node_bound`, route through `address_for_node_input` instead — flat-only matching silently misses dot-pathed private GraphNode inputs.
+- **Local-name input lookups**: see "GraphNode Boundary Addressing" above. If you're touching `helpers.py` / `superstep.py` / an executor and writing `state.values[param]` or `param in node_bound`, route through `address_for_node_input` instead.

--- a/src/hypergraph/runners/_shared/helpers.py
+++ b/src/hypergraph/runners/_shared/helpers.py
@@ -278,25 +278,14 @@ class ValueSource(Enum):
 def address_for_node_input(
     node: HyperNode,
     param: str,
-    *namespaces: dict[str, Any],
 ) -> str:
-    """Resolve which key (dotted or flat) addresses ``param`` of ``node``.
+    """Return the resolved graph-scope key for an input parameter.
 
-    Under lexical scope, a GraphNode's private input may be addressed at the
-    parent scope as ``"<node.name>.<param>"`` (state.values, state.versions,
-    provided_values, graph.inputs.bound, and per-execution input_versions all
-    share this convention). When the dotted key is present in any provided
-    namespace, it wins; otherwise the flat name is the auto-link fallback.
-
-    Used both for reading (find-the-key) and recording (consistent-key) so
-    that whatever key gets written must be the same key that gets read.
+    GraphNode boundary projection happens before runner execution, so
+    ``node.inputs`` already contains parent-facing addresses. The node argument
+    is kept so call sites read as "address for this node input" while the
+    current implementation simply returns the already-resolved address.
     """
-    from hypergraph.nodes.graph_node import GraphNode
-
-    if isinstance(node, GraphNode):
-        dotted = f"{node.name}.{param}"
-        if any(dotted in ns for ns in namespaces):
-            return dotted
     return param
 
 
@@ -403,30 +392,31 @@ def get_value_source(
     """
     from hypergraph.nodes.graph_node import GraphNode
 
-    # 1. Edge / restored-state value. For a GraphNode, a checkpoint may have
-    # restored its private input under the dot-pathed address; resolve to the
-    # canonical key so the lookup matches the readiness/staleness checks.
-    state_addr = address_for_node_input(node, param, state.values)
+    # 1. Edge / restored-state value. For a GraphNode, a checkpoint restores
+    # inputs under the parent-facing address; resolve to the canonical key so
+    # the lookup matches the readiness/staleness checks.
+    state_addr = address_for_node_input(node, param)
     if state_addr in state.values and _state_value_satisfies_input(param, node, graph, state, state_addr):
         return (ValueSource.EDGE, state.values[state_addr])
 
-    # 2. Input value (from run() call). The address may be dot-pathed when
-    # this is a GraphNode's private input.
-    provided_addr = address_for_node_input(node, param, provided_values)
+    # 2. Input value (from run() call). The address may differ from the local
+    # name when the input is projected through a GraphNode boundary.
+    provided_addr = address_for_node_input(node, param)
     if provided_addr in provided_values:
         return (ValueSource.PROVIDED, provided_values[provided_addr])
 
     # 3. Bound value resolved at this graph boundary. Same addressing applies
-    # for graph.inputs.bound (dot-pathed for private subgraph inputs).
-    bound_addr = address_for_node_input(node, param, graph.inputs.bound)
+    # for graph.inputs.bound.
+    bound_addr = address_for_node_input(node, param)
     if bound_addr in graph.inputs.bound:
         return (ValueSource.BOUND, graph.inputs.bound[bound_addr])
 
     # 3b. For GraphNode: check if inner graph has it bound
     if isinstance(node, GraphNode):
-        original_param = node._resolve_original_input_name(param)
-        if original_param in node._graph.inputs.bound:
-            return (ValueSource.BOUND, node._graph.inputs.bound[original_param])
+        for local_param in node._local_inputs_for_address(param):
+            original_param = node._resolve_original_input_name(local_param)
+            if original_param in node._graph.inputs.bound:
+                return (ValueSource.BOUND, node._graph.inputs.bound[original_param])
 
     # 4. Function default (from signature)
     if node.has_signature_default_for(param):
@@ -896,7 +886,7 @@ def _has_all_inputs(node: HyperNode, graph: Graph, state: GraphState) -> bool:
 
 def _has_input(param: str, node: HyperNode, graph: Graph, state: GraphState) -> bool:
     """Check if a single input parameter is available."""
-    addr = address_for_node_input(node, param, state.values, graph.inputs.bound)
+    addr = address_for_node_input(node, param)
     if addr in state.values and _state_value_satisfies_input(param, node, graph, state, addr):
         return True
     if addr in graph.inputs.bound:
@@ -1046,9 +1036,8 @@ def _is_stale(
             # Descendant Producer Rule: all producers are downstream (DAGs only)
             if param in downstream:
                 continue
-        # Resolve the key the same way it was recorded -- dotted for a
-        # GraphNode's private input, flat otherwise.
-        addr = address_for_node_input(node, param, state.versions, last_exec.input_versions)
+        # Resolve the key the same way it was recorded at the graph boundary.
+        addr = address_for_node_input(node, param)
         current_version = state.versions.get(addr, 0)
         consumed_version = last_exec.input_versions.get(addr, 0)
         if current_version == consumed_version:
@@ -1357,10 +1346,8 @@ def _collect_interrupt_resume_keys(
 ) -> set[str]:
     """Collect valid interrupt resume keys for this graph scope.
 
-    Top-level interrupt outputs are exposed directly (``decision``).
-    Nested graph interrupts are exposed with dotted graph-node prefixes
-    (``inner.decision`` / ``outer.inner.decision``), matching
-    ``PauseInfo.response_key``.
+    Interrupt outputs are projected through GraphNode boundary maps the same
+    way ordinary outputs are.
     """
     from hypergraph.nodes.graph_node import GraphNode
 
@@ -1370,9 +1357,8 @@ def _collect_interrupt_resume_keys(
             allowed_outputs.update(f"{prefix}{output}" for output in node.data_outputs)
             continue
         if isinstance(node, GraphNode):
-            nested_prefix = f"{prefix}{node.name}."
             nested_keys = _collect_interrupt_resume_keys_from_nodes(node.iter_active_inner_nodes())
-            allowed_outputs.update(f"{nested_prefix}{node.map_resume_key_from_original(key)}" for key in nested_keys)
+            allowed_outputs.update(f"{prefix}{node.map_resume_key_from_original(key)}" for key in nested_keys)
     return allowed_outputs
 
 
@@ -1390,9 +1376,8 @@ def _collect_interrupt_resume_keys_from_nodes(
             allowed_outputs.update(f"{prefix}{output}" for output in node.data_outputs)
             continue
         if isinstance(node, GraphNode):
-            nested_prefix = f"{prefix}{node.name}."
             nested_keys = _collect_interrupt_resume_keys_from_nodes(node.iter_active_inner_nodes())
-            allowed_outputs.update(f"{nested_prefix}{node.map_resume_key_from_original(key)}" for key in nested_keys)
+            allowed_outputs.update(f"{prefix}{node.map_resume_key_from_original(key)}" for key in nested_keys)
     return allowed_outputs
 
 

--- a/src/hypergraph/runners/_shared/input_normalization.py
+++ b/src/hypergraph/runners/_shared/input_normalization.py
@@ -71,11 +71,10 @@ def normalize_inputs(
     """Normalize inputs from values dict + kwargs shorthand.
 
     When ``graph`` is provided, nested-dict entries whose top-level keys match a
-    GraphNode in the graph (or any descendant addressable via further nested
-    dicts) are flattened to dot-paths (``{"A": {"overwrite": True}}`` becomes
-    ``{"A.overwrite": True}``). This makes nested-dict and dot-path forms two
-    equivalent surfaces over the same canonical address form. Dict values whose
-    top-level key is not a subgraph name are passed through unchanged.
+    namespaced GraphNode in the graph are flattened to resolved port addresses
+    (``{"A": {"overwrite": True}}`` becomes ``{"A.overwrite": True}``).
+    Dict values whose top-level key is not a namespaced GraphNode are passed
+    through unchanged.
     """
     base_values = dict(values) if values is not None else {}
 

--- a/src/hypergraph/runners/_shared/types.py
+++ b/src/hypergraph/runners/_shared/types.py
@@ -620,9 +620,11 @@ class PauseInfo:
     def response_keys(self) -> dict[str, str]:
         """Map output names to resume keys.
 
-        Returns a dict mapping each output parameter name to the key to use
-        when providing the response value in the input dict. Namespaced and
-        exposed GraphNode boundaries have already projected these keys.
+        Returns a dict mapping each output parameter name to the key to use when
+        providing the response value in the input dict. The names are already
+        resolved graph-scope addresses after GraphNode projection, so both key
+        and value are the same address (for example, ``"decision"`` in flat
+        mode or ``"review.decision"`` in namespaced mode).
         """
         params = self.output_params or (self.output_param,)
         return {p: p for p in params}

--- a/src/hypergraph/runners/_shared/types.py
+++ b/src/hypergraph/runners/_shared/types.py
@@ -612,25 +612,20 @@ class PauseInfo:
     def response_key(self) -> str:
         """Key to use in values dict when resuming (first output).
 
-        Top-level: returns output_param directly (e.g., 'decision').
-        Nested: dot-separated path (e.g., 'review.decision').
+        ``output_param`` is already the resolved graph-scope response address.
         """
-        parts = self.node_name.split("/")
-        if len(parts) == 1:
-            return self.output_param
-        return ".".join(parts[:-1]) + "." + self.output_param
+        return self.output_param
 
     @property
     def response_keys(self) -> dict[str, str]:
         """Map output names to resume keys.
 
         Returns a dict mapping each output parameter name to the key to use
-        when providing the response value in the input dict.
+        when providing the response value in the input dict. Namespaced and
+        exposed GraphNode boundaries have already projected these keys.
         """
         params = self.output_params or (self.output_param,)
-        parts = self.node_name.split("/")
-        prefix = ".".join(parts[:-1]) + "." if len(parts) > 1 else ""
-        return {p: prefix + p for p in params}
+        return {p: p for p in params}
 
 
 class PauseExecution(BaseException):

--- a/src/hypergraph/runners/_shared/validation.py
+++ b/src/hypergraph/runners/_shared/validation.py
@@ -114,6 +114,12 @@ def validate_item_inputs(
         )
 
     if unknown:
+        stale_exposed_message = _build_stale_exposed_address_message(
+            unknown=unknown,
+            active_nodes=ctx.active_nodes,
+        )
+        if stale_exposed_message is not None:
+            raise ValueError(stale_exposed_message)
         _warn_on_unrecognized_inputs(
             unknown=unknown,
             expected_inputs=expected_inputs,
@@ -224,8 +230,9 @@ def _build_missing_input_message(
 
     if not any_dotted:
         # The bind()-returns-new-graph hint applies when the user is wrestling
-        # with bind() chaining. For dot-pathed lexical-scope misses it's a
-        # distraction -- the actual fix is to use the right address form.
+        # with bind() chaining. For namespaced address misses it's a
+        # distraction -- the actual fix is to use the right parent-facing
+        # address form.
         msg += "\n\nHint: If you used graph.bind(), remember it returns a NEW graph."
         msg += "\n  ❌ graph.bind(x=10)           # Result discarded!"
         msg += "\n  ✅ graph = graph.bind(x=10)   # Correct"
@@ -340,7 +347,7 @@ def _get_interrupt_outputs(
             continue
         if isinstance(node, GraphNode):
             nested_outputs = _get_interrupt_outputs({inner.name: inner for inner in node.iter_active_inner_nodes()})
-            outputs.update(f"{prefix}{node.name}.{node.map_resume_key_from_original(output)}" for output in nested_outputs)
+            outputs.update(f"{prefix}{node.map_resume_key_from_original(output)}" for output in nested_outputs)
     return outputs
 
 
@@ -404,13 +411,39 @@ def _find_internal_override_conflicts(
 def _node_is_runnable_from_seed_values(node: HyperNode, provided: set[str]) -> bool:
     """True when node can run from provided/bound/default values before execution.
 
-    Resolves each input via the canonical address so a GraphNode's private
-    input addressed as ``"<node.name>.<param>"`` in ``provided`` is matched
-    correctly under lexical scope (matches sync/async runners' get_value_source).
+    Resolves each input via the canonical parent-facing address so GraphNode
+    inputs match sync/async runners' ``get_value_source`` behavior.
     """
     from hypergraph.runners._shared.helpers import address_for_node_input
 
-    return all(address_for_node_input(node, param, provided) in provided or node.has_default_for(param) for param in node.inputs)
+    return all(address_for_node_input(node, param) in provided or node.has_default_for(param) for param in node.inputs)
+
+
+def _build_stale_exposed_address_message(
+    *,
+    unknown: set[str],
+    active_nodes: dict[str, HyperNode],
+) -> str | None:
+    """Detect stale graph-node addresses and suggest the current address."""
+    from hypergraph.nodes.graph_node import GraphNode
+
+    replacements: list[tuple[str, str]] = []
+    for address in sorted(unknown):
+        for node in active_nodes.values():
+            if not isinstance(node, GraphNode):
+                continue
+            replacement = node.replacement_for_stale_input_address(address)
+            if replacement is not None:
+                replacements.append((address, replacement))
+                break
+
+    if not replacements:
+        return None
+
+    lines = ["Input address is no longer valid:"]
+    for stale, replacement in replacements:
+        lines.append(f"  {stale!r} is no longer valid. Use {replacement!r}.")
+    return "\n".join(lines)
 
 
 def _warn_on_unrecognized_inputs(

--- a/src/hypergraph/runners/async_/executors/graph_node.py
+++ b/src/hypergraph/runners/async_/executors/graph_node.py
@@ -55,11 +55,9 @@ class AsyncGraphNodeExecutor:
         child_workflow_id = graphnode_child_workflow_id(ctx.workflow_id, node.name, state)
         map_config = node.map_config
 
-        # Route interrupt resume values into the inner graph.
-        # On pause, _handle_nested_result prefixes the node_name ("ask_user/ask_slack")
-        # and PauseInfo.response_key becomes "ask_user.user_input".  On resume the
-        # caller puts that dotted key into the outer state — we strip the prefix here
-        # so the inner graph sees the unprefixed key ("user_input").
+        # Route interrupt resume values into the inner graph. The parent sees
+        # the GraphNode's resolved output address ("decision", "review.verdict",
+        # etc.); the child run resumes with the inner graph's local output name.
         # When resuming a persisted child workflow, do not re-send normal child
         # inputs like "draft" — those are already captured by the child
         # checkpoint and would be treated as illegal overrides.
@@ -69,17 +67,27 @@ class AsyncGraphNodeExecutor:
             child_fork_from: str | None = None
             child_retry_from: str | None = None
             prefix = f"{node.name}."
-            # Resume-values are interrupt outputs prefixed with the GraphNode's
-            # name. Skip suffixes that match this node's public inputs -- those
-            # are dot-pathed user-provided inputs already routed via inner_inputs.
+            # Skip values that match this node's public inputs; those are
+            # user-provided GraphNode inputs already routed via inner_inputs.
             node_input_set = set(node.inputs)
-            resume_values = {
-                node.resolve_original_output_name(suffix): value
-                for key, value in state.values.items()
-                if key.startswith(prefix)
-                for suffix in [key[len(prefix) :]]
-                if suffix not in node_input_set
-            }
+            resume_values = {}
+            if not node.namespaced:
+                resume_values.update(
+                    {
+                        node.resolve_original_output_name(suffix): value
+                        for key, value in state.values.items()
+                        if key.startswith(prefix)
+                        for suffix in [key[len(prefix) :]]
+                        if suffix not in node_input_set
+                    }
+                )
+            resume_values.update(
+                {
+                    node.resolve_original_output_name(key): value
+                    for key, value in state.values.items()
+                    if key in node.outputs and key not in node_input_set
+                }
+            )
 
             if map_config is None and child_workflow_id is not None and self.runner._checkpointer is not None:
                 existing_child_run = await self.runner._checkpointer.get_run_async(child_workflow_id)

--- a/src/hypergraph/runners/async_/superstep.py
+++ b/src/hypergraph/runners/async_/superstep.py
@@ -102,9 +102,9 @@ async def run_superstep_async(
     ) -> tuple[HyperNode, dict[str, Any], dict[str, int], dict[str, int], float, bool]:
         """Execute a single node with event emission."""
         inputs = collect_inputs_for_node(node, graph, state, provided_values)
-        # Record input versions under the same addressed key the staleness
-        # check reads -- dotted for a GraphNode's private input, flat otherwise.
-        input_versions = {(addr := address_for_node_input(node, param, state.versions)): state.versions.get(addr, 0) for param in node.inputs}
+        # Record input versions under the same parent-facing key the staleness
+        # check reads.
+        input_versions = {(addr := address_for_node_input(node, param)): state.versions.get(addr, 0) for param in node.inputs}
         wait_for_versions = {name: state.get_version(name) for name in node.wait_for}
 
         # Check cache before execution

--- a/src/hypergraph/runners/daft/operations.py
+++ b/src/hypergraph/runners/daft/operations.py
@@ -249,12 +249,9 @@ class GraphNodeOperation(DaftOperation):
         from hypergraph.runners._shared.helpers import address_for_node_input
 
         node = self.node
-        # Resolve each public input to the actual DataFrame column. Under
-        # lexical scope a private GraphNode input may arrive under its
-        # dot-pathed address; address_for_node_input picks whichever column
-        # the schema actually has.
-        df_columns = {name: None for name in df.column_names}
-        param_to_col = {p: address_for_node_input(node, p, df_columns) for p in self.input_columns}
+        # GraphNode inputs are already projected to DataFrame column names:
+        # flat, namespaced, or exposed depending on the boundary.
+        param_to_col = {p: address_for_node_input(node, p) for p in self.input_columns}
         col_names_for_df = list(param_to_col.values())
         col_names_for_inner = list(param_to_col.keys())
 
@@ -268,8 +265,8 @@ class GraphNodeOperation(DaftOperation):
         map_config = node.map_config
 
         # Capture for the closure: build inner_inputs from positional args
-        # using the GraphNode's public input names (not the DataFrame column
-        # names, which may be dot-pathed).
+        # using the GraphNode's projected input names (not necessarily the same
+        # strings as the DataFrame column names).
         inner_param_names = col_names_for_inner
 
         @daft_mod.func(return_dtype=daft_mod.DataType.python())
@@ -339,20 +336,17 @@ def create_operation(
     from hypergraph.nodes.graph_node import GraphNode
     from hypergraph.runners._shared.helpers import address_for_node_input
 
-    # Determine which bound values apply to this node. For a GraphNode private
-    # input, bound_values may be keyed by dot-path; resolve to the canonical
-    # address (matching the sync/async runners) and store under the flat param
-    # name the inner node expects.
+    # Determine which bound values apply to this node. GraphNode bound values
+    # are keyed by their resolved parent-facing address; store them under the
+    # input name this operation receives.
     node_bound: dict[str, Any] = {}
     for param in node.inputs:
-        addr = address_for_node_input(node, param, bound_values)
+        addr = address_for_node_input(node, param)
         if addr in bound_values:
             node_bound[param] = bound_values[addr]
 
-    # Determine input columns (those not provided by bound values). For
-    # GraphNode private inputs the actual DataFrame column may be either flat
-    # or dot-pathed depending on how the user addressed the input -- the
-    # GraphNodeOperation resolves at apply() time once the schema is known.
+    # Determine input columns (those not provided by bound values). GraphNode
+    # boundaries have already projected the parent-facing column addresses.
     input_cols = [p for p in node.inputs if p not in node_bound]
     output_cols = list(node.data_outputs)
 

--- a/src/hypergraph/runners/daft/runner.py
+++ b/src/hypergraph/runners/daft/runner.py
@@ -186,11 +186,12 @@ class DaftRunner(BaseRunner):
         _validate_error_handling(error_handling)
         effective_selected = resolve_runtime_selected(select, graph)
         _validate_on_missing(on_missing)
-        precompute_input_validation(
+        ctx = precompute_input_validation(
             graph,
             entrypoint=None,
             selected=effective_selected,
         )
+        validate_item_inputs(ctx, normalized)
 
         map_over_list = [map_over] if isinstance(map_over, str) else list(map_over)
         input_variations = list(
@@ -294,6 +295,15 @@ class DaftRunner(BaseRunner):
         # Merge graph.bind() + broadcast values — both captured in UDF closures
         bound = dict(graph.inputs.bound) if graph.inputs.bound else {}
         all_bound = {**bound, **normalized}
+        validation_values = {name: None for name in column_names}
+        validation_values.update(all_bound)
+        ctx = precompute_input_validation(graph, entrypoint=None, selected=None)
+        # DataFrames often carry passthrough columns that are not graph inputs.
+        # Keep stale-address and missing-input validation, but do not warn for
+        # extra columns that Daft will preserve untouched.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            validate_item_inputs(ctx, validation_values)
 
         plan = build_execution_plan(graph, all_bound, self._cache, clone)
         return execute_plan(dataframe.select(*column_names), plan)

--- a/src/hypergraph/runners/sync/executors/graph_node.py
+++ b/src/hypergraph/runners/sync/executors/graph_node.py
@@ -48,11 +48,9 @@ class SyncGraphNodeExecutor:
         child_workflow_id = graphnode_child_workflow_id(ctx.workflow_id, node.name, state)
         map_config = node.map_config
 
-        # Route interrupt resume values into the inner graph.
-        # On pause, _handle_nested_result prefixes the node_name ("ask_user/ask_slack")
-        # and PauseInfo.response_key becomes "ask_user.user_input".  On resume the
-        # caller puts that dotted key into the outer state — we strip the prefix here
-        # so the inner graph sees the unprefixed key ("user_input").
+        # Route interrupt resume values into the inner graph. The parent sees
+        # the GraphNode's resolved output address ("decision", "review.verdict",
+        # etc.); the child run resumes with the inner graph's local output name.
         # When resuming a persisted child workflow, do not re-send normal child
         # inputs like "draft" — those are already captured by the child
         # checkpoint and would be treated as illegal overrides.
@@ -60,17 +58,27 @@ class SyncGraphNodeExecutor:
         # executed so the inner interrupt should fire again, not skip.
         if node.name not in state.node_executions:
             prefix = f"{node.name}."
-            # Resume-values are interrupt outputs prefixed with the GraphNode's
-            # name. Skip suffixes that match this node's public inputs -- those
-            # are dot-pathed user-provided inputs already routed via inner_inputs.
+            # Skip values that match this node's public inputs; those are
+            # user-provided GraphNode inputs already routed via inner_inputs.
             node_input_set = set(node.inputs)
-            resume_values = {
-                node.resolve_original_output_name(suffix): value
-                for key, value in state.values.items()
-                if key.startswith(prefix)
-                for suffix in [key[len(prefix) :]]
-                if suffix not in node_input_set
-            }
+            resume_values = {}
+            if not node.namespaced:
+                resume_values.update(
+                    {
+                        node.resolve_original_output_name(suffix): value
+                        for key, value in state.values.items()
+                        if key.startswith(prefix)
+                        for suffix in [key[len(prefix) :]]
+                        if suffix not in node_input_set
+                    }
+                )
+            resume_values.update(
+                {
+                    node.resolve_original_output_name(key): value
+                    for key, value in state.values.items()
+                    if key in node.outputs and key not in node_input_set
+                }
+            )
             child_fork_from: str | None = None
             child_retry_from: str | None = None
 

--- a/src/hypergraph/runners/sync/superstep.py
+++ b/src/hypergraph/runners/sync/superstep.py
@@ -70,9 +70,9 @@ def run_superstep_sync(
         # in this superstep see the same values (deterministic execution order)
         inputs = collect_inputs_for_node(node, graph, state, provided_values)
 
-        # Record input versions under the same addressed key the staleness
-        # check reads -- dotted for a GraphNode's private input, flat otherwise.
-        input_versions = {(addr := address_for_node_input(node, param, state.versions)): state.versions.get(addr, 0) for param in node.inputs}
+        # Record input versions under the same parent-facing key the staleness
+        # check reads.
+        input_versions = {(addr := address_for_node_input(node, param)): state.versions.get(addr, 0) for param in node.inputs}
 
         # Check cache before execution
         cache_key, cached_outputs = ("", None)

--- a/src/hypergraph/viz/AGENTS.md
+++ b/src/hypergraph/viz/AGENTS.md
@@ -32,10 +32,10 @@ scene client-side without a kernel round-trip.
 4. `performCompoundLayout()` handles expanded containers with a compound dagre pass.
 5. `CustomEdge` renders B-spline curves through dagre-provided points via `curveBasis()`.
 
-**Mermaid (untouched)**: `mermaid.py` still consumes the legacy
-`renderer/nodes.py` + `renderer/scope.py` helpers. PR #88 keeps those modules
-alive so Mermaid output is byte-identical; migration to the IR path is
-out of scope.
+**Mermaid**: `mermaid.py` still consumes `renderer/nodes.py` +
+`renderer/scope.py` helpers rather than the compact IR path. Keep Mermaid and
+interactive viz aligned on resolved port addresses even though the rendering
+pipelines differ.
 
 ## Viz.js Architecture
 

--- a/src/hypergraph/viz/_common.py
+++ b/src/hypergraph/viz/_common.py
@@ -192,11 +192,11 @@ def enumerate_valid_expansion_states(
 
 
 def external_input_display_name(param: str) -> str:
-    """Return the leaf segment of a dot-pathed external-input name.
+    """Return the leaf segment of an external-input address.
 
-    Synthetic INPUT-node IDs (``input_<name>``) and visible labels use the
-    leaf segment so users see ``x`` rather than ``middle.inner.x``. The
-    full dot path is an implementation detail of input addressing.
+    The renderer shows resolved graph-scope port addresses as labels. This
+    helper remains useful for stable synthetic IDs and type fallbacks where
+    the local leaf segment is useful.
     """
     if not param:
         return param
@@ -206,11 +206,11 @@ def external_input_display_name(param: str) -> str:
 def disambiguate_external_input_ids(
     params_by_group: list[list[str]],
 ) -> dict[str, str]:
-    """Map each dot-pathed external-input name to a unique synthetic id.
+    """Map each external-input address to a unique synthetic id segment.
 
     Returns ``{full_param: id_safe_name}``. When two groups would otherwise
     collide on the leaf segment (e.g. ``A.x`` and ``B.x`` both map to
-    ``x``), each colliding name keeps its full dot-path so the synthetic
+    ``x``), each colliding name keeps its full address so the synthetic
     ``input_*`` node IDs stay unique.
     """
     leaf_counts: dict[str, int] = {}
@@ -227,21 +227,23 @@ def disambiguate_external_input_ids(
     return mapping
 
 
-def resolve_dot_path_consumers(
+def resolve_port_address_consumers(
     param: str,
     flat_graph: nx.DiGraph,
 ) -> list[str]:
-    """Resolve a dot-pathed external-input name to its consumer chain.
+    """Resolve an external input port address to its consumer chain.
 
-    External inputs surface in ``input_spec.required`` as dot paths like
-    ``"middle.inner.x"`` — meaning the GraphNode named ``middle`` (a child
-    of the current scope) has a subscope where ``inner.x`` is the further
-    address. This walks the chain and returns every consumer along it,
-    from outermost to innermost.
+    External inputs can surface in ``input_spec.required`` as graph-scope
+    addresses like ``"middle.inner.x"``. Each GraphNode on the path declares
+    the address visible at its parent boundary (``"middle.inner.x"`` on
+    ``middle``, then ``"inner.x"`` on ``middle/inner``), while the leaf node
+    still consumes its local input name (``"x"``). This walks that chain and
+    returns every consumer along it, from outermost to innermost.
 
     For a path ``head.rest`` at scope ``S``:
-    - the child of ``S`` named ``head`` (a GraphNode whose scope-local
-      inputs include ``rest``) is a consumer.
+    - the child of ``S`` named ``head`` is a consumer when it declares either
+      the current graph-scope address or the remaining address at that child
+      boundary.
     - recurse into that container with ``rest``.
 
     At the leaf (no remaining dots), every descendant of the current
@@ -264,7 +266,9 @@ def resolve_dot_path_consumers(
         if attrs is None or attrs.get("node_type") != "GRAPH":
             return []  # unresolvable: malformed path
         rest_local = ".".join(parts[idx + 1 :])
-        if rest_local not in attrs.get("inputs", ()):
+        current_address = ".".join(parts[idx:])
+        declared_inputs = attrs.get("inputs", ())
+        if rest_local not in declared_inputs and current_address not in declared_inputs:
             return []  # container does not declare this scope-local input
         consumers.append(candidate)
         current_scope = candidate
@@ -317,16 +321,15 @@ def build_param_to_consumer_map(
                 param_to_consumers[param] = []
             param_to_consumers[param].append(node_id)
 
-    # External inputs surface as dot-pathed lexical addresses (issue #94).
-    # Resolve each one against the flat-graph hierarchy so the consumer
-    # chain (container -> ... -> leaf) is available for visibility-aware
-    # filtering below. Plain (non-dotted) params already match by exact
-    # name in the loop above and are skipped here.
+    # External inputs can surface as namespaced graph-scope addresses.
+    # Resolve each one against the flat-graph hierarchy so the consumer chain
+    # (container -> ... -> leaf) is available for visibility-aware filtering
+    # below. Plain params already match by exact name and are skipped here.
     input_spec = flat_graph.graph.get("input_spec", {})
     for param in tuple(input_spec.get("required", ())) + tuple(input_spec.get("optional", ())):
         if "." not in param:
             continue
-        chain = resolve_dot_path_consumers(param, flat_graph)
+        chain = resolve_port_address_consumers(param, flat_graph)
         if not chain:
             continue
         if not use_deepest:

--- a/src/hypergraph/viz/assets/scene_builder.js
+++ b/src/hypergraph/viz/assets/scene_builder.js
@@ -124,8 +124,8 @@
       var typeHints = ext.type_hints || [];
       var isGroup = params.length > 1;
       // ``id_segments`` falls back to ``params`` (leaf names) and mirrors
-      // the Python disambiguator that swaps in the full dot-path when
-      // leaf names collide between sibling subgraphs (issue #94).
+      // the Python disambiguator that swaps in the full port address when
+      // suffixes collide between sibling subgraphs (issue #94).
       var idSegments = (ext.id_segments && ext.id_segments.length === params.length) ? ext.id_segments : params;
       var inputId = isGroup ? 'input_group_' + idSegments.join('_') : 'input_' + idSegments[0];
       var data = isGroup

--- a/src/hypergraph/viz/ir_schema.py
+++ b/src/hypergraph/viz/ir_schema.py
@@ -59,14 +59,13 @@ class IRExternalInput:
     `beta`) render as INPUT_GROUP with a stable id like
     `input_group_alpha_beta`.
 
-    ``params`` stores the user-visible leaf names (the lexical-scope leaf
-    of dot-pathed external inputs from issue #94). ``id_segments`` are
-    the corresponding identifier-safe segments used to construct the
-    synthetic ``input_*`` node id; they are equal to ``params`` except
-    when colliding leaf names force a fallback to the full dot-path.
+    ``params`` stores the user-visible graph-scope port addresses.
+    ``id_segments`` are the corresponding identifier-safe segments used to
+    construct the synthetic ``input_*`` node id; they usually use the leaf
+    segment, falling back to the full address when leaf names collide.
     """
 
-    params: tuple[str, ...]  # display labels (leaf segments)
+    params: tuple[str, ...]  # display labels (graph-scope port addresses)
     deepest_owner: str | None = None
     consumers: tuple[str, ...] = ()
     type_hints: tuple[str | None, ...] = ()  # one per param

--- a/src/hypergraph/viz/mermaid.py
+++ b/src/hypergraph/viz/mermaid.py
@@ -776,14 +776,14 @@ def to_mermaid(
         lines.append("    %% Inputs")
     for group in input_groups:
         params = group["params"]
-        # Display labels are scope-local leaf names; type lookup falls
-        # back to the leaf if the dot-pathed key has no entry.
-        display_params = [external_input_display_name(p) for p in params]
+        # Display labels are resolved graph-scope port addresses; type lookup
+        # falls back to the leaf if the projected key has no entry.
+        display_params = list(params)
         param_types = [format_type(_get_param_type(p, flat_graph) or _get_param_type(external_input_display_name(p), flat_graph)) for p in params]
         label = _build_input_label(display_params, param_types, show_types)
 
         if len(params) == 1:
-            node_id = f"input_{id_for_param.get(params[0], display_params[0])}"
+            node_id = f"input_{id_for_param.get(params[0], external_input_display_name(params[0]))}"
             node_type = "INPUT"
         else:
             id_segs = [id_for_param.get(p, external_input_display_name(p)) for p in params]

--- a/src/hypergraph/viz/renderer/instructions.py
+++ b/src/hypergraph/viz/renderer/instructions.py
@@ -350,10 +350,8 @@ def _add_input_nodes(
     id_for_param = disambiguate_external_input_ids([[p] for p in external_inputs])
 
     for param in external_inputs:
-        # Dot-pathed external inputs (issue #94) carry the lexical scope
-        # in their name (``middle.inner.x``); the param's *type* lives
-        # under its scope-local leaf name on the leaf consumer's
-        # ``input_types``.
+        # Namespaced external inputs carry their graph-scope address in the
+        # label; leaf consumers still keep type hints under the local name.
         leaf = external_input_display_name(param)
         param_type = None
         for _node_id, attrs in flat_graph.nodes(data=True):
@@ -369,7 +367,7 @@ def _add_input_nodes(
             VizNode(
                 id=f"input_{id_for_param[param]}",
                 type=NodeType.INPUT,
-                label=leaf,
+                label=param,
                 type_hint=_format_type(param_type),
                 theme=theme,
                 show_types=show_types,

--- a/src/hypergraph/viz/renderer/ir_builder.py
+++ b/src/hypergraph/viz/renderer/ir_builder.py
@@ -94,19 +94,19 @@ def _build_input_group(
     consumers: list[str] = []
     seen: set[str] = set()
     for param in raw_params:
-        # Resolve consumers using the (possibly dot-pathed) full name so
-        # the dot-path walk in get_deepest_consumers can address nested
-        # subgraphs (issue #94). Deduplicate while preserving order.
+        # Resolve consumers using the full graph-scope address so boundary
+        # projection can address nested subgraphs. Deduplicate while preserving
+        # order.
         for consumer in get_deepest_consumers(param, flat_graph):
             if consumer not in seen:
                 seen.add(consumer)
                 consumers.append(consumer)
     deepest_owner = compute_deepest_input_scope(raw_params[0], flat_graph)
-    # Type hints are looked up by the dot-pathed name first. If that misses
-    # (collapsed view, leaf consumer carries the type under its scope-local
+    # Type hints are looked up by the parent-facing address first. If that
+    # misses (collapsed view, leaf consumer carries the type under its local
     # name), fall back to the leaf name -- but only when at least one of the
     # param's actual consumers exposes that type, to avoid grabbing an
-    # unrelated sibling's annotation when two private inputs share a leaf name.
+    # unrelated sibling's annotation when two namespaced inputs share a leaf.
     type_hints: list[str | None] = []
     for p in raw_params:
         param_type = get_param_type(p, flat_graph)
@@ -118,9 +118,9 @@ def _build_input_group(
                     param_type = consumer_type
                     break
         type_hints.append(format_type(param_type))
-    # Display labels are the leaf segments; synthetic ids fall back to
-    # the full dot-path when leaf names collide.
-    display_params = tuple(external_input_display_name(p) for p in raw_params)
+    # Display labels are resolved graph-scope port addresses. Synthetic ids
+    # still use the short leaf segment when it is unambiguous.
+    display_params = raw_params
     id_segments = tuple((id_for_param or {}).get(p, external_input_display_name(p)) for p in raw_params)
     return IRExternalInput(
         params=display_params,

--- a/src/hypergraph/viz/renderer/nodes.py
+++ b/src/hypergraph/viz/renderer/nodes.py
@@ -227,9 +227,8 @@ def create_input_nodes(
     id_for_param = disambiguate_external_input_ids([list(g["params"]) for g in input_groups])
 
     def _typed(param: str) -> type | None:
-        # Dot-pathed external inputs (issue #94) carry the lexical scope
-        # in their name; the type lives under the scope-local leaf on the
-        # leaf consumer's ``input_types``.
+        # Namespaced external inputs carry their graph-scope address in the
+        # label; leaf consumers still keep type hints under the local name.
         param_type = get_param_type(param, flat_graph)
         if param_type is None:
             param_type = get_param_type(external_input_display_name(param), flat_graph)
@@ -240,8 +239,7 @@ def create_input_nodes(
         is_bound = group["is_bound"]
         if len(params) == 1:
             param = params[0]
-            display = external_input_display_name(param)
-            input_node_id = f"input_{id_for_param.get(param, display)}"
+            input_node_id = f"input_{id_for_param.get(param, external_input_display_name(param))}"
             param_type = _typed(param)
             actual_targets = get_group_targets([param], flat_graph, param_to_consumers)
             owner_container = compute_input_scope(param, flat_graph, expansion_state)
@@ -253,7 +251,7 @@ def create_input_nodes(
                 "position": {"x": 0, "y": 0},
                 "data": {
                     "nodeType": "INPUT",
-                    "label": display,
+                    "label": param,
                     "typeHint": format_type(param_type),
                     "isBound": is_bound,
                     "actualTargets": actual_targets,
@@ -269,7 +267,6 @@ def create_input_nodes(
         else:
             id_segs = [id_for_param.get(p, external_input_display_name(p)) for p in params]
             group_id = f"input_group_{'_'.join(id_segs)}"
-            display_params = [external_input_display_name(p) for p in params]
             param_types = [format_type(_typed(p)) for p in params]
             actual_targets = get_group_targets(params, flat_graph, param_to_consumers)
 
@@ -282,7 +279,7 @@ def create_input_nodes(
                 "position": {"x": 0, "y": 0},
                 "data": {
                     "nodeType": "INPUT_GROUP",
-                    "params": display_params,
+                    "params": list(params),
                     "paramTypes": param_types,
                     "isBound": is_bound,
                     "actualTargets": actual_targets,

--- a/src/hypergraph/viz/renderer/scope.py
+++ b/src/hypergraph/viz/renderer/scope.py
@@ -14,7 +14,7 @@ from hypergraph.viz._common import (
     get_parent,
     is_descendant_of,
     is_node_visible,
-    resolve_dot_path_consumers,
+    resolve_port_address_consumers,
 )
 
 if TYPE_CHECKING:
@@ -28,12 +28,12 @@ def get_deepest_consumers(param: str, flat_graph: nx.DiGraph) -> list[str]:
     as an input, we return only the internal nodes - they are the "actual"
     consumers.
 
-    Dot-pathed external-input names (e.g. ``"middle.inner.x"``) are
+    Namespaced external-input addresses (e.g. ``"middle.inner.x"``) are
     resolved through the GraphNode chain — see
-    :func:`resolve_dot_path_consumers`.
+    :func:`resolve_port_address_consumers`.
     """
     if "." in param:
-        all_consumers = resolve_dot_path_consumers(param, flat_graph)
+        all_consumers = resolve_port_address_consumers(param, flat_graph)
     else:
         all_consumers = [node_id for node_id, attrs in flat_graph.nodes(data=True) if param in attrs.get("inputs", ())]
 

--- a/tests/capabilities/builders.py
+++ b/tests/capabilities/builders.py
@@ -346,18 +346,19 @@ def _apply_renaming(graph: Graph, renaming: Renaming) -> Graph:
 def _apply_binding(graph: Graph, binding: Binding, topology: Topology) -> Graph:
     """Apply binding to the graph based on the binding mode.
 
-    Returns a new graph with bound values. Under lexical scope, private inner
-    inputs surface as dot-paths on the outer graph, so we look up the actual
-    addressable name in graph.inputs.all rather than assuming flat names.
+    Returns a new graph with bound values. GraphNode inputs use projected
+    parent-facing addresses, so we look up the actual addressable name in
+    graph.inputs.all rather than assuming only local names.
     """
     if binding == Binding.NONE:
         return graph
 
     def _resolve_addressable(graph: Graph, target: str) -> str | None:
-        """Find the addressable input name (dot-path or flat) ending in `target`.
+        """Find the addressable input name ending in `target`.
 
-        Returns None when no match exists OR when multiple dot-paths share the
-        same leaf -- ambiguous targets must be addressed by their full path.
+        Returns None when no match exists OR when multiple projected addresses
+        share the same leaf -- ambiguous targets must be addressed by their
+        full address.
         """
         all_inputs = graph.inputs.all
         if target in all_inputs:
@@ -446,12 +447,12 @@ def _get_map_input_for_topology(topology: Topology) -> str | None:
 
 
 def remap_inputs_to_addressable(inputs: dict, graph: Graph) -> dict:
-    """Remap flat input names to their addressable form (dot-path or flat).
+    """Remap flat input names to the graph's addressable form.
 
-    Under lexical scope, an input that is private to a nested GraphNode appears
-    on the outer graph as ``"<graphnode>.<name>"``. This helper looks up each
-    flat key in graph.inputs.all and rewrites it to whatever addressable form
-    the graph exposes (matching by suffix when no flat key is found).
+    GraphNode boundaries may expose flat or namespaced addresses. This helper
+    looks up each flat key in graph.inputs.all and rewrites it to whatever
+    addressable form the graph exposes (matching by suffix when no flat key is
+    found).
     """
     all_inputs = set(graph.inputs.all)
     remapped: dict = {}
@@ -459,7 +460,7 @@ def remap_inputs_to_addressable(inputs: dict, graph: Graph) -> dict:
         if key in all_inputs:
             remapped[key] = value
             continue
-        # Find a dot-pathed equivalent ending in `.{key}`
+        # Find a projected equivalent ending in `.{key}`
         candidates = [name for name in all_inputs if name.endswith(f".{key}")]
         if len(candidates) == 1:
             remapped[candidates[0]] = value

--- a/tests/events/test_async_events.py
+++ b/tests/events/test_async_events.py
@@ -382,8 +382,8 @@ class TestNestedGraphEvents:
         runner = AsyncRunner()
         lp = ListProcessor()
 
-        # x is private to inner GraphNode → addressed via dot-path
-        result = await runner.run(outer, {"inner.x": 5}, event_processors=[lp])
+        # x is owned by inner GraphNode → addressed by its parent-facing key
+        result = await runner.run(outer, {"x": 5}, event_processors=[lp])
 
         assert result["final"] == 11
 
@@ -408,8 +408,8 @@ class TestNestedGraphEvents:
         runner = AsyncRunner()
         lp = ListProcessor()
 
-        # x is private to inner GraphNode → addressed via dot-path
-        await runner.run(outer, {"inner.x": 5}, event_processors=[lp])
+        # x is owned by inner GraphNode → addressed by its parent-facing key
+        await runner.run(outer, {"x": 5}, event_processors=[lp])
 
         run_starts = lp.of_type(RunStartEvent)
         assert len(run_starts) == 2

--- a/tests/events/test_sync_events.py
+++ b/tests/events/test_sync_events.py
@@ -285,8 +285,8 @@ class TestNestedGraphEvents:
         runner = SyncRunner()
         lp = ListProcessor()
 
-        # x is private to inner GraphNode → addressed via dot-path
-        result = runner.run(outer, {"inner.x": 5}, event_processors=[lp])
+        # x is owned by inner GraphNode → addressed by its parent-facing key
+        result = runner.run(outer, {"x": 5}, event_processors=[lp])
 
         assert result["final"] == 11
 
@@ -310,8 +310,8 @@ class TestNestedGraphEvents:
         runner = SyncRunner()
         lp = ListProcessor()
 
-        # x is private to inner GraphNode → addressed via dot-path
-        runner.run(outer, {"inner.x": 5}, event_processors=[lp])
+        # x is owned by inner GraphNode → addressed by its parent-facing key
+        runner.run(outer, {"x": 5}, event_processors=[lp])
 
         run_starts = lp.of_type(RunStartEvent)
         assert len(run_starts) == 2
@@ -505,8 +505,8 @@ class TestDeeplyNestedGraph:
         runner = SyncRunner()
         lp = ListProcessor()
 
-        # x is private through middle.inner GraphNode chain
-        result = runner.run(outer, {"middle.inner.x": 3}, event_processors=[lp])
+        # x is projected through the middle.inner GraphNode chain.
+        result = runner.run(outer, {"x": 3}, event_processors=[lp])
 
         assert result["final"] == 7  # 3 * 2 + 1
 
@@ -531,8 +531,8 @@ class TestDeeplyNestedGraph:
         runner = SyncRunner()
         lp = ListProcessor()
 
-        # x is private through middle.inner GraphNode chain
-        runner.run(outer, {"middle.inner.x": 3}, event_processors=[lp])
+        # x is projected through the middle.inner GraphNode chain.
+        runner.run(outer, {"x": 3}, event_processors=[lp])
 
         run_starts = lp.of_type(RunStartEvent)
         run_ids = [s.run_id for s in run_starts]
@@ -554,11 +554,11 @@ class TestMapWithNestedError:
         runner = SyncRunner()
         lp = ListProcessor()
 
-        # x is private to inner GraphNode → addressed via dot-path; map_over uses that name
+        # x is owned by inner GraphNode → addressed by its parent-facing key; map_over uses that name
         results = runner.map(
             graph,
-            {"inner.x": [1, 2, 3]},
-            map_over="inner.x",
+            {"x": [1, 2, 3]},
+            map_over="x",
             error_handling="continue",
             event_processors=[lp],
         )

--- a/tests/test_bind_defaults.py
+++ b/tests/test_bind_defaults.py
@@ -39,7 +39,7 @@ def test_bound_params_not_treated_as_defaults():
     # Outer binds config at the scope where it's declared (auto-links into inner).
     outer_graph = Graph([inner_graph.as_node(), outer_func], name="outer").bind(config="bound_value")
 
-    # x is owned by inner GraphNode -> addressed as inner.x
+    # x is projected as flat parent-facing key "x".
     assert set(outer_graph.inputs.required) == {"x"}
     assert "config" in outer_graph.inputs.bound
 
@@ -262,12 +262,12 @@ def test_three_level_nested_binding():
     assert "vector_store" in retrieval_graph.inputs.bound
 
     # Key assertion: bound values from retrieval_graph must appear in rag_graph
-    # embedder/vector_store are owned by retrieval GraphNode → addressed as retrieval.X
+    # embedder/vector_store project through retrieval as flat parent-facing keys.
     assert "embedder" in rag_graph.inputs.bound
     assert "vector_store" in rag_graph.inputs.bound
 
     # Key assertion: bound values must propagate to eval_graph
-    # embedder/vector_store are projected through rag.retrieval.
+    # embedder/vector_store continue projecting flat through rag.retrieval.
     assert "embedder" in eval_graph.inputs.bound
     assert "vector_store" in eval_graph.inputs.bound
     # llm bound at eval scope; auto-links to both judge.llm and rag.generate.llm.
@@ -319,7 +319,7 @@ def test_nested_bound_values_use_graphnode_public_input_names():
     nested = inner.as_node().with_inputs(cfg="public_cfg")
     outer = Graph([nested], name="outer")
 
-    # public_cfg is owned by inner GraphNode → addressed as inner.public_cfg
+    # public_cfg is projected to outer as flat parent-facing "public_cfg".
     assert "public_cfg" in outer.inputs.bound
     assert "cfg" not in outer.inputs.bound
     assert outer.inputs.bound["public_cfg"] == "inner-cfg"

--- a/tests/test_bind_defaults.py
+++ b/tests/test_bind_defaults.py
@@ -23,7 +23,7 @@ def test_bound_params_not_treated_as_defaults():
     so it shouldn't trigger the "inconsistent defaults" validation error.
     """
 
-    # Inner graph (no bind on config -- under lexical scope, an inner bind on a
+    # Inner graph (no bind on config -- with projected GraphNode boundaries, an inner bind on a
     # name the outer declares would be shadowed and is a build-time error).
     @node(output_name="result")
     def inner_func(x: int, config: str) -> str:
@@ -39,8 +39,8 @@ def test_bound_params_not_treated_as_defaults():
     # Outer binds config at the scope where it's declared (auto-links into inner).
     outer_graph = Graph([inner_graph.as_node(), outer_func], name="outer").bind(config="bound_value")
 
-    # x is private to inner GraphNode -> addressed as inner.x
-    assert set(outer_graph.inputs.required) == {"inner.x"}
+    # x is owned by inner GraphNode -> addressed as inner.x
+    assert set(outer_graph.inputs.required) == {"x"}
     assert "config" in outer_graph.inputs.bound
 
 
@@ -76,8 +76,8 @@ def test_nested_graph_with_bound_and_defaults():
 
     # Should work: y has consistent defaults, x is bound (not a default)
     graph = Graph([inner.as_node(), outer_func])
-    # Both x and y are optional: x is bound in inner (private → inner.x), y has defaults
-    assert set(graph.inputs.optional) == {"inner.x", "y"}
+    # Both x and y are optional: x is bound inside inner, y has defaults.
+    assert set(graph.inputs.optional) == {"x", "y"}
     assert set(graph.inputs.required) == set()
 
 
@@ -262,24 +262,24 @@ def test_three_level_nested_binding():
     assert "vector_store" in retrieval_graph.inputs.bound
 
     # Key assertion: bound values from retrieval_graph must appear in rag_graph
-    # embedder/vector_store are private to retrieval GraphNode → addressed as retrieval.X
-    assert "retrieval.embedder" in rag_graph.inputs.bound
-    assert "retrieval.vector_store" in rag_graph.inputs.bound
+    # embedder/vector_store are owned by retrieval GraphNode → addressed as retrieval.X
+    assert "embedder" in rag_graph.inputs.bound
+    assert "vector_store" in rag_graph.inputs.bound
 
     # Key assertion: bound values must propagate to eval_graph
-    # embedder/vector_store are private through rag.retrieval.X
-    assert "rag.retrieval.embedder" in eval_graph.inputs.bound
-    assert "rag.retrieval.vector_store" in eval_graph.inputs.bound
+    # embedder/vector_store are projected through rag.retrieval.
+    assert "embedder" in eval_graph.inputs.bound
+    assert "vector_store" in eval_graph.inputs.bound
     # llm bound at eval scope; auto-links to both judge.llm and rag.generate.llm.
     assert "llm" in eval_graph.inputs.bound
 
     # Runtime execution should work
-    # text is private at rag.retrieval (consumed by leaf 'embed' inside retrieval graph,
+    # text is projected through rag.retrieval (consumed by leaf 'embed' inside retrieval graph,
     # which is a GraphNode at rag scope and a sub-GraphNode at eval scope)
     runner = SyncRunner()
     result = runner.run(
         eval_graph,
-        {"rag.retrieval.text": "test query", "query": "test query", "expected_answer": "expected"},
+        {"text": "test query", "query": "test query", "expected_answer": "expected"},
     )
 
     assert result["judgment"] == "Judged: Answer: test query"
@@ -298,14 +298,14 @@ def test_sibling_nested_bindings_do_not_leak():
 
     inner_a = Graph([use_a], name="inner_a").bind(cfg="CFG_A")
     inner_b = Graph([use_b], name="inner_b").bind(cfg="CFG_B")
-    graph = Graph([inner_a.as_node(), inner_b.as_node()], name="outer")
+    graph = Graph([inner_a.as_node(namespaced=True), inner_b.as_node(namespaced=True)], name="outer")
 
     assert "cfg" not in graph.inputs.bound
+    assert graph.inputs.bound == {"inner_a.cfg": "CFG_A", "inner_b.cfg": "CFG_B"}
 
-    # x is private to each inner GraphNode → addressed by dot-path
     result = SyncRunner().run(graph, {"inner_a.x": 1, "inner_b.x": 1})
-    assert result["out_a"] == "A:1:CFG_A"
-    assert result["out_b"] == "B:1:CFG_B"
+    assert result["inner_a.out_a"] == "A:1:CFG_A"
+    assert result["inner_b.out_b"] == "B:1:CFG_B"
 
 
 def test_nested_bound_values_use_graphnode_public_input_names():
@@ -319,7 +319,7 @@ def test_nested_bound_values_use_graphnode_public_input_names():
     nested = inner.as_node().with_inputs(cfg="public_cfg")
     outer = Graph([nested], name="outer")
 
-    # public_cfg is private to inner GraphNode → addressed as inner.public_cfg
-    assert "inner.public_cfg" in outer.inputs.bound
+    # public_cfg is owned by inner GraphNode → addressed as inner.public_cfg
+    assert "public_cfg" in outer.inputs.bound
     assert "cfg" not in outer.inputs.bound
-    assert outer.inputs.bound["inner.public_cfg"] == "inner-cfg"
+    assert outer.inputs.bound["public_cfg"] == "inner-cfg"

--- a/tests/test_bind_edge_cases.py
+++ b/tests/test_bind_edge_cases.py
@@ -581,7 +581,8 @@ class TestBindWithGraphNode:
 
         # Outer bind at the same projected flat address wins over the inner bind.
         outer_bound = outer.bind(factor=4)
-        assert outer_bound.inputs.bound == {"factor": 4}
+        with pytest.warns(UserWarning, match="Parent bind.*factor.*overrides nested bind"):
+            assert outer_bound.inputs.bound == {"factor": 4}
         result = runner.run(outer_bound, {"x": 5})
         assert result["result"] == 20
 

--- a/tests/test_bind_edge_cases.py
+++ b/tests/test_bind_edge_cases.py
@@ -3,6 +3,7 @@
 import pytest
 
 from hypergraph.graph import Graph
+from hypergraph.graph.validation import GraphConfigError
 from hypergraph.nodes.function import node
 
 
@@ -530,8 +531,8 @@ class TestBindWithGraphNode:
         inner = Graph([double], name="inner")
         outer = Graph([inner.as_node()])
 
-        # x is private to inner GraphNode → bind via dot-path
-        outer_bound = outer.bind(**{"inner.x": 5})
+        # x is a parent-facing input address on the inner GraphNode.
+        outer_bound = outer.bind(**{"x": 5})
 
         runner = SyncRunner()
         result = runner.run(outer_bound, {})
@@ -550,8 +551,8 @@ class TestBindWithGraphNode:
         outer = Graph([inner_bound.as_node()])
 
         runner = SyncRunner()
-        # x is private to inner GraphNode → addressed via dot-path
-        result = runner.run(outer, {"inner.x": 5})
+        # x is owned by inner GraphNode → addressed by its parent-facing key
+        result = runner.run(outer, {"x": 5})
         assert result["result"] == 15
 
     def test_outer_bind_overrides_inner(self):
@@ -568,15 +569,36 @@ class TestBindWithGraphNode:
 
         runner = SyncRunner()
 
-        # x and factor are private to inner GraphNode → addressed via dot-path
+        # Flat as_node() keeps x and factor in the parent flow.
         # Run with inner's binding
-        result = runner.run(outer, {"inner.x": 5})
+        result = runner.run(outer, {"x": 5})
         assert result["result"] == 10
 
         # Override with runtime value (warning expected for the bind override)
-        with pytest.warns(UserWarning, match="(?i)override.*inner\\.factor"):
-            result = runner.run(outer, {"inner.x": 5, "inner.factor": 3})
+        with pytest.warns(UserWarning, match="(?i)override.*factor"):
+            result = runner.run(outer, {"x": 5, "factor": 3})
         assert result["result"] == 15
+
+        # Outer bind at the same projected flat address wins over the inner bind.
+        outer_bound = outer.bind(factor=4)
+        assert outer_bound.inputs.bound == {"factor": 4}
+        result = runner.run(outer_bound, {"x": 5})
+        assert result["result"] == 20
+
+    def test_conflicting_flat_sibling_inner_binds_error(self):
+        @node(output_name="a")
+        def use_a(cfg: str) -> str:
+            return cfg
+
+        @node(output_name="b")
+        def use_b(cfg: str) -> str:
+            return cfg
+
+        inner_a = Graph([use_a], name="a").bind(cfg="A")
+        inner_b = Graph([use_b], name="b").bind(cfg="B")
+
+        with pytest.raises(GraphConfigError, match="Conflicting nested binds"):
+            Graph([inner_a.as_node(), inner_b.as_node()])
 
 
 class TestBindWithGates:

--- a/tests/test_cache_behavior.py
+++ b/tests/test_cache_behavior.py
@@ -208,8 +208,8 @@ class TestCacheWithNestedGraph:
         outer = Graph([inner.as_node()])
         runner = SyncRunner(cache=InMemoryCache())
 
-        # x is private to inner GraphNode → addressed via dot-path
-        result = runner.run(outer, {"inner.x": 5})
+        # x is owned by inner GraphNode → addressed by its parent-facing key
+        result = runner.run(outer, {"x": 5})
 
         assert result.status == RunStatus.COMPLETED
         assert result["doubled"] == 10
@@ -338,8 +338,8 @@ class TestCacheWithMapOver:
         outer = Graph([inner.as_node().map_over("x")])
         runner = SyncRunner(cache=InMemoryCache())
 
-        # x is private to inner GraphNode → addressed via dot-path
-        result = runner.run(outer, {"inner.x": [1, 2, 3]})
+        # x is owned by inner GraphNode → addressed by its parent-facing key
+        result = runner.run(outer, {"x": [1, 2, 3]})
 
         assert result.status == RunStatus.COMPLETED
         assert result["doubled"] == [2, 4, 6]
@@ -359,8 +359,8 @@ class TestCacheWithMapOver:
         runner = SyncRunner(cache=InMemoryCache())
 
         # Same value repeated — cache should deduplicate
-        # x is private to inner GraphNode → addressed via dot-path
-        result = runner.run(outer, {"inner.x": [5, 5, 5]})
+        # x is owned by inner GraphNode → addressed by its parent-facing key
+        result = runner.run(outer, {"x": [5, 5, 5]})
 
         assert result.status == RunStatus.COMPLETED
         assert result["doubled"] == [10, 10, 10]

--- a/tests/test_checkpointer/test_hierarchical_checkpointing.py
+++ b/tests/test_checkpointer/test_hierarchical_checkpointing.py
@@ -145,7 +145,7 @@ class TestNestedGraphCheckpointing:
         inner = Graph([double], name="inner")
         outer = Graph([inner.as_node(name="embed"), triple], name="outer")
 
-        result = await runner.run(outer, {"embed.x": 5}, workflow_id="nested")
+        result = await runner.run(outer, {"x": 5}, workflow_id="nested")
 
         assert result["tripled"] == 30
 
@@ -162,7 +162,7 @@ class TestNestedGraphCheckpointing:
         inner = Graph([double], name="inner")
         outer = Graph([inner.as_node(name="embed"), triple], name="outer")
 
-        await runner.run(outer, {"embed.x": 5}, workflow_id="nested-step")
+        await runner.run(outer, {"x": 5}, workflow_id="nested-step")
 
         steps = async_cp.steps("nested-step")
         embed_step = next(s for s in steps if s.node_name == "embed")
@@ -178,8 +178,7 @@ class TestNestedGraphCheckpointing:
         embed = inner.as_node(name="embed").map_over("x")
         outer = Graph([embed], name="outer")
 
-        # x is private to "embed" GraphNode → addressed via dot-path
-        await runner.run(outer, {"embed.x": [1, 2]}, workflow_id="nested-map")
+        await runner.run(outer, {"x": [1, 2]}, workflow_id="nested-map")
 
         runs = async_cp.runs()
         run_ids = {r.id for r in runs}
@@ -204,8 +203,7 @@ class TestNestedGraphCheckpointing:
         outer_node = mid.as_node(name="A")
         outer = Graph([outer_node], name="outer")
 
-        # x is private through A.B GraphNode chain (mid_node B wraps inner C)
-        result = await runner.run(outer, {"A.B.x": 5}, workflow_id="deep")
+        result = await runner.run(outer, {"x": 5}, workflow_id="deep")
         assert result["result"] == 6
 
         runs = async_cp.runs()
@@ -220,8 +218,7 @@ class TestNestedGraphCheckpointing:
         inner = Graph([double], name="inner")
         outer = Graph([inner.as_node(name="embed"), triple], name="outer")
 
-        # x is private to "embed" GraphNode → addressed via dot-path
-        result = await runner.run(outer, {"embed.x": 5})
+        result = await runner.run(outer, {"x": 5})
         assert result["tripled"] == 30
         assert result.workflow_id is not None
 
@@ -236,10 +233,9 @@ class TestNestedGraphCheckpointing:
         inner = Graph([double], name="inner")
         outer = Graph([inner.as_node(name="embed"), triple], name="outer")
 
-        await runner.run(outer, {"embed.x": 5}, workflow_id="nested-root")
+        await runner.run(outer, {"x": 5}, workflow_id="nested-root")
         fork_id, fork_cp = async_cp.fork_workflow("nested-root", workflow_id="nested-root-fork")
-        # x is private to "embed" GraphNode → use nested-dict form (alternative to dot-path)
-        await runner.run(outer, {"embed": {"x": 10}}, checkpoint=fork_cp, workflow_id=fork_id)
+        await runner.run(outer, {"x": 10}, checkpoint=fork_cp, workflow_id=fork_id)
 
         fork_run = async_cp.get_run("nested-root-fork")
         assert fork_run is not None
@@ -313,7 +309,7 @@ class TestSyncNestedCheckpointing:
         inner = Graph([double], name="inner")
         outer = Graph([inner.as_node(name="embed"), triple], name="outer")
 
-        result = runner.run(outer, {"embed.x": 5}, workflow_id="sync-nested")
+        result = runner.run(outer, {"x": 5}, workflow_id="sync-nested")
         assert result["tripled"] == 30
 
         db = sync_cp._sync_db()
@@ -329,7 +325,7 @@ class TestSyncNestedCheckpointing:
         inner = Graph([double], name="inner")
         outer = Graph([inner.as_node(name="embed"), triple], name="outer")
 
-        runner.run(outer, {"embed.x": 5}, workflow_id="sync-step")
+        runner.run(outer, {"x": 5}, workflow_id="sync-step")
 
         db = sync_cp._sync_db()
         step = db.execute(
@@ -345,8 +341,7 @@ class TestSyncNestedCheckpointing:
         embed = inner.as_node(name="embed").map_over("x")
         outer = Graph([embed], name="outer")
 
-        # x is private to "embed" GraphNode → addressed via dot-path
-        runner.run(outer, {"embed.x": [1, 2]}, workflow_id="sync-map-nest")
+        runner.run(outer, {"x": [1, 2]}, workflow_id="sync-map-nest")
 
         db = sync_cp._sync_db()
         runs = db.execute("SELECT id FROM runs ORDER BY id").fetchall()

--- a/tests/test_checkpointer/test_lineage_semantics.py
+++ b/tests/test_checkpointer/test_lineage_semantics.py
@@ -202,7 +202,7 @@ class TestLineageSemantics:
         paused = await runner.run(graph, {"query": "hello"}, workflow_id="wf-nested-paused")
         assert paused.status == RunStatus.PAUSED
         assert paused.pause is not None
-        assert paused.pause.response_key == "inner.decision"
+        assert paused.pause.response_key == "decision"
         stored_parent = checkpointer.get_run("wf-nested-paused")
         stored_child = checkpointer.get_run("wf-nested-paused/inner")
         assert stored_parent is not None and stored_parent.status == WorkflowStatus.PAUSED
@@ -236,7 +236,7 @@ class TestLineageSemantics:
         paused = await runner.run(graph, {"query": "hello"}, workflow_id="wf-renamed-nested-paused")
         assert paused.status == RunStatus.PAUSED
         assert paused.pause is not None
-        assert paused.pause.response_key == "inner.verdict"
+        assert paused.pause.response_key == "verdict"
 
         resumed = await runner.run(
             graph,
@@ -269,12 +269,12 @@ class TestLineageSemantics:
         paused = await runner.run(graph, {"query": "hello"}, workflow_id="wf-inactive-interrupt")
         assert paused.status == RunStatus.PAUSED
         assert paused.pause is not None
-        assert paused.pause.response_key == "inner.verdict"
+        assert paused.pause.response_key == "verdict"
 
         with pytest.raises(InputOverrideRequiresForkError):
             await runner.run(
                 graph,
-                {"inner.decision_b": "wrong"},
+                {"decision_b": "wrong"},
                 workflow_id="wf-inactive-interrupt",
             )
 
@@ -352,8 +352,8 @@ class TestLineageSemantics:
         outer_v2 = Graph([Graph([inner_v2_mid, inner_v2_end], name="inner").as_node(name="nested"), finalize])
 
         runner = AsyncRunner(checkpointer=checkpointer)
-        # x is private to "nested" GraphNode → addressed via dot-path
-        await runner.run(outer_v1, {"nested.x": 5}, workflow_id="wf-nested-hash")
+        # x is owned by "nested" GraphNode → addressed by its parent-facing key
+        await runner.run(outer_v1, {"x": 5}, workflow_id="wf-nested-hash")
 
         with pytest.raises(GraphChangedError):
             await runner.run(outer_v2, workflow_id="wf-nested-hash")

--- a/tests/test_checkpointer/test_memory.py
+++ b/tests/test_checkpointer/test_memory.py
@@ -47,8 +47,8 @@ class TestMemoryCheckpointer:
         inner = Graph([double], name="inner")
         outer = Graph([inner.as_node(name="embed"), triple], name="outer")
 
-        # x is private to "embed" GraphNode → addressed via dot-path
-        result = await runner.run(outer, {"embed.x": 5}, workflow_id="nested-memory")
+        # x is owned by "embed" GraphNode → addressed by its parent-facing key
+        result = await runner.run(outer, {"x": 5}, workflow_id="nested-memory")
 
         assert result["tripled"] == 30
 

--- a/tests/test_daft_examples.py
+++ b/tests/test_daft_examples.py
@@ -17,7 +17,7 @@ def test_quickstart_orders_example():
     result = runner.run(
         graph,
         {
-            "process_orders.orders": [
+            "orders": [
                 {"order_id": "A-1", "customer": " ada ", "country": "us", "unit_price": 25, "quantity": 2},
                 {"order_id": "B-2", "customer": "grace", "country": "uk", "unit_price": 80, "quantity": 2},
                 {"order_id": "C-3", "customer": "linus", "country": "de", "unit_price": 10, "quantity": 1, "rush": True},
@@ -40,7 +40,7 @@ def test_document_processing_example():
     result = runner.run(
         graph,
         {
-            "process_documents.documents": [
+            "documents": [
                 "Hypergraph composes graphs into larger workflows. Daft scales dataset fan-out.",
                 "This background note talks about deployment plans and rollout windows.",
             ]
@@ -59,17 +59,17 @@ def test_scenario_sweep_example():
     graph = build_scenario_sweep_graph()
     runner = DaftRunner()
 
-    # `weights` and `candidates` are owned by the `evaluate_candidates`
-    # GraphNode with projected GraphNode boundaries; `scenario_id` is consumed at outer.
+    # `weights` and `candidates` are projected flat from the
+    # `evaluate_candidates` GraphNode; `scenario_id` is consumed at outer.
     results = runner.map(
         graph,
         {
             "scenario_id": ["latency_sensitive", "quality_first"],
-            "evaluate_candidates.weights": [
+            "weights": [
                 {"accuracy": 1.0, "latency": 0.01, "cost": 0.5},
                 {"accuracy": 2.5, "latency": 0.002, "cost": 0.2},
             ],
-            "evaluate_candidates.candidates": [
+            "candidates": [
                 [
                     {"name": "fast-small", "accuracy": 0.81, "latency_ms": 40, "cost": 0.01},
                     {"name": "balanced", "accuracy": 0.9, "latency_ms": 85, "cost": 0.03},
@@ -80,10 +80,26 @@ def test_scenario_sweep_example():
                 ],
             ],
         },
-        map_over=["scenario_id", "evaluate_candidates.weights", "evaluate_candidates.candidates"],
+        map_over=["scenario_id", "weights", "candidates"],
     )
 
     assert results["best_candidate"] == [
         {"scenario_id": "latency_sensitive", "name": "fast-small", "score": 0.405, "accuracy": 0.81, "latency_ms": 40.0},
         {"scenario_id": "quality_first", "name": "accurate-large", "score": 2.108, "accuracy": 0.96, "latency_ms": 140.0},
     ]
+
+
+def test_daft_map_rejects_stale_flat_graphnode_input_address():
+    graph = build_scenario_sweep_graph()
+    runner = DaftRunner()
+
+    with pytest.raises(ValueError, match=r"'evaluate_candidates\.weights' is no longer valid\. Use 'weights'"):
+        runner.map(
+            graph,
+            {
+                "scenario_id": ["latency_sensitive"],
+                "evaluate_candidates.weights": [{"accuracy": 1.0, "latency": 0.01, "cost": 0.5}],
+                "evaluate_candidates.candidates": [[{"name": "fast-small", "accuracy": 0.81, "latency_ms": 40, "cost": 0.01}]],
+            },
+            map_over=["scenario_id", "evaluate_candidates.weights", "evaluate_candidates.candidates"],
+        )

--- a/tests/test_daft_examples.py
+++ b/tests/test_daft_examples.py
@@ -59,8 +59,8 @@ def test_scenario_sweep_example():
     graph = build_scenario_sweep_graph()
     runner = DaftRunner()
 
-    # `weights` and `candidates` are private to the `evaluate_candidates`
-    # GraphNode under lexical scope; `scenario_id` is consumed at outer.
+    # `weights` and `candidates` are owned by the `evaluate_candidates`
+    # GraphNode with projected GraphNode boundaries; `scenario_id` is consumed at outer.
     results = runner.map(
         graph,
         {

--- a/tests/test_deep_nesting_issues.py
+++ b/tests/test_deep_nesting_issues.py
@@ -67,9 +67,7 @@ class TestFourLevelNestingSync:
         g1 = Graph(nodes=[g2.as_node(), level1], name="g1")
 
         runner = SyncRunner()
-        # x is consumed only by leaf level4 inside g4 (innermost), and is private
-        # at every level it bubbles through → addressed as g2.g3.g4.x
-        result = runner.run(g1, {"g2.g3.g4.x": 0})
+        result = runner.run(g1, {"x": 0})
 
         assert result["l4"] == 1
         assert result["l3"] == 2
@@ -91,8 +89,8 @@ class TestSameInnerGraphTwice:
 
         outer = Graph(nodes=[node_a, node_b])
         runner = SyncRunner()
-        # a/b are private to inner_a/inner_b GraphNodes → addressed via dot-path
-        result = runner.run(outer, {"inner_a.a": 3, "inner_b.b": 5})
+        # a/b are owned by inner_a/inner_b GraphNodes → addressed by its parent-facing key
+        result = runner.run(outer, {"a": 3, "b": 5})
 
         assert result["res_a"] == 6
         assert result["res_b"] == 10

--- a/tests/test_empty_collections.py
+++ b/tests/test_empty_collections.py
@@ -181,8 +181,8 @@ class TestEmptyListToMapOver:
         outer = Graph([inner.as_node().map_over("x")])
         runner = SyncRunner()
 
-        # x is private to inner GraphNode → addressed via dot-path
-        result = runner.run(outer, {"inner.x": []})
+        # x is owned by inner GraphNode → addressed by its parent-facing key
+        result = runner.run(outer, {"x": []})
 
         assert result.status == RunStatus.COMPLETED
         assert result["doubled"] == []
@@ -201,8 +201,8 @@ class TestEmptyListToMapOver:
         outer = Graph([inner.as_node().map_over("x")])
         runner = SyncRunner()
 
-        # x is private to inner GraphNode → addressed via dot-path
-        result = runner.run(outer, {"inner.x": []})
+        # x is owned by inner GraphNode → addressed by its parent-facing key
+        result = runner.run(outer, {"x": []})
 
         assert result.status == RunStatus.COMPLETED
         assert call_count == 0
@@ -218,8 +218,8 @@ class TestNestedGraphWithEmptyInput:
         outer = Graph([inner.as_node()])
         runner = SyncRunner()
 
-        # items is private to inner GraphNode → addressed via dot-path
-        result = runner.run(outer, {"inner.items": []})
+        # items is owned by inner GraphNode → addressed by its parent-facing key
+        result = runner.run(outer, {"items": []})
 
         assert result.status == RunStatus.COMPLETED
         assert result["processed"] == []
@@ -230,8 +230,8 @@ class TestNestedGraphWithEmptyInput:
         outer = Graph([inner.as_node()])
         runner = SyncRunner()
 
-        # items is private to inner GraphNode → addressed via dot-path
-        result = runner.run(outer, {"inner.items": []})
+        # items is owned by inner GraphNode → addressed by its parent-facing key
+        result = runner.run(outer, {"items": []})
 
         assert result.status == RunStatus.COMPLETED
         assert result["length"] == 0

--- a/tests/test_error_handling_edge_cases.py
+++ b/tests/test_error_handling_edge_cases.py
@@ -237,8 +237,8 @@ class TestMapOverAllFail:
         gn = inner.as_node().map_over("x", error_handling="continue")
         outer = Graph([gn, passthrough])
         runner = SyncRunner()
-        # x is private to inner GraphNode → addressed via dot-path
-        result = runner.run(outer, {"inner.x": [1, 2, 3]})
+        # x is owned by inner GraphNode → addressed by its parent-facing key
+        result = runner.run(outer, {"x": [1, 2, 3]})
         assert result.status == RunStatus.COMPLETED
         assert result["result"] == [None, None, None]
 
@@ -248,8 +248,8 @@ class TestMapOverAllFail:
         gn = inner.as_node().map_over("x", error_handling="continue")
         outer = Graph([gn, passthrough])
         runner = AsyncRunner()
-        # x is private to inner GraphNode → addressed via dot-path
-        result = await runner.run(outer, {"inner.x": [1, 2, 3]})
+        # x is owned by inner GraphNode → addressed by its parent-facing key
+        result = await runner.run(outer, {"x": [1, 2, 3]})
         assert result.status == RunStatus.COMPLETED
         assert result["result"] == [None, None, None]
 
@@ -262,8 +262,8 @@ class TestMapOverMultipleFailures:
         gn = inner.as_node().map_over("x", error_handling="continue")
         outer = Graph([gn, passthrough])
         runner = SyncRunner()
-        # x is private to inner GraphNode → addressed via dot-path
-        result = runner.run(outer, {"inner.x": [1, 2, 3, 4, 5]})
+        # x is owned by inner GraphNode → addressed by its parent-facing key
+        result = runner.run(outer, {"x": [1, 2, 3, 4, 5]})
         assert result.status == RunStatus.COMPLETED
         assert result["result"] == [None, 4, None, 8, None]
 
@@ -276,8 +276,8 @@ class TestMapOverSingleItem:
         gn = inner.as_node().map_over("x", error_handling="continue")
         outer = Graph([gn, passthrough])
         runner = SyncRunner()
-        # x is private to inner GraphNode → addressed via dot-path
-        result = runner.run(outer, {"inner.x": [1]})
+        # x is owned by inner GraphNode → addressed by its parent-facing key
+        result = runner.run(outer, {"x": [1]})
         assert result.status == RunStatus.COMPLETED
         assert result["result"] == [None]
 
@@ -287,8 +287,8 @@ class TestMapOverSingleItem:
         outer = Graph([gn, passthrough])
         runner = SyncRunner()
         with pytest.raises(FailError):
-            # x is private to inner GraphNode → addressed via dot-path
-            runner.run(outer, {"inner.x": [1]})
+            # x is owned by inner GraphNode → addressed by its parent-facing key
+            runner.run(outer, {"x": [1]})
 
 
 class TestMapOverWithRenamedOutputs:
@@ -304,8 +304,8 @@ class TestMapOverWithRenamedOutputs:
 
         outer = Graph([gn, consume])
         runner = SyncRunner()
-        # x is private to inner GraphNode → addressed via dot-path
-        result = runner.run(outer, {"inner.x": [1, 2, 3, 4]})
+        # x is owned by inner GraphNode → addressed by its parent-facing key
+        result = runner.run(outer, {"x": [1, 2, 3, 4]})
         assert result.status == RunStatus.COMPLETED
         assert result["final"] == [None, 4, None, 8]
 
@@ -318,8 +318,8 @@ class TestMapOverEmptyInput:
         gn = inner.as_node().map_over("x", error_handling="continue")
         outer = Graph([gn, passthrough])
         runner = SyncRunner()
-        # x is private to inner GraphNode → addressed via dot-path
-        result = runner.run(outer, {"inner.x": []})
+        # x is owned by inner GraphNode → addressed by its parent-facing key
+        result = runner.run(outer, {"x": []})
         assert result.status == RunStatus.COMPLETED
         assert result["result"] == []
 
@@ -334,5 +334,5 @@ class TestMapOverRaisePartialValues:
         outer = Graph([gn, passthrough])
         runner = SyncRunner()
         with pytest.raises(FailError):
-            # x is private to inner GraphNode → addressed via dot-path
-            runner.run(outer, {"inner.x": [1, 2]})
+            # x is owned by inner GraphNode → addressed by its parent-facing key
+            runner.run(outer, {"x": [1, 2]})

--- a/tests/test_exception_propagation.py
+++ b/tests/test_exception_propagation.py
@@ -115,8 +115,8 @@ class TestExceptionInNestedGraphNode:
 
         runner = SyncRunner()
         with pytest.raises(CustomError, match="inner graph failed"):
-            # x is private to inner GraphNode → addressed via dot-path
-            runner.run(outer, {"inner.x": 5})
+            # x is owned by inner GraphNode → addressed by its parent-facing key
+            runner.run(outer, {"x": 5})
 
     def test_exception_in_deeply_nested_graph(self):
         """Exception in deeply nested graph propagates."""
@@ -131,8 +131,8 @@ class TestExceptionInNestedGraphNode:
 
         runner = SyncRunner()
         with pytest.raises(CustomError, match="deep failure"):
-            # x is private all the way down → level2.level3.x
-            runner.run(level1, {"level2.level3.x": 5})
+            # x is projected through each GraphNode boundary.
+            runner.run(level1, {"x": 5})
 
     def test_exception_after_successful_nested_graph(self):
         """Exception after nested graph completes successfully."""
@@ -151,8 +151,8 @@ class TestExceptionInNestedGraphNode:
 
         runner = SyncRunner()
         with pytest.raises(CustomError, match="outer failed after inner success"):
-            # x is private to inner GraphNode → addressed via dot-path
-            runner.run(outer, {"inner.x": 5})
+            # x is owned by inner GraphNode → addressed by its parent-facing key
+            runner.run(outer, {"x": 5})
 
 
 class TestExceptionInCycle:
@@ -217,8 +217,8 @@ class TestExceptionInMapOver:
 
         runner = SyncRunner()
         with pytest.raises(CustomError, match="failed on x=3"):
-            # x is private to inner GraphNode → addressed via dot-path
-            runner.run(outer, {"inner.x": [1, 2, 3, 4, 5]})
+            # x is owned by inner GraphNode → addressed by its parent-facing key
+            runner.run(outer, {"x": [1, 2, 3, 4, 5]})
 
     def test_exception_in_first_map_iteration(self):
         """Exception in first iteration of map_over."""
@@ -232,8 +232,8 @@ class TestExceptionInMapOver:
 
         runner = SyncRunner()
         with pytest.raises(CustomError, match="always fails"):
-            # x is private to inner GraphNode → addressed via dot-path
-            runner.run(outer, {"inner.x": [1, 2, 3]})
+            # x is owned by inner GraphNode → addressed by its parent-facing key
+            runner.run(outer, {"x": [1, 2, 3]})
 
 
 class TestExceptionPreservesPartialResults:
@@ -352,8 +352,8 @@ class TestAsyncExceptionHandling:
 
         runner = AsyncRunner()
         with pytest.raises(CustomError, match="async inner failure"):
-            # x is private to inner GraphNode → addressed via dot-path
-            await runner.run(outer, {"inner.x": 5})
+            # x is owned by inner GraphNode → addressed by its parent-facing key
+            await runner.run(outer, {"x": 5})
 
     async def test_async_partial_values_on_failure(self):
         """Async runner returns partial values when a node fails."""

--- a/tests/test_framework_ports.py
+++ b/tests/test_framework_ports.py
@@ -29,7 +29,7 @@ def test_agentic_rag_routes_latest_questions_to_web():
         graph,
         {
             "question": "What changed in the latest release for interrupts?",
-            # `local_documents` and `web_documents` are private to the
+            # `local_documents` and `web_documents` are owned by the
             # `retrieve_context` GraphNode at outer scope.
             "retrieve_context.local_documents": [
                 "Hypergraph supports interrupt nodes for human review.",
@@ -60,8 +60,8 @@ async def test_support_inbox_nested_interrupt_propagates_pause():
                 "issue": "refund API timeout after release",
             }
         },
-        # `knowledge_base` is private to `customer_support`; `release_notes` is
-        # private to `technical_support`.
+        # `knowledge_base` is owned by `customer_support`; `release_notes` is
+        # owned by `technical_support`.
         "customer_support.knowledge_base": [
             "General account changes are applied within one hour.",
         ],
@@ -87,7 +87,7 @@ def test_ml_model_selection_uses_mapped_trials_to_pick_best_model():
         graph,
         {
             "dataset_name": "toy_flowers",
-            # `feature_names` and `model_types` are private to the `trial` GraphNode.
+            # `feature_names` and `model_types` are owned by the `trial` GraphNode.
             "trial.feature_names": ("length", "width"),
             "trial.model_types": ["threshold", "centroid"],
         },
@@ -106,7 +106,7 @@ def test_document_batch_pipeline_maps_one_document_graph_over_many_inputs():
     result = runner.run(
         graph,
         {
-            # `documents` is private to the `process_document` GraphNode at outer scope.
+            # `documents` is owned by the `process_document` GraphNode at outer scope.
             "process_document.documents": [
                 "Hypergraph composes graphs into larger workflows. It keeps nodes testable.",
                 "Mapped graph nodes let one document pipeline scale across a batch. Automatic wiring keeps the graph readable.",

--- a/tests/test_framework_ports.py
+++ b/tests/test_framework_ports.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import warnings
+
 import pytest
 
 from examples.framework_ports.agentic_rag import build_agentic_rag_graph
@@ -29,13 +31,13 @@ def test_agentic_rag_routes_latest_questions_to_web():
         graph,
         {
             "question": "What changed in the latest release for interrupts?",
-            # `local_documents` and `web_documents` are owned by the
-            # `retrieve_context` GraphNode at outer scope.
-            "retrieve_context.local_documents": [
+            # `local_documents` and `web_documents` are projected flat from
+            # the `retrieve_context` GraphNode.
+            "local_documents": [
                 "Hypergraph supports interrupt nodes for human review.",
                 "Nested graphs make composition natural.",
             ],
-            "retrieve_context.web_documents": [
+            "web_documents": [
                 "Latest release notes mention better interrupt resume semantics.",
                 "Recent release adds richer run logs for nested graphs.",
             ],
@@ -60,12 +62,12 @@ async def test_support_inbox_nested_interrupt_propagates_pause():
                 "issue": "refund API timeout after release",
             }
         },
-        # `knowledge_base` is owned by `customer_support`; `release_notes` is
-        # owned by `technical_support`.
-        "customer_support.knowledge_base": [
+        # `knowledge_base` and `release_notes` are projected flat from their
+        # support subgraphs.
+        "knowledge_base": [
             "General account changes are applied within one hour.",
         ],
-        "technical_support.release_notes": [
+        "release_notes": [
             "Refund API timeout fixed in patch 2026.03.",
             "Release 2026.03 improves webhook retries.",
         ],
@@ -76,7 +78,7 @@ async def test_support_inbox_nested_interrupt_propagates_pause():
     assert paused.paused is True
     assert paused.pause is not None
     assert paused.pause.node_name == "technical_support/request_developer_review"
-    assert paused.pause.response_key == "technical_support.developer_reply"
+    assert paused.pause.response_key == "developer_reply"
 
 
 def test_ml_model_selection_uses_mapped_trials_to_pick_best_model():
@@ -87,9 +89,9 @@ def test_ml_model_selection_uses_mapped_trials_to_pick_best_model():
         graph,
         {
             "dataset_name": "toy_flowers",
-            # `feature_names` and `model_types` are owned by the `trial` GraphNode.
-            "trial.feature_names": ("length", "width"),
-            "trial.model_types": ["threshold", "centroid"],
+            # `feature_names` and `model_types` are projected flat from `trial`.
+            "feature_names": ("length", "width"),
+            "model_types": ["threshold", "centroid"],
         },
     )
 
@@ -106,8 +108,8 @@ def test_document_batch_pipeline_maps_one_document_graph_over_many_inputs():
     result = runner.run(
         graph,
         {
-            # `documents` is owned by the `process_document` GraphNode at outer scope.
-            "process_document.documents": [
+            # `documents` is projected flat from `process_document`.
+            "documents": [
                 "Hypergraph composes graphs into larger workflows. It keeps nodes testable.",
                 "Mapped graph nodes let one document pipeline scale across a batch. Automatic wiring keeps the graph readable.",
             ]
@@ -134,6 +136,24 @@ def test_daft_quickstart_port_processes_dataframe_rows():
 
     assert results["cleaned_text"] == ["alpha beta alpha", "gamma delta epsilon zeta eta"]
     assert results["review_bucket"] == ["short", "long"]
+
+
+def test_daft_map_dataframe_preserves_passthrough_columns_without_warning():
+    graph = build_daft_quickstart_graph()
+    runner = DaftRunner()
+    frame = daft.from_pylist(
+        [
+            {"text": "  Alpha beta alpha  ", "source": "sample-a"},
+        ]
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        result_df = runner.map_dataframe(graph, frame)
+
+    results = result_df.collect().to_pydict()
+    assert results["source"] == ["sample-a"]
+    assert results["cleaned_text"] == ["alpha beta alpha"]
 
 
 def test_daft_llm_dataset_port_uses_nested_chunk_graphs():
@@ -176,3 +196,19 @@ def test_daft_image_query_port_maps_patch_classifier_inside_each_asset():
     assert results["patch_label"][0] == ["bright", "dark"]
     assert results["asset_summary"][0]["dominant_label"] == "bright"
     assert results["asset_summary"][1]["dominant_label"] == "dark"
+
+
+def test_daft_map_dataframe_rejects_stale_flat_graphnode_column_address():
+    graph = build_daft_llm_dataset_graph()
+    runner = DaftRunner()
+    frame = daft.from_pylist(
+        [
+            {
+                "query": "alpha",
+                "score_chunks.chunks": ["alpha alpha beta", "alpha beta gamma"],
+            }
+        ]
+    )
+
+    with pytest.raises(ValueError, match=r"'score_chunks\.chunks' is no longer valid\. Use 'chunks'"):
+        runner.map_dataframe(graph, frame)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1028,8 +1028,8 @@ class TestGraphAsNode:
         outer = Graph([gnode])
         assert outer.has_cycles is False
 
-    def test_graphnode_definition_hash(self):
-        """Test GraphNode.definition_hash returns graph's hash."""
+    def test_graphnode_definition_hash_includes_boundary_surface(self):
+        """GraphNode.definition_hash includes graph code and boundary projection."""
 
         @node(output_name="result")
         def foo(x: int) -> int:
@@ -1038,7 +1038,8 @@ class TestGraphAsNode:
         g = Graph([foo], name="my_graph")
         gnode = g.as_node()
 
-        assert gnode.definition_hash == g.definition_hash
+        assert gnode.definition_hash != g.definition_hash
+        assert gnode.definition_hash != g.as_node(namespaced=True).definition_hash
 
     def test_graphnode_graph_property(self):
         """Test GraphNode.graph property returns wrapped graph."""
@@ -1493,7 +1494,7 @@ class TestGraphNodeRename:
         renamed = original.with_name("new_name")
 
         assert renamed.graph is original.graph
-        assert renamed.definition_hash == original.definition_hash
+        assert renamed.definition_hash != original.definition_hash
 
     def test_with_inputs_renames_inputs(self):
         """with_inputs renames inputs in returned GraphNode."""
@@ -1806,13 +1807,10 @@ class TestGraphNodeCapabilities:
         assert outer_gn.get_output_type("intermediate") is str
         assert outer_gn.get_output_type("final") is int
 
-        # Both a and b are private to the nested inner GraphNode at outer's scope,
-        # so they appear under the dot-path "inner.a" / "inner.b"
-        assert "inner.a" in outer_gn.inputs
-        assert "inner.b" in outer_gn.inputs
-        # b has a default (the bound value), addressed via dot-path
-        assert outer_gn.has_default_for("inner.b") is True
-        assert outer_gn.get_default_for("inner.b") == 10
+        assert "a" in outer_gn.inputs
+        assert "b" in outer_gn.inputs
+        assert outer_gn.has_default_for("b") is True
+        assert outer_gn.get_default_for("b") == 10
 
 
 class TestStrictTypesWithNestedGraphNode:

--- a/tests/test_graph_topologies.py
+++ b/tests/test_graph_topologies.py
@@ -433,7 +433,7 @@ class TestDeeplyNestedGraphs:
 
         # No exception raised
         assert "middle" in outer.nodes
-        # x is owned by middle.inner_inner GraphNode chain
+        # x from nested inner_inner projects flat to the outer surface.
         assert outer.inputs.required == ("x",)
         assert outer.outputs == ("z",)
 

--- a/tests/test_graph_topologies.py
+++ b/tests/test_graph_topologies.py
@@ -433,8 +433,8 @@ class TestDeeplyNestedGraphs:
 
         # No exception raised
         assert "middle" in outer.nodes
-        # x is private to middle.inner_inner GraphNode chain
-        assert outer.inputs.required == ("middle.inner_inner.x",)
+        # x is owned by middle.inner_inner GraphNode chain
+        assert outer.inputs.required == ("x",)
         assert outer.outputs == ("z",)
 
     def test_three_level_inputs_propagate(self):
@@ -461,10 +461,10 @@ class TestDeeplyNestedGraphs:
         # Level 1: contains level 2 + its own node
         outer = Graph([middle.as_node(), level1_node], name="outer")
 
-        # All external inputs propagate (private inputs surface as dot-paths)
+        # All external inputs propagate (projected inputs surface as parent-facing addresses)
         all_inputs = outer.inputs.all
-        assert "middle.inner_inner.x" in all_inputs  # from level 3 (private through middle.inner_inner)
-        assert "middle.y" in all_inputs  # from level 2 (private through middle)
+        assert "x" in all_inputs  # from level 3 (projected through middle.inner_inner)
+        assert "y" in all_inputs  # from level 2 (projected through middle)
         assert "z" in all_inputs  # from level 1 (consumed by leaf at outer)
 
     def test_three_level_outputs_visible(self):

--- a/tests/test_graph_validation.py
+++ b/tests/test_graph_validation.py
@@ -216,26 +216,24 @@ class TestConsistentDefaultsValidation:
         assert g2.inputs.bound == {"x": 100}
 
 
-class TestNamespaceCollisionValidation:
-    """Test GraphNode name collision with output names."""
+class TestGraphNodeNameOutputOverlap:
+    """GraphNode names and port addresses are separate surfaces."""
 
-    def test_graphnode_name_matches_output_raises(self):
-        """GraphNode name colliding with output name raises error."""
-
-        # Outer node outputs "subgraph" - same as GraphNode name
+    def test_graphnode_name_may_match_flat_output_name(self):
         @node(output_name="subgraph")
         def source_node(x: int) -> int:
             return x * 2
 
-        # Inner graph will be named "subgraph" - collision!
         @node(output_name="inner_out")
         def inner_func(a: int) -> int:
             return a
 
         inner_graph = Graph([inner_func], name="subgraph")
 
-        with pytest.raises(GraphConfigError, match="collides with output"):
-            Graph([source_node, inner_graph.as_node()])
+        graph = Graph([source_node, inner_graph.as_node()])
+
+        assert graph.nodes["subgraph"].name == "subgraph"
+        assert "subgraph" in graph.outputs
 
     def test_no_collision_different_names(self):
         """No error when GraphNode name differs from all outputs."""
@@ -273,9 +271,7 @@ class TestNamespaceCollisionValidation:
         outer = Graph([source_node, inner_graph.as_node()])
         assert "my-inner-graph" in outer.nodes
 
-    def test_graphnode_output_collision_with_other_graphnode(self):
-        """GraphNode name colliding with another GraphNode's output raises error."""
-
+    def test_graphnode_name_may_match_other_graphnode_output(self):
         @node(output_name="collider")
         def inner1_func(a: int) -> int:
             return a
@@ -288,8 +284,10 @@ class TestNamespaceCollisionValidation:
         inner1 = Graph([inner1_func], name="inner1")
         inner2 = Graph([inner2_func], name="collider")
 
-        with pytest.raises(GraphConfigError, match="collides with output"):
-            Graph([inner1.as_node(), inner2.as_node()])
+        graph = Graph([inner1.as_node(), inner2.as_node()])
+
+        assert graph.nodes["collider"].name == "collider"
+        assert "collider" in graph.outputs
 
 
 class TestNameValidationEdgeCases:

--- a/tests/test_graphnode_boundary_projection.py
+++ b/tests/test_graphnode_boundary_projection.py
@@ -292,7 +292,7 @@ def test_with_inputs_renames_local_name_before_projection():
     assert result["retrieval.answer"] == "answer:hello"
 
 
-def test_map_over_and_clone_use_local_input_names():
+def test_map_over_and_clone_accept_local_and_projected_input_names():
     @node(output_name="doubled")
     def double(x: int, config: dict[str, int]) -> int:
         return x * config["multiplier"]
@@ -309,11 +309,18 @@ def test_map_over_and_clone_use_local_input_names():
 
     assert result["worker.doubled"] == [3, 6]
 
-    with pytest.raises(ValueError, match="not an input"):
-        inner.as_node(namespaced=True).map_over("worker.x")
+    projected = inner.as_node(namespaced=True).map_over("worker.x", clone=["worker.config"])
+    projected_outer = Graph([projected])
+
+    assert projected.map_config is not None
+    assert projected.map_config[0] == ["x"]
+
+    projected_result = SyncRunner().run(projected_outer, {"worker.x": [1, 2], "worker.config": {"multiplier": 4}})
+
+    assert projected_result["worker.doubled"] == [4, 8]
 
     with pytest.raises(ValueError, match="not an input"):
-        inner.as_node(namespaced=True).map_over("x", clone=["worker.config"])
+        inner.as_node(namespaced=True).map_over("other.x")
 
 
 def test_same_local_name_can_be_projected_as_input_and_output_for_cycles():

--- a/tests/test_graphnode_boundary_projection.py
+++ b/tests/test_graphnode_boundary_projection.py
@@ -1,0 +1,509 @@
+"""GraphNode boundary projection semantics."""
+
+from __future__ import annotations
+
+import pytest
+
+from hypergraph import Graph, interrupt, node
+from hypergraph.exceptions import MissingInputError
+from hypergraph.graph.validation import GraphConfigError
+from hypergraph.nodes import RenameError
+from hypergraph.runners import AsyncRunner, SyncRunner
+
+
+def test_namespaced_graphnode_projects_parent_facing_addresses_and_runs():
+    @node(output_name="y")
+    def double(x: int) -> int:
+        return x * 2
+
+    inner = Graph([double])
+
+    graph_node = inner.as_node(name="researcher", namespaced=True)
+    assert graph_node.inputs == ("researcher.x",)
+    assert graph_node.outputs == ("researcher.y",)
+
+    outer = Graph([graph_node], name="outer")
+
+    assert outer.inputs.required == ("researcher.x",)
+
+    result = SyncRunner().run(outer, {"researcher.x": 2})
+
+    assert result["researcher.y"] == 4
+
+
+@pytest.mark.asyncio
+async def test_deep_namespaced_interrupt_resume_key_is_validated_as_parent_address():
+    @interrupt(output_name="decision")
+    def approve() -> str | None:
+        return None
+
+    inner = Graph([approve], name="inner")
+    middle = Graph([inner.as_node(namespaced=True)], name="middle")
+    outer = Graph([middle.as_node(namespaced=True)], name="outer")
+
+    runner = AsyncRunner()
+
+    paused = await runner.run(outer, {})
+    assert paused.pause is not None
+    assert paused.pause.response_key == "middle.inner.decision"
+
+    resumed = await runner.run(outer, {paused.pause.response_key: "yes"})
+
+    assert resumed["middle.inner.decision"] == "yes"
+
+
+@pytest.mark.asyncio
+async def test_stale_partial_interrupt_resume_key_is_not_accepted_for_deep_namespaced_graphnode():
+    @interrupt(output_name="decision")
+    def approve() -> str | None:
+        return None
+
+    inner = Graph([approve], name="inner")
+    middle = Graph([inner.as_node(namespaced=True)], name="middle")
+    outer = Graph([middle.as_node(namespaced=True)], name="outer")
+
+    with pytest.warns(UserWarning, match="Not recognized"):
+        paused = await AsyncRunner().run(outer, {"inner.decision": "yes"})
+
+    assert paused.pause is not None
+    assert paused.pause.response_key == "middle.inner.decision"
+
+
+def test_describe_uses_resolved_graphnode_port_addresses():
+    @node(output_name="docs")
+    def retrieve(query: str) -> str:
+        return f"docs:{query}"
+
+    outer = Graph([Graph([retrieve], name="retrieval").as_node(namespaced=True)], name="outer")
+
+    summary = outer.describe(show_types=False)
+
+    assert "required: retrieval.query" in summary
+    assert "Outputs: retrieval.docs" in summary
+
+
+def test_exposed_namespaced_inputs_share_one_flat_parent_input():
+    @node(output_name="retrieved")
+    def retrieve(query: str) -> str:
+        return f"docs:{query}"
+
+    @node(output_name="answer")
+    def generate(query: str) -> str:
+        return f"answer:{query}"
+
+    retrieval = Graph([retrieve], name="retrieval")
+    generation = Graph([generate], name="generation")
+
+    outer = Graph(
+        [
+            retrieval.as_node(namespaced=True).expose("query"),
+            generation.as_node(namespaced=True).expose("query"),
+        ],
+        name="rag",
+    )
+
+    assert outer.inputs.required == ("query",)
+    assert "retrieval.query" not in outer.inputs.all
+    assert "generation.query" not in outer.inputs.all
+
+    result = SyncRunner().run(outer, {"query": "what is hypergraph?"})
+
+    assert result["retrieval.retrieved"] == "docs:what is hypergraph?"
+    assert result["generation.answer"] == "answer:what is hypergraph?"
+
+
+def test_exposed_output_alias_is_flat_and_autowires_downstream():
+    @node(output_name=("response", "trace"))
+    def agent(prompt: str) -> tuple[str, str]:
+        return (f"response:{prompt}", "trace")
+
+    @node(output_name="judgement")
+    def judge(researcher_response: str) -> str:
+        return f"judged:{researcher_response}"
+
+    agent_graph = Graph([agent], name="agent")
+    researcher = agent_graph.as_node(name="researcher", namespaced=True).expose(response="researcher_response")
+    outer = Graph([researcher, judge], name="team")
+
+    assert researcher.outputs == ("researcher_response", "researcher.trace")
+    assert outer.inputs.required == ("researcher.prompt",)
+
+    result = SyncRunner().run(outer, {"researcher.prompt": "hello"})
+
+    assert result["researcher_response"] == "response:hello"
+    assert result["researcher.trace"] == "trace"
+    assert result["judgement"] == "judged:response:hello"
+
+
+def test_expose_targets_local_port_names_not_projected_addresses():
+    @node(output_name="answer")
+    def agent(query: str) -> str:
+        return query
+
+    graph_node = Graph([agent], name="retrieval").as_node(namespaced=True)
+
+    with pytest.raises(ValueError, match="Local port names"):
+        graph_node.expose("retrieval.query")
+
+
+def test_expose_replaces_namespaced_address_for_input():
+    @node(output_name="answer")
+    def agent(query: str) -> str:
+        return query
+
+    graph_node = Graph([agent], name="retrieval").as_node(namespaced=True).expose("query")
+
+    assert graph_node.inputs == ("query",)
+    assert "retrieval.query" not in graph_node.inputs
+
+
+def test_exposed_alias_stays_flat_when_graphnode_is_renamed():
+    @node(output_name="answer")
+    def agent(query: str) -> str:
+        return query
+
+    graph_node = Graph([agent], name="retrieval").as_node(namespaced=True).expose(answer="final_answer")
+    renamed = graph_node.with_name("generation")
+
+    assert renamed.inputs == ("generation.query",)
+    assert renamed.outputs == ("final_answer",)
+
+
+def test_stale_namespaced_input_address_after_rename_suggests_current_address():
+    @node(output_name="answer")
+    def agent(query: str) -> str:
+        return query
+
+    graph_node = Graph([agent], name="retrieval").as_node(namespaced=True).with_inputs(query="user_query")
+    outer = Graph([graph_node])
+
+    with pytest.raises(ValueError, match="Use 'retrieval.user_query'"):
+        SyncRunner().run(outer, {"retrieval.query": "hello"})
+
+
+def test_stale_namespaced_input_address_after_graphnode_rename_suggests_current_address():
+    @node(output_name="answer")
+    def agent(query: str) -> str:
+        return query
+
+    graph_node = Graph([agent], name="retrieval").as_node(namespaced=True).with_name("generation")
+    outer = Graph([graph_node])
+
+    with pytest.raises(ValueError, match="Use 'generation.query'"):
+        SyncRunner().run(outer, {"retrieval.query": "hello"})
+
+
+def test_stale_namespaced_input_address_for_flat_graphnode_suggests_flat_address():
+    @node(output_name="answer")
+    def agent(query: str) -> str:
+        return query
+
+    outer = Graph([Graph([agent], name="retrieval").as_node()])
+
+    with pytest.raises(ValueError, match="Use 'query'"):
+        SyncRunner().run(outer, {"retrieval.query": "hello"})
+
+
+def test_renaming_exposed_local_port_is_rejected():
+    @node(output_name="answer")
+    def agent(query: str) -> str:
+        return query
+
+    graph_node = Graph([agent], name="retrieval").as_node(namespaced=True).expose("query", "answer")
+
+    with pytest.raises(RenameError, match="Cannot rename exposed local input"):
+        graph_node.with_inputs(query="user_query")
+
+    with pytest.raises(RenameError, match="Cannot rename exposed local output"):
+        graph_node.with_outputs(answer="final_answer")
+
+
+def test_nested_dict_addressing_is_valid_for_namespaced_inputs():
+    @node(output_name="answer")
+    def agent(query: str) -> str:
+        return f"answer:{query}"
+
+    outer = Graph([Graph([agent], name="retrieval").as_node(namespaced=True)])
+
+    result = SyncRunner().run(outer, {"retrieval": {"query": "hello"}})
+
+    assert result["retrieval.answer"] == "answer:hello"
+
+
+def test_nested_dict_addressing_is_not_created_for_flat_graphnodes():
+    @node(output_name="answer")
+    def agent(query: str) -> str:
+        return f"answer:{query}"
+
+    outer = Graph([Graph([agent], name="retrieval").as_node()])
+
+    with pytest.warns(UserWarning, match="Not recognized"), pytest.raises(MissingInputError) as exc:
+        SyncRunner().run(outer, {"retrieval": {"query": "hello"}})
+
+    assert exc.value.missing == ["query"]
+    assert "retrieval" in exc.value.provided
+
+
+def test_stale_exposed_runtime_address_errors_with_suggestion():
+    @node(output_name="answer")
+    def agent(query: str) -> str:
+        return f"answer:{query}"
+
+    graph_node = Graph([agent], name="retrieval").as_node(namespaced=True).expose("query")
+    outer = Graph([graph_node])
+
+    with pytest.raises(ValueError, match="Use 'query'"):
+        SyncRunner().run(outer, {"retrieval.query": "hello"})
+
+    with pytest.raises(ValueError, match="Use 'query'"):
+        SyncRunner().run(outer, {"query": "hello", "retrieval.query": "hello"})
+
+    with pytest.raises(ValueError, match="Use 'query'"):
+        SyncRunner().run(outer, {"retrieval": {"query": "hello"}})
+
+
+def test_inner_bind_values_project_through_namespaced_and_exposed_boundary():
+    @node(output_name="answer")
+    def agent(query: str, model: str) -> str:
+        return f"{model}:{query}"
+
+    inner = Graph([agent], name="agent").bind(model="gpt")
+
+    namespaced = Graph([inner.as_node(name="researcher", namespaced=True)])
+    exposed = Graph([inner.as_node(name="researcher", namespaced=True).expose("model")])
+
+    assert namespaced.inputs.bound == {"researcher.model": "gpt"}
+    assert exposed.inputs.bound == {"model": "gpt"}
+
+
+def test_with_inputs_renames_local_name_before_projection():
+    @node(output_name="answer")
+    def agent(query: str) -> str:
+        return f"answer:{query}"
+
+    graph_node = Graph([agent], name="retrieval").as_node(namespaced=True).with_inputs(query="user_query")
+    outer = Graph([graph_node])
+
+    assert graph_node.local_inputs == ("user_query",)
+    assert graph_node.inputs == ("retrieval.user_query",)
+
+    result = SyncRunner().run(outer, {"retrieval.user_query": "hello"})
+
+    assert result["retrieval.answer"] == "answer:hello"
+
+
+def test_map_over_and_clone_use_local_input_names():
+    @node(output_name="doubled")
+    def double(x: int, config: dict[str, int]) -> int:
+        return x * config["multiplier"]
+
+    inner = Graph([double], name="worker")
+
+    graph_node = inner.as_node(namespaced=True).map_over("x", clone=["config"])
+    outer = Graph([graph_node])
+
+    assert graph_node.map_config is not None
+    assert graph_node.map_config[0] == ["x"]
+
+    result = SyncRunner().run(outer, {"worker.x": [1, 2], "worker.config": {"multiplier": 3}})
+
+    assert result["worker.doubled"] == [3, 6]
+
+    with pytest.raises(ValueError, match="not an input"):
+        inner.as_node(namespaced=True).map_over("worker.x")
+
+    with pytest.raises(ValueError, match="not an input"):
+        inner.as_node(namespaced=True).map_over("x", clone=["worker.config"])
+
+
+def test_same_local_name_can_be_projected_as_input_and_output_for_cycles():
+    @node(output_name="messages")
+    def append_message(messages: list[str]) -> list[str]:
+        return [*messages, "assistant"]
+
+    graph_node = Graph([append_message], name="chat", entrypoint="append_message").as_node(namespaced=True)
+    outer = Graph([graph_node], entrypoint="chat")
+
+    assert "chat.messages" in graph_node.inputs
+    assert "chat.messages" in graph_node.outputs
+    assert outer.inputs.required == ("chat.messages",)
+
+
+def test_duplicate_exposed_outputs_inside_one_graphnode_error():
+    @node(output_name=("a", "b"))
+    def produce() -> tuple[int, int]:
+        return (1, 2)
+
+    graph_node = Graph([produce], name="producer").as_node(namespaced=True)
+
+    with pytest.raises(ValueError, match="already used"):
+        graph_node.expose(a="x", b="x")
+
+
+def test_cross_direction_exposed_alias_collision_inside_one_graphnode_errors():
+    @node(output_name="response")
+    def produce(query: str) -> str:
+        return query
+
+    graph_node = Graph([produce], name="producer").as_node(namespaced=True)
+
+    with pytest.raises(ValueError, match="already used"):
+        graph_node.expose(query="shared", response="shared")
+
+
+def test_duplicate_exposed_input_aliases_inside_one_graphnode_error():
+    @node(output_name="combined")
+    def combine(query: str, prompt: str) -> str:
+        return f"{query}:{prompt}"
+
+    graph_node = Graph([combine], name="producer").as_node(namespaced=True)
+
+    with pytest.raises(ValueError, match="already used"):
+        graph_node.expose(query="shared", prompt="shared")
+
+
+def test_select_defines_exposable_output_surface():
+    @node(output_name=("response", "trace"))
+    def agent(prompt: str) -> tuple[str, str]:
+        return (f"response:{prompt}", "trace")
+
+    selected = Graph([agent], name="agent").select("response")
+
+    graph_node = selected.as_node(name="researcher", namespaced=True).expose("response")
+
+    assert graph_node.outputs == ("response",)
+    with pytest.raises(ValueError, match="not on GraphNode surface"):
+        selected.as_node(name="researcher", namespaced=True).expose("trace")
+
+
+def test_exposed_inputs_follow_default_consistency_rules():
+    @node(output_name="retrieved")
+    def retrieve(query: str = "docs") -> str:
+        return query
+
+    @node(output_name="answer")
+    def generate(query: str = "answer") -> str:
+        return query
+
+    retrieval = Graph([retrieve], name="retrieval").as_node(namespaced=True).expose("query")
+    generation = Graph([generate], name="generation").as_node(namespaced=True).expose("query")
+
+    with pytest.raises(GraphConfigError, match="Inconsistent defaults for 'query'"):
+        Graph([retrieval, generation])
+
+
+def test_strict_types_validate_exposed_parent_address():
+    @node(output_name="value")
+    def produce() -> int:
+        return 1
+
+    @node(output_name="result")
+    def consume(shared: int) -> int:
+        return shared + 1
+
+    producer = Graph([produce], name="producer").as_node(namespaced=True).expose(value="shared")
+    graph = Graph([producer, consume], strict_types=True)
+
+    assert SyncRunner().run(graph, {})["result"] == 2
+
+
+def test_parent_wait_for_uses_resolved_namespaced_and_exposed_emit_addresses():
+    @node(output_name="value", emit="done")
+    def produce(query: str) -> str:
+        return query
+
+    @node(output_name="after", wait_for="retrieval.done")
+    def after_namespaced() -> str:
+        return "after"
+
+    namespaced = Graph([Graph([produce], name="retrieval").as_node(namespaced=True), after_namespaced])
+    assert SyncRunner().run(namespaced, {"retrieval.query": "hello"})["after"] == "after"
+
+    @node(output_name="after", wait_for="done")
+    def after_exposed() -> str:
+        return "after"
+
+    exposed_node = Graph([produce], name="retrieval").as_node(namespaced=True).expose("done")
+    exposed = Graph([exposed_node, after_exposed])
+    assert SyncRunner().run(exposed, {"retrieval.query": "hello"})["after"] == "after"
+
+
+def test_graphnode_data_outputs_exclude_projected_emit_outputs():
+    @node(output_name="value", emit="done")
+    def produce() -> str:
+        return "value"
+
+    graph_node = Graph([produce], name="producer").as_node(namespaced=True)
+
+    assert graph_node.outputs == ("producer.value", "producer.done")
+    assert graph_node.data_outputs == ("producer.value",)
+
+
+def test_boundary_projection_changes_definition_and_structural_hashes():
+    @node(output_name="answer")
+    def agent(query: str) -> str:
+        return query
+
+    inner = Graph([agent], name="agent")
+
+    flat = inner.as_node()
+    namespaced = inner.as_node(namespaced=True)
+    exposed = inner.as_node(namespaced=True).expose("query")
+
+    assert flat.definition_hash != namespaced.definition_hash
+    assert namespaced.definition_hash != exposed.definition_hash
+    assert Graph([flat]).structural_hash != Graph([namespaced]).structural_hash
+    assert Graph([namespaced]).structural_hash != Graph([exposed]).structural_hash
+
+
+def test_checkpoint_steps_use_parent_addresses_at_graphnode_boundary(tmp_path):
+    from hypergraph.checkpointers import CheckpointPolicy, SqliteCheckpointer
+    from hypergraph.checkpointers._migrate import ensure_schema
+
+    @node(output_name="answer")
+    def agent(query: str) -> str:
+        return f"answer:{query}"
+
+    checkpointer = SqliteCheckpointer(str(tmp_path / "checkpoint.db"))
+    checkpointer.policy = CheckpointPolicy(durability="sync", retention="full")
+    ensure_schema(checkpointer._sync_db())
+    try:
+        graph_node = Graph([agent], name="agent").as_node(name="researcher", namespaced=True).expose("query")
+        graph = Graph([graph_node])
+
+        SyncRunner(checkpointer=checkpointer).run(graph, {"query": "hello"}, workflow_id="wf")
+
+        parent_step = next(step for step in checkpointer.steps("wf") if step.node_name == "researcher")
+        child_step = next(step for step in checkpointer.steps("wf/researcher") if step.node_name == "agent")
+
+        assert parent_step.input_versions == {"query": 1}
+        assert parent_step.values == {"researcher.answer": "answer:hello"}
+        assert child_step.input_versions == {"query": 1}
+        assert child_step.values == {"answer": "answer:hello"}
+    finally:
+        checkpointer._sync_db().close()
+
+
+@pytest.mark.asyncio
+async def test_async_runner_uses_same_namespaced_expose_projection():
+    @node(output_name="retrieved")
+    async def retrieve(query: str) -> str:
+        return f"docs:{query}"
+
+    @node(output_name="answer")
+    async def generate(query: str) -> str:
+        return f"answer:{query}"
+
+    retrieval = Graph([retrieve], name="retrieval")
+    generation = Graph([generate], name="generation")
+    outer = Graph(
+        [
+            retrieval.as_node(namespaced=True).expose("query"),
+            generation.as_node(namespaced=True).expose("query"),
+        ]
+    )
+
+    result = await AsyncRunner().run(outer, {"query": "hello"})
+
+    assert result["retrieval.retrieved"] == "docs:hello"
+    assert result["generation.answer"] == "answer:hello"

--- a/tests/test_interrupt_node.py
+++ b/tests/test_interrupt_node.py
@@ -244,11 +244,11 @@ class TestPauseInfo:
 
     def test_response_key_nested(self):
         p = PauseInfo(node_name="review/approval", output_param="decision", value=None)
-        assert p.response_key == "review.decision"
+        assert p.response_key == "decision"
 
     def test_response_key_deeply_nested(self):
         p = PauseInfo(node_name="outer/review/approval", output_param="decision", value=None)
-        assert p.response_key == "outer.review.decision"
+        assert p.response_key == "decision"
 
     def test_response_keys_single_output(self):
         p = PauseInfo(node_name="approval", output_param="decision", value=None)
@@ -270,10 +270,7 @@ class TestPauseInfo:
             value=None,
             output_params=("decision", "notes"),
         )
-        assert p.response_keys == {
-            "decision": "review.decision",
-            "notes": "review.notes",
-        }
+        assert p.response_keys == {"decision": "decision", "notes": "notes"}
 
     def test_multi_input_values(self):
         p = PauseInfo(
@@ -675,7 +672,7 @@ class TestNestedInterruptPropagation:
         result = await runner.run(outer, {"query": "hello"})
         assert result.paused
         assert result.pause.node_name == "inner/approval"
-        assert result.pause.response_key == "inner.y"
+        assert result.pause.response_key == "y"
         assert result.pause.value == "hello"
 
 
@@ -842,7 +839,7 @@ class TestInterruptNodeInCycle:
         r1 = await runner.run(graph, {"messages": []})
         assert r1.paused
         assert r1.pause.node_name == "ask/ask_user"
-        assert r1.pause.response_key == "ask.query"
+        assert r1.pause.response_key == "query"
 
         # Run 2: resume with query — cycle processes it, pauses again with updated messages
         r2 = await runner.run(
@@ -1248,7 +1245,7 @@ class TestInterruptDecoratorExecution:
         result = await runner.run(outer, {"query": "hello"})
         assert result.paused
         assert result.pause.node_name == "inner/approval"
-        assert result.pause.response_key == "inner.decision"
+        assert result.pause.response_key == "decision"
 
     @pytest.mark.asyncio
     async def test_nested_graph_interrupt_respects_graphnode_output_rename(self):
@@ -1273,7 +1270,7 @@ class TestInterruptDecoratorExecution:
         paused = await runner.run(outer, {"query": "hello"})
         assert paused.paused
         assert paused.pause.node_name == "inner/approval"
-        assert paused.pause.response_key == "inner.verdict"
+        assert paused.pause.response_key == "verdict"
 
         resumed = await runner.run(outer, {"query": "hello", paused.pause.response_key: "approved"})
         assert resumed.status == RunStatus.COMPLETED

--- a/tests/test_lexical_scope.py
+++ b/tests/test_lexical_scope.py
@@ -1,12 +1,4 @@
-"""Lexical scope semantics for nested subgraph inputs (issue #94).
-
-Under lexical scope, an input name that no ancestor scope declares is private
-to its subgraph; outer addresses it via the dot-path ``subgraph.name``.
-
-Each test in this module exercises one observable behavior end-to-end through
-the public Graph / Runner API. Implementation details (the scope tree, the
-old lift/promote machinery) are not asserted here.
-"""
+"""Nested graph boundary addressing semantics."""
 
 from __future__ import annotations
 
@@ -14,49 +6,59 @@ import pytest
 
 from hypergraph import Graph, node
 from hypergraph.exceptions import MissingInputError
-from hypergraph.graph.validation import GraphConfigError
 from hypergraph.runners import SyncRunner
 
 
-def test_sibling_subgraphs_private_inputs_appear_as_dot_paths():
-    """Two siblings sharing an input name are private to each subgraph.
-
-    A bind on one sibling does not leak into the other's required set, and the
-    outer ``inputs.required`` / ``inputs.bound`` address each via dot-path.
-    """
-
+def test_flat_sibling_subgraphs_share_input_and_bind_by_default():
     @node(output_name="out_a")
-    def use_a(overwrite: bool) -> bool:
-        return overwrite
+    def use_a(overwrite: bool) -> str:
+        return f"A:{overwrite}"
 
     @node(output_name="out_b")
-    def use_b(overwrite: bool) -> bool:
-        return overwrite
+    def use_b(overwrite: bool) -> str:
+        return f"B:{overwrite}"
 
     inner_a = Graph([use_a], name="A").bind(overwrite=True)
     inner_b = Graph([use_b], name="B")
     outer = Graph([inner_a.as_node(), inner_b.as_node()], name="outer")
 
+    assert outer.inputs.required == ()
+    assert outer.inputs.bound == {"overwrite": True}
+
+    result = SyncRunner().run(outer)
+    assert result["out_a"] == "A:True"
+    assert result["out_b"] == "B:True"
+
+
+def test_namespaced_sibling_subgraphs_keep_same_input_separate():
+    @node(output_name="out_a")
+    def use_a(overwrite: bool) -> str:
+        return f"A:{overwrite}"
+
+    @node(output_name="out_b")
+    def use_b(overwrite: bool) -> str:
+        return f"B:{overwrite}"
+
+    inner_a = Graph([use_a], name="A").bind(overwrite=True)
+    inner_b = Graph([use_b], name="B")
+    outer = Graph([inner_a.as_node(namespaced=True), inner_b.as_node(namespaced=True)], name="outer")
+
     assert outer.inputs.required == ("B.overwrite",)
     assert outer.inputs.bound == {"A.overwrite": True}
-    assert "overwrite" not in outer.inputs.required
-    assert "overwrite" not in outer.inputs.bound
+
+    result = SyncRunner().run(outer, {"B.overwrite": False})
+    assert result["A.out_a"] == "A:True"
+    assert result["B.out_b"] == "B:False"
 
 
 @pytest.mark.parametrize(
     "values",
     [
-        pytest.param({"A.overwrite": True, "B.overwrite": False}, id="dot-path"),
+        pytest.param({"A.overwrite": True, "B.overwrite": False}, id="port-address"),
         pytest.param({"A": {"overwrite": True}, "B": {"overwrite": False}}, id="nested-dict"),
     ],
 )
-def test_run_addresses_private_inputs_by_dot_path_or_nested_dict(values):
-    """Dot-path and nested-dict forms route a value to the right subgraph.
-
-    Both forms must produce identical results -- they are two surfaces over the
-    same canonical addressing.
-    """
-
+def test_namespaced_runtime_values_accept_dot_path_or_nested_dict(values):
     @node(output_name="out_a")
     def use_a(overwrite: bool) -> str:
         return f"A:{overwrite}"
@@ -67,344 +69,96 @@ def test_run_addresses_private_inputs_by_dot_path_or_nested_dict(values):
 
     inner_a = Graph([use_a], name="A")
     inner_b = Graph([use_b], name="B")
-    outer = Graph([inner_a.as_node(), inner_b.as_node()], name="outer")
+    outer = Graph([inner_a.as_node(namespaced=True), inner_b.as_node(namespaced=True)], name="outer")
 
     result = SyncRunner().run(outer, values)
 
-    assert result["out_a"] == "A:True"
-    assert result["out_b"] == "B:False"
+    assert result["A.out_a"] == "A:True"
+    assert result["B.out_b"] == "B:False"
 
 
-def test_bind_shadowed_by_ancestor_leaf_consumer_is_build_time_error():
-    """A bind inside a subgraph errors at build time when an ancestor scope
-    declares the same name.
-
-    Without the check, the parent's value would silently override the bind at
-    run time -- the bind would look like a lock but NOT be one. The validator
-    fires at the outermost graph that surfaces the conflict and reports both
-    the bind path and the ancestor scope that shadowed it.
-    """
-
-    @node(output_name="inner_out")
-    def consume_x_inner(x: int) -> int:
-        return x * 2
-
-    @node(output_name="outer_out")
-    def consume_x_outer(x: int) -> int:
-        return x + 1
-
-    inner = Graph([consume_x_inner], name="inner").bind(x=10)
-    with pytest.raises(GraphConfigError, match="(?i)bind.*shadow|shadow.*bind|bind.*conflict"):
-        Graph([consume_x_outer, inner.as_node()], name="outer")
-
-
-def test_bind_with_no_ancestor_declaration_builds_cleanly():
-    """A bind on a name nobody else declares is just a normal default and is
-    silent (no warning, no error)."""
-
-    @node(output_name="inner_out")
-    def consume_x(x: int) -> int:
-        return x * 2
-
-    @node(output_name="outer_out")
-    def consume_y(y: int) -> int:  # outer leaf consumes y, NOT x -- no conflict
-        return y + 1
-
-    inner = Graph([consume_x], name="inner").bind(x=10)
-    outer = Graph([consume_y, inner.as_node()], name="outer")
-
-    assert outer.inputs.bound == {"inner.x": 10}
-
-
-def test_run_value_overriding_primitive_bind_emits_warning_with_values():
-    """A run value that overrides a bound primitive emits a warning showing
-    both the bound and the new value."""
-
+def test_bare_name_satisfies_flat_nested_input():
     @node(output_name="out")
     def use_x(x: int) -> int:
         return x
 
-    graph = Graph([use_x], name="g").bind(x=10)
+    inner = Graph([use_x], name="inner")
+    outer = Graph([inner.as_node()], name="outer")
 
-    with pytest.warns(UserWarning, match=r"(?i)override.*x.*10.*42|override.*x.*42.*10"):
-        result = SyncRunner().run(graph, {"x": 42})
-
-    assert result["out"] == 42
-
-
-def test_run_value_overriding_opaque_bind_emits_generic_warning():
-    """A run value that overrides a bound non-primitive value emits a generic
-    warning without dumping the value text."""
-
-    class Opaque:
-        def __repr__(self) -> str:
-            return "<should-not-appear-in-warning>"
-
-    @node(output_name="out")
-    def use_x(x) -> str:
-        return "ok"
-
-    graph = Graph([use_x], name="g").bind(x=Opaque())
-
-    with pytest.warns(UserWarning) as records:
-        SyncRunner().run(graph, {"x": Opaque()})
-
-    msgs = [str(w.message) for w in records]
-    assert any("override" in m.lower() and "x" in m for m in msgs)
-    assert not any("should-not-appear-in-warning" in m for m in msgs)
+    assert outer.inputs.required == ("x",)
+    assert SyncRunner().run(outer, {"x": 5})["out"] == 5
 
 
-def test_run_with_no_override_emits_no_warning():
-    """A run that doesn't override anything emits no warnings."""
-
+def test_bare_name_does_not_satisfy_namespaced_nested_input():
     @node(output_name="out")
     def use_x(x: int) -> int:
         return x
 
-    graph = Graph([use_x], name="g").bind(x=10)
+    inner = Graph([use_x], name="inner")
+    outer = Graph([inner.as_node(namespaced=True)], name="outer")
 
-    import warnings as _warnings
+    assert outer.inputs.required == ("inner.x",)
 
-    with _warnings.catch_warnings():
-        _warnings.simplefilter("error")
-        result = SyncRunner().run(graph)
+    with pytest.warns(UserWarning, match="Not recognized"), pytest.raises(MissingInputError) as exc_info:
+        SyncRunner().run(outer, {"x": 5})
 
-    assert result["out"] == 10
+    assert exc_info.value.missing == ["inner.x"]
 
 
-def test_run_value_overriding_dot_pathed_bind_emits_warning():
-    """Override warning fires uniformly for dot-path overrides (not just flat)."""
-
+def test_inner_bind_projects_flat_or_namespaced_by_boundary():
     @node(output_name="out")
     def use_x(x: int) -> int:
         return x
 
     inner = Graph([use_x], name="inner").bind(x=10)
 
-    @node(output_name="other_out")
-    def consume_unrelated(y: int = 0) -> int:
-        return y
+    flat = Graph([inner.as_node()], name="flat")
+    namespaced = Graph([inner.as_node(namespaced=True)], name="namespaced")
 
-    outer = Graph([inner.as_node(), consume_unrelated], name="outer")
+    assert flat.inputs.bound == {"x": 10}
+    assert namespaced.inputs.bound == {"inner.x": 10}
+
+
+def test_run_value_overriding_projected_bind_emits_warning():
+    @node(output_name="out")
+    def use_x(x: int) -> int:
+        return x
+
+    inner = Graph([use_x], name="inner").bind(x=10)
+    outer = Graph([inner.as_node(namespaced=True)], name="outer")
 
     with pytest.warns(UserWarning, match=r"(?i)override.*inner\.x"):
         result = SyncRunner().run(outer, {"inner.x": 99})
 
-    assert result["out"] == 99
+    assert result["inner.out"] == 99
 
 
-def test_private_input_with_signature_default_is_optional_not_required():
-    """A private subgraph input whose inner function has a signature default
-    must be classified as optional at the outer scope, not required.
-
-    Regression for #95 review feedback: before this test, the addressed-param
-    categorizer dropped the `source` GraphNode and only checked
-    _all_consumers_have_default with the original (flat) name. For a single
-    GraphNode whose inner has a default, that worked; for siblings where only
-    one inner declares a default, it incorrectly returned False (required).
-    """
-
-    @node(output_name="out")
-    def use_x(x: int = 5) -> int:
-        return x * 2
-
-    inner = Graph([use_x], name="inner")
-    outer = Graph([inner.as_node()], name="outer")
-
-    assert "inner.x" in outer.inputs.optional
-    assert "inner.x" not in outer.inputs.required
-
-    # Run without providing inner.x: the inner function's default fires.
-    assert SyncRunner().run(outer)["out"] == 10
-
-
-def test_sibling_private_inputs_with_only_one_default_classified_per_source():
-    """Each private input is classified per its OWNING GraphNode's defaults.
-
-    A's inner has a default for x; B's inner does not. Outer should report
-    A.x as optional and B.x as required, not both as required.
-    """
-
-    @node(output_name="out_a")
-    def use_a(x: int = 7) -> int:
-        return x
-
-    @node(output_name="out_b")
-    def use_b(x: int) -> int:
-        return x
-
-    inner_a = Graph([use_a], name="A")
-    inner_b = Graph([use_b], name="B")
-    outer = Graph([inner_a.as_node(), inner_b.as_node()], name="outer")
-
-    assert "A.x" in outer.inputs.optional
-    assert "B.x" in outer.inputs.required
-    assert "A.x" not in outer.inputs.required
-
-
-def test_with_inputs_renames_leaf_label_only_not_scope():
-    """with_inputs(...) changes only the leaf label of an input's path; it
-    does not move the input out of the subgraph's scope.
-
-    Before: a bare-name with_inputs implicitly "lifted" the input. Under
-    lexical scope the renamed input stays under the subgraph (the path is
-    still ``<graphnode>.<new_label>``), and a same-named ancestor input
-    remains independent.
-    """
-
+def test_with_inputs_renames_local_name_then_boundary_projects_it():
     @node(output_name="inner_out")
     def consume_x(x: int) -> int:
         return x
-
-    @node(output_name="outer_out")
-    def consume_x_outer(x: int) -> int:  # outer also has x; declared at outer
-        return x + 1000
 
     inner_graph = Graph([consume_x], name="inner")
-    # Rename inner's "x" -> "inner_x" via with_inputs on the GraphNode.
-    inner_node = inner_graph.as_node().with_inputs(x="inner_x")
 
-    outer = Graph([inner_node, consume_x_outer], name="outer")
+    flat = Graph([inner_graph.as_node().with_inputs(x="inner_x")], name="flat")
+    namespaced = Graph([inner_graph.as_node(namespaced=True).with_inputs(x="inner_x")], name="namespaced")
 
-    # The renamed input stays under the subgraph -- new leaf label only.
-    assert "inner.inner_x" in outer.inputs.required
-    # Outer's own x is still an independent flat input.
-    assert "x" in outer.inputs.required
-    # Bare "inner_x" at outer is NOT auto-linked: rename didn't move scope.
-    assert "inner_x" not in outer.inputs.required
-
-
-def test_no_warning_or_error_on_silent_bind_with_no_ancestor_declaration():
-    """A bind on a name no ancestor declares is a normal default and is silent."""
-    import warnings as _warnings
-
-    @node(output_name="out")
-    def use_x(x: int) -> int:
-        return x
-
-    inner = Graph([use_x], name="inner").bind(x=10)
-
-    with _warnings.catch_warnings():
-        _warnings.simplefilter("error")
-        outer = Graph([inner.as_node()], name="outer")
-        # Building the graph emits no warnings/errors -- bind is private and silent.
-        assert outer.inputs.bound == {"inner.x": 10}
-
-
-def test_missing_input_error_names_subgraph_for_dot_pathed_inputs():
-    """MissingInputError text annotates each dot-pathed missing input with
-    its owning subgraph, so the user knows where the input belongs."""
-
-    @node(output_name="out")
-    def use_x(x: int) -> int:
-        return x
-
-    inner = Graph([use_x], name="inner")
-    outer = Graph([inner.as_node()], name="outer")
-
-    with pytest.raises(MissingInputError) as exc_info:
-        SyncRunner().run(outer, {})
-
-    msg = str(exc_info.value)
-    # The new annotation: "input 'x' of subgraph 'inner'".
-    assert "'x' of subgraph 'inner'" in msg
-    # The bind() hint, irrelevant to a lexical-scope miss, is gone.
-    assert "graph.bind(x=10)" not in msg
-
-
-def test_bind_conflict_error_names_scope_and_shadowing_node():
-    """The bind-conflict GraphConfigError names the scope (graph) and the
-    specific shadowing node (a leaf at this scope) -- not just the bare
-    leaf name -- so the user can navigate to the source of the conflict."""
-
-    @node(output_name="inner_out")
-    def consume_x(x: int) -> int:
-        return x
-
-    @node(output_name="judge_out")
-    def judge_consumes_x(x: int) -> int:  # leaf at outer that shadows the bind
-        return x
-
-    inner = Graph([consume_x], name="inner").bind(x=10)
-    with pytest.raises(GraphConfigError) as exc_info:
-        Graph([inner.as_node(), judge_consumes_x], name="evaluation")
-
-    msg = str(exc_info.value)
-    # Scope (graph name) named explicitly.
-    assert "evaluation" in msg
-    # Shadowing leaf node named explicitly.
-    assert "judge_consumes_x" in msg
-    # Original bind path still present.
-    assert "inner.x" in msg
-
-
-def test_override_warning_annotates_subgraph_for_dot_pathed_address():
-    """The override UserWarning annotates the dot-pathed override target with
-    its owning subgraph, matching the missing-input message style."""
-
-    @node(output_name="out")
-    def use_x(x: int) -> int:
-        return x
-
-    inner = Graph([use_x], name="inner").bind(x=10)
-    outer = Graph([inner.as_node()], name="outer")
-
-    with pytest.warns(UserWarning) as records:
-        SyncRunner().run(outer, {"inner.x": 99})
-
-    msgs = [str(w.message) for w in records]
-    assert any("'x' of subgraph 'inner'" in m for m in msgs), msgs
-
-
-@pytest.mark.parametrize(
-    "bind_call",
-    [
-        pytest.param(lambda outer, value: outer.bind(A={"x": value}), id="nested-dict-kwarg"),
-        pytest.param(lambda outer, value: outer.bind({"A.x": value}), id="dot-path-positional-dict"),
-    ],
-)
-def test_bind_addresses_private_subgraph_input_via_nested_dict_or_dot_path(bind_call):
-    """A user can bind a private subgraph input using either form, mirroring
-    the run() addressing surfaces. Both produce the same canonical entry on
-    inputs.bound and the same runtime behavior.
-    """
-
-    @node(output_name="out")
-    def use_x(x: int) -> int:
-        return x
-
-    inner = Graph([use_x], name="A")
-    outer = Graph([inner.as_node()], name="outer")
-
-    bound = bind_call(outer, 42)
-
-    assert bound.inputs.bound == {"A.x": 42}
-    assert SyncRunner().run(bound)["out"] == 42
+    assert flat.inputs.required == ("inner_x",)
+    assert namespaced.inputs.required == ("inner.inner_x",)
 
 
 def test_bind_with_dict_value_for_non_subgraph_key_passes_through_as_value():
-    """When the outer key isn't a GraphNode name, a dict value is just an
-    opaque value -- not addressing. Mirrors normalize_inputs's rule."""
-
     @node(output_name="out")
     def use_config(config: dict) -> dict:
         return config
 
     graph = Graph([use_config], name="g")
-    bound = graph.bind(config={"key": "value"})  # config is a flat input, value IS a dict
+    bound = graph.bind(config={"key": "value"})
 
     assert bound.inputs.bound == {"config": {"key": "value"}}
 
 
-def test_changed_dot_pathed_input_marks_graphnode_as_stale_on_replay():
-    """A GraphNode whose private dot-pathed input changed must be seen as stale
-    against its previous execution record.
-
-    This locks in the invariant that the version recorded for a GraphNode
-    input at execution time uses the same key the staleness check reads.
-    Without alignment, _is_stale silently classifies a changed dot-pathed
-    input as unchanged (both record and read default to 0).
-    """
+def test_changed_namespaced_input_marks_graphnode_as_stale_on_replay():
     from hypergraph.runners._shared.helpers import _is_stale
     from hypergraph.runners._shared.types import GraphState, NodeExecution
 
@@ -413,75 +167,20 @@ def test_changed_dot_pathed_input_marks_graphnode_as_stale_on_replay():
         return x * 2
 
     inner = Graph([double], name="inner")
-    outer = Graph([inner.as_node(name="embed")], name="outer")
+    outer = Graph([inner.as_node(name="embed", namespaced=True)], name="outer")
     embed_node = outer._nodes["embed"]
 
-    # Simulate a prior run that consumed embed.x=5 (state v1, recorded v1).
     state = GraphState()
     state.update_value("embed.x", 5)
-    # Record what an aligned superstep WOULD record for embed's prior exec.
-    # The address used here must match the staleness-check lookup.
     prior_exec = NodeExecution(
         node_name="embed",
-        input_versions={"embed.x": 1},  # aligned key
-        outputs={"doubled": 10},
-        output_versions={"doubled": 1},
+        input_versions={"embed.x": 1},
+        outputs={"embed.doubled": 10},
+        output_versions={"embed.doubled": 1},
         wait_for_versions={},
     )
     state.node_executions["embed"] = prior_exec
 
-    # User provides a new value -- state version advances for the dotted key.
     state.update_value("embed.x", 10)
-    assert state.versions["embed.x"] == 2
 
-    # The staleness check must see embed's prior input as stale (consumed v1, current v2).
     assert _is_stale(embed_node, outer, state, prior_exec) is True
-
-
-def test_bare_name_at_outer_resolving_only_to_private_input_errors():
-    """Strict mode: a bare name passed to runner.run() that doesn't resolve at
-    the call's scope errors instead of silently smart-routing to a deeper
-    private input. The error names the actual expected dot-path."""
-
-    @node(output_name="out")
-    def use_x(x: int) -> int:
-        return x
-
-    inner = Graph([use_x], name="inner")
-    outer = Graph([inner.as_node()], name="outer")
-
-    # x is private to inner (no leaf at outer declares it). Bare 'x' must
-    # error -- the user has to address it as 'inner.x' (or via nested-dict).
-    # The validator emits a warning naming the expected path AND raises a
-    # MissingInputError; both surface the same fact.
-    with pytest.warns(UserWarning, match=r"inner\.x"), pytest.raises(MissingInputError, match=r"inner\.x"):
-        SyncRunner().run(outer, {"x": 5})
-
-    # And the legitimate dot-path works.
-    result = SyncRunner().run(outer, {"inner.x": 5})
-    assert result["out"] == 5
-
-
-def test_bind_conflict_walks_descendants_fires_at_outermost():
-    """A deeply-nested bind whose leaf name matches an ancestor declaration
-    triggers a build-time error at the outermost graph that surfaces it."""
-
-    @node(output_name="out")
-    def use_x(x: int) -> int:
-        return x
-
-    @node(output_name="root_out")
-    def consume_x_at_root(x: int) -> int:
-        return x
-
-    # Three-level nest: bind x at the innermost.
-    inner = Graph([use_x], name="inner").bind(x=10)
-    middle = Graph([inner.as_node()], name="middle")  # builds clean -- no x at middle
-
-    # Sanity: middle holds the bind dot-pathed and didn't error.
-    assert middle.inputs.bound == {"inner.x": 10}
-
-    # Outermost scope declares x via a leaf -- the bind's leaf name `x` is
-    # shadowed even though the addressing chain is `inner.x`.
-    with pytest.raises(GraphConfigError, match=r"(?i)bind.*shadow|shadow.*bind|bind.*conflict"):
-        Graph([middle.as_node(), consume_x_at_root], name="root")

--- a/tests/test_map_over_error_handling.py
+++ b/tests/test_map_over_error_handling.py
@@ -39,7 +39,7 @@ class TestSyncMapOverErrorHandling:
         outer = Graph([inner.as_node().map_over("x"), passthrough])
         runner = SyncRunner()
         with pytest.raises(CustomMapError):
-            runner.run(outer, {"inner.x": [1, 2, 3, 4, 5]})
+            runner.run(outer, {"x": [1, 2, 3, 4, 5]})
 
     def test_continue_mode_returns_none_placeholders(self):
         """error_handling='continue' uses None for failed items, preserving list length."""
@@ -47,7 +47,7 @@ class TestSyncMapOverErrorHandling:
         gn = inner.as_node().map_over("x", error_handling="continue")
         outer = Graph([gn, passthrough])
         runner = SyncRunner()
-        result = runner.run(outer, {"inner.x": [1, 2, 3, 4, 5]})
+        result = runner.run(outer, {"x": [1, 2, 3, 4, 5]})
         assert result.status == RunStatus.COMPLETED
         # List length preserved: 5 items in, 5 items out
         assert result["result"] == [2, 4, None, 8, 10]
@@ -58,7 +58,7 @@ class TestSyncMapOverErrorHandling:
         gn = inner.as_node().map_over("x", error_handling="continue")
         outer = Graph([gn, passthrough])
         runner = SyncRunner()
-        result = runner.run(outer, {"inner.x": [1, 2, 4, 5]})
+        result = runner.run(outer, {"x": [1, 2, 4, 5]})
         assert result.status == RunStatus.COMPLETED
         assert result["result"] == [2, 4, 8, 10]
 
@@ -88,7 +88,7 @@ class TestAsyncMapOverErrorHandling:
         outer = Graph([inner.as_node().map_over("x"), passthrough])
         runner = AsyncRunner()
         with pytest.raises(CustomMapError):
-            await runner.run(outer, {"inner.x": [1, 2, 3, 4, 5]})
+            await runner.run(outer, {"x": [1, 2, 3, 4, 5]})
 
     @pytest.mark.asyncio
     async def test_continue_mode_returns_none_placeholders(self):
@@ -96,7 +96,7 @@ class TestAsyncMapOverErrorHandling:
         gn = inner.as_node().map_over("x", error_handling="continue")
         outer = Graph([gn, passthrough])
         runner = AsyncRunner()
-        result = await runner.run(outer, {"inner.x": [1, 2, 3, 4, 5]})
+        result = await runner.run(outer, {"x": [1, 2, 3, 4, 5]})
         assert result.status == RunStatus.COMPLETED
         assert result["result"] == [2, 4, None, 8, 10]
 
@@ -106,6 +106,6 @@ class TestAsyncMapOverErrorHandling:
         gn = inner.as_node().map_over("x", error_handling="continue")
         outer = Graph([gn, passthrough])
         runner = AsyncRunner()
-        result = await runner.run(outer, {"inner.x": [1, 2, 4, 5]})
+        result = await runner.run(outer, {"x": [1, 2, 4, 5]})
         assert result.status == RunStatus.COMPLETED
         assert result["result"] == [2, 4, 8, 10]

--- a/tests/test_multi_output_graphnode.py
+++ b/tests/test_multi_output_graphnode.py
@@ -60,7 +60,7 @@ class TestMultiOutputGraphNode:
         inner = Graph([compute_a, compute_b], name="inner")
         outer = Graph([inner.as_node(), consume_both])
         runner = SyncRunner()
-        result = runner.run(outer, {"inner.x": 5})
+        result = runner.run(outer, {"x": 5})
         assert result.status == RunStatus.COMPLETED
         assert result["final"] == {"a": 6, "b": 50}
 
@@ -69,7 +69,7 @@ class TestMultiOutputGraphNode:
         inner = Graph([async_compute_a, async_compute_b], name="inner")
         outer = Graph([inner.as_node(), consume_both])
         runner = AsyncRunner()
-        result = await runner.run(outer, {"inner.x": 5})
+        result = await runner.run(outer, {"x": 5})
         assert result.status == RunStatus.COMPLETED
         assert result["final"] == {"a": 6, "b": 50}
 
@@ -80,8 +80,8 @@ class TestMultiOutputGraphNode:
         # 'a' and 'b' should NOT be in required inputs — they come from inner
         assert "a" not in outer.inputs.required
         assert "b" not in outer.inputs.required
-        # x is private to inner GraphNode → addressed as inner.x
-        assert "inner.x" in outer.inputs.required
+        # x is owned by inner GraphNode → addressed as inner.x
+        assert "x" in outer.inputs.required
 
 
 # ============================================================
@@ -97,7 +97,7 @@ class TestMultiOutputGraphNodeMapOver:
         gn = inner.as_node().map_over("x")
         outer = Graph([gn, consume_both_lists])
         runner = SyncRunner()
-        result = runner.run(outer, {"inner.x": [1, 2, 3]})
+        result = runner.run(outer, {"x": [1, 2, 3]})
         assert result.status == RunStatus.COMPLETED
         assert result["final"] == {"a": [2, 3, 4], "b": [10, 20, 30]}
 
@@ -121,7 +121,7 @@ class TestMultiOutputGraphNodeMapOver:
         gn = inner.as_node().map_over("x", error_handling="continue")
         outer = Graph([gn, consume_both_lists])
         runner = SyncRunner()
-        result = runner.run(outer, {"inner.x": [-1, 2, 3]})
+        result = runner.run(outer, {"x": [-1, 2, 3]})
         assert result.status == RunStatus.COMPLETED
         assert result["final"] == {"a": [None, 3, 4], "b": [None, 20, 30]}
 
@@ -144,7 +144,7 @@ class TestMultiOutputPartialConsumption:
         inner = Graph([compute_a, compute_b], name="inner")
         outer = Graph([inner.as_node(), use_a])
         runner = SyncRunner()
-        result = runner.run(outer, {"inner.x": 5})
+        result = runner.run(outer, {"x": 5})
         assert result.status == RunStatus.COMPLETED
         assert result["result"] == 600
 
@@ -162,7 +162,7 @@ class TestMultiOutputPartialConsumption:
         inner = Graph([compute_a, compute_b], name="inner")
         outer = Graph([inner.as_node(), use_a, use_b])
         runner = SyncRunner()
-        result = runner.run(outer, {"inner.x": 5})
+        result = runner.run(outer, {"x": 5})
         assert result.status == RunStatus.COMPLETED
         assert result["ra"] == 600
         assert result["rb"] == 51

--- a/tests/test_multi_output_graphnode.py
+++ b/tests/test_multi_output_graphnode.py
@@ -80,7 +80,7 @@ class TestMultiOutputGraphNode:
         # 'a' and 'b' should NOT be in required inputs — they come from inner
         assert "a" not in outer.inputs.required
         assert "b" not in outer.inputs.required
-        # x is owned by inner GraphNode → addressed as inner.x
+        # x is owned by inner GraphNode, projected flat in default mode.
         assert "x" in outer.inputs.required
 
 

--- a/tests/test_nested_cycle_topologies.py
+++ b/tests/test_nested_cycle_topologies.py
@@ -53,8 +53,8 @@ class TestThreeLevelNestedWithInnerCycle:
 
         runner = SyncRunner()
         # count auto-links upward via each GraphNode's output. limit stays
-        # private to the innermost subgraph.
-        result = runner.run(outer, {"count": 0, "middle.inner.limit": 3})
+        # owned by the innermost subgraph.
+        result = runner.run(outer, {"count": 0, "limit": 3})
 
         assert result.status == RunStatus.COMPLETED
         assert result["count"] == 3
@@ -80,8 +80,8 @@ class TestThreeLevelNestedWithInnerCycle:
 
         runner = SyncRunner()
         # count auto-links across every level (GraphNode outputs declare it at the
-        # parent scope). limit is private at every level.
-        result = runner.run(outer, {"count": 0, "middle.inner.limit": 2})
+        # parent scope). limit is projected through each GraphNode boundary.
+        result = runner.run(outer, {"count": 0, "limit": 2})
 
         # count goes 0->1->2, then 2*10=20, then 20+1=21
         assert result.status == RunStatus.COMPLETED
@@ -159,14 +159,14 @@ class TestParallelNestedGraphsWithCycles:
 
         runner = SyncRunner()
         # count_a/count_b consumed by leaf combine at outer → declared, stay flat.
-        # limit_a/limit_b only consumed inside inner_a/inner_b → private dot-paths.
+        # limit_a/limit_b only consumed inside inner_a/inner_b → projected parent-facing keys.
         result = runner.run(
             outer,
             {
                 "count_a": 0,
-                "inner_a.limit_a": 3,
+                "limit_a": 3,
                 "count_b": 0,
-                "inner_b.limit_b": 5,
+                "limit_b": 5,
             },
         )
 
@@ -236,13 +236,13 @@ class TestDeeplyNestedConvergence:
 
         runner = SyncRunner()
         # approx auto-links through level2.level3 (GraphNode outputs declare it at
-        # each parent scope). target and rate stay private to level3.
+        # each parent scope). target and rate stay owned by level3.
         result = runner.run(
             outer,
             {
                 "approx": 0.0,
-                "level2.level3.target": 10.0,
-                "level2.level3.rate": 0.5,
+                "target": 10.0,
+                "rate": 0.5,
             },
         )
 
@@ -277,12 +277,12 @@ class TestNestedCyclesWithDifferentSeeds:
 
         runner = SyncRunner()
         # inner_count/multiplier consumed by leaf process_inner → declared, stay flat.
-        # inner_limit only inside inner GraphNode → private dot-path.
+        # inner_limit is resolved through the GraphNode boundary.
         result = runner.run(
             outer,
             {
                 "inner_count": 0,
-                "inner.inner_limit": 3,
+                "inner_limit": 3,
                 "multiplier": 10,
             },
         )
@@ -325,14 +325,14 @@ class TestNestedCyclesWithDifferentSeeds:
 
         runner = SyncRunner()
         # a/b consumed by leaf combine → declared, stay flat.
-        # limit_a/limit_b private to inner_a/inner_b GraphNodes.
+        # limit_a/limit_b owned by inner_a/inner_b GraphNodes.
         result = runner.run(
             outer,
             {
                 "a": 0,
-                "inner_a.limit_a": 3,
+                "limit_a": 3,
                 "b": 0,
-                "inner_b.limit_b": 5,
+                "limit_b": 5,
             },
         )
 
@@ -351,8 +351,8 @@ class TestNestedCyclesAsync:
         outer = Graph([inner.as_node()], entrypoint="inner")
 
         runner = AsyncRunner()
-        # count auto-links via inner's output. limit is private to inner.
-        result = await runner.run(outer, {"count": 0, "inner.limit": 3})
+        # count auto-links via inner's output. limit is owned by inner.
+        result = await runner.run(outer, {"count": 0, "limit": 3})
 
         assert result.status == RunStatus.COMPLETED
         assert result["count"] == 3
@@ -374,8 +374,8 @@ class TestNestedCyclesAsync:
         outer = Graph([middle.as_node()], entrypoint="middle")
 
         runner = AsyncRunner()
-        # count auto-links through middle.inner. limit is private to inner.
-        result = await runner.run(outer, {"count": 0, "middle.inner.limit": 3})
+        # count auto-links through middle.inner. limit is owned by inner.
+        result = await runner.run(outer, {"count": 0, "limit": 3})
 
         assert result.status == RunStatus.COMPLETED
         assert result["count"] == 3
@@ -393,12 +393,12 @@ class TestCycleWithMapOver:
         outer = Graph([inner.as_node().map_over("count")], entrypoint="inner")
 
         runner = SyncRunner()
-        # count auto-links via inner's output (mapped). limit is private to inner.
+        # count auto-links via inner's output (mapped). limit is owned by inner.
         result = runner.run(
             outer,
             {
                 "count": [0, 1, 2],
-                "inner.limit": 5,
+                "limit": 5,
             },
         )
 
@@ -412,12 +412,12 @@ class TestCycleWithMapOver:
         outer = Graph([inner.as_node().map_over("count", "limit", mode="zip")], entrypoint="inner")
 
         runner = SyncRunner()
-        # count auto-links via inner's output (mapped). limit is private to inner.
+        # count auto-links via inner's output (mapped). limit is owned by inner.
         result = runner.run(
             outer,
             {
                 "count": [0, 0, 0],
-                "inner.limit": [2, 3, 4],
+                "limit": [2, 3, 4],
             },
         )
 

--- a/tests/test_pr32_review_bugs.py
+++ b/tests/test_pr32_review_bugs.py
@@ -61,7 +61,7 @@ class TestCollectAsListsLengthConsistency:
         gn = inner.as_node().map_over("x")
         outer = Graph([gn, combine])
         runner = SyncRunner()
-        result = runner.run(outer, {"inner.x": [1, 2, 3]})
+        result = runner.run(outer, {"x": [1, 2, 3]})
         assert result["combined"]["a"] == [2, 3, 4]
         assert result["combined"]["b"] == [10, 20, 30]
 
@@ -75,7 +75,7 @@ class TestCollectAsListsLengthConsistency:
         gn = inner.as_node().map_over("x", error_handling="continue")
         outer = Graph([gn, combine])
         runner = SyncRunner()
-        result = runner.run(outer, {"inner.x": [1, 2, 3, 4]})
+        result = runner.run(outer, {"x": [1, 2, 3, 4]})
         a_list = result["combined"]["a"]
         b_list = result["combined"]["b"]
         # Both lists must be same length (4 items)
@@ -95,7 +95,7 @@ class TestCollectAsListsLengthConsistency:
 
         outer = Graph([gn, use_renamed])
         runner = SyncRunner()
-        result = runner.run(outer, {"inner.x": [1, 2, 3]})
+        result = runner.run(outer, {"x": [1, 2, 3]})
         assert len(result["result"]["alpha"]) == len(result["result"]["beta"]) == 3
 
     def test_runner_map_continue_multi_output_graph(self):

--- a/tests/test_red_team_fixes.py
+++ b/tests/test_red_team_fixes.py
@@ -347,7 +347,7 @@ class TestOutputRenamePropagation:
 
         outer_graph = Graph(nodes=[graph_node, outer_step])
         runner = SyncRunner()
-        # x is private to inner GraphNode → addressed via dot-path
-        result = runner.run(outer_graph, {"inner.x": 5})
+        # x is owned by inner GraphNode → addressed by its parent-facing key
+        result = runner.run(outer_graph, {"x": 5})
 
         assert result["final"] == 11, f"Expected 11 (5*2+1), got {result['final']}"

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -655,7 +655,7 @@ class TestMapResultProgressiveDisclosure:
             graph_name="test",
         )
         html = mr._repr_html_()
-        # Each item drills down to a nested RunResult panel
+        # Each item drills down to its per-item RunResult panel.
         assert "Item 0:" in html
         assert "Item 1:" in html
         assert "RunResult:" in html

--- a/tests/test_run_log/test_run_log.py
+++ b/tests/test_run_log/test_run_log.py
@@ -334,8 +334,8 @@ class TestInnerLogs:
         """A nested GraphNode step.log returns a single RunLog."""
         inner = Graph([_double], name="inner")
         outer = Graph([inner.as_node()])
-        # x is private to inner GraphNode → addressed via dot-path
-        result = SyncRunner().run(outer, {"inner.x": 5})
+        # x is owned by inner GraphNode → addressed by its parent-facing key
+        result = SyncRunner().run(outer, {"x": 5})
 
         assert result["doubled"] == 10
         assert result.log is not None
@@ -355,8 +355,8 @@ class TestInnerLogs:
         """A map_over GraphNode step.log returns a MapLog when N inner."""
         inner = Graph([_double], name="inner")
         outer = Graph([inner.as_node().map_over("x")])
-        # x is private to inner GraphNode → addressed via dot-path
-        result = SyncRunner().run(outer, {"inner.x": [1, 2, 3]})
+        # x is owned by inner GraphNode → addressed by its parent-facing key
+        result = SyncRunner().run(outer, {"x": [1, 2, 3]})
 
         step = result.log.steps[0]
 
@@ -386,8 +386,8 @@ class TestInnerLogs:
             name="middle",
         )
         outer = Graph([middle.as_node()])
-        # x is private through middle.innermost GraphNode chain
-        result = SyncRunner().run(outer, {"middle.innermost.x": 5})
+        # x is projected through the middle.innermost GraphNode chain.
+        result = SyncRunner().run(outer, {"x": 5})
 
         assert result["incremented"] == 11
         # Outer step → middle RunLog
@@ -402,8 +402,8 @@ class TestInnerLogs:
         """to_dict() serializes inner_log via .log accessor."""
         inner = Graph([_double], name="inner")
         outer = Graph([inner.as_node()])
-        # x is private to inner GraphNode → addressed via dot-path
-        result = SyncRunner().run(outer, {"inner.x": 5})
+        # x is owned by inner GraphNode → addressed by its parent-facing key
+        result = SyncRunner().run(outer, {"x": 5})
 
         d = result.log.to_dict()
         step_dict = d["steps"][0]
@@ -421,8 +421,8 @@ class TestInnerLogs:
         """__str__() shows '(N inner)' for steps with inner logs."""
         inner = Graph([_double], name="inner")
         outer = Graph([inner.as_node()])
-        # x is private to inner GraphNode → addressed via dot-path
-        result = SyncRunner().run(outer, {"inner.x": 5})
+        # x is owned by inner GraphNode → addressed by its parent-facing key
+        result = SyncRunner().run(outer, {"x": 5})
 
         output = str(result.log)
         assert "(1 inner)" in output
@@ -431,8 +431,8 @@ class TestInnerLogs:
         """__str__() footer has .steps[i].log drill-down hint."""
         inner = Graph([_double], name="inner")
         outer = Graph([inner.as_node()])
-        # x is private to inner GraphNode → addressed via dot-path
-        result = SyncRunner().run(outer, {"inner.x": 5})
+        # x is owned by inner GraphNode → addressed by its parent-facing key
+        result = SyncRunner().run(outer, {"x": 5})
 
         output = str(result.log)
         assert ".steps[0].log" in output
@@ -442,8 +442,8 @@ class TestInnerLogs:
         """Async runner also surfaces inner RunLogs via .log."""
         inner = Graph([_double], name="inner")
         outer = Graph([inner.as_node()])
-        # x is private to inner GraphNode → addressed via dot-path
-        result = await AsyncRunner().run(outer, {"inner.x": 5})
+        # x is owned by inner GraphNode → addressed by its parent-facing key
+        result = await AsyncRunner().run(outer, {"x": 5})
 
         assert result["doubled"] == 10
         step = result.log.steps[0]
@@ -458,8 +458,8 @@ class TestInnerLogs:
         """Async runner step.log returns MapLog for map_over."""
         inner = Graph([_double], name="inner")
         outer = Graph([inner.as_node().map_over("x")])
-        # x is private to inner GraphNode → addressed via dot-path
-        result = await AsyncRunner().run(outer, {"inner.x": [1, 2, 3]})
+        # x is owned by inner GraphNode → addressed by its parent-facing key
+        result = await AsyncRunner().run(outer, {"x": [1, 2, 3]})
 
         step = result.log.steps[0]
 

--- a/tests/test_runners/test_async_runner.py
+++ b/tests/test_runners/test_async_runner.py
@@ -409,7 +409,7 @@ class TestAsyncRunnerRun:
         outer = Graph([inner.as_node()])
         runner = AsyncRunner()
 
-        result = await runner.run(outer, {"inner.x": 5})
+        result = await runner.run(outer, {"x": 5})
 
         assert result["doubled"] == 10
 
@@ -419,7 +419,7 @@ class TestAsyncRunnerRun:
         outer = Graph([inner.as_node(), async_add.with_inputs(a="doubled")])
         runner = AsyncRunner()
 
-        result = await runner.run(outer, {"inner.x": 5, "b": 3})
+        result = await runner.run(outer, {"x": 5, "b": 3})
 
         assert result["sum"] == 13
 
@@ -733,9 +733,7 @@ class TestDisconnectedSubgraphs:
         level1 = Graph([level2.as_node(), level1_node])
 
         runner = AsyncRunner()
-        # a is consumed only by leaf level3_node inside level3 GraphNode (private),
-        # which is wrapped by level2 GraphNode → addressed as level2.level3.a
-        result = await runner.run(level1, {"level2.level3.a": 5})
+        result = await runner.run(level1, {"a": 5})
 
         # a=5 -> x=10 -> y=11 -> z=33
         assert result.status == RunStatus.COMPLETED
@@ -823,8 +821,7 @@ class TestDisconnectedSubgraphs:
         outer = Graph([inner.as_node(), other_node])
         runner = AsyncRunner()
 
-        # a is private to inner GraphNode → dot-path; b is declared at outer (consumed by other_node)
-        result = await runner.run(outer, {"inner.a": 5, "b": 3})
+        result = await runner.run(outer, {"a": 5, "b": 3})
 
         assert result.status == RunStatus.COMPLETED
         assert result["inner_result"] == 10
@@ -862,8 +859,7 @@ class TestDeeplyNestedAsync:
         l1_graph = Graph([l2_graph.as_node(), level1])
 
         runner = AsyncRunner()
-        # x is private through l2.l3.l4 GraphNode chain
-        result = await runner.run(l1_graph, {"l2.l3.l4.x": 0})
+        result = await runner.run(l1_graph, {"x": 0})
 
         # 0 -> 1 -> 2 -> 3 -> 4
         assert result.status == RunStatus.COMPLETED
@@ -893,8 +889,7 @@ class TestDeeplyNestedAsync:
         outer = Graph([inner.as_node()])
 
         runner = AsyncRunner()
-        # x is private to inner GraphNode → addressed via dot-path
-        result = await runner.run(outer, {"inner.x": 5})
+        result = await runner.run(outer, {"x": 5})
 
         # a=10, b=15, sum=25
         assert result.status == RunStatus.COMPLETED
@@ -947,8 +942,7 @@ class TestGlobalConcurrencyLimit:
         outer = Graph([inner.as_node(), outer_slow])
         runner = AsyncRunner()
 
-        # x is private to inner GraphNode; y is declared at outer (consumed by outer_slow)
-        result = await runner.run(outer, {"inner.x": 5, "y": 10}, max_concurrency=1)
+        result = await runner.run(outer, {"x": 5, "y": 10}, max_concurrency=1)
 
         assert result.status == RunStatus.COMPLETED
         # With max_concurrency=1, only one operation should run at a time
@@ -1020,10 +1014,9 @@ class TestGlobalConcurrencyLimit:
         outer = Graph([inner_mapped, outer_tracked])
         runner = AsyncRunner()
 
-        # item is private to inner GraphNode; x declared at outer (consumed by outer_tracked)
         result = await runner.run(
             outer,
-            {"inner.item": [1, 2, 3], "x": 5},
+            {"item": [1, 2, 3], "x": 5},
             max_concurrency=2,
         )
 
@@ -1077,8 +1070,7 @@ class TestGlobalConcurrencyLimit:
         l1_graph = Graph([l2_graph.as_node(), level1])
 
         runner = AsyncRunner()
-        # a is private through l2.l3 GraphNode chain
-        result = await runner.run(l1_graph, {"l2.l3.a": 5}, max_concurrency=1)
+        result = await runner.run(l1_graph, {"a": 5}, max_concurrency=1)
 
         assert result.status == RunStatus.COMPLETED
         # All three levels share max_concurrency=1
@@ -1107,11 +1099,10 @@ class TestGlobalConcurrencyLimit:
         runner = AsyncRunner()
 
         # 4 map items, each with a nested graph.
-        # x is private to inner GraphNode → addressed via dot-path; map_over uses that name.
         results = await runner.map(
             outer,
-            {"inner.x": [1, 2, 3, 4]},
-            map_over="inner.x",
+            {"x": [1, 2, 3, 4]},
+            map_over="x",
             max_concurrency=2,
         )
 

--- a/tests/test_runners/test_daft_runner.py
+++ b/tests/test_runners/test_daft_runner.py
@@ -47,8 +47,8 @@ def test_daft_runner_run_nested_graphnode_with_map_over():
     outer = Graph([inner.as_node(name="mapper").with_inputs(x="items").map_over("items")], name="outer")
 
     runner = DaftRunner()
-    # `items` is private to the `mapper` GraphNode at outer scope.
-    result = runner.run(outer, {"mapper.items": [2, 4, 6]})
+    # `items` is owned by the `mapper` GraphNode at outer scope.
+    result = runner.run(outer, {"items": [2, 4, 6]})
 
     assert result["doubled"] == [4, 8, 12]
 
@@ -61,8 +61,8 @@ def test_daft_runner_handles_bound_inputs_inside_nested_map_over():
     scorer = Graph([score], name="scorer").bind(multiplier=3)
     batch_graph = Graph([scorer.as_node(name="score_many").with_inputs(text="texts").map_over("texts")], name="batch_graph")
 
-    # `texts` is private to the `score_many` GraphNode at batch_graph scope.
-    result = DaftRunner().run(batch_graph, {"score_many.texts": ["a", "tool", "hypergraph"]})
+    # `texts` is owned by the `score_many` GraphNode at batch_graph scope.
+    result = DaftRunner().run(batch_graph, {"texts": ["a", "tool", "hypergraph"]})
 
     assert result["scored"] == [3, 12, 30]
 
@@ -113,7 +113,7 @@ def test_daft_runner_rejects_nested_graph_with_async_nodes():
     outer = Graph([inner.as_node(name="sub").with_inputs(x="val")], name="outer")
 
     with pytest.raises(IncompatibleRunnerError, match="async nodes"):
-        DaftRunner().run(outer, {"sub.val": 1})
+        DaftRunner().run(outer, {"val": 1})
 
 
 def test_daft_runner_rejects_with_runner_override():

--- a/tests/test_runners/test_delegation.py
+++ b/tests/test_runners/test_delegation.py
@@ -106,8 +106,8 @@ class TestDelegationExecution:
         outer = Graph([gn])
 
         parent_runner = SyncRunner()
-        # x is private to inner GraphNode → addressed via dot-path (use dict form)
-        result = parent_runner.run(outer, {"inner.x": 5})
+        # x is owned by inner GraphNode → addressed by its parent-facing key (use dict form)
+        result = parent_runner.run(outer, {"x": 5})
         assert result.values["doubled"] == 10
 
     def test_sync_delegation_with_map_over(self):
@@ -118,8 +118,8 @@ class TestDelegationExecution:
         outer = Graph([mapped])
 
         parent_runner = SyncRunner()
-        # x is private to inner GraphNode → addressed via dot-path
-        result = parent_runner.run(outer, {"inner.x": [1, 2, 3]})
+        # x is owned by inner GraphNode → addressed by its parent-facing key
+        result = parent_runner.run(outer, {"x": [1, 2, 3]})
         assert result.values["doubled"] == [2, 4, 6]
 
     @pytest.mark.asyncio
@@ -131,8 +131,8 @@ class TestDelegationExecution:
         outer = Graph([gn])
 
         parent_runner = AsyncRunner()
-        # x is private to inner GraphNode → addressed via dot-path
-        result = await parent_runner.run(outer, {"inner.x": 5})
+        # x is owned by inner GraphNode → addressed by its parent-facing key
+        result = await parent_runner.run(outer, {"x": 5})
         assert result.values["doubled"] == 10
 
     def test_delegation_with_renamed_inputs(self):
@@ -141,8 +141,8 @@ class TestDelegationExecution:
         gn = inner.as_node(runner=SyncRunner()).with_inputs(x="val")
         outer = Graph([gn])
 
-        # val (renamed from x) is private to inner GraphNode → dot-path
-        result = SyncRunner().run(outer, {"inner.val": 7})
+        # val (renamed from x) is the parent-facing input address.
+        result = SyncRunner().run(outer, {"val": 7})
         assert result.values["doubled"] == 14
 
     def test_delegation_in_multi_node_graph(self):
@@ -151,7 +151,7 @@ class TestDelegationExecution:
         gn = inner.as_node(runner=SyncRunner())
         outer = Graph([gn, add.with_inputs(a="doubled")])
 
-        # x is private to inner GraphNode; b is declared at outer (consumed by add)
-        result = SyncRunner().run(outer, {"inner.x": 3, "b": 10})
+        # x is owned by inner GraphNode; b is declared at outer (consumed by add)
+        result = SyncRunner().run(outer, {"x": 3, "b": 10})
         assert result.values["doubled"] == 6
         assert result.values["sum"] == 16

--- a/tests/test_runners/test_graphnode_map_over.py
+++ b/tests/test_runners/test_graphnode_map_over.py
@@ -165,8 +165,8 @@ class TestMapOverRenameExecution:
         inner = Graph(nodes=[process_item], name="inner")
         mapped_node = inner.as_node(name="process_all").with_inputs(item="items").map_over("items")
 
-        # multiplier is private to mapped_node (process_all) → bind via dot-path
-        outer = Graph(nodes=[produce_items, mapped_node]).bind(**{"process_all.multiplier": 2})
+        # multiplier is a parent-facing input address on mapped_node.
+        outer = Graph(nodes=[produce_items, mapped_node]).bind(**{"multiplier": 2})
         runner = SyncRunner()
 
         result = runner.run(outer, {"count": 3})
@@ -270,8 +270,8 @@ class TestMapOverRenameExecution:
         outer = Graph(nodes=[produce, mapped_node])
         runner = SyncRunner()
 
-        # factor is private to mapped GraphNode (multiplier) → addressed via dot-path
-        result = runner.run(outer, {"multiplier.factor": 10})
+        # factor is owned by mapped GraphNode (multiplier) → addressed by its parent-facing key
+        result = runner.run(outer, {"factor": 10})
 
         assert result.status == RunStatus.COMPLETED
         assert result["result"] == [10, 20, 30]
@@ -351,8 +351,8 @@ class TestMapOverExecution:
         outer = Graph([inner.as_node().map_over("x")])
         runner = SyncRunner()
 
-        # x is private to inner GraphNode → addressed via dot-path
-        result = runner.run(outer, {"inner.x": [1, 2, 3]})
+        # x is owned by inner GraphNode → addressed by its parent-facing key
+        result = runner.run(outer, {"x": [1, 2, 3]})
 
         assert result.status == RunStatus.COMPLETED
         assert result["doubled"] == [2, 4, 6]
@@ -363,8 +363,8 @@ class TestMapOverExecution:
         outer = Graph([inner.as_node().map_over("a", "b", mode="zip")])
         runner = SyncRunner()
 
-        # a, b are private to inner GraphNode → addressed via dot-path
-        result = runner.run(outer, {"inner.a": [1, 2, 3], "inner.b": [10, 20, 30]})
+        # a, b are owned by inner GraphNode → addressed by its parent-facing key
+        result = runner.run(outer, {"a": [1, 2, 3], "b": [10, 20, 30]})
 
         assert result["sum"] == [11, 22, 33]
 
@@ -374,8 +374,8 @@ class TestMapOverExecution:
         outer = Graph([inner.as_node().map_over("a", "b", mode="product")])
         runner = SyncRunner()
 
-        # a, b are private to inner GraphNode → addressed via dot-path
-        result = runner.run(outer, {"inner.a": [1, 2], "inner.b": [10, 20]})
+        # a, b are owned by inner GraphNode → addressed by its parent-facing key
+        result = runner.run(outer, {"a": [1, 2], "b": [10, 20]})
 
         # 2 * 2 = 4 results
         assert len(result["sum"]) == 4
@@ -396,8 +396,8 @@ class TestMapOverExecution:
         # This test documents current behavior — may succeed or raise
         # depending on how the downstream node handles list input
         try:
-            # x is private to inner GraphNode; b is declared at outer (consumed by add)
-            result = runner.run(outer, {"inner.x": [1, 2], "b": 0})
+            # x is owned by inner GraphNode; b is declared at outer (consumed by add)
+            result = runner.run(outer, {"x": [1, 2], "b": 0})
             assert result.status == RunStatus.COMPLETED
         except Exception:
             pass  # Also acceptable — type mismatch in downstream node
@@ -408,8 +408,8 @@ class TestMapOverExecution:
         outer = Graph([inner.as_node().map_over("x")])
         runner = AsyncRunner()
 
-        # x is private to inner GraphNode → addressed via dot-path
-        result = await runner.run(outer, {"inner.x": [1, 2, 3]})
+        # x is owned by inner GraphNode → addressed by its parent-facing key
+        result = await runner.run(outer, {"x": [1, 2, 3]})
 
         assert result.status == RunStatus.COMPLETED
         assert result["doubled"] == [2, 4, 6]
@@ -420,8 +420,8 @@ class TestMapOverExecution:
         outer = Graph([inner.as_node().map_over("x")])
         runner = SyncRunner()
 
-        # x is private to inner GraphNode → addressed via dot-path
-        result = runner.run(outer, {"inner.x": []})
+        # x is owned by inner GraphNode → addressed by its parent-facing key
+        result = runner.run(outer, {"x": []})
 
         assert result["doubled"] == []
 
@@ -431,8 +431,8 @@ class TestMapOverExecution:
         outer = Graph([inner.as_node().map_over("a")])
         runner = SyncRunner()
 
-        # a, b are private to inner GraphNode → addressed via dot-path
-        result = runner.run(outer, {"inner.a": [1, 2, 3], "inner.b": 10})
+        # a, b are owned by inner GraphNode → addressed by its parent-facing key
+        result = runner.run(outer, {"a": [1, 2, 3], "b": 10})
 
         assert result["sum"] == [11, 12, 13]
 
@@ -456,8 +456,8 @@ class TestConcurrentNestedMaps:
         outer = Graph([middle.as_node(), collect])
         runner = SyncRunner()
 
-        # x is private through middle.inner GraphNode chain
-        result = runner.run(outer, {"middle.inner.x": [1, 2, 3]})
+        # x is projected through the middle.inner GraphNode chain.
+        result = runner.run(outer, {"x": [1, 2, 3]})
 
         assert result.status == RunStatus.COMPLETED
         assert result["doubled"] == [2, 4, 6]
@@ -478,8 +478,8 @@ class TestConcurrentNestedMaps:
         runner = AsyncRunner()
 
         # Multiple items should process concurrently
-        # x is private to inner GraphNode → addressed via dot-path
-        result = await runner.run(outer, {"inner.x": [1, 2, 3, 4, 5]})
+        # x is owned by inner GraphNode → addressed by its parent-facing key
+        result = await runner.run(outer, {"x": [1, 2, 3, 4, 5]})
 
         assert result.status == RunStatus.COMPLETED
         assert result["value"] == [2, 4, 6, 8, 10]
@@ -501,9 +501,9 @@ class TestConcurrentNestedMaps:
 
         # With max_concurrency=1 on outer, nested map should still work (no deadlock)
         # Nested executions don't inherit outer concurrency limits
-        # x is private to inner GraphNode → addressed via dot-path
+        # x is owned by inner GraphNode → addressed by its parent-facing key
         start = time.time()
-        result = await runner.run(outer, {"inner.x": [1, 2, 3]}, max_concurrency=1)
+        result = await runner.run(outer, {"x": [1, 2, 3]}, max_concurrency=1)
         elapsed = time.time() - start
 
         assert result.status == RunStatus.COMPLETED
@@ -527,9 +527,9 @@ class TestConcurrentNestedMaps:
         runner = AsyncRunner()
 
         # With default concurrency (unlimited), should run in parallel
-        # x is private to inner GraphNode → addressed via dot-path
+        # x is owned by inner GraphNode → addressed by its parent-facing key
         start = time.time()
-        result = await runner.run(outer, {"inner.x": [1, 2, 3, 4, 5]})
+        result = await runner.run(outer, {"x": [1, 2, 3, 4, 5]})
         elapsed = time.time() - start
 
         assert result.status == RunStatus.COMPLETED
@@ -548,8 +548,8 @@ class TestConcurrentNestedMaps:
         outer = Graph([inner.as_node().map_over("x")])
 
         runner = AsyncRunner()
-        # x is private to inner GraphNode → addressed via dot-path
-        result = await runner.run(outer, {"inner.x": [1, 2, 3]})
+        # x is owned by inner GraphNode → addressed by its parent-facing key
+        result = await runner.run(outer, {"x": [1, 2, 3]})
 
         assert result.status == RunStatus.COMPLETED
         assert result["value"] == [2, 4, 6]
@@ -569,8 +569,8 @@ class TestConcurrentNestedMaps:
         outer = Graph([inner.as_node().map_over("x")])
 
         runner = AsyncRunner()
-        # x is private to inner GraphNode → addressed via dot-path
-        result = await runner.run(outer, {"inner.x": [1, 2, 3]})
+        # x is owned by inner GraphNode → addressed by its parent-facing key
+        result = await runner.run(outer, {"x": [1, 2, 3]})
 
         assert result.status == RunStatus.COMPLETED
         # (1+1)*2=4, (2+1)*2=6, (3+1)*2=8
@@ -588,8 +588,8 @@ class TestConcurrentNestedMaps:
         outer = Graph([middle.as_node()])
 
         runner = SyncRunner()
-        # x is private through middle.innermost GraphNode chain
-        result = runner.run(outer, {"middle.innermost.x": [1, 2, 3]})
+        # x is projected through the middle.innermost GraphNode chain.
+        result = runner.run(outer, {"x": [1, 2, 3]})
 
         assert result.status == RunStatus.COMPLETED
         assert result["doubled"] == [2, 4, 6]
@@ -623,8 +623,8 @@ class TestConcurrentNestedMaps:
         )
 
         runner = SyncRunner()
-        # vals_a private to inner_a, vals_b private to inner_b → dot-paths
-        result = runner.run(outer, {"inner_a.vals_a": [1, 2], "inner_b.vals_b": [10, 20]})
+        # vals_a and vals_b are parent-facing input addresses on their GraphNodes.
+        result = runner.run(outer, {"vals_a": [1, 2], "vals_b": [10, 20]})
 
         assert result.status == RunStatus.COMPLETED
         assert result["a"] == [2, 4]
@@ -807,11 +807,11 @@ class TestMaxConcurrency:
 
         # With max_concurrency=1 on outer, the two GraphNodes run sequentially
         # But their inner maps run concurrently (nested execution is independent)
-        # x private to inner_a, y private to inner_b → dot-paths
+        # x and y are parent-facing input addresses on their GraphNodes.
         start = time.time()
         result = await runner.run(
             outer,
-            {"inner_a.x": [1, 2], "inner_b.y": [10, 20]},
+            {"x": [1, 2], "y": [10, 20]},
             max_concurrency=1,
         )
         elapsed = time.time() - start
@@ -835,16 +835,16 @@ class TestMaxConcurrency:
         # Three levels of nesting
         level1 = Graph([async_double], name="level1")
         level2 = Graph([level1.as_node()], name="level2")
-        # level2 exposes its inner private input as "level1.x"; map_over uses that name.
-        level3 = Graph([level2.as_node().map_over("level1.x")])
+        # level2 projects its inner input as "x"; map_over uses that name.
+        level3 = Graph([level2.as_node().map_over("x")])
 
         runner = AsyncRunner()
 
         # Should work even with max_concurrency=1
-        # x is private through level2.level1 GraphNode chain at level3 scope
+        # x is projected through the level2.level1 GraphNode chain at level3 scope.
         result = await runner.run(
             level3,
-            {"level2.level1.x": [1, 2, 3]},
+            {"x": [1, 2, 3]},
             max_concurrency=1,
         )
 
@@ -867,9 +867,9 @@ class TestMaxConcurrency:
         runner = AsyncRunner()
 
         # Product of [1,2] x [10,20] = 4 combinations
-        # a, b are private to inner GraphNode → addressed via dot-path
+        # a, b are owned by inner GraphNode → addressed by its parent-facing key
         start = time.time()
-        result = await runner.run(outer, {"inner.a": [1, 2], "inner.b": [10, 20]})
+        result = await runner.run(outer, {"a": [1, 2], "b": [10, 20]})
         elapsed = time.time() - start
 
         assert result.status == RunStatus.COMPLETED
@@ -893,10 +893,10 @@ class TestMaxConcurrency:
         runner = AsyncRunner()
 
         with pytest.raises(ValueError, match="x cannot be 2"):
-            # x is private to inner GraphNode → addressed via dot-path
+            # x is owned by inner GraphNode → addressed by its parent-facing key
             await runner.run(
                 outer,
-                {"inner.x": [1, 2, 3]},
+                {"x": [1, 2, 3]},
                 max_concurrency=1,
             )
 
@@ -912,10 +912,10 @@ class TestMaxConcurrency:
 
         runner = AsyncRunner()
 
-        # x is private to inner GraphNode → addressed via dot-path
+        # x is owned by inner GraphNode → addressed by its parent-facing key
         result = await runner.run(
             outer,
-            {"inner.x": []},
+            {"x": []},
             max_concurrency=1,
         )
 
@@ -936,10 +936,10 @@ class TestMaxConcurrency:
 
         runner = AsyncRunner()
 
-        # x is private to inner GraphNode → addressed via dot-path
+        # x is owned by inner GraphNode → addressed by its parent-facing key
         result = await runner.run(
             outer,
-            {"inner.x": [42]},
+            {"x": [42]},
             max_concurrency=1,
         )
 
@@ -1009,8 +1009,8 @@ class TestCloneExecution:
         runner = SyncRunner()
 
         config = {"key": "value"}
-        # x and config are private to inner GraphNode → addressed via dot-path
-        result = runner.run(outer, {"inner.x": [1, 2, 3], "inner.config": config})
+        # x and config are owned by inner GraphNode → addressed by its parent-facing key
+        result = runner.run(outer, {"x": [1, 2, 3], "config": config})
 
         assert result.status == RunStatus.COMPLETED
         # All iterations should see the same object
@@ -1029,8 +1029,8 @@ class TestCloneExecution:
         runner = SyncRunner()
 
         config = {"key": "value"}
-        # x and config are private to inner GraphNode → addressed via dot-path
-        result = runner.run(outer, {"inner.x": [1, 2, 3], "inner.config": config})
+        # x and config are owned by inner GraphNode → addressed by its parent-facing key
+        result = runner.run(outer, {"x": [1, 2, 3], "config": config})
 
         assert result.status == RunStatus.COMPLETED
         ids = result["item_id"]
@@ -1048,8 +1048,8 @@ class TestCloneExecution:
         outer = Graph([inner.as_node().map_over("x", clone=["config"])])
         runner = SyncRunner()
 
-        # x, config, factor are private to inner GraphNode → addressed via dot-path
-        result = runner.run(outer, {"inner.x": [1, 2, 3], "inner.config": {"k": "v"}, "inner.factor": 10})
+        # x, config, factor are owned by inner GraphNode → addressed by its parent-facing key
+        result = runner.run(outer, {"x": [1, 2, 3], "config": {"k": "v"}, "factor": 10})
 
         assert result.status == RunStatus.COMPLETED
         # config should be cloned (different ids)
@@ -1073,8 +1073,8 @@ class TestCloneExecution:
         outer = Graph([inner.as_node().map_over("x", clone=True)])
         runner = SyncRunner()
 
-        # x and config are private to inner GraphNode → addressed via dot-path
-        result = runner.run(outer, {"inner.x": [1, 2, 3], "inner.config": {"count": 0}})
+        # x and config are owned by inner GraphNode → addressed by its parent-facing key
+        result = runner.run(outer, {"x": [1, 2, 3], "config": {"count": 0}})
 
         assert result.status == RunStatus.COMPLETED
         # With clone=True, each iteration gets a fresh copy with count=0
@@ -1096,8 +1096,8 @@ class TestCloneExecution:
         runner = SyncRunner()
 
         with pytest.raises(GraphConfigError, match="cannot be deep-copied for clone"):
-            # x and lock are private to inner GraphNode → addressed via dot-path
-            runner.run(outer, {"inner.x": [1, 2], "inner.lock": threading.Lock()})
+            # x and lock are owned by inner GraphNode → addressed by its parent-facing key
+            runner.run(outer, {"x": [1, 2], "lock": threading.Lock()})
 
     async def test_clone_with_async_runner(self):
         """Clone works with AsyncRunner."""
@@ -1111,8 +1111,8 @@ class TestCloneExecution:
         outer = Graph([inner.as_node().map_over("x", clone=True)])
         runner = AsyncRunner()
 
-        # x and config are private to inner GraphNode → addressed via dot-path
-        result = await runner.run(outer, {"inner.x": [1, 2, 3], "inner.config": {"count": 0}})
+        # x and config are owned by inner GraphNode → addressed by its parent-facing key
+        result = await runner.run(outer, {"x": [1, 2, 3], "config": {"count": 0}})
 
         assert result.status == RunStatus.COMPLETED
         # Each iteration sees a fresh config with count=0
@@ -1130,8 +1130,8 @@ class TestCloneExecution:
         outer = Graph([inner.as_node().map_over("a", "b", mode="product", clone=True)])
         runner = SyncRunner()
 
-        # a, b, state are private to inner GraphNode → addressed via dot-path
-        result = runner.run(outer, {"inner.a": [1, 2], "inner.b": [10, 20], "inner.state": {}})
+        # a, b, state are owned by inner GraphNode → addressed by its parent-facing key
+        result = runner.run(outer, {"a": [1, 2], "b": [10, 20], "state": {}})
 
         assert result.status == RunStatus.COMPLETED
         # Product: (1,10), (1,20), (2,10), (2,20) → sums: 11, 21, 12, 22
@@ -1150,8 +1150,8 @@ class TestCloneExecution:
         outer = Graph([inner.as_node().map_over("x", clone=True)])
         runner = SyncRunner()
 
-        # x is private to inner GraphNode → addressed via dot-path
-        result = runner.run(outer, {"inner.x": [1, 2, 3]})
+        # x is owned by inner GraphNode → addressed by its parent-facing key
+        result = runner.run(outer, {"x": [1, 2, 3]})
 
         assert result.status == RunStatus.COMPLETED
         # Inner-bound config is resolved inside each inner run, not through clone
@@ -1174,8 +1174,8 @@ class TestCloneExecution:
         outer = Graph([mapped_node])
         runner = SyncRunner()
 
-        # x and config (renamed from cfg) are private to inner GraphNode → dot-paths
-        result = runner.run(outer, {"inner.x": [1, 2, 3], "inner.config": {"count": 0}})
+        # x and config (renamed from cfg) are parent-facing input addresses.
+        result = runner.run(outer, {"x": [1, 2, 3], "config": {"count": 0}})
 
         assert result.status == RunStatus.COMPLETED
         # Each iteration sees fresh config
@@ -1193,10 +1193,10 @@ class TestCloneExecution:
 
         inner = Graph([use_lock], name="inner")
         # Outer bind — values DO pass through generate_map_inputs
-        # lock is private to inner GraphNode → bind via dot-path key
-        outer = Graph([inner.as_node().map_over("x", clone=True)]).bind(**{"inner.lock": threading.Lock()})
+        # lock is a parent-facing input address on the inner GraphNode.
+        outer = Graph([inner.as_node().map_over("x", clone=True)]).bind(**{"lock": threading.Lock()})
         runner = SyncRunner()
 
         with pytest.raises(GraphConfigError, match="cannot be deep-copied for clone"):
-            # x is private to inner GraphNode → addressed via dot-path
-            runner.run(outer, {"inner.x": [1, 2]})
+            # x is owned by inner GraphNode → addressed by its parent-facing key
+            runner.run(outer, {"x": [1, 2]})

--- a/tests/test_runners/test_mutex_branch_outputs.py
+++ b/tests/test_runners/test_mutex_branch_outputs.py
@@ -118,7 +118,7 @@ def explicit_edge_missing_false_branch() -> Graph:
     [
         (same_graph, "x"),
         (consumer_in_subgraph, "x"),
-        (producers_and_consumer_in_separate_subgraphs, "producer_graph.x"),
+        (producers_and_consumer_in_separate_subgraphs, "x"),
         (explicit_edges_both_branches, "x"),
     ],
 )
@@ -190,7 +190,7 @@ def test_missing_output_versions_still_accept_current_declared_writer() -> None:
 
 
 async def test_async_mutex_duplicate_outputs_feed_consumer_at_runtime() -> None:
-    result = await AsyncRunner().run(producers_and_consumer_in_separate_subgraphs(), {"producer_graph.x": -1})
+    result = await AsyncRunner().run(producers_and_consumer_in_separate_subgraphs(), {"x": -1})
 
     assert result.status == RunStatus.COMPLETED
     assert result["final"] == "final:b:-1"

--- a/tests/test_runners/test_sync_runner.py
+++ b/tests/test_runners/test_sync_runner.py
@@ -398,7 +398,7 @@ class TestSyncRunnerRun:
         outer = Graph([inner.as_node()])
         runner = SyncRunner()
 
-        result = runner.run(outer, {"inner.x": 5})
+        result = runner.run(outer, {"x": 5})
 
         assert result["doubled"] == 10
 
@@ -413,7 +413,7 @@ class TestSyncRunnerRun:
         )
         runner = SyncRunner()
 
-        result = runner.run(outer, {"inner.x": 5, "b": 3})
+        result = runner.run(outer, {"x": 5, "b": 3})
 
         assert result["sum"] == 13
 
@@ -424,11 +424,8 @@ class TestSyncRunnerRun:
         outer = Graph([middle.as_node()])
         runner = SyncRunner()
 
-        # `increment.with_inputs(x="doubled")` renames increment's parameter, so it
-        # consumes the output of `double` rather than an external "x". `double`
-        # (inside `innermost`) is the only consumer of external "x", so "x" is private
-        # to `innermost` within `middle`, and addressed from outer as "middle.innermost.x".
-        result = runner.run(outer, {"middle.innermost.x": 5})
+        # Flat nested graphs keep the inner input in the parent flow.
+        result = runner.run(outer, {"x": 5})
 
         assert result["incremented"] == 11  # (5*2) + 1
 

--- a/tests/test_runners/test_value_resolution.py
+++ b/tests/test_runners/test_value_resolution.py
@@ -104,9 +104,9 @@ class TestNonCopyableBoundValues:
         outer_graph = Graph([inner_graph.as_node()], name="outer")
 
         # Should NOT raise error about deep-copy failure.
-        # query is private to inner GraphNode → addressed via dot-path
+        # Flat as_node() keeps query in the parent flow.
         runner = SyncRunner()
-        result = runner.run(outer_graph, {"inner.query": "test"})
+        result = runner.run(outer_graph, {"query": "test"})
 
         assert result["result"] == "Used test"
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -105,8 +105,8 @@ class TestSelectNested:
             return f"val={sum}"
 
         outer = Graph([inner.as_node(), fmt])
-        # x and b are private to inner GraphNode → addressed via dot-path
-        result = SyncRunner().run(outer, {"inner.x": 5, "inner.b": 3})
+        # x and b are owned by inner GraphNode → addressed by its parent-facing key
+        result = SyncRunner().run(outer, {"x": 5, "b": 3})
         assert result.values["formatted"] == "val=13"
 
     def test_nested_graph_hides_unselected_from_parent(self):

--- a/tests/viz/test_graphnode_boundary_projection.py
+++ b/tests/viz/test_graphnode_boundary_projection.py
@@ -1,0 +1,70 @@
+"""Visualization coverage for GraphNode boundary projection."""
+
+from hypergraph import Graph, node
+from hypergraph.viz.renderer.ir_builder import build_graph_ir
+from hypergraph.viz.scene_builder import build_initial_scene
+
+
+def test_namespaced_graphnode_input_renders_resolved_address_and_routes_to_leaf():
+    @node(output_name="docs")
+    def retrieve(query: str) -> str:
+        return f"docs:{query}"
+
+    graph = Graph([Graph([retrieve], name="retrieval").as_node(namespaced=True)])
+    ir = build_graph_ir(graph.to_flat_graph())
+
+    external = ir.external_inputs[0]
+    assert external.params == ("retrieval.query",)
+    assert external.consumers == ("retrieval/retrieve",)
+    assert external.deepest_owner == "retrieval"
+
+    scene = build_initial_scene(ir, expansion_state={"retrieval": True})
+    input_node = next(n for n in scene["nodes"] if n["id"] == "input_query")
+    input_edges = [e for e in scene["edges"] if e["source"] == "input_query" and not e.get("hidden")]
+
+    assert input_node["data"]["label"] == "retrieval.query"
+    assert input_node["data"]["actualTargets"] == ["retrieval/retrieve"]
+    assert {edge["target"] for edge in input_edges} == {"retrieval/retrieve"}
+
+
+def test_exposed_shared_input_renders_once_at_parent_boundary():
+    @node(output_name="docs")
+    def retrieve(query: str) -> str:
+        return f"docs:{query}"
+
+    @node(output_name="answer")
+    def generate(query: str) -> str:
+        return f"answer:{query}"
+
+    graph = Graph(
+        [
+            Graph([retrieve], name="retrieval").as_node(namespaced=True).expose("query"),
+            Graph([generate], name="generation").as_node(namespaced=True).expose("query"),
+        ]
+    )
+    ir = build_graph_ir(graph.to_flat_graph())
+
+    assert len(ir.external_inputs) == 1
+    external = ir.external_inputs[0]
+    assert external.params == ("query",)
+    assert set(external.consumers) == {"retrieval/retrieve", "generation/generate"}
+    assert external.deepest_owner is None
+
+    scene = build_initial_scene(ir, expansion_state={"retrieval": True, "generation": True})
+    input_nodes = [n for n in scene["nodes"] if n["data"]["nodeType"] == "INPUT"]
+    input_edges = [e for e in scene["edges"] if e["source"] == "input_query" and not e.get("hidden")]
+
+    assert [(n["id"], n["data"]["label"]) for n in input_nodes] == [("input_query", "query")]
+    assert {edge["target"] for edge in input_edges} == {"retrieval/retrieve", "generation/generate"}
+
+
+def test_mermaid_namespaced_input_label_uses_resolved_port_address():
+    @node(output_name="docs")
+    def retrieve(query: str) -> str:
+        return f"docs:{query}"
+
+    graph = Graph([Graph([retrieve], name="retrieval").as_node(namespaced=True)])
+
+    mermaid = graph.to_mermaid(depth=1)
+
+    assert 'input_query(["retrieval.query: str"])' in mermaid


### PR DESCRIPTION
## Problem / Bug / Challenge

Nested graph composition needed two modes without overloading the user-facing API:

- flat flow composition, where shared names like `query` and `messages` intentionally connect through the parent graph
- namespaced/capsule composition, where repeated subgraphs keep same-named ports independent unless explicitly exposed

This PR implements the Issue #97 model: flat `as_node()` by default, opt-in `as_node(namespaced=True)`, and `.expose(...)` to bring selected namespaced ports back into the parent flat flow.

## Before / After

**Before:**

```python
runner.run(rag, {"retrieval.query": query, "generation.query": query})
```

**After:**

```python
rag = Graph([
    retrieval.as_node(),
    generation.as_node(),
])
runner.run(rag, {"query": query})
```

For reusable/capsule graphs:

```python
team = Graph([
    agent.as_node(name="researcher", namespaced=True),
    agent.as_node(name="critic", namespaced=True),
])
# researcher.query, critic.query, researcher.response, critic.response
```

And for intentional sharing:

```python
rag = Graph([
    retrieval.as_node(namespaced=True).expose("query"),
    generation.as_node(namespaced=True).expose("query"),
])
```

## Test Plan

- [x] `uv run ruff check src/hypergraph tests/test_graphnode_boundary_projection.py tests/viz/test_graphnode_boundary_projection.py tests/test_bind_edge_cases.py`
- [x] `uv run pytest -W error -W 'ignore::pytest.PytestUnraisableExceptionWarning'`
- [x] Claude CLI review pass 1 against `origin/master`, fixes applied
- [x] Claude CLI review pass 2 against targeted changed files, fixes applied
- [x] Claude CLI review pass 3 against targeted changed files, no blockers/high issues found

Result: `2437 passed, 110 skipped`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * **GraphNode boundary projection:** Nested graph inputs/outputs now flatten to parent scope by default. Use `as_node(namespaced=True)` to restore dot-path addressing. New `.expose()` API selectively re-exposes local ports at parent level.
  * **Runtime addressing:** Pass nested graph inputs via parent-facing keys (e.g., `{"x": ...}` instead of `{"inner.x": ...}`). Interrupt response keys now flat instead of dot-pathed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gilad-rubin/hypergraph/pull/98)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->