### PR TITLE
[codex] add rename port APIs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -53,7 +53,7 @@ _Avoid_: Start node, root node
 - `GraphNode.inputs` and `GraphNode.outputs` are resolved parent-facing **Port addresses** after boundary projection, not raw child **Local port names**.
 - The same **Port address** may appear in both `GraphNode.inputs` and `GraphNode.outputs`; cyclic values such as `messages` need both an input seed and a produced output.
 - A **Selected output** controls which outputs a graph makes available to callers or parent graphs before graph-node boundary transforms are applied.
-- `with_inputs(...)` and `with_outputs(...)` rename **Local port names** only; they do not connect values and do not rename exposed parent-facing addresses.
+- `rename_inputs(...)` and `rename_outputs(...)` rename **Local port names** only; they do not connect values and do not rename exposed parent-facing addresses.
 - An **Exposed port** replaces the child port's namespaced parent-facing address for both inputs and outputs; callers use the exposed flat name, not both names.
 - An `expose(...)` alias is the final flat parent-facing **Port address** at that graph-node boundary, not a renamed **Local port name** that is later namespaced.
 - An **Exposed port** defines the final parent-facing flat address for that port; rename the **Local port name** before exposing it, or expose directly with an alias.
@@ -79,7 +79,7 @@ _Avoid_: Start node, root node
 > **Dev:** "If `chat.messages` is both an input and output, does exposing `messages` only expose the input?"
 > **Domain expert:** "No. An **Exposed port** opens the matching child port into the parent flat flow; if the child has both input and output ports named `messages`, both are exposed."
 >
-> **Dev:** "Can I expose `response` as `research_answer` and then use `with_outputs(research_answer='answer')`?"
+> **Dev:** "Can I expose `response` as `research_answer` and then use `rename_outputs(research_answer='answer')`?"
 > **Domain expert:** "No. `research_answer` is the parent-facing **Port address**, not a **Local port name**. Rename the local name first, or choose the final exposed name in `expose(...)`."
 >
 > **Dev:** "After `namespaced=True`, does `GraphNode.outputs` contain `response` or `researcher.response`?"
@@ -91,6 +91,6 @@ _Avoid_: Start node, root node
 - "shared input" and "shared output" were used for cyclic state, but **Shared parameter** is the canonical term because the value is stateful rather than an ordinary one-way port.
 - "expose" was considered as adding an extra alias, but **Exposed port** is now resolved as a parent-facing rename: the exposed flat name replaces the namespaced address at that boundary.
 - Existing docs sometimes say `select()` controls which outputs are "exposed" when nested; use **Selected output** for that concept to avoid confusing it with `.expose(...)`.
-- `with_inputs(...)` and `with_outputs(...)` were sometimes used as wiring language, but they are canonical **Local port name** renames only.
+- `rename_inputs(...)` and `rename_outputs(...)` were sometimes used as wiring language, but they are canonical **Local port name** renames only.
 - `link_inputs` was considered for shared input fan-out, but the MVP keeps **Exposed port** as the single boundary-flattening concept; `link_inputs` may be added later as direct-child input-only sugar.
 - Direction-specific expose was considered, but the MVP keeps **Exposed port** name-based across matching input and output directions.

--- a/dev/ARCHITECTURE-MAP.md
+++ b/dev/ARCHITECTURE-MAP.md
@@ -142,7 +142,7 @@ That means the graph layer owns more than "validation". It also owns the definit
 - **active scope**: the nodes and outputs still relevant after entrypoint and select slicing
 - **shared params**: parameters intentionally excluded from auto-wiring
 - **seed**: a value needed to start a cycle
-- **rename history**: the mapping chain created by `with_inputs()` / `with_outputs()`
+- **rename history**: the mapping chain created by `rename_inputs()` / `rename_outputs()`
 - **runner delegation**: using a specific runner for a nested graph node
 
 ## Zone 2: Execution Kernel

--- a/dev/ARCHITECTURE.md
+++ b/dev/ARCHITECTURE.md
@@ -28,7 +28,7 @@ Node types and decorators. Each node is a value object wrapping a callable.
 | `_callable.py` | Internal: callable introspection (signatures, type hints) |
 | `_rename.py` | Internal: copy-on-rename machinery, batch ID tracking |
 
-**Rule**: Node objects are immutable values. `with_*` methods return new instances. Never mutate a node in place.
+**Rule**: Node objects are immutable values. Rename/configuration methods return new instances. Never mutate a node in place.
 
 ### graph/
 

--- a/dev/CODE-CONVENTIONS.md
+++ b/dev/CODE-CONVENTIONS.md
@@ -22,7 +22,7 @@ raise GraphConfigError(
 
 ## Immutability Pattern
 
-All `with_*` methods follow this pattern:
+All node configuration methods follow this pattern:
 
 ```python
 def with_name(self, name: str) -> Self:
@@ -34,7 +34,7 @@ def with_name(self, name: str) -> Self:
 
 - `_copy()` → modify → `_invalidate_cached_properties()` → return
 - Rename history tracked with batch IDs (see `_rename.py`)
-- Never mutate `self` in a `with_*` method
+- Never mutate `self` in a rename/configuration method
 
 ## Type Hints
 

--- a/dev/CORE-BELIEFS.md
+++ b/dev/CORE-BELIEFS.md
@@ -38,7 +38,7 @@ Errors caught at `Graph()` construction, not hours into a run. Invalid targets, 
 
 ## 5. Immutability
 
-`with_*`, `bind`, `select`, `unbind`, `with_entrypoint` return new instances. No in-place mutation.
+`rename_*`, `with_*`, `bind`, `select`, `unbind`, and `with_entrypoint` return new instances. No in-place mutation.
 
 **What breaks**: In-place mutation creates spooky action at a distance. `base = Graph([a, b, c]); configured = base.bind(x=1)` — if `bind` mutates `base`, anyone holding a reference to `base` gets the binding unexpectedly.
 

--- a/dev/REVIEW-CHECKLIST.md
+++ b/dev/REVIEW-CHECKLIST.md
@@ -112,7 +112,7 @@ Before pushing or creating a PR:
 - [ ] **New public API** added to `__init__.py` `__all__`?
 - [ ] **New public event/callback** mirrored in package-root exports, API docs, and example code?
 - [ ] **Error messages** include "How to fix:" guidance?
-- [ ] **Immutability preserved** — `with_*` returns new instance, no in-place mutation?
+- [ ] **Immutability preserved** — rename/configuration methods return new instances, no in-place mutation?
 - [ ] **Internal modules** prefixed with `_`?
 - [ ] **Capability matrix updated** if adding new node type or runner feature?
 - [ ] **Conventional commit** message with scope? (`feat(graph): add X`)
@@ -136,7 +136,7 @@ When reviewing code changes:
 - [ ] No unnecessary state mutation?
 - [ ] Composition used instead of configuration flags?
 - [ ] Active-set enforcement: does `with_entrypoint` / `select` properly scope both validation AND execution? (Not just one or the other)
-- [ ] Nested graph boundaries preserve the configured public interface? (`with_inputs`/`with_outputs`, scoped outputs, and bound values don't leak across sibling GraphNodes)
+- [ ] Nested graph boundaries preserve the configured public interface? (`rename_inputs`/`rename_outputs`, scoped outputs, and bound values don't leak across sibling GraphNodes)
 - [ ] Checkpointed nested execution can re-run safely? (Repeated GraphNode execution, especially inside cycles, must not collide with child workflow IDs)
 
 ### Code Quality

--- a/docs/01-introduction/when-to-use.md
+++ b/docs/01-introduction/when-to-use.md
@@ -82,7 +82,7 @@ single_item = Graph([embed], name="single_item")
 # Many items
 batch = Graph([
     load_texts,
-    single_item.as_node().with_inputs(text="texts").map_over("texts"),
+    single_item.as_node().rename_inputs(text="texts").map_over("texts"),
     summarize_embeddings,
 ])
 ```

--- a/docs/02-core-concepts/getting-started.md
+++ b/docs/02-core-concepts/getting-started.md
@@ -114,7 +114,7 @@ The return value must be a tuple matching the number of output names. Unpacking 
 
 ### Renaming Inputs and Outputs
 
-Use `with_inputs()` and `with_outputs()` to rename without creating new functions:
+Use `rename_inputs()` and `rename_outputs()` to rename without creating new functions:
 
 ```python
 @node(output_name="result")
@@ -122,7 +122,7 @@ def process(text: str) -> str:
     return text.upper()
 
 # Rename to fit your graph's naming convention
-adapted = process.with_inputs(text="raw_input").with_outputs(result="processed")
+adapted = process.rename_inputs(text="raw_input").rename_outputs(result="processed")
 
 print(adapted.inputs)   # ("raw_input",)
 print(adapted.outputs)  # ("processed",)
@@ -147,8 +147,8 @@ All rename methods return new instances:
 custom = (
     process
     .with_name("preprocessor")
-    .with_inputs(text="raw")
-    .with_outputs(result="cleaned")
+    .rename_inputs(text="raw")
+    .rename_outputs(result="cleaned")
 )
 
 print(custom.name)     # "preprocessor"
@@ -503,15 +503,15 @@ When you try to rename a name that doesn't exist, you get a helpful error:
 def process(x: int) -> int: pass
 
 # Try to rename non-existent input
-process.with_inputs(y="renamed")
+process.rename_inputs(y="renamed")
 # RenameError: 'y' not found. Current inputs: ('x',)
 ```
 
 If you renamed and then try to use the old name:
 
 ```python
-renamed = process.with_inputs(x="input")
-renamed.with_inputs(x="different")  # ERROR - x was already renamed to "input"
+renamed = process.rename_inputs(x="input")
+renamed.rename_inputs(x="different")  # ERROR - x was already renamed to "input"
 
 # Error message shows history:
 # RenameError: 'x' was renamed to 'input'. Current inputs: ('input',)

--- a/docs/03-patterns/04-hierarchical.md
+++ b/docs/03-patterns/04-hierarchical.md
@@ -338,7 +338,7 @@ graph_node = my_graph.as_node()
 graph_node = my_graph.as_node(name="custom_name")
 
 # With input/output renaming
-graph_node = my_graph.as_node().with_inputs(old="new")
+graph_node = my_graph.as_node().rename_inputs(old="new")
 
 # With map_over for fan-out
 graph_node = my_graph.as_node().map_over("items")

--- a/docs/03-patterns/07-human-in-the-loop.md
+++ b/docs/03-patterns/07-human-in-the-loop.md
@@ -548,8 +548,8 @@ InterruptNode(my_func, name="review", output_name="decision",
 | Method | Returns | Description |
 |--------|---------|-------------|
 | `with_name(name)` | `InterruptNode` | New instance with a different name |
-| `with_inputs(**kwargs)` | `InterruptNode` | New instance with renamed inputs |
-| `with_outputs(**kwargs)` | `InterruptNode` | New instance with renamed outputs |
+| `rename_inputs(**kwargs)` | `InterruptNode` | New instance with renamed inputs |
+| `rename_outputs(**kwargs)` | `InterruptNode` | New instance with renamed outputs |
 
 ### PauseInfo
 

--- a/docs/05-how-to/daft-workflows.md
+++ b/docs/05-how-to/daft-workflows.md
@@ -111,7 +111,7 @@ sentence_graph = Graph([clean_sentence, score_sentence], name="sentence_graph")
 workflow = Graph(
     [
         split_sentences,
-        sentence_graph.as_node(name="analyze").with_inputs(text="sentences").map_over("sentences"),
+        sentence_graph.as_node(name="analyze").rename_inputs(text="sentences").map_over("sentences"),
     ],
     name="document_triage",
 )

--- a/docs/05-how-to/rename-and-adapt.md
+++ b/docs/05-how-to/rename-and-adapt.md
@@ -8,17 +8,17 @@ The same logic often applies in different contexts with different naming convent
 
 ```python
 # Same embedding function, different contexts
-embed_query = embed.with_inputs(text="query")
-embed_document = embed.with_inputs(text="document")
+embed_query = embed.rename_inputs(text="query")
+embed_document = embed.rename_inputs(text="document")
 
 # Same validation, different pipelines
-validate_order = validate.with_outputs(result="order_valid")
-validate_user = validate.with_outputs(result="user_valid")
+validate_order = validate.rename_outputs(result="order_valid")
+validate_user = validate.rename_outputs(result="user_valid")
 ```
 
 ## Renaming Inputs
 
-Use `.with_inputs()` to rename input parameters:
+Use `.rename_inputs()` to rename input parameters:
 
 ```python
 from hypergraph import node
@@ -31,19 +31,19 @@ def embed(text: str) -> list[float]:
 print(embed.inputs)  # ('text',)
 
 # Adapted to take "query"
-query_embed = embed.with_inputs(text="query")
+query_embed = embed.rename_inputs(text="query")
 print(query_embed.inputs)  # ('query',)
 
 # Adapted to take "document"
-doc_embed = embed.with_inputs(text="document")
+doc_embed = embed.rename_inputs(text="document")
 print(doc_embed.inputs)  # ('document',)
 ```
 
-**Important**: The original node is unchanged. `.with_inputs()` returns a new node.
+**Important**: The original node is unchanged. `.rename_inputs()` returns a new node.
 
 ## Renaming Outputs
 
-Use `.with_outputs()` to rename output names:
+Use `.rename_outputs()` to rename output names:
 
 ```python
 @node(output_name="result")
@@ -54,7 +54,7 @@ def process(data: str) -> str:
 print(process.outputs)  # ('result',)
 
 # Adapted to produce "processed_text"
-text_processor = process.with_outputs(result="processed_text")
+text_processor = process.rename_outputs(result="processed_text")
 print(text_processor.outputs)  # ('processed_text',)
 ```
 
@@ -85,8 +85,8 @@ def embed(text: str) -> list[float]:
 query_embed = (
     embed
     .with_name("embed_query")
-    .with_inputs(text="query")
-    .with_outputs(embedding="query_embedding")
+    .rename_inputs(text="query")
+    .rename_outputs(embedding="query_embedding")
 )
 
 print(query_embed.name)     # 'embed_query'
@@ -105,11 +105,11 @@ def statistics(data: list, weights: list) -> tuple[float, float]:
     return mean_val, std_val
 
 # Rename both inputs
-adapted = statistics.with_inputs(data="values", weights="importance")
+adapted = statistics.rename_inputs(data="values", weights="importance")
 print(adapted.inputs)  # ('values', 'importance')
 
 # Rename both outputs
-adapted = statistics.with_outputs(mean="average", std="deviation")
+adapted = statistics.rename_outputs(mean="average", std="deviation")
 print(adapted.outputs)  # ('average', 'deviation')
 ```
 
@@ -126,15 +126,15 @@ def embed(text: str) -> list[float]:
 embed_query = (
     embed
     .with_name("embed_query")
-    .with_inputs(text="query")
-    .with_outputs(embedding="query_vec")
+    .rename_inputs(text="query")
+    .rename_outputs(embedding="query_vec")
 )
 
 embed_doc = (
     embed
     .with_name("embed_doc")
-    .with_inputs(text="document")
-    .with_outputs(embedding="doc_vec")
+    .rename_inputs(text="document")
+    .rename_outputs(embedding="doc_vec")
 )
 
 @node(output_name="similarity")
@@ -159,14 +159,14 @@ print(rag.inputs.required)  # ('text', 'query')
 search_rag = (
     rag.as_node()
     .with_name("search_rag")
-    .with_inputs(text="search_query", query="search_query")
+    .rename_inputs(text="search_query", query="search_query")
 )
 
 # Adapt for chat context
 chat_rag = (
     rag.as_node()
     .with_name("chat_rag")
-    .with_inputs(text="user_message", query="user_message")
+    .rename_inputs(text="user_message", query="user_message")
 )
 ```
 
@@ -180,15 +180,15 @@ def process(x: int) -> int:
     return x * 2
 
 # Try to rename non-existent input
-process.with_inputs(y="new_name")
+process.rename_inputs(y="new_name")
 # RenameError: 'y' not found. Current inputs: ('x',)
 ```
 
 If you renamed and try to use the old name:
 
 ```python
-renamed = process.with_inputs(x="input")
-renamed.with_inputs(x="different")
+renamed = process.rename_inputs(x="input")
+renamed.rename_inputs(x="different")
 # RenameError: 'x' was renamed to 'input'. Current inputs: ('input',)
 ```
 
@@ -201,7 +201,7 @@ The underlying function is the same:
 def double(x: int) -> int:
     return x * 2
 
-renamed = double.with_inputs(x="value").with_outputs(result="doubled")
+renamed = double.rename_inputs(x="value").rename_outputs(result="doubled")
 
 # Both call the same function
 assert double.func(5) == 10

--- a/docs/06-api-reference/gates.md
+++ b/docs/06-api-reference/gates.md
@@ -171,7 +171,7 @@ Get default value for a parameter. Raises `KeyError` if no default.
 
 Return a new node with a different name.
 
-#### `with_inputs(mapping=None, /, **kwargs) -> IfElseNode`
+#### `rename_inputs(mapping=None, /, **kwargs) -> IfElseNode`
 
 Return a new node with renamed inputs.
 
@@ -464,12 +464,12 @@ print(renamed.name)  # "router"
 print(decide.name)   # "decide" (unchanged)
 ```
 
-#### `with_inputs(mapping=None, /, **kwargs) -> RouteNode`
+#### `rename_inputs(mapping=None, /, **kwargs) -> RouteNode`
 
 Return a new node with renamed inputs.
 
 ```python
-adapted = decide.with_inputs(x="value", threshold="cutoff")
+adapted = decide.rename_inputs(x="value", threshold="cutoff")
 print(adapted.inputs)  # ("value", "cutoff")
 ```
 

--- a/docs/06-api-reference/nodes.md
+++ b/docs/06-api-reference/nodes.md
@@ -53,7 +53,7 @@ print(process.name)     # "process" (original unchanged)
 
 **Raises:** None (always succeeds)
 
-### `with_inputs(mapping=None, /, **kwargs) -> HyperNode`
+### `rename_inputs(mapping=None, /, **kwargs) -> HyperNode`
 
 Return a new node with renamed inputs.
 
@@ -63,11 +63,11 @@ def process(text: str, config: dict) -> str:
     return text.upper()
 
 # Using keyword args
-adapted = process.with_inputs(text="raw_input", config="settings")
+adapted = process.rename_inputs(text="raw_input", config="settings")
 print(adapted.inputs)  # ("raw_input", "settings")
 
 # Using dict (for reserved keywords or dynamic renames)
-adapted = process.with_inputs({"text": "raw_input", "class": "category"})
+adapted = process.rename_inputs({"text": "raw_input", "class": "category"})
 ```
 
 **Args:**
@@ -80,7 +80,9 @@ adapted = process.with_inputs({"text": "raw_input", "class": "category"})
 - `RenameError` - If any old name not found in current inputs
 - `RenameError` - Includes helpful history if name was already renamed
 
-### `with_outputs(mapping=None, /, **kwargs) -> HyperNode`
+**Compatibility:** `with_inputs(...)` remains available as an alias.
+
+### `rename_outputs(mapping=None, /, **kwargs) -> HyperNode`
 
 Return a new node with renamed outputs.
 
@@ -90,11 +92,11 @@ def process(x: int) -> int:
     return x * 2
 
 # Using keyword args
-adapted = process.with_outputs(result="doubled")
+adapted = process.rename_outputs(result="doubled")
 print(adapted.outputs)  # ("doubled",)
 
 # Using dict
-adapted = process.with_outputs({"result": "doubled"})
+adapted = process.rename_outputs({"result": "doubled"})
 ```
 
 **Args:**
@@ -107,15 +109,17 @@ adapted = process.with_outputs({"result": "doubled"})
 - `RenameError` - If any old name not found in current outputs
 - `RenameError` - Includes helpful history if name was already renamed
 
+**Compatibility:** `with_outputs(...)` remains available as an alias.
+
 ### Immutability Pattern
 
-All `with_*` methods return new instances. The original is never modified:
+All rename/configuration methods return new instances. The original is never modified:
 
 ```python
 original = process
 v1 = original.with_name("v1")
 v2 = original.with_name("v2")
-v3 = v1.with_inputs(x="input")
+v3 = v1.rename_inputs(x="input")
 
 print(original.name)  # "process" (unchanged)
 print(v1.name)        # "v1"
@@ -258,7 +262,7 @@ def add(x: int, y: int) -> int:
 
 print(add.inputs)  # ("x", "y")
 
-adapted = add.with_inputs(x="a", y="b")
+adapted = add.rename_inputs(x="a", y="b")
 print(adapted.inputs)  # ("a", "b")
 ```
 
@@ -569,7 +573,7 @@ def process(x: int) -> int:
     return x * 2
 
 try:
-    process.with_inputs(y="renamed")  # 'y' doesn't exist
+    process.rename_inputs(y="renamed")  # 'y' doesn't exist
 except RenameError as e:
     print(e)
     # 'y' not found. Current inputs: ('x',)
@@ -585,11 +589,11 @@ def process(x: int) -> int:
     return x * 2
 
 # Rename x to input
-renamed = process.with_inputs(x="input")
+renamed = process.rename_inputs(x="input")
 
 # Try to use old name
 try:
-    renamed.with_inputs(x="something_else")
+    renamed.rename_inputs(x="something_else")
 except RenameError as e:
     print(e)
     # 'x' was renamed to 'input'. Current inputs: ('input',)
@@ -692,8 +696,8 @@ print(node_instance.is_generator)   # False
 adapted = (
     node_instance
     .with_name("math_ops")
-    .with_inputs(first="a", second="b")
-    .with_outputs(sum="total", product="multiply")
+    .rename_inputs(first="a", second="b")
+    .rename_outputs(sum="total", product="multiply")
 )
 
 print(adapted.name)     # "math_ops"
@@ -881,11 +885,11 @@ GraphNode supports the same rename methods as other nodes:
 gn = inner.as_node()
 
 # Rename inputs
-adapted = gn.with_inputs(x="input_value")
+adapted = gn.rename_inputs(x="input_value")
 print(adapted.inputs)  # ('input_value',)
 
 # Rename outputs
-adapted = gn.with_outputs(doubled="result")
+adapted = gn.rename_outputs(doubled="result")
 print(adapted.outputs)  # ('result',)
 
 # Rename the node itself
@@ -893,7 +897,7 @@ adapted = gn.with_name("my_processor")
 print(adapted.name)  # "my_processor"
 ```
 
-For namespaced GraphNodes, `with_inputs(...)` and `with_outputs(...)` names target the current local port names before namespace projection. `map_over(...)` and `clone` accept either current local names or projected parent-facing input addresses, then normalize to local names internally.
+For namespaced GraphNodes, `rename_inputs(...)` and `rename_outputs(...)` names target the current local port names before namespace projection. `map_over(...)` and `clone` accept either current local names or projected parent-facing input addresses, then normalize to local names internally.
 
 ### expose()
 
@@ -1031,7 +1035,7 @@ When you rename inputs, map_over configuration updates automatically:
 
 ```python
 gn = inner.as_node().map_over("x")
-renamed = gn.with_inputs(x="input_value")
+renamed = gn.rename_inputs(x="input_value")
 
 # map_over now references "input_value"
 print(renamed.inputs)  # ('input_value',)
@@ -1221,7 +1225,7 @@ approval = InterruptNode(
 
 ### Methods
 
-#### Inherited: `with_name()`, `with_inputs()`, `with_outputs()`
+#### Inherited: `with_name()`, `rename_inputs()`, `rename_outputs()`
 
 All HyperNode rename methods work as expected.
 

--- a/docs/06-api-reference/nodes.md
+++ b/docs/06-api-reference/nodes.md
@@ -67,7 +67,7 @@ adapted = process.rename_inputs(text="raw_input", config="settings")
 print(adapted.inputs)  # ("raw_input", "settings")
 
 # Using dict (for reserved keywords or dynamic renames)
-adapted = process.rename_inputs({"text": "raw_input", "class": "category"})
+adapted = process.rename_inputs({"text": "raw_input", "config": "class"})
 ```
 
 **Args:**

--- a/docs/06-api-reference/runners.md
+++ b/docs/06-api-reference/runners.md
@@ -392,7 +392,7 @@ sentence_graph = Graph([clean_sentence], name="sentence_graph")
 workflow = Graph(
     [
         split_sentences,
-        sentence_graph.as_node(name="analyze").with_inputs(text="sentences").map_over("sentences"),
+        sentence_graph.as_node(name="analyze").rename_inputs(text="sentences").map_over("sentences"),
     ]
 )
 

--- a/docs/07-design/guiding-principles.md
+++ b/docs/07-design/guiding-principles.md
@@ -220,7 +220,7 @@ Nodes and graphs behave like values. Transformations produce new instances.
 
 ### Explicit signals
 
-- `with_*`, `bind`, `select` are documented as immutable transformations.
+- `rename_*`, `with_*`, `bind`, and `select` are documented as immutable transformations.
 
 ### Implicit invariants
 
@@ -248,7 +248,7 @@ Be explicit about outputs, renames, and control flow intent.
 ### Explicit signals
 
 - Output names are declared.
-- Renames are deliberate (`with_inputs`, `with_outputs`, `with_name`).
+- Renames are deliberate (`rename_inputs`, `rename_outputs`, `with_name`).
 
 ### Implicit invariants
 
@@ -261,7 +261,7 @@ Be explicit about outputs, renames, and control flow intent.
 @node(output_name="embedding")
 def embed(text: str) -> list[float]: ...
 
-adapted = embed.with_inputs(text="document")
+adapted = embed.rename_inputs(text="document")
 ```
 
 ### Break example

--- a/docs/07-design/philosophy.md
+++ b/docs/07-design/philosophy.md
@@ -124,7 +124,7 @@ Nodes are pure functions. They take inputs, produce outputs, and have no side ef
 Output names must be declared explicitly. Rename operations are explicit. No magic defaults or surprise behavior.
 
 ### Immutability
-Nodes are immutable - `with_*` methods return new instances. Outputs flow forward. No retroactive state modifications.
+Nodes are immutable - rename/configuration methods return new instances. Outputs flow forward. No retroactive state modifications.
 
 ### Build-Time Validation
 Graphs are validated when constructed. Missing inputs, invalid routes, and type mismatches are caught before execution.

--- a/docs/07-design/roadmap.md
+++ b/docs/07-design/roadmap.md
@@ -12,7 +12,7 @@ Core features are working and stable. API may still change before 1.0.
 - `@node` decorator for wrapping functions (sync, async, generators)
 - `Graph` construction with automatic edge inference
 - `InputSpec` categorization (required, optional, bound, internal)
-- Rename API (`.with_inputs()`, `.with_outputs()`, `.with_name()`)
+- Rename API (`.rename_inputs()`, `.rename_outputs()`, `.with_name()`)
 - Build-time validation with helpful error messages
 
 ### Composition

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -19,7 +19,7 @@ Instructions for writing and maintaining hypergraph documentation.
 ### Task-Based Organization
 
 - Organize guides by **user task** ("How do I..."), not framework feature
-- Bad: "The with_inputs() method"
+- Bad: "The rename_inputs() method"
 - Good: "How do I rename inputs to fit my naming convention?"
 
 ## Hypergraph's Key Differentiators

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -48,7 +48,7 @@
 
 - **Bind precedence is parent-first at a projected address** — If an inner graph bind and an outer graph bind project to the same parent-facing address, the outer bind wins and emits a warning when the effective bound inputs are computed. If sibling inner graph binds project different values to the same flat address, graph construction errors instead of choosing one silently. Runtime values can still override the effective bind and emit the warning above.
 
-- **`with_inputs(...)` and `with_outputs(...)` target local names** — GraphNode renames operate on the current local port names before boundary projection. `map_over(...)` and `clone` accept either current local names or projected parent-facing input addresses, then normalize to local names internally. Changing the GraphNode name recomputes namespaced addresses; exposed aliases stay flat.
+- **`rename_inputs(...)` and `rename_outputs(...)` target local names** — GraphNode renames operate on the current local port names before boundary projection. `map_over(...)` and `clone` accept either current local names or projected parent-facing input addresses, then normalize to local names internally. Changing the GraphNode name recomputes namespaced addresses; exposed aliases stay flat.
 
 - **GraphNode boundary hashes include the projected surface** — `definition_hash` / `structural_hash` now include boundary namespacing, exposed-port mappings, projected inputs/outputs, and local renames. Existing checkpoint compatibility and cache keys may change after upgrading graphs that use nested composition.
 

--- a/examples/daft/document_processing.py
+++ b/examples/daft/document_processing.py
@@ -51,8 +51,8 @@ def build_document_processing_graph() -> Graph:
 
     mapped_documents = (
         single_document_graph.as_node(name="process_documents")
-        .with_inputs(document="documents")
-        .with_outputs(
+        .rename_inputs(document="documents")
+        .rename_outputs(
             document_report="document_reports",
             document_label="document_labels",
             sentence_count="sentence_counts",

--- a/examples/daft/hierarchical_document_batches.py
+++ b/examples/daft/hierarchical_document_batches.py
@@ -45,7 +45,7 @@ sentence_graph = Graph(
     name="sentence_graph",
 )
 
-analyze_sentences = sentence_graph.as_node(name="analyze_sentences").with_inputs(text="sentences").map_over("sentences")
+analyze_sentences = sentence_graph.as_node(name="analyze_sentences").rename_inputs(text="sentences").map_over("sentences")
 
 
 @node(output_name="report")

--- a/examples/daft/nested_document_scoring.py
+++ b/examples/daft/nested_document_scoring.py
@@ -37,7 +37,7 @@ def split_document(document: str) -> list[str]:
 document_graph = Graph(
     [
         split_document,
-        sentence_graph.as_node(name="analyze").with_inputs(text="sentences").map_over("sentences"),
+        sentence_graph.as_node(name="analyze").rename_inputs(text="sentences").map_over("sentences"),
     ],
     name="document_pipeline",
 )

--- a/examples/daft/nested_review_objects.py
+++ b/examples/daft/nested_review_objects.py
@@ -45,7 +45,7 @@ review_graph = Graph(
     name="review_graph",
 )
 
-assess_reviews = review_graph.as_node(name="assess_reviews").with_inputs(review="reviews").map_over("reviews")
+assess_reviews = review_graph.as_node(name="assess_reviews").rename_inputs(review="reviews").map_over("reviews")
 
 
 @node(output_name="summary")

--- a/examples/daft/quickstart_orders.py
+++ b/examples/daft/quickstart_orders.py
@@ -60,8 +60,8 @@ def build_quickstart_orders_graph() -> Graph:
     )
     mapped_orders = (
         order_graph.as_node(name="process_orders")
-        .with_inputs(order="orders")
-        .with_outputs(
+        .rename_inputs(order="orders")
+        .rename_outputs(
             fulfillment_record="fulfillment_records",
             review_queue="review_queues",
             order_total="order_totals",

--- a/examples/daft/scenario_sweeps.py
+++ b/examples/daft/scenario_sweeps.py
@@ -46,8 +46,8 @@ def build_scenario_sweep_graph() -> Graph:
     candidate_graph = Graph([normalize_candidate, score_candidate, build_candidate_report], name="candidate_graph")
     mapped_candidates = (
         candidate_graph.as_node(name="evaluate_candidates")
-        .with_inputs(candidate="candidates")
-        .with_outputs(candidate_report="candidate_reports")
+        .rename_inputs(candidate="candidates")
+        .rename_outputs(candidate_report="candidate_reports")
         .map_over("candidates")
     )
     return Graph([mapped_candidates, choose_best], name="scenario_sweep")

--- a/examples/framework_ports/daft_workflows.py
+++ b/examples/framework_ports/daft_workflows.py
@@ -71,7 +71,7 @@ def build_daft_llm_dataset_graph() -> Graph:
     chunk_graph = Graph([score_chunk], name="chunk_ranker")
     return Graph(
         [
-            chunk_graph.as_node(name="score_chunks").with_inputs(chunk="chunks").map_over("chunks"),
+            chunk_graph.as_node(name="score_chunks").rename_inputs(chunk="chunks").map_over("chunks"),
             select_top_chunk,
             summarize_bundle,
         ],
@@ -129,7 +129,7 @@ def build_daft_image_query_graph() -> Graph:
     patch_graph = Graph([compute_patch_brightness, label_patch], name="patch_classifier")
     return Graph(
         [
-            patch_graph.as_node(name="classify_patches").with_inputs(patch="patches").map_over("patches"),
+            patch_graph.as_node(name="classify_patches").rename_inputs(patch="patches").map_over("patches"),
             summarize_asset,
         ],
         name="daft_image_query_port",

--- a/examples/framework_ports/document_batch_pipeline.py
+++ b/examples/framework_ports/document_batch_pipeline.py
@@ -69,8 +69,8 @@ def build_ingestion_report(doc_stats: list[dict]) -> dict:
 def build_document_batch_graph() -> Graph:
     mapped_documents = (
         document_graph.as_node(name="process_document")
-        .with_inputs(document="documents")
-        .with_outputs(summary="document_summaries")
+        .rename_inputs(document="documents")
+        .rename_outputs(summary="document_summaries")
         .map_over("documents")
     )
     return Graph(

--- a/examples/framework_ports/ml_model_selection.py
+++ b/examples/framework_ports/ml_model_selection.py
@@ -101,7 +101,7 @@ def select_best_model(evaluated_model_type: list[str], accuracy: list[float], tr
 
 
 def build_ml_model_selection_graph() -> Graph:
-    mapped_trials = trial_graph.as_node(name="trial").with_inputs(model_type="model_types").map_over("model_types")
+    mapped_trials = trial_graph.as_node(name="trial").rename_inputs(model_type="model_types").map_over("model_types")
     return Graph(
         [
             load_rows,

--- a/notebooks/playground.ipynb
+++ b/notebooks/playground.ipynb
@@ -225,8 +225,8 @@
     "    [\n",
     "        inner.as_node(),\n",
     "        triple,\n",
-    "        inner.as_node(name=\"pipeline2\").with_outputs({\"doubled\": \"doubled2\"}),\n",
-    "        triple.with_inputs({\"doubled\": \"doubled2\"}).with_outputs({\"tripled\": \"tripled2\"}).with_name(\"triple2\"),\n",
+    "        inner.as_node(name=\"pipeline2\").rename_outputs({\"doubled\": \"doubled2\"}),\n",
+    "        triple.rename_inputs({\"doubled\": \"doubled2\"}).rename_outputs({\"tripled\": \"tripled2\"}).with_name(\"triple2\"),\n",
     "    ]\n",
     ")\n",
     "result = runner.run(outer, {\"x\": 5})"

--- a/scripts/test_examples.py
+++ b/scripts/test_examples.py
@@ -60,7 +60,7 @@ def process(text: str) -> str:
 
 
 print("\n=== Example 5: Renaming ===")
-adapted = process.with_inputs(text="raw_input").with_outputs(result="processed")
+adapted = process.rename_inputs(text="raw_input").rename_outputs(result="processed")
 print(f"adapted.inputs = {adapted.inputs}")  # ("raw_input",)
 print(f"adapted.outputs = {adapted.outputs}")  # ("processed",)
 print(f"process.inputs = {process.inputs}")  # ("text",) - unchanged

--- a/scripts/verify_docs.py
+++ b/scripts/verify_docs.py
@@ -17,8 +17,8 @@ EXTERNAL_DEP_MARKERS = [
 
 # Examples that intentionally raise errors (test differently)
 ERROR_EXAMPLES = [
-    "process.with_inputs(y=",  # RenameError
-    'renamed.with_inputs(x="different")',  # RenameError
+    "process.rename_inputs(y=",  # RenameError
+    'renamed.rename_inputs(x="different")',  # RenameError
 ]
 
 

--- a/src/hypergraph/nodes/_rename.py
+++ b/src/hypergraph/nodes/_rename.py
@@ -17,7 +17,7 @@ class RenameEntry:
         kind: Which attribute was renamed ("name", "inputs", or "outputs")
         old: Original value before rename
         new: New value after rename
-        batch_id: Groups entries from the same with_inputs/with_outputs call
+        batch_id: Groups entries from the same rename_inputs/rename_outputs call
                   (entries in the same batch should be treated as parallel transforms)
     """
 

--- a/src/hypergraph/nodes/base.py
+++ b/src/hypergraph/nodes/base.py
@@ -71,7 +71,7 @@ class HyperNode(ABC):
     - outputs: Parent-facing output names or addresses
     - _rename_history: Tracks renames for error messages
 
-    All with_* methods return new instances (immutable pattern).
+    Rename/configuration methods return new instances (immutable pattern).
 
     Universal capabilities (with sensible defaults):
     - definition_hash: Structural hash for caching/change detection
@@ -265,7 +265,7 @@ class HyperNode(ABC):
     def map_inputs_to_params(self, inputs: dict[str, Any]) -> dict[str, Any]:
         """Map renamed input names to original function parameter names.
 
-        When a node's inputs are renamed (via with_inputs or rename_inputs),
+        When a node's inputs are renamed (via rename_inputs or with_inputs),
         this method maps the current/renamed names back to the original
         parameter names expected by the underlying function.
 
@@ -331,7 +331,7 @@ class HyperNode(ABC):
         """
         return self._with_renamed("name", {self.name: name})
 
-    def with_inputs(
+    def rename_inputs(
         self: _T,
         mapping: dict[str, str] | None = None,
         /,
@@ -358,7 +358,16 @@ class HyperNode(ABC):
             return self._copy()
         return self._with_renamed("inputs", combined)
 
-    def with_outputs(
+    def with_inputs(
+        self: _T,
+        mapping: dict[str, str] | None = None,
+        /,
+        **kwargs: str,
+    ) -> _T:
+        """Compatibility alias for rename_inputs()."""
+        return self.rename_inputs(mapping, **kwargs)
+
+    def rename_outputs(
         self: _T,
         mapping: dict[str, str] | None = None,
         /,
@@ -380,6 +389,15 @@ class HyperNode(ABC):
         if not combined:
             return self._copy()
         return self._with_renamed("outputs", combined)
+
+    def with_outputs(
+        self: _T,
+        mapping: dict[str, str] | None = None,
+        /,
+        **kwargs: str,
+    ) -> _T:
+        """Compatibility alias for rename_outputs()."""
+        return self.rename_outputs(mapping, **kwargs)
 
     # === Internal Helpers ===
 

--- a/src/hypergraph/nodes/graph_node.py
+++ b/src/hypergraph/nodes/graph_node.py
@@ -400,7 +400,7 @@ class GraphNode(HyperNode):
     def map_inputs_to_params(self, inputs: dict[str, Any]) -> dict[str, Any]:
         """Map renamed input names back to original inner graph parameter names.
 
-        When a GraphNode's inputs are renamed (via with_inputs), this method
+        When a GraphNode's inputs are renamed (via rename_inputs), this method
         maps the current/renamed names back to the original parameter names
         expected by the inner graph.
 
@@ -421,7 +421,7 @@ class GraphNode(HyperNode):
         """Get map_over params translated to original inner graph names.
 
         Uses build_reverse_rename_map() to handle parallel renames correctly
-        (e.g., with_inputs(x='y', y='x')), matching the semantics of
+        (e.g., rename_inputs(x='y', y='x')), matching the semantics of
         map_inputs_to_params().
 
         Returns:
@@ -453,7 +453,7 @@ class GraphNode(HyperNode):
     def map_outputs_from_original(self, outputs: dict[str, Any]) -> dict[str, Any]:
         """Map original inner graph output names to renamed external names.
 
-        When a GraphNode's outputs are renamed (via with_outputs), this method
+        When a GraphNode's outputs are renamed (via rename_outputs), this method
         maps the original names produced by the inner graph to the renamed names
         expected by the outer graph.
 
@@ -789,7 +789,7 @@ class GraphNode(HyperNode):
             new._refresh_projected_ports()
         return new
 
-    def with_inputs(
+    def rename_inputs(
         self: _GN,
         mapping: dict[str, str] | None = None,
         /,
@@ -828,7 +828,16 @@ class GraphNode(HyperNode):
         renamed._refresh_projected_ports()
         return renamed
 
-    def with_outputs(
+    def with_inputs(
+        self: _GN,
+        mapping: dict[str, str] | None = None,
+        /,
+        **kwargs: str,
+    ) -> _GN:
+        """Compatibility alias for rename_inputs()."""
+        return self.rename_inputs(mapping, **kwargs)
+
+    def rename_outputs(
         self: _GN,
         mapping: dict[str, str] | None = None,
         /,
@@ -856,6 +865,15 @@ class GraphNode(HyperNode):
 
         renamed._refresh_projected_ports()
         return renamed
+
+    def with_outputs(
+        self: _GN,
+        mapping: dict[str, str] | None = None,
+        /,
+        **kwargs: str,
+    ) -> _GN:
+        """Compatibility alias for rename_outputs()."""
+        return self.rename_outputs(mapping, **kwargs)
 
     def expose(self: _GN, *names: str, **aliases: str) -> _GN:
         """Expose local ports from a namespaced GraphNode as flat parent addresses."""

--- a/src/hypergraph/viz/renderer/ir_builder.py
+++ b/src/hypergraph/viz/renderer/ir_builder.py
@@ -286,7 +286,7 @@ def _first_container_entrypoint(container_id: str, flat_graph: nx.DiGraph) -> st
 def _find_deepest_internal_producer(container_id: str, value_name: str, flat_graph: nx.DiGraph) -> str | None:
     """Walk down the container tree, find the deepest descendant that
     produces value_name as an output. Falls back to fuzzy substring
-    matching to handle the ``with_outputs`` rename case (e.g. container
+    matching to handle the ``rename_outputs`` rename case (e.g. container
     exposes ``recall_scores`` but the internal node produces
     ``recall_score``)."""
     descendants = [(node_id, attrs) for node_id, attrs in flat_graph.nodes(data=True) if _is_descendant(node_id, container_id, flat_graph)]
@@ -319,7 +319,7 @@ def _find_deepest_internal_consumer(container_id: str, value_name: str, flat_gra
     """Mirror of :func:`_find_deepest_internal_producer` for inputs.
 
     Falls back to fuzzy substring matching to handle the
-    ``map_over`` / ``with_inputs`` rename case (e.g. the outer edge
+    ``map_over`` / ``rename_inputs`` rename case (e.g. the outer edge
     carries ``eval_pairs`` but the per-item internal node consumes
     ``eval_pair``)."""
     descendants = [

--- a/src/hypergraph/viz/renderer/scope.py
+++ b/src/hypergraph/viz/renderer/scope.py
@@ -235,7 +235,7 @@ def find_internal_producer_for_output(
 ) -> str | None:
     """Find the internal node that produces the data that becomes `output_name`.
 
-    Handles the `with_outputs` rename case: when a container exposes
+    Handles the `rename_outputs` rename case: when a container exposes
     `retrieval_eval_results` but internally `compute_recall` produces
     `retrieval_eval_result`, we need to find `compute_recall`.
     """
@@ -273,7 +273,7 @@ def find_internal_producer_for_output(
             if is_node_visible(producer, flat_graph, expansion_state):
                 return producer
 
-    # Fuzzy fallback: with_outputs renames can differ slightly (e.g. pluralization).
+    # Fuzzy fallback: rename_outputs renames can differ slightly (e.g. pluralization).
     # Substring matching is intentionally loose to maximize recall in visualization.
     for internal_out, producers in terminal_outputs.items():
         if internal_out in output_name or output_name in internal_out:

--- a/tests/capabilities/builders.py
+++ b/tests/capabilities/builders.py
@@ -33,7 +33,7 @@ def _make_sync_func(name: str, input_name: str, output_name: str) -> FunctionNod
         return val * 2 if isinstance(val, int) else 0
 
     # Rename to match expected interface
-    return sync_node.with_name(name).with_inputs(**{list(sync_node.inputs)[0]: input_name})
+    return sync_node.with_name(name).rename_inputs(**{list(sync_node.inputs)[0]: input_name})
 
 
 def _make_async_func(name: str, input_name: str, output_name: str) -> FunctionNode:
@@ -44,7 +44,7 @@ def _make_async_func(name: str, input_name: str, output_name: str) -> FunctionNo
         val = kwargs.get(input_name, 0)
         return val * 2 if isinstance(val, int) else 0
 
-    return async_node.with_name(name).with_inputs(**{list(async_node.inputs)[0]: input_name})
+    return async_node.with_name(name).rename_inputs(**{list(async_node.inputs)[0]: input_name})
 
 
 def _make_sync_generator(name: str, input_name: str, output_name: str) -> FunctionNode:
@@ -57,7 +57,7 @@ def _make_sync_generator(name: str, input_name: str, output_name: str) -> Functi
             yield val
             yield val * 2
 
-    return sync_gen.with_name(name).with_inputs(**{list(sync_gen.inputs)[0]: input_name})
+    return sync_gen.with_name(name).rename_inputs(**{list(sync_gen.inputs)[0]: input_name})
 
 
 def _make_async_generator(name: str, input_name: str, output_name: str) -> FunctionNode:
@@ -70,7 +70,7 @@ def _make_async_generator(name: str, input_name: str, output_name: str) -> Funct
             yield val
             yield val * 2
 
-    return async_gen.with_name(name).with_inputs(**{list(async_gen.inputs)[0]: input_name})
+    return async_gen.with_name(name).rename_inputs(**{list(async_gen.inputs)[0]: input_name})
 
 
 def _make_node(node_type: NodeType, name: str, input_name: str, output_name: str) -> FunctionNode:
@@ -168,10 +168,10 @@ def _build_branching(prefer_async: bool = False) -> Graph:
     """Build A -> B1, A -> B2 (fan-out) graph."""
     if prefer_async:
         return Graph(
-            [async_double_a, async_branch1.with_inputs(a="a"), async_branch2.with_inputs(a="a")],
+            [async_double_a, async_branch1.rename_inputs(a="a"), async_branch2.rename_inputs(a="a")],
             name="branching",
         )
-    return Graph([double_a, branch1.with_inputs(a="a"), branch2.with_inputs(a="a")], name="branching")
+    return Graph([double_a, branch1.rename_inputs(a="a"), branch2.rename_inputs(a="a")], name="branching")
 
 
 def _build_converging(prefer_async: bool = False) -> Graph:
@@ -213,13 +213,13 @@ def _build_diamond(prefer_async: bool = False) -> Graph:
         return Graph(
             [
                 async_double_a,
-                async_branch1.with_inputs(a="a"),
-                async_branch2.with_inputs(a="a"),
+                async_branch1.rename_inputs(a="a"),
+                async_branch2.rename_inputs(a="a"),
                 async_merge,
             ],
             name="diamond",
         )
-    return Graph([double_a, branch1.with_inputs(a="a"), branch2.with_inputs(a="a"), merge], name="diamond")
+    return Graph([double_a, branch1.rename_inputs(a="a"), branch2.rename_inputs(a="a"), merge], name="diamond")
 
 
 def _build_cyclic(prefer_async: bool = False) -> Graph:
@@ -317,7 +317,7 @@ def _apply_renaming(graph: Graph, renaming: Renaming) -> Graph:
         if target_node.inputs:
             old_input = target_node.inputs[0]
             new_input = f"{old_input}_renamed"
-            renamed = target_node.with_inputs({old_input: new_input})
+            renamed = target_node.rename_inputs({old_input: new_input})
             new_nodes[0] = renamed
 
     elif renaming == Renaming.OUTPUTS:
@@ -328,7 +328,7 @@ def _apply_renaming(graph: Graph, renaming: Renaming) -> Graph:
             idx, target_node = leaf_nodes[0]
             old_output = target_node.outputs[0]
             new_output = f"{old_output}_renamed"
-            renamed = target_node.with_outputs({old_output: new_output})
+            renamed = target_node.rename_outputs({old_output: new_output})
             new_nodes[idx] = renamed
 
     entrypoint = graph.entrypoints_config

--- a/tests/capabilities/matrix.py
+++ b/tests/capabilities/matrix.py
@@ -84,8 +84,8 @@ class Renaming(Enum):
     """Whether nodes/inputs/outputs are renamed."""
 
     NONE = auto()  # No renaming applied
-    INPUTS = auto()  # with_inputs() applied
-    OUTPUTS = auto()  # with_outputs() applied
+    INPUTS = auto()  # rename_inputs() applied
+    OUTPUTS = auto()  # rename_outputs() applied
     NODE_NAME = auto()  # with_name() applied
 
 

--- a/tests/events/test_async_events.py
+++ b/tests/events/test_async_events.py
@@ -549,8 +549,8 @@ class TestNoProcessors:
         outer = Graph(
             [
                 produce,
-                graph_a.as_node().with_inputs(x="val"),
-                graph_b.as_node().with_inputs(y="val"),
+                graph_a.as_node().rename_inputs(x="val"),
+                graph_b.as_node().rename_inputs(y="val"),
             ],
             name="outer",
         )

--- a/tests/test_bind_defaults.py
+++ b/tests/test_bind_defaults.py
@@ -316,7 +316,7 @@ def test_nested_bound_values_use_graphnode_public_input_names():
         return f"{x}:{cfg}"
 
     inner = Graph([inner_func], name="inner").bind(cfg="inner-cfg")
-    nested = inner.as_node().with_inputs(cfg="public_cfg")
+    nested = inner.as_node().rename_inputs(cfg="public_cfg")
     outer = Graph([nested], name="outer")
 
     # public_cfg is projected to outer as flat parent-facing "public_cfg".

--- a/tests/test_cache_behavior.py
+++ b/tests/test_cache_behavior.py
@@ -47,7 +47,7 @@ class TestCachePropertyConfiguration:
         assert with_cache.cache is True
 
     def test_cache_preserved_through_rename(self):
-        """Cache flag preserved through with_name and with_inputs."""
+        """Cache flag preserved through with_name and rename_inputs."""
 
         @node(output_name="result", cache=True)
         def cached_node(x: int) -> int:
@@ -56,17 +56,17 @@ class TestCachePropertyConfiguration:
         renamed = cached_node.with_name("renamed")
         assert renamed.cache is True
 
-        with_renamed_inputs = cached_node.with_inputs(x="y")
+        with_renamed_inputs = cached_node.rename_inputs(x="y")
         assert with_renamed_inputs.cache is True
 
-    def test_cache_preserved_through_with_outputs(self):
-        """Cache flag preserved through with_outputs."""
+    def test_cache_preserved_through_rename_outputs(self):
+        """Cache flag preserved through rename_outputs."""
 
         @node(output_name="result", cache=True)
         def cached_node(x: int) -> int:
             return x * 2
 
-        with_renamed_outputs = cached_node.with_outputs(result="output")
+        with_renamed_outputs = cached_node.rename_outputs(result="output")
         assert with_renamed_outputs.cache is True
 
 

--- a/tests/test_checkpointer/test_lineage_semantics.py
+++ b/tests/test_checkpointer/test_lineage_semantics.py
@@ -231,7 +231,7 @@ class TestLineageSemantics:
             return f"Final: {verdict}"
 
         runner = AsyncRunner(checkpointer=checkpointer)
-        graph = Graph([make_draft, inner.as_node().with_outputs(decision="verdict"), finalize])
+        graph = Graph([make_draft, inner.as_node().rename_outputs(decision="verdict"), finalize])
 
         paused = await runner.run(graph, {"query": "hello"}, workflow_id="wf-renamed-nested-paused")
         assert paused.status == RunStatus.PAUSED
@@ -264,7 +264,7 @@ class TestLineageSemantics:
             return f"Final: {verdict}"
 
         runner = AsyncRunner(checkpointer=checkpointer)
-        graph = Graph([make_draft, inner.as_node().with_outputs(decision_a="verdict"), finalize])
+        graph = Graph([make_draft, inner.as_node().rename_outputs(decision_a="verdict"), finalize])
 
         paused = await runner.run(graph, {"query": "hello"}, workflow_id="wf-inactive-interrupt")
         assert paused.status == RunStatus.PAUSED

--- a/tests/test_code_review_fixes.py
+++ b/tests/test_code_review_fixes.py
@@ -51,8 +51,8 @@ class TestPython310Compatibility:
 
         assert isinstance(mapped, GraphNode)
 
-    def test_graphnode_with_inputs_returns_graphnode(self):
-        """GraphNode.with_inputs() should return a GraphNode instance."""
+    def test_graphnode_rename_inputs_returns_graphnode(self):
+        """GraphNode.rename_inputs() should return a GraphNode instance."""
 
         @node(output_name="y")
         def double(x: int) -> int:
@@ -60,7 +60,7 @@ class TestPython310Compatibility:
 
         inner = Graph([double], name="inner")
         gn = inner.as_node()
-        renamed = gn.with_inputs(x="z")
+        renamed = gn.rename_inputs(x="z")
 
         from hypergraph.nodes.graph_node import GraphNode
 
@@ -104,8 +104,8 @@ class TestAsyncSuperstepStateSafety:
 class TestRenameChaining:
     """Bug 3: Rename chaining breaks execution.
 
-    Multiple with_inputs() calls don't compose correctly:
-    node.with_inputs(a="x").with_inputs(x="z") should map z -> a
+    Multiple rename_inputs() calls don't compose correctly:
+    node.rename_inputs(a="x").rename_inputs(x="z") should map z -> a
     but it maps z -> x instead.
     """
 
@@ -117,7 +117,7 @@ class TestRenameChaining:
             return a + 1
 
         # Chain renames: a -> x -> z
-        chained = add_one.with_inputs(a="x").with_inputs(x="z")
+        chained = add_one.rename_inputs(a="x").rename_inputs(x="z")
 
         # Should have input "z" that maps to original "a"
         assert chained.inputs == ("z",)
@@ -138,7 +138,7 @@ class TestRenameChaining:
             return x * 2
 
         # Chain: x -> a -> b -> c
-        tripled = double.with_inputs(x="a").with_inputs(a="b").with_inputs(b="c")
+        tripled = double.rename_inputs(x="a").rename_inputs(a="b").rename_inputs(b="c")
 
         assert tripled.inputs == ("c",)
 
@@ -189,14 +189,14 @@ class TestFunctionNodeDefaultsWithRenames:
         # Should get default using renamed name
         assert func_with_default.get_default_for("my_param") == 42
 
-    def test_defaults_after_with_inputs(self):
-        """defaults should reflect names after with_inputs() chaining."""
+    def test_defaults_after_rename_inputs(self):
+        """defaults should reflect names after rename_inputs() chaining."""
 
         @node(output_name="result")
         def func_with_default(x: int = 5) -> int:
             return x
 
-        renamed = func_with_default.with_inputs(x="z")
+        renamed = func_with_default.rename_inputs(x="z")
 
         # z should have the default, not x
         assert renamed.has_default_for("z") is True
@@ -374,10 +374,10 @@ class TestRenameErrorMessages:
         def func(x: int) -> int:
             return x
 
-        renamed = func.with_inputs(x="y")
+        renamed = func.rename_inputs(x="y")
 
         with pytest.raises(RenameError) as exc_info:
-            renamed.with_inputs(x="z")  # x doesn't exist anymore
+            renamed.rename_inputs(x="z")  # x doesn't exist anymore
 
         error_msg = str(exc_info.value)
         assert "x" in error_msg
@@ -393,10 +393,10 @@ class TestRenameErrorMessages:
             return a
 
         # Chain: a -> x -> z
-        chained = func.with_inputs(a="x").with_inputs(x="z")
+        chained = func.rename_inputs(a="x").rename_inputs(x="z")
 
         with pytest.raises(RenameError) as exc_info:
-            chained.with_inputs(a="w")  # a doesn't exist anymore
+            chained.rename_inputs(a="w")  # a doesn't exist anymore
 
         error_msg = str(exc_info.value)
         # Should show full chain a→x→z

--- a/tests/test_deep_nesting_issues.py
+++ b/tests/test_deep_nesting_issues.py
@@ -84,8 +84,8 @@ class TestSameInnerGraphTwice:
     def test_same_graph_different_renames(self):
         inner = Graph(nodes=[double], name="inner")
 
-        node_a = inner.as_node(name="inner_a").with_inputs(x="a").with_outputs(doubled="res_a")
-        node_b = inner.as_node(name="inner_b").with_inputs(x="b").with_outputs(doubled="res_b")
+        node_a = inner.as_node(name="inner_a").rename_inputs(x="a").rename_outputs(doubled="res_a")
+        node_b = inner.as_node(name="inner_b").rename_inputs(x="b").rename_outputs(doubled="res_b")
 
         outer = Graph(nodes=[node_a, node_b])
         runner = SyncRunner()

--- a/tests/test_emit_wait_for.py
+++ b/tests/test_emit_wait_for.py
@@ -371,25 +371,25 @@ class TestEdgeCases:
         assert "done" in fn.outputs
         assert fn.wait_for == ("signal",)
 
-    def test_with_outputs_preserves_emit(self):
+    def test_rename_outputs_preserves_emit(self):
         """Renaming data outputs doesn't affect emit outputs."""
 
         @node(output_name="result", emit="done")
         def producer(x: int) -> int:
             return x
 
-        renamed = producer.with_outputs(result="renamed_result")
+        renamed = producer.rename_outputs(result="renamed_result")
         assert renamed.outputs == ("renamed_result", "done")
         assert renamed.data_outputs == ("renamed_result",)
 
-    def test_with_outputs_can_rename_emit(self):
-        """Emit outputs can also be renamed via with_outputs."""
+    def test_rename_outputs_can_rename_emit(self):
+        """Emit outputs can also be renamed via rename_outputs."""
 
         @node(output_name="result", emit="done")
         def producer(x: int) -> int:
             return x
 
-        renamed = producer.with_outputs(done="finished")
+        renamed = producer.rename_outputs(done="finished")
         assert "finished" in renamed.outputs
         assert renamed.data_outputs == ("result",)
 

--- a/tests/test_error_handling_edge_cases.py
+++ b/tests/test_error_handling_edge_cases.py
@@ -296,7 +296,7 @@ class TestMapOverWithRenamedOutputs:
 
     def test_sync_renamed_outputs_continue(self):
         inner = Graph([double_fail_on_odd], name="inner")
-        gn = inner.as_node().with_outputs(doubled="processed").map_over("x", error_handling="continue")
+        gn = inner.as_node().rename_outputs(doubled="processed").map_over("x", error_handling="continue")
 
         @node(output_name="final")
         def consume(processed: list) -> list:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1166,7 +1166,7 @@ class TestGraphNodeOutputAnnotation:
         # Original is unaffected
         assert gn.output_annotation == {"x": str}
 
-    def test_with_inputs_copy_does_not_inherit_stale_cache(self):
+    def test_rename_inputs_copy_does_not_inherit_stale_cache(self):
         """Renamed copy recomputes output_annotation independently of original."""
 
         @node(output_name="result")
@@ -1178,8 +1178,8 @@ class TestGraphNodeOutputAnnotation:
         # Populate cache on original
         assert gn.output_annotation == {"result": float}
 
-        # Copy via with_inputs rename — cache must be cleared
-        renamed = gn.with_inputs(_a="value")
+        # Copy via rename_inputs rename — cache must be cleared
+        renamed = gn.rename_inputs(_a="value")
         # output_annotation should still be correct (rename doesn't change output types)
         assert renamed.output_annotation == {"result": float}
         # But it must be a freshly computed object, not shared with original
@@ -1465,7 +1465,7 @@ class TestStrictTypesValidation:
 
 
 class TestGraphNodeRename:
-    """Test GraphNode rename operations (with_name, with_inputs, with_outputs)."""
+    """Test GraphNode rename operations (with_name, rename_inputs, rename_outputs)."""
 
     def test_with_name_returns_new_instance(self):
         """with_name returns new GraphNode with different name."""
@@ -1496,8 +1496,8 @@ class TestGraphNodeRename:
         assert renamed.graph is original.graph
         assert renamed.definition_hash != original.definition_hash
 
-    def test_with_inputs_renames_inputs(self):
-        """with_inputs renames inputs in returned GraphNode."""
+    def test_rename_inputs_renames_inputs(self):
+        """rename_inputs renames inputs in returned GraphNode."""
 
         @node(output_name="result")
         def foo(a: int, b: int) -> int:
@@ -1505,13 +1505,13 @@ class TestGraphNodeRename:
 
         g = Graph([foo], name="my_graph")
         original = g.as_node()
-        renamed = original.with_inputs(a="x")
+        renamed = original.rename_inputs(a="x")
 
         assert original.inputs == ("a", "b")
         assert renamed.inputs == ("x", "b")
 
-    def test_with_outputs_renames_outputs(self):
-        """with_outputs renames outputs in returned GraphNode."""
+    def test_rename_outputs_renames_outputs(self):
+        """rename_outputs renames outputs in returned GraphNode."""
 
         @node(output_name="result")
         def foo(x: int) -> int:
@@ -1519,9 +1519,25 @@ class TestGraphNodeRename:
 
         g = Graph([foo], name="my_graph")
         original = g.as_node()
-        renamed = original.with_outputs(result="output")
+        renamed = original.rename_outputs(result="output")
 
         assert original.outputs == ("result",)
+        assert renamed.outputs == ("output",)
+
+    def test_with_rename_compat_aliases(self):
+        """with_inputs and with_outputs remain compatibility aliases."""
+
+        @node(output_name="result")
+        def foo(a: int) -> int:
+            return a * 2
+
+        g = Graph([foo], name="my_graph")
+        original = g.as_node()
+        renamed = original.with_inputs(a="x").with_outputs(result="output")
+
+        assert original.inputs == ("a",)
+        assert original.outputs == ("result",)
+        assert renamed.inputs == ("x",)
         assert renamed.outputs == ("output",)
 
     def test_rename_preserves_inputs_outputs_types(self):
@@ -1532,12 +1548,12 @@ class TestGraphNodeRename:
             return a + b
 
         g = Graph([foo], name="my_graph")
-        gn = g.as_node().with_inputs(a="x")
+        gn = g.as_node().rename_inputs(a="x")
 
         assert isinstance(gn.inputs, tuple)
         assert isinstance(gn.outputs, tuple)
 
-    def test_with_inputs_nonexistent_raises(self):
+    def test_rename_inputs_nonexistent_raises(self):
         """Renaming non-existent input raises RenameError."""
         from hypergraph.nodes._rename import RenameError
 
@@ -1549,9 +1565,9 @@ class TestGraphNodeRename:
         gn = g.as_node()
 
         with pytest.raises(RenameError, match="'nonexistent' not found"):
-            gn.with_inputs(nonexistent="y")
+            gn.rename_inputs(nonexistent="y")
 
-    def test_with_outputs_nonexistent_raises(self):
+    def test_rename_outputs_nonexistent_raises(self):
         """Renaming non-existent output raises RenameError."""
         from hypergraph.nodes._rename import RenameError
 
@@ -1563,7 +1579,7 @@ class TestGraphNodeRename:
         gn = g.as_node()
 
         with pytest.raises(RenameError, match="'nonexistent' not found"):
-            gn.with_outputs(nonexistent="y")
+            gn.rename_outputs(nonexistent="y")
 
     def test_rename_history_tracked(self):
         """Rename history is tracked for error messages."""
@@ -1575,11 +1591,11 @@ class TestGraphNodeRename:
 
         g = Graph([foo], name="my_graph")
         gn = g.as_node()
-        renamed = gn.with_inputs(a="x")
+        renamed = gn.rename_inputs(a="x")
 
         # Try to rename 'a' again - should show history
         with pytest.raises(RenameError, match="'a' was renamed: a→x"):
-            renamed.with_inputs(a="y")
+            renamed.rename_inputs(a="y")
 
     def test_original_unchanged_after_rename(self):
         """Original GraphNode is not mutated by rename operations."""
@@ -1596,8 +1612,8 @@ class TestGraphNodeRename:
 
         # Do multiple renames
         original.with_name("new_name")
-        original.with_inputs(a="x", b="y")
-        original.with_outputs(result="out")
+        original.rename_inputs(a="x", b="y")
+        original.rename_outputs(result="out")
 
         # Original unchanged
         assert original.name == original_name
@@ -1870,7 +1886,7 @@ class TestStrictTypesWithNestedGraphNode:
             return a
 
         inner_graph = Graph([inner_consumer], name="inner")
-        inner_gn = inner_graph.as_node().with_inputs(a="x")
+        inner_gn = inner_graph.as_node().rename_inputs(a="x")
 
         with pytest.raises(GraphConfigError) as exc_info:
             Graph([producer, inner_gn], strict_types=True)

--- a/tests/test_graphnode_boundary_projection.py
+++ b/tests/test_graphnode_boundary_projection.py
@@ -174,7 +174,7 @@ def test_stale_namespaced_input_address_after_rename_suggests_current_address():
     def agent(query: str) -> str:
         return query
 
-    graph_node = Graph([agent], name="retrieval").as_node(namespaced=True).with_inputs(query="user_query")
+    graph_node = Graph([agent], name="retrieval").as_node(namespaced=True).rename_inputs(query="user_query")
     outer = Graph([graph_node])
 
     with pytest.raises(ValueError, match="Use 'retrieval.user_query'"):
@@ -212,10 +212,10 @@ def test_renaming_exposed_local_port_is_rejected():
     graph_node = Graph([agent], name="retrieval").as_node(namespaced=True).expose("query", "answer")
 
     with pytest.raises(RenameError, match="Cannot rename exposed local input"):
-        graph_node.with_inputs(query="user_query")
+        graph_node.rename_inputs(query="user_query")
 
     with pytest.raises(RenameError, match="Cannot rename exposed local output"):
-        graph_node.with_outputs(answer="final_answer")
+        graph_node.rename_outputs(answer="final_answer")
 
 
 def test_nested_dict_addressing_is_valid_for_namespaced_inputs():
@@ -276,12 +276,12 @@ def test_inner_bind_values_project_through_namespaced_and_exposed_boundary():
     assert exposed.inputs.bound == {"model": "gpt"}
 
 
-def test_with_inputs_renames_local_name_before_projection():
+def test_rename_inputs_renames_local_name_before_projection():
     @node(output_name="answer")
     def agent(query: str) -> str:
         return f"answer:{query}"
 
-    graph_node = Graph([agent], name="retrieval").as_node(namespaced=True).with_inputs(query="user_query")
+    graph_node = Graph([agent], name="retrieval").as_node(namespaced=True).rename_inputs(query="user_query")
     outer = Graph([graph_node])
 
     assert graph_node.local_inputs == ("user_query",)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -21,7 +21,7 @@ class TestEndToEndWorkflow:
         assert double.outputs == ("doubled",)
 
         # Rename input
-        renamed = double.with_inputs(x="value")
+        renamed = double.rename_inputs(x="value")
         assert renamed.inputs == ("value",)
         assert renamed.outputs == ("doubled",)
 
@@ -29,7 +29,7 @@ class TestEndToEndWorkflow:
         assert renamed(5) == 10
 
     def test_chain_multiple_renames(self):
-        """Chain with_inputs, with_outputs, and with_name."""
+        """Chain rename_inputs, rename_outputs, and with_name."""
 
         @node(output_name=("mean", "std"))
         def stats(data: list) -> tuple:
@@ -38,7 +38,7 @@ class TestEndToEndWorkflow:
             return mean, std
 
         # Chain renames
-        renamed = stats.with_inputs(data="input_data").with_outputs(mean="average", std="standard_deviation").with_name("compute_statistics")
+        renamed = stats.rename_inputs(data="input_data").rename_outputs(mean="average", std="standard_deviation").with_name("compute_statistics")
 
         assert renamed.name == "compute_statistics"
         assert renamed.inputs == ("input_data",)
@@ -57,11 +57,11 @@ class TestEndToEndWorkflow:
             return input_a + input_b
 
         # Rename input_a to x
-        renamed = process.with_inputs(input_a="x")
+        renamed = process.rename_inputs(input_a="x")
 
         # Try to rename input_a again (should fail with helpful message)
         with pytest.raises(RenameError) as exc_info:
-            renamed.with_inputs(input_a="y")
+            renamed.rename_inputs(input_a="y")
 
         error_msg = str(exc_info.value)
         assert "'input_a' was renamed: input_a→x" in error_msg
@@ -211,28 +211,28 @@ class TestImmutabilityPattern:
         assert foo.name == original_name
         assert renamed.name == "bar"
 
-    def test_with_inputs_does_not_mutate(self):
-        """with_inputs returns new instance, original unchanged."""
+    def test_rename_inputs_does_not_mutate(self):
+        """rename_inputs returns new instance, original unchanged."""
 
         @node(output_name="result")
         def foo(a, b):
             return a + b
 
         original_inputs = foo.inputs
-        renamed = foo.with_inputs(a="x")
+        renamed = foo.rename_inputs(a="x")
 
         assert foo.inputs == original_inputs
         assert renamed.inputs == ("x", "b")
 
-    def test_with_outputs_does_not_mutate(self):
-        """with_outputs returns new instance, original unchanged."""
+    def test_rename_outputs_does_not_mutate(self):
+        """rename_outputs returns new instance, original unchanged."""
 
         @node(output_name=("a", "b"))
         def foo():
             return 1, 2
 
         original_outputs = foo.outputs
-        renamed = foo.with_outputs(a="x")
+        renamed = foo.rename_outputs(a="x")
 
         assert foo.outputs == original_outputs
         assert renamed.outputs == ("x", "b")
@@ -261,7 +261,7 @@ class TestDefinitionHashConsistency:
             return x * 2
 
         original_hash = foo.definition_hash
-        renamed = foo.with_name("bar").with_inputs(x="value")
+        renamed = foo.with_name("bar").rename_inputs(x="value")
 
         assert renamed.definition_hash == original_hash
 

--- a/tests/test_interrupt_node.py
+++ b/tests/test_interrupt_node.py
@@ -162,36 +162,36 @@ class TestInterruptNodeRename:
         assert renamed.name == "review_step"
         assert n.name == "approval"  # original unchanged
 
-    def test_with_inputs(self):
+    def test_rename_inputs(self):
         def approval(draft: str) -> str:
             return "ok"
 
         n = InterruptNode(approval, output_name="decision")
-        renamed = n.with_inputs(draft="document")
+        renamed = n.rename_inputs(draft="document")
         assert renamed.inputs == ("document",)
 
-    def test_with_outputs(self):
+    def test_rename_outputs(self):
         def approval(draft: str) -> str:
             return "ok"
 
         n = InterruptNode(approval, output_name="decision")
-        renamed = n.with_outputs(decision="verdict")
+        renamed = n.rename_outputs(decision="verdict")
         assert renamed.outputs == ("verdict",)
 
-    def test_with_inputs_multi(self):
+    def test_rename_inputs_multi(self):
         def review(a: str, b: str) -> str:
             return "ok"
 
         n = InterruptNode(review, output_name="out")
-        renamed = n.with_inputs(a="c", b="d")
+        renamed = n.rename_inputs(a="c", b="d")
         assert renamed.inputs == ("c", "d")
 
-    def test_with_outputs_multi(self):
+    def test_rename_outputs_multi(self):
         def review(inp: str) -> tuple[str, str]:
             return ("a", "b")
 
         n = InterruptNode(review, output_name=("a", "b"))
-        renamed = n.with_outputs(a="c", b="d")
+        renamed = n.rename_outputs(a="c", b="d")
         assert renamed.outputs == ("c", "d")
 
 
@@ -937,7 +937,7 @@ class TestInterruptDecorator:
         assert approval.get_default_for("threshold") == 0.8
         assert approval.has_default_for("draft") is False
 
-    def test_rename_inputs(self):
+    def test_decorator_rename_inputs(self):
         @interrupt(output_name="decision", rename_inputs={"draft": "document"})
         def approval(draft: str) -> str:
             return "ok"
@@ -953,18 +953,18 @@ class TestInterruptDecorator:
         assert renamed.name == "review_step"
         assert approval.name == "approval"  # original unchanged
 
-    def test_with_inputs(self):
+    def test_rename_inputs(self):
         @interrupt(output_name="decision")
         def approval(draft: str) -> str: ...
 
-        renamed = approval.with_inputs(draft="document")
+        renamed = approval.rename_inputs(draft="document")
         assert renamed.inputs == ("document",)
 
-    def test_with_outputs(self):
+    def test_rename_outputs(self):
         @interrupt(output_name="decision")
         def approval(draft: str) -> str: ...
 
-        renamed = approval.with_outputs(decision="verdict")
+        renamed = approval.rename_outputs(decision="verdict")
         assert renamed.outputs == ("verdict",)
 
     def test_definition_hash_changes_with_code(self):
@@ -1264,7 +1264,7 @@ class TestInterruptDecoratorExecution:
         def consume(verdict: str) -> str:
             return f"got: {verdict}"
 
-        outer = Graph([produce, inner.as_node().with_outputs(decision="verdict"), consume])
+        outer = Graph([produce, inner.as_node().rename_outputs(decision="verdict"), consume])
         runner = AsyncRunner()
 
         paused = await runner.run(outer, {"query": "hello"})

--- a/tests/test_lexical_scope.py
+++ b/tests/test_lexical_scope.py
@@ -133,15 +133,15 @@ def test_run_value_overriding_projected_bind_emits_warning():
     assert result["inner.out"] == 99
 
 
-def test_with_inputs_renames_local_name_then_boundary_projects_it():
+def test_rename_inputs_renames_local_name_then_boundary_projects_it():
     @node(output_name="inner_out")
     def consume_x(x: int) -> int:
         return x
 
     inner_graph = Graph([consume_x], name="inner")
 
-    flat = Graph([inner_graph.as_node().with_inputs(x="inner_x")], name="flat")
-    namespaced = Graph([inner_graph.as_node(namespaced=True).with_inputs(x="inner_x")], name="namespaced")
+    flat = Graph([inner_graph.as_node().rename_inputs(x="inner_x")], name="flat")
+    namespaced = Graph([inner_graph.as_node(namespaced=True).rename_inputs(x="inner_x")], name="namespaced")
 
     assert flat.inputs.required == ("inner_x",)
     assert namespaced.inputs.required == ("inner.inner_x",)

--- a/tests/test_map_inputs_to_params.py
+++ b/tests/test_map_inputs_to_params.py
@@ -73,8 +73,8 @@ class TestFunctionNodeMapInputsToParams:
             return a + b
 
         fn = FunctionNode(foo, output_name="result")
-        renamed_once = fn.with_inputs(a="x")
-        renamed_twice = renamed_once.with_inputs(x="z")
+        renamed_once = fn.rename_inputs(a="x")
+        renamed_twice = renamed_once.rename_inputs(x="z")
 
         inputs = {"z": 100, "b": 200}
 
@@ -85,7 +85,7 @@ class TestFunctionNodeMapInputsToParams:
     def test_parallel_renames_same_batch(self):
         """Parallel renames in same call don't chain incorrectly.
 
-        If we rename x->y and y->z in the same with_inputs call,
+        If we rename x->y and y->z in the same rename_inputs call,
         they should NOT chain (x shouldn't map to z).
         """
 
@@ -94,7 +94,7 @@ class TestFunctionNodeMapInputsToParams:
 
         fn = FunctionNode(foo, output_name="result")
         # Rename both in same call: x->a, y->b
-        renamed = fn.with_inputs(x="a", y="b")
+        renamed = fn.rename_inputs(x="a", y="b")
 
         inputs = {"a": 10, "b": 20}
 
@@ -114,7 +114,7 @@ class TestFunctionNodeMapInputsToParams:
 
         fn = FunctionNode(foo, output_name="result")
         # Swap: x->y, y->x in same call
-        renamed = fn.with_inputs(x="y", y="x")
+        renamed = fn.rename_inputs(x="y", y="x")
 
         inputs = {"y": 10, "x": 20}  # Note: reversed from original
 
@@ -184,15 +184,15 @@ class TestRouteNodeMapInputsToParams:
 
         assert result == {"a": 10, "b": 5}
 
-    def test_chained_renames_via_with_inputs(self):
+    def test_chained_renames_via_rename_inputs(self):
         """Chained renames work for RouteNode too."""
 
         def decide(a):
             return "target_a"
 
         rn = RouteNode(decide, targets=["target_a"])
-        renamed_once = rn.with_inputs(a="x")
-        renamed_twice = renamed_once.with_inputs(x="z")
+        renamed_once = rn.rename_inputs(a="x")
+        renamed_twice = renamed_once.rename_inputs(x="z")
 
         inputs = {"z": 100}
 
@@ -277,7 +277,7 @@ class TestMapInputsToParamsIntegration:
 
         fn = FunctionNode(add, output_name="sum")
         # Chain: a -> x -> z
-        renamed = fn.with_inputs(a="x").with_inputs(x="z")
+        renamed = fn.rename_inputs(a="x").rename_inputs(x="z")
 
         graph = Graph([renamed])
         runner = SyncRunner()

--- a/tests/test_nodes_base.py
+++ b/tests/test_nodes_base.py
@@ -125,52 +125,52 @@ class TestHyperNode:
         assert renamed.name == "bar"
         assert original is not renamed
 
-    def test_with_inputs_kwargs(self):
-        """with_inputs with kwargs renames inputs."""
+    def test_rename_inputs_kwargs(self):
+        """rename_inputs with kwargs renames inputs."""
         from hypergraph.nodes.function import FunctionNode
 
         def foo(a, b):
             pass
 
         node = FunctionNode(foo, output_name="result")
-        renamed = node.with_inputs(a="x")
+        renamed = node.rename_inputs(a="x")
 
         assert node.inputs == ("a", "b")
         assert renamed.inputs == ("x", "b")
 
-    def test_with_inputs_dict(self):
-        """with_inputs with dict renames inputs."""
+    def test_rename_inputs_dict(self):
+        """rename_inputs with dict renames inputs."""
         from hypergraph.nodes.function import FunctionNode
 
         def foo(a, b):
             pass
 
         node = FunctionNode(foo, output_name="result")
-        renamed = node.with_inputs({"a": "x"})
+        renamed = node.rename_inputs({"a": "x"})
 
         assert renamed.inputs == ("x", "b")
 
-    def test_with_inputs_combined(self):
-        """with_inputs with dict and kwargs combines them."""
+    def test_rename_inputs_combined(self):
+        """rename_inputs with dict and kwargs combines them."""
         from hypergraph.nodes.function import FunctionNode
 
         def foo(a, b):
             pass
 
         node = FunctionNode(foo, output_name="result")
-        renamed = node.with_inputs({"a": "x"}, b="y")
+        renamed = node.rename_inputs({"a": "x"}, b="y")
 
         assert renamed.inputs == ("x", "y")
 
-    def test_with_outputs_same_patterns(self):
-        """with_outputs follows same patterns as with_inputs."""
+    def test_rename_outputs_same_patterns(self):
+        """rename_outputs follows same patterns as rename_inputs."""
         from hypergraph.nodes.function import FunctionNode
 
         def foo(x):
             pass
 
         node = FunctionNode(foo, output_name=("a", "b"))
-        renamed = node.with_outputs(a="x")
+        renamed = node.rename_outputs(a="x")
 
         assert node.outputs == ("a", "b")
         assert renamed.outputs == ("x", "b")
@@ -184,7 +184,7 @@ class TestHyperNode:
 
         node = FunctionNode(foo, output_name="result")
         with pytest.raises(RenameError, match="'nonexistent' not found"):
-            node.with_inputs(nonexistent="x")
+            node.rename_inputs(nonexistent="x")
 
     def test_error_shows_history(self):
         """Error message shows rename history when applicable."""
@@ -194,11 +194,11 @@ class TestHyperNode:
             pass
 
         node = FunctionNode(foo, output_name="result")
-        renamed = node.with_inputs(a="x")
+        renamed = node.rename_inputs(a="x")
 
         # Now try to rename 'a' again (it was renamed to 'x')
         with pytest.raises(RenameError, match="'a' was renamed: a→x"):
-            renamed.with_inputs(a="y")
+            renamed.rename_inputs(a="y")
 
     def test_chained_renames_track_history(self):
         """Chained renames accumulate in history."""
@@ -208,8 +208,8 @@ class TestHyperNode:
             pass
 
         node = FunctionNode(foo, output_name="result")
-        step1 = node.with_inputs(a="x")
-        step2 = step1.with_inputs(b="y")
+        step1 = node.rename_inputs(a="x")
+        step2 = step1.rename_inputs(b="y")
 
         assert len(step2._rename_history) == 2
         # Check entries by kind/old/new (batch_id varies per call)
@@ -225,38 +225,64 @@ class TestHyperNode:
             pass
 
         node = FunctionNode(foo, output_name="result")
-        renamed = node.with_inputs(a="x")
+        renamed = node.rename_inputs(a="x")
 
         # Original history should be empty
         assert len(node._rename_history) == 0
         # Renamed history should have the entry
         assert len(renamed._rename_history) == 1
 
-    def test_with_inputs_empty_returns_copy(self):
-        """with_inputs with no arguments returns a copy."""
+    def test_rename_inputs_empty_returns_copy(self):
+        """rename_inputs with no arguments returns a copy."""
         from hypergraph.nodes.function import FunctionNode
 
         def foo(a):
             pass
 
         node = FunctionNode(foo, output_name="result")
-        copy_node = node.with_inputs()
+        copy_node = node.rename_inputs()
 
         assert node is not copy_node
         assert node.inputs == copy_node.inputs
 
-    def test_with_outputs_empty_returns_copy(self):
-        """with_outputs with no arguments returns a copy."""
+    def test_with_inputs_compat_alias(self):
+        """with_inputs remains as a compatibility alias for rename_inputs."""
+        from hypergraph.nodes.function import FunctionNode
+
+        def foo(a, b):
+            pass
+
+        node = FunctionNode(foo, output_name="result")
+        renamed = node.with_inputs(a="x")
+
+        assert renamed.inputs == ("x", "b")
+        assert node.inputs == ("a", "b")
+
+    def test_rename_outputs_empty_returns_copy(self):
+        """rename_outputs with no arguments returns a copy."""
         from hypergraph.nodes.function import FunctionNode
 
         def foo(a):
             pass
 
         node = FunctionNode(foo, output_name="result")
-        copy_node = node.with_outputs()
+        copy_node = node.rename_outputs()
 
         assert node is not copy_node
         assert node.outputs == copy_node.outputs
+
+    def test_with_outputs_compat_alias(self):
+        """with_outputs remains as a compatibility alias for rename_outputs."""
+        from hypergraph.nodes.function import FunctionNode
+
+        def foo(a):
+            pass
+
+        node = FunctionNode(foo, output_name="result")
+        renamed = node.with_outputs(result="value")
+
+        assert renamed.outputs == ("value",)
+        assert node.outputs == ("result",)
 
 
 class TestHyperNodeUniversalCapabilities:

--- a/tests/test_nodes_function.py
+++ b/tests/test_nodes_function.py
@@ -313,7 +313,7 @@ class TestFunctionNodeRepr:
         fn = FunctionNode(foo)
         assert repr(fn) == "FunctionNode(foo, outputs=())"
 
-    def test_with_outputs(self):
+    def test_rename_outputs(self):
         """Repr shows outputs."""
 
         def foo():

--- a/tests/test_nodes_gate.py
+++ b/tests/test_nodes_gate.py
@@ -271,14 +271,14 @@ class TestRouteNodeConstruction:
         assert renamed.name == "new_name"
         assert decide.name == "decide"  # Original unchanged
 
-    def test_with_inputs_returns_new_instance(self):
-        """with_inputs should return a new instance."""
+    def test_rename_inputs_returns_new_instance(self):
+        """rename_inputs should return a new instance."""
 
         @route(targets=["a"])
         def decide(x):
             return "a"
 
-        renamed = decide.with_inputs(x="value")
+        renamed = decide.rename_inputs(x="value")
         assert renamed.inputs == ("value",)
         assert decide.inputs == ("x",)  # Original unchanged
 

--- a/tests/test_pr32_review_bugs.py
+++ b/tests/test_pr32_review_bugs.py
@@ -87,7 +87,7 @@ class TestCollectAsListsLengthConsistency:
     def test_renamed_multi_output_map_over_lengths_match(self):
         """Renamed outputs should still produce equal-length lists."""
         inner = Graph([produce_a, produce_b], name="inner")
-        gn = inner.as_node().map_over("x").with_outputs(a="alpha", b="beta")
+        gn = inner.as_node().map_over("x").rename_outputs(a="alpha", b="beta")
 
         @node(output_name="result")
         def use_renamed(alpha: list, beta: list) -> dict:

--- a/tests/test_red_team_fixes.py
+++ b/tests/test_red_team_fixes.py
@@ -226,7 +226,7 @@ class TestRenameCollision:
             return x, x + 1
 
         with pytest.raises(RenameError, match="duplicate"):
-            split.with_outputs(left="dup", right="dup")
+            split.rename_outputs(left="dup", right="dup")
 
     def test_duplicate_input_rename_raises(self):
         """Renaming two inputs to the same name must raise."""
@@ -236,7 +236,7 @@ class TestRenameCollision:
             return a + b
 
         with pytest.raises(RenameError, match="duplicate"):
-            add.with_inputs(a="same", b="same")
+            add.rename_inputs(a="same", b="same")
 
     def test_non_colliding_rename_works(self):
         """Non-colliding renames still work fine."""
@@ -245,7 +245,7 @@ class TestRenameCollision:
         def split(x: int) -> tuple[int, int]:
             return x, x + 1
 
-        renamed = split.with_outputs(left="a", right="b")
+        renamed = split.rename_outputs(left="a", right="b")
         assert renamed.outputs == ("a", "b")
 
     def test_mutex_graphnode_in_outer_graph(self):
@@ -281,7 +281,7 @@ class TestRenameCollision:
         assert "summary" in pipeline.outputs
 
     def test_mutex_graphnode_rename(self):
-        """GraphNode with mutex outputs can be renamed via with_outputs."""
+        """GraphNode with mutex outputs can be renamed via rename_outputs."""
 
         @node(output_name="index_results")
         def skip_document(reason: str) -> dict:
@@ -301,7 +301,7 @@ class TestRenameCollision:
         )
         graph_node = inner.as_node()
 
-        renamed = graph_node.with_outputs(index_results="all_results")
+        renamed = graph_node.rename_outputs(index_results="all_results")
         assert "all_results" in renamed.outputs
 
 
@@ -331,15 +331,15 @@ class TestControlOnlyCycles:
 
 
 class TestOutputRenamePropagation:
-    def test_graphnode_with_outputs_propagates(self):
-        """with_outputs() on a GraphNode must translate output names."""
+    def test_graphnode_rename_outputs_propagates(self):
+        """rename_outputs() on a GraphNode must translate output names."""
 
         @node(output_name="inner_out")
         def inner_step(x: int) -> int:
             return x * 2
 
         inner_graph = Graph(nodes=[inner_step], name="inner")
-        graph_node = inner_graph.as_node().with_outputs(inner_out="renamed_out")
+        graph_node = inner_graph.as_node().rename_outputs(inner_out="renamed_out")
 
         @node(output_name="final")
         def outer_step(renamed_out: int) -> int:

--- a/tests/test_run_log/test_run_log.py
+++ b/tests/test_run_log/test_run_log.py
@@ -382,7 +382,7 @@ class TestInnerLogs:
         """Inner logs propagate through multiple nesting levels via .log."""
         innermost = Graph([_double], name="innermost")
         middle = Graph(
-            [innermost.as_node(), _increment.with_inputs(doubled="doubled")],
+            [innermost.as_node(), _increment.rename_inputs(doubled="doubled")],
             name="middle",
         )
         outer = Graph([middle.as_node()])

--- a/tests/test_runners/test_async_runner.py
+++ b/tests/test_runners/test_async_runner.py
@@ -99,7 +99,7 @@ class TestAsyncRunnerRun:
 
     async def test_linear_dag(self):
         """Execute linear graph."""
-        graph = Graph([double, add.with_inputs(a="doubled")])
+        graph = Graph([double, add.rename_inputs(a="doubled")])
         runner = AsyncRunner()
 
         result = await runner.run(graph, {"x": 5, "b": 3})
@@ -179,12 +179,12 @@ class TestAsyncRunnerRun:
 
     async def test_fan_in_graph(self):
         """Node consumes outputs from multiple nodes."""
-        double2 = double.with_name("double2").with_outputs(doubled="doubled2")
+        double2 = double.with_name("double2").rename_outputs(doubled="doubled2")
         graph = Graph(
             [
                 double,
                 double2,
-                add.with_inputs(a="doubled", b="doubled2"),
+                add.rename_inputs(a="doubled", b="doubled2"),
             ]
         )
         runner = AsyncRunner()
@@ -195,13 +195,13 @@ class TestAsyncRunnerRun:
 
     async def test_diamond_graph(self):
         """Diamond-shaped graph."""
-        double2 = double.with_name("double2").with_outputs(doubled="other")
+        double2 = double.with_name("double2").rename_outputs(doubled="other")
         graph = Graph(
             [
                 increment,
-                double.with_inputs(x="incremented"),
-                double2.with_inputs(x="incremented"),
-                add.with_inputs(a="doubled", b="other"),
+                double.rename_inputs(x="incremented"),
+                double2.rename_inputs(x="incremented"),
+                add.rename_inputs(a="doubled", b="other"),
             ]
         )
         runner = AsyncRunner()
@@ -223,7 +223,7 @@ class TestAsyncRunnerRun:
 
     async def test_mixed_sync_async_nodes(self):
         """Graph with both sync and async nodes."""
-        graph = Graph([double, async_add.with_inputs(a="doubled")])
+        graph = Graph([double, async_add.rename_inputs(a="doubled")])
         runner = AsyncRunner()
 
         result = await runner.run(graph, {"x": 5, "b": 3})
@@ -272,8 +272,8 @@ class TestAsyncRunnerRun:
 
     async def test_max_concurrency_limits_parallelism(self):
         """max_concurrency limits parallel execution."""
-        slow1 = slow_node.with_name("slow1").with_outputs(result="r1")
-        slow2 = slow_node.with_name("slow2").with_outputs(result="r2")
+        slow1 = slow_node.with_name("slow1").rename_outputs(result="r1")
+        slow2 = slow_node.with_name("slow2").rename_outputs(result="r2")
 
         graph = Graph([slow1, slow2])
         runner = AsyncRunner()
@@ -328,7 +328,7 @@ class TestAsyncRunnerRun:
 
     async def test_select_filters_outputs(self):
         """Graph-level select filters outputs."""
-        graph = Graph([double, add.with_inputs(a="doubled")]).select("sum")
+        graph = Graph([double, add.rename_inputs(a="doubled")]).select("sum")
         runner = AsyncRunner()
 
         result = await runner.run(graph, {"x": 5, "b": 3})
@@ -416,7 +416,7 @@ class TestAsyncRunnerRun:
     async def test_nested_sync_graph_in_async(self):
         """Sync inner graph works in async runner."""
         inner = Graph([double], name="inner")
-        outer = Graph([inner.as_node(), async_add.with_inputs(a="doubled")])
+        outer = Graph([inner.as_node(), async_add.rename_inputs(a="doubled")])
         runner = AsyncRunner()
 
         result = await runner.run(outer, {"x": 5, "b": 3})
@@ -1128,7 +1128,7 @@ class TestGlobalConcurrencyLimit:
             return x
 
         # 4 independent nodes
-        nodes = [tracked_node.with_name(f"n{i}").with_inputs(x=f"x{i}").with_outputs(result=f"r{i}") for i in range(4)]
+        nodes = [tracked_node.with_name(f"n{i}").rename_inputs(x=f"x{i}").rename_outputs(result=f"r{i}") for i in range(4)]
         graph = Graph(nodes)
 
         runner = AsyncRunner()
@@ -1165,10 +1165,10 @@ class TestGlobalConcurrencyLimit:
             return y + 1
 
         # Two sync nodes and two async nodes (all independent)
-        sync1 = sync_node.with_name("sync1").with_inputs(x="x1").with_outputs(sync_result="s1")
-        sync2 = sync_node.with_name("sync2").with_inputs(x="x2").with_outputs(sync_result="s2")
-        async1 = async_tracked.with_name("async1").with_inputs(y="y1").with_outputs(async_result="a1")
-        async2 = async_tracked.with_name("async2").with_inputs(y="y2").with_outputs(async_result="a2")
+        sync1 = sync_node.with_name("sync1").rename_inputs(x="x1").rename_outputs(sync_result="s1")
+        sync2 = sync_node.with_name("sync2").rename_inputs(x="x2").rename_outputs(sync_result="s2")
+        async1 = async_tracked.with_name("async1").rename_inputs(y="y1").rename_outputs(async_result="a1")
+        async2 = async_tracked.with_name("async2").rename_inputs(y="y2").rename_outputs(async_result="a2")
 
         graph = Graph([sync1, sync2, async1, async2])
         runner = AsyncRunner()

--- a/tests/test_runners/test_daft_infrastructure.py
+++ b/tests/test_runners/test_daft_infrastructure.py
@@ -195,7 +195,7 @@ class TestRecursiveValidation:
             name="cyclic_inner",
             entrypoint="increment",
         )
-        outer = Graph([inner.as_node(name="nested").with_inputs(count="x")], name="outer")
+        outer = Graph([inner.as_node(name="nested").rename_inputs(count="x")], name="outer")
 
         cap = RunnerCapabilities(supports_cycles=False, supports_gates=False)
         # Should fail on either cycles or gates in the nested graph

--- a/tests/test_runners/test_daft_operations.py
+++ b/tests/test_runners/test_daft_operations.py
@@ -201,7 +201,7 @@ class TestGraphNodeOperation:
             return x * 2
 
         inner = Graph([double], name="inner")
-        gn = inner.as_node(name="mapper").with_inputs(x="items").map_over("items")
+        gn = inner.as_node(name="mapper").rename_inputs(x="items").map_over("items")
         outer = Graph([gn], name="outer")
         op = create_operation(gn, outer, bound_values={})
         df = daft.from_pydict({"items": [[1, 2, 3]]})

--- a/tests/test_runners/test_daft_runner.py
+++ b/tests/test_runners/test_daft_runner.py
@@ -44,7 +44,7 @@ def test_daft_runner_supports_product_mode():
 
 def test_daft_runner_run_nested_graphnode_with_map_over():
     inner = Graph([double], name="inner")
-    outer = Graph([inner.as_node(name="mapper").with_inputs(x="items").map_over("items")], name="outer")
+    outer = Graph([inner.as_node(name="mapper").rename_inputs(x="items").map_over("items")], name="outer")
 
     runner = DaftRunner()
     # `items` is owned by the `mapper` GraphNode at outer scope.
@@ -59,7 +59,7 @@ def test_daft_runner_handles_bound_inputs_inside_nested_map_over():
         return len(text) * multiplier
 
     scorer = Graph([score], name="scorer").bind(multiplier=3)
-    batch_graph = Graph([scorer.as_node(name="score_many").with_inputs(text="texts").map_over("texts")], name="batch_graph")
+    batch_graph = Graph([scorer.as_node(name="score_many").rename_inputs(text="texts").map_over("texts")], name="batch_graph")
 
     # `texts` is owned by the `score_many` GraphNode at batch_graph scope.
     result = DaftRunner().run(batch_graph, {"texts": ["a", "tool", "hypergraph"]})
@@ -110,7 +110,7 @@ def test_daft_runner_rejects_nested_graph_with_async_nodes():
         return x + 1
 
     inner = Graph([async_step], name="async_inner")
-    outer = Graph([inner.as_node(name="sub").with_inputs(x="val")], name="outer")
+    outer = Graph([inner.as_node(name="sub").rename_inputs(x="val")], name="outer")
 
     with pytest.raises(IncompatibleRunnerError, match="async nodes"):
         DaftRunner().run(outer, {"val": 1})

--- a/tests/test_runners/test_delegation.py
+++ b/tests/test_runners/test_delegation.py
@@ -76,7 +76,7 @@ class TestWithRunnerAPI:
 
     def test_with_runner_preserves_rename(self):
         inner = Graph([double], name="inner")
-        renamed = inner.as_node().with_inputs(x="input_val")
+        renamed = inner.as_node().rename_inputs(x="input_val")
         delegated = renamed.with_runner(SyncRunner())
 
         assert "input_val" in delegated.inputs
@@ -138,7 +138,7 @@ class TestDelegationExecution:
     def test_delegation_with_renamed_inputs(self):
         """Delegated runner respects input renaming."""
         inner = Graph([double], name="inner")
-        gn = inner.as_node(runner=SyncRunner()).with_inputs(x="val")
+        gn = inner.as_node(runner=SyncRunner()).rename_inputs(x="val")
         outer = Graph([gn])
 
         # val (renamed from x) is the parent-facing input address.
@@ -149,7 +149,7 @@ class TestDelegationExecution:
         """Only the GraphNode with runner_override is delegated."""
         inner = Graph([double], name="inner")
         gn = inner.as_node(runner=SyncRunner())
-        outer = Graph([gn, add.with_inputs(a="doubled")])
+        outer = Graph([gn, add.rename_inputs(a="doubled")])
 
         # x is owned by inner GraphNode; b is declared at outer (consumed by add)
         result = SyncRunner().run(outer, {"x": 3, "b": 10})

--- a/tests/test_runners/test_execution.py
+++ b/tests/test_runners/test_execution.py
@@ -100,7 +100,7 @@ class TestGetReadyNodes:
     def test_node_ready_when_inputs_satisfied(self):
         """Node becomes ready when inputs are available."""
         # double needs x, add needs a and b
-        graph = Graph([double, add.with_inputs(a="doubled")])
+        graph = Graph([double, add.rename_inputs(a="doubled")])
         state = initialize_state(graph, {"x": 5, "b": 10})
 
         # Initially only double is ready
@@ -123,7 +123,7 @@ class TestGetReadyNodes:
     def test_multiple_ready_nodes_returned(self):
         """Multiple independent nodes can be ready simultaneously."""
         # Two independent nodes both need x
-        double.with_name("double2").with_outputs(doubled="tripled")
+        double.with_name("double2").rename_outputs(doubled="tripled")
 
         @node(output_name="tripled")
         def triple(x: int) -> int:
@@ -139,7 +139,7 @@ class TestGetReadyNodes:
 
     def test_fan_in_waits_for_all_inputs(self):
         """Node with multiple inputs waits for all."""
-        graph = Graph([double, add.with_inputs(a="doubled")])
+        graph = Graph([double, add.rename_inputs(a="doubled")])
         state = initialize_state(graph, {"x": 5})  # Missing b
 
         # Only double is ready, add needs both doubled and b
@@ -362,7 +362,7 @@ class TestCollectInputsForNode:
 
     def test_edge_value_takes_priority(self):
         """State values (from edges) take precedence."""
-        graph = Graph([double, add.with_inputs(a="doubled")])
+        graph = Graph([double, add.rename_inputs(a="doubled")])
         state = initialize_state(graph, {"x": 5, "b": 100})
         state.update_value("doubled", 10)  # Edge value
 
@@ -429,12 +429,12 @@ class TestSyncFunctionNodeExecutor:
         self.state = GraphState()
         self.ctx = ExecutionContext()
 
-    def test_executes_function_with_inputs(self):
+    def test_executes_function_rename_inputs(self):
         """Function is called with provided inputs."""
         outputs = self.executor(double, self.state, {"x": 5}, self.ctx)
         assert outputs == {"doubled": 10}
 
-    def test_returns_dict_with_outputs(self):
+    def test_returns_dict_rename_outputs(self):
         """Returns dict mapping output names to values."""
         outputs = self.executor(add, self.state, {"a": 3, "b": 4}, self.ctx)
         assert outputs == {"sum": 7}
@@ -819,7 +819,7 @@ class TestFilterOutputs:
 
     def test_select_filters_outputs(self):
         """Select filters to specified outputs only."""
-        graph = Graph([double, add.with_inputs(a="doubled")])
+        graph = Graph([double, add.rename_inputs(a="doubled")])
         state = GraphState(values={"doubled": 10, "sum": 15, "x": 5, "b": 5})
 
         result = filter_outputs(state, graph, select=["sum"])
@@ -844,7 +844,7 @@ class TestFilterOutputs:
 
     def test_single_string_select(self):
         """select="name" (single string) works as shorthand for select=["name"]."""
-        graph = Graph([double, add.with_inputs(a="doubled")])
+        graph = Graph([double, add.rename_inputs(a="doubled")])
         state = GraphState(values={"doubled": 10, "sum": 15, "x": 5, "b": 5})
 
         result = filter_outputs(state, graph, select="sum")

--- a/tests/test_runners/test_graphnode_map_over.py
+++ b/tests/test_runners/test_graphnode_map_over.py
@@ -111,7 +111,7 @@ class TestMapOverRenameIntegration:
         gn = inner.as_node()
 
         mapped = gn.map_over("x")
-        renamed = mapped.with_inputs(x="input_x")
+        renamed = mapped.rename_inputs(x="input_x")
 
         assert renamed._map_over == ["input_x"]
         assert "input_x" in renamed.inputs
@@ -121,7 +121,7 @@ class TestMapOverRenameIntegration:
         inner = Graph([double], name="inner")
         gn = inner.as_node()
 
-        renamed = gn.with_inputs(x="input_x")
+        renamed = gn.rename_inputs(x="input_x")
         mapped = renamed.map_over("input_x")
 
         assert mapped._map_over == ["input_x"]
@@ -132,7 +132,7 @@ class TestMapOverRenameIntegration:
         gn = inner.as_node()
 
         mapped = gn.map_over("a")
-        renamed = mapped.with_inputs(b="input_b")
+        renamed = mapped.rename_inputs(b="input_b")
 
         assert renamed._map_over == ["a"]
 
@@ -150,7 +150,7 @@ class TestMapOverRenameExecution:
         This is a regression test for the bug where:
         - Producer outputs "items" (a list)
         - Inner graph expects "item" (singular)
-        - with_inputs(item="items") renames to match producer
+        - rename_inputs(item="items") renames to match producer
         - map_over("items") iterates over the list
         """
 
@@ -163,7 +163,7 @@ class TestMapOverRenameExecution:
             return {"id": item["id"], "result": item["value"] * multiplier}
 
         inner = Graph(nodes=[process_item], name="inner")
-        mapped_node = inner.as_node(name="process_all").with_inputs(item="items").map_over("items")
+        mapped_node = inner.as_node(name="process_all").rename_inputs(item="items").map_over("items")
 
         # multiplier is a parent-facing input address on mapped_node.
         outer = Graph(nodes=[produce_items, mapped_node]).bind(**{"multiplier": 2})
@@ -195,7 +195,7 @@ class TestMapOverRenameExecution:
             return x * 2
 
         inner = Graph(nodes=[process], name="inner")
-        mapped_node = inner.as_node(name="mapper").with_inputs(x="items").with_outputs(doubled="results").map_over("items")
+        mapped_node = inner.as_node(name="mapper").rename_inputs(x="items").rename_outputs(doubled="results").map_over("items")
 
         outer = Graph(nodes=[produce, mapped_node])
         runner = SyncRunner()
@@ -217,7 +217,7 @@ class TestMapOverRenameExecution:
             return value + 1
 
         inner = Graph(nodes=[process], name="inner")
-        mapped_node = inner.as_node(name="mapper").with_inputs(value="items").map_over("items")
+        mapped_node = inner.as_node(name="mapper").rename_inputs(value="items").map_over("items")
 
         outer = Graph(nodes=[produce, mapped_node])
         runner = AsyncRunner()
@@ -243,7 +243,7 @@ class TestMapOverRenameExecution:
             return a + b
 
         inner = Graph(nodes=[add_nums], name="inner")
-        mapped_node = inner.as_node(name="adder").with_inputs(a="xs", b="ys").map_over("xs", "ys", mode="zip")
+        mapped_node = inner.as_node(name="adder").rename_inputs(a="xs", b="ys").map_over("xs", "ys", mode="zip")
 
         outer = Graph(nodes=[produce_xs, produce_ys, mapped_node])
         runner = SyncRunner()
@@ -265,7 +265,7 @@ class TestMapOverRenameExecution:
             return value * factor
 
         inner = Graph(nodes=[multiply], name="inner")
-        mapped_node = inner.as_node(name="multiplier").with_inputs(value="items").map_over("items")
+        mapped_node = inner.as_node(name="multiplier").rename_inputs(value="items").map_over("items")
 
         outer = Graph(nodes=[produce, mapped_node])
         runner = SyncRunner()
@@ -290,8 +290,8 @@ class TestMapOverRenameExecution:
         inner = Graph(nodes=[process], name="inner")
         mapped_node = (
             inner.as_node(name="processor")
-            .with_inputs(x="temp")  # x -> temp
-            .with_inputs(temp="data")  # temp -> data
+            .rename_inputs(x="temp")  # x -> temp
+            .rename_inputs(temp="data")  # temp -> data
             .map_over("data")
         )
 
@@ -306,7 +306,7 @@ class TestMapOverRenameExecution:
     def test_parallel_renames_with_map_over(self):
         """Parallel renames (same batch) work correctly with map_over.
 
-        Regression test for handling parallel renames like with_inputs(a='b', b='a')
+        Regression test for handling parallel renames like rename_inputs(a='b', b='a')
         which require special handling via build_reverse_rename_map.
         """
 
@@ -326,8 +326,8 @@ class TestMapOverRenameExecution:
         # Swap parameter names in a single call (parallel renames)
         mapped_node = (
             inner.as_node(name="adder")
-            .with_inputs({"a": "temp_a", "b": "temp_b"})  # Parallel batch 1
-            .with_inputs({"temp_a": "ys", "temp_b": "xs"})  # Parallel batch 2
+            .rename_inputs({"a": "temp_a", "b": "temp_b"})  # Parallel batch 1
+            .rename_inputs({"temp_a": "ys", "temp_b": "xs"})  # Parallel batch 2
             .map_over("xs", "ys", mode="zip")
         )
 
@@ -387,7 +387,7 @@ class TestMapOverExecution:
         outer = Graph(
             [
                 inner.as_node().map_over("x"),
-                add.with_inputs(a="doubled"),  # "doubled" is now a list
+                add.rename_inputs(a="doubled"),  # "doubled" is now a list
             ]
         )
         runner = SyncRunner()
@@ -1158,7 +1158,7 @@ class TestCloneExecution:
         assert result["result"] == ["1-value", "2-value", "3-value"]
 
     def test_clone_with_renamed_input(self):
-        """with_inputs() updates clone list correctly."""
+        """rename_inputs() updates clone list correctly."""
 
         @node(output_name="result")
         def process(x: int, cfg: dict) -> int:
@@ -1166,7 +1166,7 @@ class TestCloneExecution:
             return cfg["count"]
 
         inner = Graph([process], name="inner")
-        mapped_node = inner.as_node().map_over("x", clone=["cfg"]).with_inputs(cfg="config")
+        mapped_node = inner.as_node().map_over("x", clone=["cfg"]).rename_inputs(cfg="config")
 
         # Verify _clone was updated
         assert mapped_node._clone == ["config"]

--- a/tests/test_runners/test_sync_runner.py
+++ b/tests/test_runners/test_sync_runner.py
@@ -102,7 +102,7 @@ class TestSyncRunnerRun:
 
     def test_linear_dag_two_nodes(self):
         """Execute linear graph with two nodes."""
-        graph = Graph([double, add.with_inputs(a="doubled")])
+        graph = Graph([double, add.rename_inputs(a="doubled")])
         runner = SyncRunner()
 
         result = runner.run(graph, {"x": 5, "b": 3})
@@ -113,8 +113,8 @@ class TestSyncRunnerRun:
 
     def test_linear_dag_three_nodes(self):
         """Execute linear graph with three nodes."""
-        incr = increment.with_inputs(x="sum").with_outputs(incremented="final")
-        graph = Graph([double, add.with_inputs(a="doubled"), incr])
+        incr = increment.rename_inputs(x="sum").rename_outputs(incremented="final")
+        graph = Graph([double, add.rename_inputs(a="doubled"), incr])
         runner = SyncRunner()
 
         result = runner.run(graph, {"x": 5, "b": 3})
@@ -139,12 +139,12 @@ class TestSyncRunnerRun:
 
     def test_fan_in_graph(self):
         """Node consumes outputs from multiple nodes."""
-        double2 = double.with_name("double2").with_outputs(doubled="doubled2")
+        double2 = double.with_name("double2").rename_outputs(doubled="doubled2")
         graph = Graph(
             [
                 double,
                 double2,
-                add.with_inputs(a="doubled", b="doubled2"),
+                add.rename_inputs(a="doubled", b="doubled2"),
             ]
         )
         runner = SyncRunner()
@@ -155,13 +155,13 @@ class TestSyncRunnerRun:
 
     def test_diamond_graph(self):
         """Diamond-shaped graph with fan-out then fan-in."""
-        double2 = double.with_name("double2").with_outputs(doubled="other")
+        double2 = double.with_name("double2").rename_outputs(doubled="other")
         graph = Graph(
             [
                 increment,  # x -> incremented (6)
-                double.with_inputs(x="incremented"),  # -> doubled (12)
-                double2.with_inputs(x="incremented"),  # -> other (12)
-                add.with_inputs(a="doubled", b="other"),  # -> sum (24)
+                double.rename_inputs(x="incremented"),  # -> doubled (12)
+                double2.rename_inputs(x="incremented"),  # -> other (12)
+                add.rename_inputs(a="doubled", b="other"),  # -> sum (24)
             ]
         )
         runner = SyncRunner()
@@ -316,7 +316,7 @@ class TestSyncRunnerRun:
 
     def test_result_contains_all_outputs(self):
         """Result contains all graph outputs by default."""
-        graph = Graph([double, add.with_inputs(a="doubled")])
+        graph = Graph([double, add.rename_inputs(a="doubled")])
         runner = SyncRunner()
 
         result = runner.run(graph, {"x": 5, "b": 3})
@@ -326,7 +326,7 @@ class TestSyncRunnerRun:
 
     def test_select_filters_outputs(self):
         """Graph-level select filters which outputs to return."""
-        graph = Graph([double, add.with_inputs(a="doubled")]).select("sum")
+        graph = Graph([double, add.rename_inputs(a="doubled")]).select("sum")
         runner = SyncRunner()
 
         result = runner.run(graph, {"x": 5, "b": 3})
@@ -408,7 +408,7 @@ class TestSyncRunnerRun:
         outer = Graph(
             [
                 inner.as_node(),
-                add.with_inputs(a="doubled"),
+                add.rename_inputs(a="doubled"),
             ]
         )
         runner = SyncRunner()
@@ -420,7 +420,7 @@ class TestSyncRunnerRun:
     def test_deeply_nested_graph(self):
         """Multiple levels of nesting work."""
         innermost = Graph([double], name="innermost")
-        middle = Graph([innermost.as_node(), increment.with_inputs(x="doubled")], name="middle")
+        middle = Graph([innermost.as_node(), increment.rename_inputs(x="doubled")], name="middle")
         outer = Graph([middle.as_node()])
         runner = SyncRunner()
 
@@ -720,7 +720,7 @@ class TestSyncRunnerMap:
 
     def test_map_select(self):
         """Map respects graph-level selected outputs."""
-        graph = Graph([double, add.with_inputs(a="doubled")]).select("sum")
+        graph = Graph([double, add.rename_inputs(a="doubled")]).select("sum")
         runner = SyncRunner()
 
         results = runner.map(

--- a/tests/test_runners/test_validation.py
+++ b/tests/test_runners/test_validation.py
@@ -288,7 +288,7 @@ class TestValidateMapCompatible:
 
     def test_dag_graph_passes(self):
         """DAG graphs are map-compatible."""
-        graph = Graph([double, add.with_inputs(a="doubled")])
+        graph = Graph([double, add.rename_inputs(a="doubled")])
         # Should not raise
         validate_map_compatible(graph)
 

--- a/tests/viz/test_complex_nested_graphs.py
+++ b/tests/viz/test_complex_nested_graphs.py
@@ -176,8 +176,8 @@ def make_batch_recommendations_graph() -> Graph:
 
     mapped = (
         single.as_node(name="map_recommendations")
-        .with_inputs(result="results", feedback="feedbacks")
-        .with_outputs(
+        .rename_inputs(result="results", feedback="feedbacks")
+        .rename_outputs(
             recommendation="per_query_recommendations",
             chat_messages="single_chat_messages",
         )
@@ -261,7 +261,9 @@ def make_batch_recall_graph() -> Graph:
         name="recall",
     )
 
-    mapped = recall.as_node(name="batch_recall").with_inputs(eval_pair="eval_pairs").with_outputs(recall_score="recall_scores").map_over("eval_pairs")
+    mapped = (
+        recall.as_node(name="batch_recall").rename_inputs(eval_pair="eval_pairs").rename_outputs(recall_score="recall_scores").map_over("eval_pairs")
+    )
 
     return Graph(
         nodes=[batch_build_pairs, mapped, batch_aggregate_scores],

--- a/tests/viz/test_cross_boundary_edge.py
+++ b/tests/viz/test_cross_boundary_edge.py
@@ -74,8 +74,8 @@ def build_triple_nested_graph():
 
     batch_recall = (
         retrieval_recall_graph.as_node(name="batch_recall")
-        .with_inputs(eval_pair="eval_pairs")
-        .with_outputs(retrieval_eval_result="retrieval_eval_results")
+        .rename_inputs(eval_pair="eval_pairs")
+        .rename_outputs(retrieval_eval_result="retrieval_eval_results")
         .map_over("eval_pairs")
     )
 

--- a/tests/viz/test_scope_aware_visibility.py
+++ b/tests/viz/test_scope_aware_visibility.py
@@ -475,7 +475,7 @@ def make_batch_eval_graph() -> Graph:
     - compute_metrics consumes eval_results
     """
     batch_eval = Graph(nodes=[run_single_eval], name="batch_eval")
-    mapped_eval = batch_eval.as_node().with_inputs(eval_pair="eval_pairs").with_outputs(eval_result="eval_results").map_over("eval_pairs")
+    mapped_eval = batch_eval.as_node().rename_inputs(eval_pair="eval_pairs").rename_outputs(eval_result="eval_results").map_over("eval_pairs")
 
     return Graph(
         nodes=[build_pairs, mapped_eval, compute_metrics],


### PR DESCRIPTION
## Problem / Bug / Challenge

The node port rename API currently uses `.with_inputs(...)` and `.with_outputs(...)` as the primary spelling. Those names correctly imply copy-returning behavior, but they are easy to read as value binding or wiring language in a framework where input names drive graph connections.

This PR makes `.rename_inputs(...)` and `.rename_outputs(...)` the preferred public API while preserving `.with_inputs(...)` and `.with_outputs(...)` as compatibility aliases.

## Before / After

**Before:**

```python
adapted = (
    process
    .with_name("preprocessor")
    .with_inputs(text="raw")
    .with_outputs(result="cleaned")
)
```

**After:**

```python
adapted = (
    process
    .with_name("preprocessor")
    .rename_inputs(text="raw")
    .rename_outputs(result="cleaned")
)
```

Compatibility remains:

```python
process.with_inputs(text="raw")
process.with_outputs(result="cleaned")
```

## Test Plan

- [x] `uv run pytest -q`
- [x] `uv run pytest -W error -W 'ignore::pytest.PytestUnraisableExceptionWarning'`
- [x] `uv run ruff check src tests`
- [x] `uv run ruff format --check src tests`
- [x] Pre-commit hooks during commit
- [x] Pre-push hooks during push

Note: `uv run python scripts/verify_docs.py` was checked separately and still fails on existing non-self-contained docs snippets, including examples that depend on prior code blocks or intentionally raise graph construction errors; the rename-specific skips were updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `rename_inputs()` and `rename_outputs()` methods that clearly rename local port names. Previous `with_inputs()` and `with_outputs()` methods remain available as compatibility aliases.

* **Documentation**
  * Updated all documentation and examples to reflect the new `rename_inputs()` and `rename_outputs()` naming, providing clearer guidance on local port renaming.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gilad-rubin/hypergraph/pull/99?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->