### PR TITLE
feat(daft): add typed integration facade

### DIFF
--- a/docs/05-how-to/daft-workflows.md
+++ b/docs/05-how-to/daft-workflows.md
@@ -18,13 +18,20 @@ workflow model:
 uv sync --extra daft
 ```
 
+Hypergraph's Daft extra requires `daft>=0.7.14`. The integration targets
+Daft's current UDF APIs (`daft.func`, `daft.func.batch`, `daft.cls`,
+`daft.method`, and `daft.method.batch`) and their typed resource/retry
+options.
+
 ## The Mental Model
 
 `DaftRunner` translates your graph into a Daft query plan:
 
-1. Each node becomes a Daft UDF (via `@daft.func`, `@daft.cls`, or `@daft.func.batch`).
-2. Nodes are chained in topological order via `df.with_column()`.
-3. Nested `GraphNode`s run their inner graph via `SyncRunner` inside a single UDF.
+1. Plain `@node` functions become `@daft.func` UDFs.
+2. `hypergraph.integrations.daft.node(..., batch=True)` becomes `@daft.func.batch`.
+3. Bound `@stateful` resources become `@daft.cls` wrappers with `@daft.method` or `@daft.method.batch`.
+4. Nodes are chained in topological order via `df.with_column()`.
+5. Nested `GraphNode`s run their inner graph via `SyncRunner` inside a single UDF.
 
 An item can still contain lists, and those lists can still be processed with a
 nested `GraphNode.map_over(...)`.
@@ -34,6 +41,14 @@ Pick the entrypoint that matches your data:
 - Use `runner.map(...)` when your outer dataset is a Python collection — returns `MapResult`.
 - Use `runner.map_dataframe(...)` when your dataset is a Daft DataFrame — returns a Daft DataFrame (no Python conversion).
 
+Use the integration namespace only when you want Daft-specific execution
+controls. Plain `@node` stays backend-neutral and still auto-lowers under
+`DaftRunner`; `daft_node` is for Daft-only dtype, batch, retry, resource, and
+concurrency settings.
+
+Migration note: older examples that used `@node(..., batch=True)` should use
+`@daft_node(..., batch=True, return_dtype=...)` instead.
+
 ## Standalone Examples
 
 These checked-in scripts are the clearest place to start:
@@ -41,7 +56,8 @@ These checked-in scripts are the clearest place to start:
 - `examples/daft/text_processing.py` - linear DAG with sync nodes, single run + batch
 - `examples/daft/async_api_calls.py` - async nodes in a diamond DAG (Daft handles the event loop)
 - `examples/daft/ml_embeddings.py` - `@stateful` decorator for once-per-worker model loading
-- `examples/daft/batch_normalization.py` - vectorized batch UDFs with `batch=True`
+- `examples/daft/batch_normalization.py` - vectorized batch UDFs with `daft_node(..., batch=True)`
+- `examples/daft/advanced_udf_patterns.py` - stateful + batch UDF patterns inspired by Daft docs
 - `examples/daft/nested_document_scoring.py` - `GraphNode` with `map_over` inside DaftRunner
 - `examples/daft/quickstart_customer_enrichment.py` - quickstart-style tabular enrichment
 - `examples/daft/hierarchical_document_batches.py` - nested `GraphNode.map_over(...)` inside a batch
@@ -54,7 +70,8 @@ This mirrors the spirit of Daft's quickstart tabular transforms, but with
 Hypergraph's "think singular, then map it" pattern.
 
 ```python
-from hypergraph import DaftRunner, Graph, node
+from hypergraph import Graph, node
+from hypergraph.integrations.daft import DaftRunner
 
 @node(output_name="full_name")
 def full_name(first_name: str, last_name: str) -> str:
@@ -92,7 +109,8 @@ This is where Hypergraph adds something useful to Daft-style pipelines:
 reusable inner workflows.
 
 ```python
-from hypergraph import DaftRunner, Graph, node
+from hypergraph import Graph, node
+from hypergraph.integrations.daft import DaftRunner
 
 @node(output_name="sentences")
 def split_sentences(document: str) -> list[str]:
@@ -139,7 +157,8 @@ everything in Daft's columnar format — no roundtrip through Python dicts.
 
 ```python
 import daft
-from hypergraph import DaftRunner, Graph, node
+from hypergraph import Graph, node
+from hypergraph.integrations.daft import DaftRunner
 
 @node(output_name="doubled")
 def double(x: int) -> int:
@@ -163,11 +182,21 @@ def greet(name: str, prefix: str) -> str:
     return f"{prefix}, {name}!"
 
 graph = Graph([greet], name="greeter")
-df = daft.from_pydict({"name": ["Alice", "Bob"]})
+df = daft.from_pydict(
+    {
+        "name": ["Alice", "Bob"],
+        "source": ["crm", "csv"],
+    }
+)
 
 result_df = DaftRunner().map_dataframe(graph, df, prefix="Hi")
 # Each row gets prefix="Hi" via the UDF closure
+# The source passthrough column is preserved in result_df
 ```
+
+`map_dataframe` preserves passthrough columns by default. Graph outputs must
+not collide with existing DataFrame columns; rename the node output or drop the
+existing column before calling `map_dataframe`.
 
 ## Async Nodes
 
@@ -176,7 +205,8 @@ configuration:
 
 ```python
 import asyncio
-from hypergraph import DaftRunner, Graph, node
+from hypergraph import Graph, node
+from hypergraph.integrations.daft import DaftRunner
 
 async def _mock_embed(text: str) -> list[float]:
     await asyncio.sleep(0.01)
@@ -216,7 +246,7 @@ Use it when:
 - you want columnar batch execution or distributed fan-out via Daft
 - the item workflow benefits from nested graphs, graph reuse, or internal `map_over(...)`
 - you have stateful resources (ML models) that should load once per worker (`@stateful`)
-- you need vectorized batch operations (`batch=True`)
+- you need vectorized batch operations (`daft_node(..., batch=True)`)
 
 Prefer `SyncRunner` or `AsyncRunner` when:
 
@@ -232,10 +262,10 @@ worker instead of once per row. Use the `@stateful` decorator and bind the
 instance to the graph:
 
 ```python
-from hypergraph import DaftRunner, Graph, node
-from hypergraph.runners.daft import stateful
+from hypergraph import Graph, node
+from hypergraph.integrations.daft import DaftRunner, stateful
 
-@stateful
+@stateful(max_concurrency=2)
 class Embedder:
     def __init__(self):
         self.model = load_heavy_model()
@@ -253,27 +283,32 @@ results = runner.map(graph, {"text": texts}, map_over="text")
 ```
 
 DaftRunner wraps stateful objects with `@daft.cls` so `__init__` runs once per
-worker process. The class must support zero-argument construction.
+worker process. The class must support zero-argument construction. Hypergraph
+validates that contract by signature during plan build, then constructs the
+resource inside the Daft worker on first use so expensive model/client setup is
+not accidentally triggered while building a lazy plan.
 See `examples/daft/ml_embeddings.py` for a complete example.
 
 ## Vectorized Batch UDFs
 
 For operations that benefit from processing all rows at once (NumPy, Arrow),
-use `batch=True` on the `@node` decorator to get `daft.Series` inputs instead
-of scalars:
+use `hypergraph.integrations.daft.node` to opt into Daft batch execution.
+Batch nodes receive `daft.Series` inputs instead of scalars:
 
 ```python
 import daft
-from hypergraph import DaftRunner, Graph, node
+from hypergraph import Graph
+from hypergraph.integrations.daft import DaftRunner
+from hypergraph.integrations.daft import node as daft_node
 
-@node(output_name="normalized", batch=True)
-def normalize(values: daft.Series) -> daft.Series:
+@daft_node(output_name="normalized", batch=True, return_dtype=daft.DataType.float64())
+def normalize(values: daft.Series) -> list[float]:
     arr = values.to_pylist()
     mean = sum(arr) / len(arr)
     std = (sum((x - mean) ** 2 for x in arr) / len(arr)) ** 0.5
     if std == 0:
-        return daft.Series.from_pylist([0.0] * len(arr))
-    return daft.Series.from_pylist([round((x - mean) / std, 4) for x in arr])
+        return [0.0] * len(arr)
+    return [round((x - mean) / std, 4) for x in arr]
 
 graph = Graph([normalize], name="batch_norm")
 runner = DaftRunner()
@@ -281,6 +316,59 @@ results = runner.map(graph, {"values": [10.0, 20.0, 30.0, 40.0, 50.0]}, map_over
 ```
 
 See `examples/daft/batch_normalization.py` for a complete example.
+
+## Daft Options
+
+Pass common Daft UDF controls directly to `daft_node`, or reuse a typed
+`Options` value when several nodes share the same settings:
+
+```python
+import daft
+from hypergraph.integrations.daft import Options
+from hypergraph.integrations.daft import node as daft_node
+
+embedding_options = Options(
+    return_dtype=daft.DataType.list(daft.DataType.float64()),
+    batch=True,
+    batch_size=64,
+    max_retries=2,
+    on_error="log",
+)
+
+@daft_node(output_name="embedding", options=embedding_options)
+def embed_batch(text: daft.Series) -> list[list[float] | None]:
+    return embed_many(text.to_pylist())
+```
+
+`Options` validates Daft's current public rules early: `on_error` is one of
+`"raise"`, `"log"`, or `"ignore"`; `max_concurrency` must be positive; `gpus`
+above `1.0` must be whole numbers; and `ray_options` cannot include
+`"num_cpus"`, `"num_gpus"`, or `"memory"`. Put class-level resource controls on
+`@stateful(...)`; put dtype, batch, and unnest settings on `daft_node(...)`.
+
+## Dashboard and Extensions
+
+Hypergraph does not wrap Daft's dashboard or native extension APIs. Configure
+them the same way you would for a direct Daft script:
+
+```bash
+daft dashboard start
+DAFT_DASHBOARD_URL=http://localhost:3238 python my_workflow.py
+```
+
+Native extensions should be loaded before running the graph:
+
+```python
+import daft
+import hello_extension
+
+daft.load_extension(hello_extension)
+
+result_df = DaftRunner().map_dataframe(graph, frame)
+```
+
+The Daft dashboard protocol and native extension ABI are still evolving
+upstream, so this integration keeps those as Daft-owned setup concerns.
 
 ## Current Limitations
 

--- a/docs/06-api-reference/nodes.md
+++ b/docs/06-api-reference/nodes.md
@@ -758,7 +758,7 @@ GraphNodes also inherit the parent runner by default. Use
 delegate to a different compatible runner:
 
 ```python
-from hypergraph import DaftRunner
+from hypergraph.integrations.daft import DaftRunner
 
 gn = inner.as_node(runner=DaftRunner())
 gn = inner.as_node().with_runner(DaftRunner())  # equivalent

--- a/docs/06-api-reference/runners.md
+++ b/docs/06-api-reference/runners.md
@@ -262,7 +262,7 @@ caps.supports_interrupts   # False
 Translation runner: converts DAGs into chained Daft `df.with_column()` UDF calls.
 
 ```python
-from hypergraph import DaftRunner
+from hypergraph.integrations.daft import DaftRunner
 ```
 
 `DaftRunner` translates each node into a Daft UDF and chains them via
@@ -327,7 +327,8 @@ Execute a graph once via a 1-row Daft plan.
 **Example:**
 
 ```python
-from hypergraph import DaftRunner, Graph, node
+from hypergraph import Graph, node
+from hypergraph.integrations.daft import DaftRunner
 
 @node(output_name="doubled")
 def double(x: int) -> int:
@@ -380,7 +381,8 @@ entrypoint when your data is a Python collection.
 **Example:**
 
 ```python
-from hypergraph import DaftRunner, Graph, node
+from hypergraph import Graph, node
+from hypergraph.integrations.daft import DaftRunner
 
 @node(output_name="sentences")
 def split_sentences(document: str) -> list[str]:
@@ -438,11 +440,16 @@ DataFrame columns without materializing rows back into Python.
 
 **Returns:** Daft DataFrame with original input columns plus graph output columns.
 
+Output columns are added to the original DataFrame; passthrough columns are
+preserved. If a graph output would overwrite an existing DataFrame column,
+`map_dataframe` raises a graph configuration error instead of replacing data.
+
 **Example:**
 
 ```python
 import daft
-from hypergraph import DaftRunner, Graph, node
+from hypergraph import Graph, node
+from hypergraph.integrations.daft import DaftRunner
 
 @node(output_name="cleaned_text")
 def clean(text: str) -> str:
@@ -502,10 +509,10 @@ stateful objects with `@daft.cls` instead of `@daft.func`, so heavy resources
 once per row.
 
 ```python
-from hypergraph import DaftRunner, Graph, node
-from hypergraph.runners.daft import stateful
+from hypergraph import Graph, node
+from hypergraph.integrations.daft import DaftRunner, stateful
 
-@stateful
+@stateful(max_concurrency=2)
 class Embedder:
     def __init__(self):
         self.model = load_heavy_model()
@@ -525,29 +532,65 @@ results = runner.map(graph, {"text": texts}, map_over="text")
 The class must support zero-argument construction (`__init__()` with no
 required args) so Daft can re-create it on each worker.
 
-### batch=True
+### daft_node(..., batch=True)
 
-Use `batch=True` on the `@node` decorator for vectorized `@daft.func.batch`
-execution. Batch UDFs receive `daft.Series` instead of scalar values, useful
-for NumPy/Arrow operations.
+Use `hypergraph.integrations.daft.node` for vectorized `@daft.func.batch`
+execution. Batch UDFs receive `daft.Series` instead of scalar values and must
+declare an explicit Daft `return_dtype`.
 
 ```python
 import daft
-from hypergraph import DaftRunner, Graph, node
+from hypergraph import Graph
+from hypergraph.integrations.daft import DaftRunner
+from hypergraph.integrations.daft import node as daft_node
 
-@node(output_name="normalized", batch=True)
-def normalize(values: daft.Series) -> daft.Series:
+@daft_node(output_name="normalized", batch=True, return_dtype=daft.DataType.float64())
+def normalize(values: daft.Series) -> list[float]:
     arr = values.to_pylist()
     mean = sum(arr) / len(arr)
     std = (sum((x - mean) ** 2 for x in arr) / len(arr)) ** 0.5
     if std == 0:
-        return daft.Series.from_pylist([0.0] * len(arr))
-    return daft.Series.from_pylist([round((x - mean) / std, 4) for x in arr])
+        return [0.0] * len(arr)
+    return [round((x - mean) / std, 4) for x in arr]
 
 graph = Graph([normalize], name="batch_norm")
 runner = DaftRunner()
 results = runner.map(graph, {"values": [10.0, 20.0, 30.0]}, map_over="values")
 ```
+
+### Options
+
+Typed Daft lowering options can be passed directly to `daft_node` or reused via
+`Options`:
+
+```python
+import daft
+from hypergraph.integrations.daft import Options
+from hypergraph.integrations.daft import node as daft_node
+
+batch_options = Options(
+    return_dtype=daft.DataType.int64(),
+    batch=True,
+    batch_size=128,
+    max_retries=2,
+    on_error="log",
+)
+
+@daft_node(output_name="token_count", options=batch_options)
+def count_tokens(text: daft.Series) -> list[int | None]:
+    return [len(value.split()) for value in text.to_pylist()]
+```
+
+Use `@stateful(cpus=..., gpus=..., max_concurrency=...)` for class-level
+`@daft.cls` controls. `stateful(options=...)` accepts only class resource,
+retry, and error-handling settings; dtype, batch, and unnest settings belong on
+`daft_node(...)`.
+
+### Dashboard and Extensions
+
+`DaftRunner` does not add a Hypergraph-specific dashboard or extension API.
+Start Daft's dashboard and set `DAFT_DASHBOARD_URL` before running, or call
+`daft.load_extension(...)` before constructing/executing the Daft plan.
 
 ---
 
@@ -1131,7 +1174,7 @@ The runner automatically:
 Override the runner only when a subgraph has a different compatible execution strategy:
 
 ```python
-from hypergraph import DaftRunner
+from hypergraph.integrations.daft import DaftRunner
 
 inner = Graph([normalize], name="columnar_step")
 outer = Graph([inner.as_node(runner=DaftRunner()), summarize])

--- a/examples/daft/advanced_udf_patterns.py
+++ b/examples/daft/advanced_udf_patterns.py
@@ -1,0 +1,76 @@
+"""Advanced Daft UDF patterns expressed with Hypergraph.
+
+Inspired by Daft's UDF patterns docs:
+- plain Hypergraph nodes still auto-lower to daft.func
+- daft_node(..., batch=True) lowers to daft.func.batch
+- @stateful lowers bound worker resources to daft.cls
+"""
+
+from __future__ import annotations
+
+import daft
+
+from hypergraph import Graph, node
+from hypergraph.integrations.daft import DaftRunner, stateful
+from hypergraph.integrations.daft import node as daft_node
+
+
+@node(output_name="clean_text")
+def clean_text(text: str) -> str:
+    return " ".join(text.lower().strip().split())
+
+
+@daft_node(
+    output_name="word_count",
+    batch=True,
+    return_dtype=daft.DataType.int64(),
+    batch_size=2,
+)
+def count_words(clean_text: daft.Series) -> list[int]:
+    return [len(value.split()) for value in clean_text.to_pylist()]
+
+
+@stateful(max_concurrency=2)
+class KeywordClassifier:
+    def __init__(self) -> None:
+        self._labels = {
+            "urgent": ("blocked", "crash", "down"),
+            "billing": ("refund", "invoice", "charge"),
+        }
+
+    def classify(self, text: str) -> str:
+        for label, keywords in self._labels.items():
+            if any(keyword in text for keyword in keywords):
+                return label
+        return "general"
+
+
+@node(output_name="ticket_label")
+def classify_ticket(clean_text: str, classifier: KeywordClassifier) -> str:
+    return classifier.classify(clean_text)
+
+
+graph = Graph([clean_text, count_words, classify_ticket], name="advanced_daft_udfs")
+graph = graph.bind(classifier=KeywordClassifier())
+
+
+def main() -> list[dict[str, object]]:
+    frame = daft.from_pydict(
+        {
+            "ticket_id": [101, 102, 103],
+            "text": [
+                "Checkout is blocked after deploy",
+                "Need invoice for annual charge",
+                "Dark mode feedback for the dashboard",
+            ],
+        }
+    )
+
+    result = DaftRunner().map_dataframe(graph, frame).collect().to_pylist()
+    for row in result:
+        print(row)
+    return result
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/daft/async_api_calls.py
+++ b/examples/daft/async_api_calls.py
@@ -10,7 +10,8 @@ Inspired by Daft's async UDF documentation.
 
 import asyncio
 
-from hypergraph import DaftRunner, Graph, node
+from hypergraph import Graph, node
+from hypergraph.integrations.daft import DaftRunner
 
 
 # Mock async API calls

--- a/examples/daft/batch_normalization.py
+++ b/examples/daft/batch_normalization.py
@@ -19,8 +19,8 @@ from hypergraph.integrations.daft import node as daft_node
 def normalize(values: daft.Series) -> list[float]:
     """Z-score normalize a column of values.
 
-    This is a batch UDF: it receives and returns daft.Series,
-    processing all rows at once instead of one-by-one.
+    This is a batch UDF: it receives a daft.Series and returns a list
+    aligned to the batch rows.
     """
     arr = values.to_pylist()
     mean = sum(arr) / len(arr)

--- a/examples/daft/batch_normalization.py
+++ b/examples/daft/batch_normalization.py
@@ -1,7 +1,7 @@
-"""Batch normalization — vectorized UDFs with batch=True.
+"""Batch normalization — vectorized Daft UDFs with daft_node(..., batch=True).
 
 Demonstrates:
-- batch=True on @node() for vectorized processing
+- daft_node(..., batch=True) for vectorized processing
 - Batch UDFs receive daft.Series instead of scalars
 - Useful for NumPy/Arrow-based operations
 
@@ -10,11 +10,13 @@ Inspired by Daft's batch UDF documentation.
 
 import daft
 
-from hypergraph import DaftRunner, Graph, node
+from hypergraph import Graph
+from hypergraph.integrations.daft import DaftRunner
+from hypergraph.integrations.daft import node as daft_node
 
 
-@node(output_name="normalized", batch=True)
-def normalize(values: daft.Series) -> daft.Series:
+@daft_node(output_name="normalized", batch=True, return_dtype=daft.DataType.float64())
+def normalize(values: daft.Series) -> list[float]:
     """Z-score normalize a column of values.
 
     This is a batch UDF: it receives and returns daft.Series,
@@ -24,8 +26,8 @@ def normalize(values: daft.Series) -> daft.Series:
     mean = sum(arr) / len(arr)
     std = (sum((x - mean) ** 2 for x in arr) / len(arr)) ** 0.5
     if std == 0:
-        return daft.Series.from_pylist([0.0] * len(arr))
-    return daft.Series.from_pylist([round((x - mean) / std, 4) for x in arr])
+        return [0.0] * len(arr)
+    return [round((x - mean) / std, 4) for x in arr]
 
 
 graph = Graph([normalize], name="batch_norm")

--- a/examples/daft/document_processing.py
+++ b/examples/daft/document_processing.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from hypergraph import DaftRunner, Graph, node
+from hypergraph import Graph, node
+from hypergraph.integrations.daft import DaftRunner
 
 
 @node(output_name="clean_document")

--- a/examples/daft/hierarchical_document_batches.py
+++ b/examples/daft/hierarchical_document_batches.py
@@ -7,7 +7,8 @@ chunks and then over multiple documents.
 
 from __future__ import annotations
 
-from hypergraph import DaftRunner, Graph, node
+from hypergraph import Graph, node
+from hypergraph.integrations.daft import DaftRunner
 
 
 @node(output_name="sentences")

--- a/examples/daft/ml_embeddings.py
+++ b/examples/daft/ml_embeddings.py
@@ -8,11 +8,11 @@ Demonstrates:
 Inspired by Daft's stateful UDF tutorial.
 """
 
-from hypergraph import DaftRunner, Graph, node
-from hypergraph.runners.daft import stateful
+from hypergraph import Graph, node
+from hypergraph.integrations.daft import DaftRunner, stateful
 
 
-@stateful
+@stateful(max_concurrency=2)
 class MockEmbedder:
     """Simulates a heavy ML model loaded once per worker.
 

--- a/examples/daft/nested_document_scoring.py
+++ b/examples/daft/nested_document_scoring.py
@@ -11,7 +11,8 @@ This is the core Hypergraph pattern:
 3. Scale over many documents with DaftRunner.map()
 """
 
-from hypergraph import DaftRunner, Graph, node
+from hypergraph import Graph, node
+from hypergraph.integrations.daft import DaftRunner
 
 
 # Inner pipeline: process ONE sentence

--- a/examples/daft/nested_review_objects.py
+++ b/examples/daft/nested_review_objects.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from hypergraph import DaftRunner, Graph, node
+from hypergraph import Graph, node
+from hypergraph.integrations.daft import DaftRunner
 
 
 @dataclass(frozen=True)

--- a/examples/daft/quickstart_customer_enrichment.py
+++ b/examples/daft/quickstart_customer_enrichment.py
@@ -6,7 +6,8 @@ Inspired by Daft's tabular quickstart examples, but expressed in Hypergraph's
 
 from __future__ import annotations
 
-from hypergraph import DaftRunner, Graph, node
+from hypergraph import Graph, node
+from hypergraph.integrations.daft import DaftRunner
 
 
 @node(output_name="full_name")

--- a/examples/daft/quickstart_orders.py
+++ b/examples/daft/quickstart_orders.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from hypergraph import DaftRunner, Graph, node
+from hypergraph import Graph, node
+from hypergraph.integrations.daft import DaftRunner
 
 
 @node(output_name="normalized_order")

--- a/examples/daft/scenario_sweeps.py
+++ b/examples/daft/scenario_sweeps.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from hypergraph import DaftRunner, Graph, node
+from hypergraph import Graph, node
+from hypergraph.integrations.daft import DaftRunner
 
 
 @node(output_name="normalized_candidate")

--- a/examples/daft/text_processing.py
+++ b/examples/daft/text_processing.py
@@ -8,7 +8,8 @@ Demonstrates:
 Inspired by Daft's quickstart UDF tutorial.
 """
 
-from hypergraph import DaftRunner, Graph, node
+from hypergraph import Graph, node
+from hypergraph.integrations.daft import DaftRunner
 
 
 @node(output_name="cleaned")

--- a/examples/framework_ports/daft_workflows.py
+++ b/examples/framework_ports/daft_workflows.py
@@ -12,7 +12,8 @@ from collections import Counter
 
 import daft
 
-from hypergraph import DaftRunner, Graph, node
+from hypergraph import Graph, node
+from hypergraph.integrations.daft import DaftRunner
 
 
 @node(output_name="cleaned_text")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ batch = [
 ]
 
 daft = [
-    "daft>=0.7.5",
+    "daft>=0.7.14",
 ]
 
 viz = [
@@ -78,7 +78,7 @@ telemetry = [
 
 all = [
     "pyarrow>=14.0.0",
-    "daft>=0.7.5",
+    "daft>=0.7.14",
     "hypercache>=0.2.2",
     "ipykernel<7",
     "ipywidgets>=8.1.7",
@@ -95,7 +95,7 @@ modal = [
 
 examples = [
     "colbert-ai>=0.2.22",
-    "daft>=0.7.5",
+    "daft>=0.7.14",
     "diskcache>=5.6.3",
     "hypercache>=0.2.2",
     "ipykernel>=6.31.0",

--- a/src/hypergraph/integrations/AGENTS.md
+++ b/src/hypergraph/integrations/AGENTS.md
@@ -1,0 +1,20 @@
+# Integration Agent Guide
+
+Public integration packages are opt-in facades over core Hypergraph behavior.
+
+## Public Boundary
+
+- Keep backend-specific user APIs under `hypergraph.integrations.<name>` instead
+  of adding backend knobs to core decorators or package-root exports.
+- Prefer typed option models over arbitrary dictionaries. Use dictionaries only
+  when an upstream library exposes that shape directly.
+- Keep implementation-heavy logic in the owning runner or subsystem; integration
+  modules should mostly compose and re-export the public surface.
+
+## Mirrors
+
+- When changing an integration API, update examples, API docs, and runner tests
+  that show the import path.
+- Docs should recommend explicit imports that avoid collisions with third-party
+  package names, for example `from hypergraph.integrations.daft import node as
+  daft_node`.

--- a/src/hypergraph/integrations/CLAUDE.md
+++ b/src/hypergraph/integrations/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/hypergraph/integrations/daft/__init__.py
+++ b/src/hypergraph/integrations/daft/__init__.py
@@ -1,12 +1,7 @@
-"""Compatibility re-export for the public Daft runner.
+"""Public Daft integration surface."""
 
-Prefer:
+from hypergraph.integrations.daft.decorators import node, stateful
+from hypergraph.integrations.daft.options import Options
+from hypergraph.runners.daft.runner import DaftRunner
 
-    from hypergraph import DaftRunner
-
-This module remains as a stable import path for older examples and notebooks.
-"""
-
-from hypergraph.runners.daft import DaftRunner
-
-__all__ = ["DaftRunner"]
+__all__ = ["DaftRunner", "Options", "node", "stateful"]

--- a/src/hypergraph/integrations/daft/decorators.py
+++ b/src/hypergraph/integrations/daft/decorators.py
@@ -1,0 +1,122 @@
+"""Public decorators for Hypergraph's Daft integration."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import replace
+from typing import Any, Literal
+
+from hypergraph.nodes.function import FunctionNode
+from hypergraph.runners.daft._options import Options, set_node_options
+from hypergraph.runners.daft._stateful import stateful
+
+__all__ = ["node", "stateful"]
+
+
+def node(
+    source: Callable | None = None,
+    output_name: str | tuple[str, ...] | None = None,
+    *,
+    rename_inputs: dict[str, str] | None = None,
+    cache: bool = False,
+    hide: bool = False,
+    emit: str | tuple[str, ...] | None = None,
+    wait_for: str | tuple[str, ...] | None = None,
+    options: Options | None = None,
+    batch: bool = False,
+    return_dtype: Any | None = None,
+    batch_size: int | None = None,
+    unnest: bool | None = None,
+    cpus: float | None = None,
+    use_process: bool | None = None,
+    max_concurrency: int | None = None,
+    max_retries: int | None = None,
+    on_error: Literal["raise", "log", "ignore"] | None = None,
+    gpus: float | None = None,
+    ray_options: dict[str, Any] | None = None,
+) -> FunctionNode | Callable[[Callable], FunctionNode]:
+    """Wrap a function as a Hypergraph node with Daft-specific lowering hints."""
+
+    daft_options = _merge_options(
+        options,
+        batch=batch,
+        return_dtype=return_dtype,
+        batch_size=batch_size,
+        unnest=unnest,
+        cpus=cpus,
+        use_process=use_process,
+        max_concurrency=max_concurrency,
+        max_retries=max_retries,
+        on_error=on_error,
+        gpus=gpus,
+        ray_options=ray_options,
+    )
+
+    def decorator(func: Callable) -> FunctionNode:
+        fn_node = FunctionNode(
+            source=func,
+            output_name=output_name,
+            rename_inputs=rename_inputs,
+            cache=cache,
+            hide=hide,
+            emit=emit,
+            wait_for=wait_for,
+        )
+        fn_node.__wrapped__ = func
+        set_node_options(fn_node, daft_options)
+        return fn_node
+
+    if source is not None:
+        return decorator(source)
+    return decorator
+
+
+def _merge_options(
+    options: Options | None,
+    *,
+    batch: bool,
+    return_dtype: Any | None,
+    batch_size: int | None,
+    unnest: bool | None,
+    cpus: float | None,
+    use_process: bool | None,
+    max_concurrency: int | None,
+    max_retries: int | None,
+    on_error: Literal["raise", "log", "ignore"] | None,
+    gpus: float | None,
+    ray_options: dict[str, Any] | None,
+) -> Options:
+    if options is not None and any(
+        value is not None
+        for value in (
+            return_dtype,
+            batch_size,
+            unnest,
+            cpus,
+            use_process,
+            max_concurrency,
+            max_retries,
+            on_error,
+            gpus,
+            ray_options,
+        )
+    ):
+        raise TypeError("Pass either options=Options(...) or direct Daft option keywords, not both")
+
+    if options is None:
+        return Options(
+            return_dtype=return_dtype,
+            batch=batch,
+            batch_size=batch_size,
+            unnest=unnest,
+            cpus=cpus,
+            use_process=use_process,
+            max_concurrency=max_concurrency,
+            max_retries=max_retries,
+            on_error=on_error,
+            gpus=gpus,
+            ray_options=ray_options,
+        )
+    if batch and not options.batch:
+        return replace(options, batch=True)
+    return options

--- a/src/hypergraph/integrations/daft/options.py
+++ b/src/hypergraph/integrations/daft/options.py
@@ -1,0 +1,5 @@
+"""Compatibility import for typed Daft integration options."""
+
+from hypergraph.runners.daft._options import DEFAULT_OPTIONS, Options
+
+__all__ = ["DEFAULT_OPTIONS", "Options"]

--- a/src/hypergraph/nodes/function.py
+++ b/src/hypergraph/nodes/function.py
@@ -113,7 +113,6 @@ class FunctionNode(CallableMixin, HyperNode):
         hide: bool = False,
         emit: str | tuple[str, ...] | None = None,
         wait_for: str | tuple[str, ...] | None = None,
-        batch: bool = False,
     ) -> None:
         """Wrap a function as a node.
 
@@ -129,9 +128,6 @@ class FunctionNode(CallableMixin, HyperNode):
                   when node runs. Participates in edge inference like output_name.
             wait_for: Ordering-only graph-scope output/emit address(es). Node
                       won't run until these values exist and are fresh.
-            batch: If True, DaftRunner uses vectorized batch UDF execution
-                   (receives ``daft.Series`` instead of scalars).
-
         Warning:
             If the function has a return type annotation but no output_name
             is provided, a warning is emitted. This helps catch cases where
@@ -149,7 +145,6 @@ class FunctionNode(CallableMixin, HyperNode):
         self.func = func
         self._cache = cache
         self._hide = hide
-        self._batch = batch
         self._definition_hash = hash_definition(func)
         self._emit = ensure_tuple(emit) if emit else ()
         self._wait_for = ensure_tuple(wait_for) if wait_for else ()
@@ -193,11 +188,6 @@ class FunctionNode(CallableMixin, HyperNode):
     def hide(self) -> bool:
         """Whether this node is hidden from visualization."""
         return self._hide
-
-    @property
-    def batch(self) -> bool:
-        """Whether this node uses vectorized batch execution in DaftRunner."""
-        return self._batch
 
     @property
     def wait_for(self) -> tuple[str, ...]:
@@ -307,7 +297,6 @@ def node(
     hide: bool = False,
     emit: str | tuple[str, ...] | None = None,
     wait_for: str | tuple[str, ...] | None = None,
-    batch: bool = False,
 ) -> FunctionNode | Callable[[Callable], FunctionNode]:
     """Decorator to wrap a function as a FunctionNode.
 
@@ -330,9 +319,6 @@ def node(
               when node runs. Participates in edge inference like output_name.
         wait_for: Ordering-only graph-scope output/emit address(es). Node
                   won't run until these values exist and are fresh.
-        batch: If True, DaftRunner uses vectorized batch UDF execution
-               (receives ``daft.Series`` instead of scalars).
-
     Returns:
         FunctionNode if source provided, else decorator function.
 
@@ -356,7 +342,6 @@ def node(
             hide=hide,
             emit=emit,
             wait_for=wait_for,
-            batch=batch,
         )
         fn_node.__wrapped__ = func
         return fn_node

--- a/src/hypergraph/runners/daft/AGENTS.md
+++ b/src/hypergraph/runners/daft/AGENTS.md
@@ -11,6 +11,16 @@ DataFrame plan is built.
 - Add tests for `select(...)`, configured entrypoints, and mapped inputs when
   changing plan construction.
 
+## Integration Boundary
+
+- Document user-facing Daft APIs through `hypergraph.integrations.daft`, not
+  `hypergraph.runners.daft`.
+- Keep typed Daft metadata in focused private modules such as `_options.py` and
+  `_stateful.py`; do not let `operations.py` accumulate public decorators or
+  option-merging policy.
+- When adding a Daft lowering option, update the typed option model, operation
+  validation, docs/examples, and at least one runtime test together.
+
 ## GraphNode Outputs
 
 - Never rely on dictionary iteration to pick GraphNode outputs. Use explicit

--- a/src/hypergraph/runners/daft/__init__.py
+++ b/src/hypergraph/runners/daft/__init__.py
@@ -1,6 +1,6 @@
 """Daft-backed runner package."""
 
-from hypergraph.runners.daft.operations import DaftStateful, stateful
+from hypergraph.runners.daft._stateful import DaftStateful, stateful
 from hypergraph.runners.daft.runner import DaftRunner
 
 __all__ = ["DaftRunner", "DaftStateful", "stateful"]

--- a/src/hypergraph/runners/daft/_options.py
+++ b/src/hypergraph/runners/daft/_options.py
@@ -27,8 +27,9 @@ class Options:
     def __post_init__(self) -> None:
         if self.on_error not in (None, "raise", "log", "ignore"):
             raise ValueError("on_error must be one of 'raise', 'log', or 'ignore'")
-        if self.max_concurrency is not None and self.max_concurrency < 1:
-            raise ValueError("max_concurrency must be a positive integer")
+        _validate_int("max_concurrency", self.max_concurrency, minimum=1)
+        _validate_int("max_retries", self.max_retries, minimum=0)
+        _validate_int("batch_size", self.batch_size, minimum=1)
         if self.cpus is not None and self.cpus < 0:
             raise ValueError(f"cpus must be non-negative, got {self.cpus}")
         if self.gpus is not None:
@@ -126,6 +127,14 @@ class Options:
                 "on_error": self.on_error,
             }
         )
+
+
+def _validate_int(name: str, value: int | None, *, minimum: int) -> None:
+    if value is None:
+        return
+    if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+        qualifier = "positive" if minimum == 1 else "non-negative"
+        raise ValueError(f"{name} must be a {qualifier} integer")
 
 
 DEFAULT_OPTIONS = Options()

--- a/src/hypergraph/runners/daft/_options.py
+++ b/src/hypergraph/runners/daft/_options.py
@@ -1,0 +1,148 @@
+"""Internal typed Daft options shared by the public integration and runner."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+NODE_OPTIONS_ATTR = "_daft_options"
+
+
+@dataclass(frozen=True, slots=True)
+class Options:
+    """Daft lowering options for integration-specific nodes and resources."""
+
+    return_dtype: Any | None = None
+    batch: bool = False
+    batch_size: int | None = None
+    unnest: bool | None = None
+    cpus: float | None = None
+    use_process: bool | None = None
+    max_concurrency: int | None = None
+    max_retries: int | None = None
+    on_error: Literal["raise", "log", "ignore"] | None = None
+    gpus: float | None = None
+    ray_options: dict[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        if self.on_error not in (None, "raise", "log", "ignore"):
+            raise ValueError("on_error must be one of 'raise', 'log', or 'ignore'")
+        if self.max_concurrency is not None and self.max_concurrency < 1:
+            raise ValueError("max_concurrency must be a positive integer")
+        if self.cpus is not None and self.cpus < 0:
+            raise ValueError(f"cpus must be non-negative, got {self.cpus}")
+        if self.gpus is not None:
+            if self.gpus < 0:
+                raise ValueError(f"gpus must be non-negative, got {self.gpus}")
+            if self.gpus > 1 and not float(self.gpus).is_integer():
+                raise ValueError(f"gpus greater than 1 must be an integer, got {self.gpus}")
+        if self.ray_options is not None:
+            unsupported = sorted({"memory", "num_cpus", "num_gpus"} & set(self.ray_options))
+            if unsupported:
+                names = ", ".join(repr(name) for name in unsupported)
+                raise ValueError(f"ray_options cannot include {names}; use cpus/gpus instead")
+
+    def validate_stateful_class_options(self) -> None:
+        """Reject node/method-only settings when options are used for ``stateful``."""
+        unsupported = []
+        if self.return_dtype is not None:
+            unsupported.append("return_dtype")
+        if self.batch:
+            unsupported.append("batch")
+        if self.batch_size is not None:
+            unsupported.append("batch_size")
+        if self.unnest is not None:
+            unsupported.append("unnest")
+        if unsupported:
+            names = ", ".join(unsupported)
+            raise ValueError(f"stateful Options cannot include {names}; put node/method options on daft_node(...)")
+
+    def for_func(self) -> dict[str, Any]:
+        """Keyword arguments accepted by ``daft.func``."""
+        return _drop_none(
+            {
+                "return_dtype": self.return_dtype,
+                "unnest": self.unnest,
+                "cpus": self.cpus,
+                "gpus": self.gpus,
+                "use_process": self.use_process,
+                "max_concurrency": self.max_concurrency,
+                "max_retries": self.max_retries,
+                "on_error": self.on_error,
+                "ray_options": self.ray_options,
+            }
+        )
+
+    def for_batch_func(self) -> dict[str, Any]:
+        """Keyword arguments accepted by ``daft.func.batch``."""
+        return _drop_none(
+            {
+                "return_dtype": self.return_dtype,
+                "unnest": self.unnest,
+                "cpus": self.cpus,
+                "gpus": self.gpus,
+                "use_process": self.use_process,
+                "max_concurrency": self.max_concurrency,
+                "batch_size": self.batch_size,
+                "max_retries": self.max_retries,
+                "on_error": self.on_error,
+                "ray_options": self.ray_options,
+            }
+        )
+
+    def for_cls(self) -> dict[str, Any]:
+        """Keyword arguments accepted by ``daft.cls``."""
+        return _drop_none(
+            {
+                "cpus": self.cpus,
+                "gpus": self.gpus,
+                "use_process": self.use_process,
+                "max_concurrency": self.max_concurrency,
+                "max_retries": self.max_retries,
+                "on_error": self.on_error,
+                "ray_options": self.ray_options,
+            }
+        )
+
+    def for_method(self) -> dict[str, Any]:
+        """Keyword arguments accepted by ``daft.method``."""
+        return _drop_none(
+            {
+                "return_dtype": self.return_dtype,
+                "unnest": self.unnest,
+                "max_retries": self.max_retries,
+                "on_error": self.on_error,
+            }
+        )
+
+    def for_batch_method(self) -> dict[str, Any]:
+        """Keyword arguments accepted by ``daft.method.batch``."""
+        return _drop_none(
+            {
+                "return_dtype": self.return_dtype,
+                "unnest": self.unnest,
+                "batch_size": self.batch_size,
+                "max_retries": self.max_retries,
+                "on_error": self.on_error,
+            }
+        )
+
+
+DEFAULT_OPTIONS = Options()
+
+
+def get_node_options(node: Any) -> Options:
+    """Return Daft lowering options attached to a node."""
+    options = getattr(node, NODE_OPTIONS_ATTR, None)
+    if options is None:
+        return DEFAULT_OPTIONS
+    return options
+
+
+def set_node_options(node: Any, options: Options) -> None:
+    """Attach Daft lowering options to a node."""
+    setattr(node, NODE_OPTIONS_ATTR, options)
+
+
+def _drop_none(values: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in values.items() if value is not None}

--- a/src/hypergraph/runners/daft/_stateful.py
+++ b/src/hypergraph/runners/daft/_stateful.py
@@ -1,0 +1,97 @@
+"""Stateful resource markers for Daft execution."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, ClassVar, Literal, Protocol, runtime_checkable
+
+from hypergraph.runners.daft._options import DEFAULT_OPTIONS, Options
+
+STATEFUL_ATTR = "__daft_stateful__"
+STATEFUL_OPTIONS_ATTR = "__daft_options__"
+
+
+@runtime_checkable
+class DaftStateful(Protocol):
+    """Protocol for objects marked as Daft stateful resources."""
+
+    __daft_stateful__: ClassVar[bool]
+
+
+def stateful(
+    cls: type | None = None,
+    *,
+    options: Options | None = None,
+    cpus: float | None = None,
+    gpus: float | None = None,
+    use_process: bool | None = None,
+    max_concurrency: int | None = None,
+    max_retries: int | None = None,
+    on_error: Literal["raise", "log", "ignore"] | None = None,
+    ray_options: dict[str, Any] | None = None,
+) -> type | Callable[[type], type]:
+    """Mark a class for per-worker initialization in DaftRunner."""
+    daft_options = _merge_stateful_options(
+        options,
+        cpus=cpus,
+        gpus=gpus,
+        use_process=use_process,
+        max_concurrency=max_concurrency,
+        max_retries=max_retries,
+        on_error=on_error,
+        ray_options=ray_options,
+    )
+
+    def decorate(class_: type) -> type:
+        setattr(class_, STATEFUL_ATTR, True)
+        setattr(class_, STATEFUL_OPTIONS_ATTR, daft_options)
+        return class_
+
+    if cls is not None:
+        return decorate(cls)
+    return decorate
+
+
+def is_stateful(value: Any) -> bool:
+    """Return whether ``value`` is marked as a Daft stateful resource."""
+    return getattr(type(value), STATEFUL_ATTR, False) is True
+
+
+def has_stateful_values(bound_values: dict[str, Any]) -> bool:
+    """Check if any bound values are marked as Daft stateful resources."""
+    return any(is_stateful(value) for value in bound_values.values())
+
+
+def get_stateful_options(value: Any) -> Options:
+    """Return Daft class options attached to a stateful resource."""
+    return getattr(type(value), STATEFUL_OPTIONS_ATTR, DEFAULT_OPTIONS)
+
+
+def _merge_stateful_options(
+    options: Options | None,
+    *,
+    cpus: float | None,
+    gpus: float | None,
+    use_process: bool | None,
+    max_concurrency: int | None,
+    max_retries: int | None,
+    on_error: Literal["raise", "log", "ignore"] | None,
+    ray_options: dict[str, Any] | None,
+) -> Options:
+    direct_values = (cpus, gpus, use_process, max_concurrency, max_retries, on_error, ray_options)
+    if options is not None and any(value is not None for value in direct_values):
+        raise TypeError("Pass either options=Options(...) or direct Daft option keywords, not both")
+
+    if options is not None:
+        options.validate_stateful_class_options()
+        return options
+
+    return Options(
+        cpus=cpus,
+        gpus=gpus,
+        use_process=use_process,
+        max_concurrency=max_concurrency,
+        max_retries=max_retries,
+        on_error=on_error,
+        ray_options=ray_options,
+    )

--- a/src/hypergraph/runners/daft/operations.py
+++ b/src/hypergraph/runners/daft/operations.py
@@ -192,7 +192,7 @@ class BatchNodeOperation(DaftOperation):
             kwargs = {**bound, **dict(zip(col_names, series_args, strict=True))}
             return func(**kwargs)
 
-        udf = daft_mod.func.batch(**_batch_func_options(node, daft_mod))(batch_wrapper)
+        udf = daft_mod.func.batch(**_batch_func_options(node))(batch_wrapper)
 
         col_refs = [df[c] for c in input_cols]
         return df.with_column(output_col, udf(*col_refs))
@@ -349,6 +349,7 @@ def create_operation(
             _validate_batch_options(node, output_cols)
         if has_stateful_values(node_bound):
             _validate_stateful_constructable(node_bound)
+            _validate_stateful_node_options(node)
             return StatefulNodeOperation(
                 node=node,
                 input_columns=input_cols,
@@ -404,6 +405,11 @@ def _validate_stateful_constructable(bound_values: dict[str, Any]) -> None:
 def _validate_batch_options(node: HyperNode, output_cols: list[str]) -> None:
     from hypergraph.runners._shared.validation import IncompatibleRunnerError
 
+    if asyncio.iscoroutinefunction(node.func):
+        raise IncompatibleRunnerError(
+            f"Async batch UDF node {node.name!r} is not supported until Daft batch lowering supports awaiting coroutine results.",
+            capability="node_types",
+        )
     if len(output_cols) > 1:
         raise IncompatibleRunnerError(
             f"Batch UDFs with multiple outputs are not supported (node {node.name!r} has {output_cols}).",
@@ -412,6 +418,19 @@ def _validate_batch_options(node: HyperNode, output_cols: list[str]) -> None:
     if get_options(node).return_dtype is None:
         raise IncompatibleRunnerError(
             f"Batch UDF node {node.name!r} requires return_dtype. Pass return_dtype=... to hypergraph.integrations.daft.node(..., batch=True).",
+            capability="node_types",
+        )
+
+
+def _validate_stateful_node_options(node: HyperNode) -> None:
+    from hypergraph.runners._shared.validation import IncompatibleRunnerError
+
+    options = get_options(node)
+    unsupported = [name for name in ("cpus", "gpus", "use_process", "max_concurrency", "ray_options") if getattr(options, name) is not None]
+    if unsupported:
+        names = ", ".join(unsupported)
+        raise IncompatibleRunnerError(
+            f"Daft resource option(s) {names} on stateful node {node.name!r} must be set on @stateful(...), not daft_node(...).",
             capability="node_types",
         )
 
@@ -447,11 +466,8 @@ def _func_options(node: HyperNode, daft_mod: Any) -> dict[str, Any]:
     return kwargs
 
 
-def _batch_func_options(node: HyperNode, daft_mod: Any) -> dict[str, Any]:
-    options = get_options(node)
-    kwargs = options.for_batch_func()
-    kwargs.setdefault("return_dtype", daft_mod.DataType.python())
-    return kwargs
+def _batch_func_options(node: HyperNode) -> dict[str, Any]:
+    return get_options(node).for_batch_func()
 
 
 def _method_options(node: HyperNode, daft_mod: Any) -> dict[str, Any]:
@@ -475,15 +491,12 @@ def _stateful_options(stateful_vals: dict[str, Any]) -> Options:
 
 def _stateful_method_decorator(daft_mod: Any, node: HyperNode) -> Callable[[Callable], Callable]:
     if is_batch(node):
-        return daft_mod.method.batch(**_batch_method_options(node, daft_mod))
+        return daft_mod.method.batch(**_batch_method_options(node))
     return daft_mod.method(**_method_options(node, daft_mod))
 
 
-def _batch_method_options(node: HyperNode, daft_mod: Any) -> dict[str, Any]:
-    options = get_options(node)
-    kwargs = options.for_batch_method()
-    kwargs.setdefault("return_dtype", daft_mod.DataType.python())
-    return kwargs
+def _batch_method_options(node: HyperNode) -> dict[str, Any]:
+    return get_options(node).for_batch_method()
 
 
 def _unpack_multi_output(

--- a/src/hypergraph/runners/daft/operations.py
+++ b/src/hypergraph/runners/daft/operations.py
@@ -3,8 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, ClassVar, Protocol, runtime_checkable
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from hypergraph.runners.daft._options import DEFAULT_OPTIONS, Options, get_node_options
+from hypergraph.runners.daft._stateful import DaftStateful, get_stateful_options, has_stateful_values, is_stateful
 
 if TYPE_CHECKING:
     import daft
@@ -14,62 +19,14 @@ if TYPE_CHECKING:
     from hypergraph.nodes.base import HyperNode
 
 
-@runtime_checkable
-class DaftStateful(Protocol):
-    """Protocol for objects loaded once per Daft worker.
-
-    Mark a class with ``@stateful`` so DaftRunner wraps it with ``@daft.cls``
-    instead of ``@daft.func``.  This is useful for heavy resources
-    (ML models, DB connections) that should be initialized once per
-    worker process rather than once per row.
-
-    Example::
-
-        @stateful
-        class MyModel:
-            def __init__(self):
-                self.model = load_heavy_model()
-
-        graph = Graph([embed]).bind(model=MyModel())
-        DaftRunner().map(graph, {"text": texts}, map_over="text")
-    """
-
-    __daft_stateful__: ClassVar[bool]
-
-
-def stateful(cls: type) -> type:
-    """Mark a class for per-worker initialization in DaftRunner.
-
-    Stateful objects are re-created once per Daft worker process via
-    ``@daft.cls``, so heavy resources (models, DB connections) aren't
-    serialized per row.
-
-    Example::
-
-        @stateful
-        class MyModel:
-            def __init__(self):
-                self.model = load_heavy_model()
-
-        graph = Graph([embed]).bind(model=MyModel())
-    """
-    cls.__daft_stateful__ = True
-    return cls
-
-
 def is_batch(node: HyperNode) -> bool:
     """Check if a node is marked for batch (vectorized) execution."""
-    return getattr(node, "batch", False) is True
+    return get_options(node).batch is True
 
 
-def _is_stateful(v: Any) -> bool:
-    """Check if a value is DaftStateful (attribute exists AND is truthy)."""
-    return getattr(type(v), "__daft_stateful__", False) is True
-
-
-def has_stateful_values(bound_values: dict[str, Any]) -> bool:
-    """Check if any bound values implement DaftStateful protocol."""
-    return any(_is_stateful(v) for v in bound_values.values())
+def get_options(node: HyperNode) -> Options:
+    """Return Daft lowering options for a node."""
+    return get_node_options(node)
 
 
 # ---------------------------------------------------------------------------
@@ -137,9 +94,9 @@ class FunctionNodeOperation(DaftOperation):
                 kwargs = {**bound, **dict(zip(col_names, args, strict=True))}
                 return await func(**kwargs)
 
-            udf = daft_mod.func(return_dtype=daft_mod.DataType.python())(async_wrapper)
+            udf = daft_mod.func(**_func_options(node, daft_mod))(async_wrapper)
         else:
-            udf = daft_mod.func(return_dtype=daft_mod.DataType.python())(wrapper)
+            udf = daft_mod.func(**_func_options(node, daft_mod))(wrapper)
 
         col_refs = [df[c] for c in input_cols]
         df = df.with_column(output_col, udf(*col_refs))
@@ -169,24 +126,41 @@ class StatefulNodeOperation(DaftOperation):
         col_names = input_cols  # capture for closure
 
         # Separate stateful from plain bound values
-        stateful_vals = {k: v for k, v in bound.items() if _is_stateful(v)}
-        plain_vals = {k: v for k, v in bound.items() if not _is_stateful(v)}
+        stateful_vals = {k: v for k, v in bound.items() if is_stateful(v)}
+        stateful_types = {k: type(v) for k, v in stateful_vals.items()}
+        plain_vals = {k: v for k, v in bound.items() if not is_stateful(v)}
 
-        @daft_mod.cls
+        class_options = _stateful_options(stateful_vals)
+
+        @daft_mod.cls(**class_options.for_cls())
         class StatefulWrapper:
             def __init__(self):
-                # Each stateful object is re-created once per worker
-                self._stateful = {k: type(v)() for k, v in stateful_vals.items()}
+                self._stateful: dict[str, Any] | None = None
                 self._plain = plain_vals
 
-            @daft_mod.method(return_dtype=daft_mod.DataType.python())
-            def __call__(self, *args: Any) -> Any:
-                kwargs = {
-                    **self._stateful,
+            def _stateful_values(self) -> dict[str, Any]:
+                if self._stateful is None:
+                    self._stateful = {k: cls() for k, cls in stateful_types.items()}
+                return self._stateful
+
+            def _call_kwargs(self, *args: Any) -> dict[str, Any]:
+                return {
+                    **self._stateful_values(),
                     **self._plain,
                     **dict(zip(col_names, args, strict=True)),
                 }
-                return func(**kwargs)
+
+            if asyncio.iscoroutinefunction(func):
+
+                @_stateful_method_decorator(daft_mod, node)
+                async def __call__(self, *args: Any) -> Any:
+                    return await func(**self._call_kwargs(*args))
+
+            else:
+
+                @_stateful_method_decorator(daft_mod, node)
+                def __call__(self, *args: Any) -> Any:
+                    return func(**self._call_kwargs(*args))
 
         col_refs = [df[c] for c in input_cols]
         df = df.with_column(output_col, StatefulWrapper()(*col_refs))
@@ -218,7 +192,7 @@ class BatchNodeOperation(DaftOperation):
             kwargs = {**bound, **dict(zip(col_names, series_args, strict=True))}
             return func(**kwargs)
 
-        udf = daft_mod.func.batch(return_dtype=daft_mod.DataType.python())(batch_wrapper)
+        udf = daft_mod.func.batch(**_batch_func_options(node, daft_mod))(batch_wrapper)
 
         col_refs = [df[c] for c in input_cols]
         return df.with_column(output_col, udf(*col_refs))
@@ -370,15 +344,11 @@ def create_operation(
         )
 
     if isinstance(node, FunctionNode):
+        _validate_common_options(node)
+        if is_batch(node):
+            _validate_batch_options(node, output_cols)
         if has_stateful_values(node_bound):
             _validate_stateful_constructable(node_bound)
-            if asyncio.iscoroutinefunction(node.func):
-                from hypergraph.runners._shared.validation import IncompatibleRunnerError
-
-                raise IncompatibleRunnerError(
-                    f"Stateful UDFs with async node functions are not supported (node {node.name!r}).",
-                    capability="node_types",
-                )
             return StatefulNodeOperation(
                 node=node,
                 input_columns=input_cols,
@@ -386,14 +356,8 @@ def create_operation(
                 bound_values=node_bound,
                 clone=clone,
             )
+        _validate_stateless_options(node)
         if is_batch(node):
-            if len(output_cols) > 1:
-                from hypergraph.runners._shared.validation import IncompatibleRunnerError
-
-                raise IncompatibleRunnerError(
-                    f"Batch UDFs with multiple outputs are not supported (node {node.name!r} has {output_cols}).",
-                    capability="node_types",
-                )
             return BatchNodeOperation(
                 node=node,
                 input_columns=input_cols,
@@ -428,13 +392,98 @@ def _validate_stateful_constructable(bound_values: dict[str, Any]) -> None:
         if not isinstance(v, DaftStateful):
             continue
         try:
-            type(v)()
+            inspect.signature(type(v)).bind()
         except TypeError as e:
             raise TypeError(
                 f"DaftStateful object {k!r} ({type(v).__name__}) must support "
                 f"zero-arg construction for per-worker re-initialization. Got: {e}\n\n"
                 f"How to fix: Ensure {type(v).__name__}.__init__() works with no arguments."
             ) from e
+
+
+def _validate_batch_options(node: HyperNode, output_cols: list[str]) -> None:
+    from hypergraph.runners._shared.validation import IncompatibleRunnerError
+
+    if len(output_cols) > 1:
+        raise IncompatibleRunnerError(
+            f"Batch UDFs with multiple outputs are not supported (node {node.name!r} has {output_cols}).",
+            capability="node_types",
+        )
+    if get_options(node).return_dtype is None:
+        raise IncompatibleRunnerError(
+            f"Batch UDF node {node.name!r} requires return_dtype. Pass return_dtype=... to hypergraph.integrations.daft.node(..., batch=True).",
+            capability="node_types",
+        )
+
+
+def _validate_common_options(node: HyperNode) -> None:
+    from hypergraph.runners._shared.validation import IncompatibleRunnerError
+
+    options = get_options(node)
+    if options.batch_size is not None and not is_batch(node):
+        raise IncompatibleRunnerError(
+            f"Daft option batch_size is only supported for batch UDF nodes (node {node.name!r} is not batch=True).",
+            capability="node_types",
+        )
+
+
+def _validate_stateless_options(node: HyperNode) -> None:
+    from hypergraph.runners._shared.validation import IncompatibleRunnerError
+
+    options = get_options(node)
+    if options.max_concurrency is not None and not asyncio.iscoroutinefunction(node.func):
+        raise IncompatibleRunnerError(
+            f"Daft option max_concurrency is only supported for async stateless UDF nodes "
+            f"(node {node.name!r} is synchronous). Use @stateful(max_concurrency=...) "
+            f"for actor-pool concurrency.",
+            capability="node_types",
+        )
+
+
+def _func_options(node: HyperNode, daft_mod: Any) -> dict[str, Any]:
+    options = get_options(node)
+    kwargs = options.for_func()
+    kwargs.setdefault("return_dtype", daft_mod.DataType.python())
+    return kwargs
+
+
+def _batch_func_options(node: HyperNode, daft_mod: Any) -> dict[str, Any]:
+    options = get_options(node)
+    kwargs = options.for_batch_func()
+    kwargs.setdefault("return_dtype", daft_mod.DataType.python())
+    return kwargs
+
+
+def _method_options(node: HyperNode, daft_mod: Any) -> dict[str, Any]:
+    options = get_options(node)
+    kwargs = options.for_method()
+    kwargs.setdefault("return_dtype", daft_mod.DataType.python())
+    return kwargs
+
+
+def _stateful_options(stateful_vals: dict[str, Any]) -> Options:
+    options_by_name = {name: get_stateful_options(value) for name, value in stateful_vals.items()}
+    unique: list[Options] = []
+    for options in options_by_name.values():
+        if options not in unique:
+            unique.append(options)
+    if len(unique) > 1:
+        details = ", ".join(f"{name}={options!r}" for name, options in sorted(options_by_name.items()))
+        raise ValueError(f"Stateful Daft resources in one node must use identical class options. Got: {details}")
+    return unique[0] if unique else DEFAULT_OPTIONS
+
+
+def _stateful_method_decorator(daft_mod: Any, node: HyperNode) -> Callable[[Callable], Callable]:
+    if is_batch(node):
+        return daft_mod.method.batch(**_batch_method_options(node, daft_mod))
+    return daft_mod.method(**_method_options(node, daft_mod))
+
+
+def _batch_method_options(node: HyperNode, daft_mod: Any) -> dict[str, Any]:
+    options = get_options(node)
+    kwargs = options.for_batch_method()
+    kwargs.setdefault("return_dtype", daft_mod.DataType.python())
+    return kwargs
 
 
 def _unpack_multi_output(

--- a/src/hypergraph/runners/daft/runner.py
+++ b/src/hypergraph/runners/daft/runner.py
@@ -52,7 +52,8 @@ class DaftRunner(BaseRunner):
 
     Each node becomes a Daft UDF chained via ``df.with_column()``.
     Supports sync nodes, async nodes (Daft handles natively),
-    stateful UDFs (``@stateful``), batch UDFs (``batch=True``),
+    stateful UDFs (``@stateful``), integration batch UDFs
+    (``hypergraph.integrations.daft.node(..., batch=True)``),
     and nested GraphNodes.
 
     Does NOT support cycles, gates, interrupts, or runner delegation
@@ -306,7 +307,8 @@ class DaftRunner(BaseRunner):
             validate_item_inputs(ctx, validation_values)
 
         plan = build_execution_plan(graph, all_bound, self._cache, clone)
-        return execute_plan(dataframe.select(*column_names), plan)
+        _check_output_column_collision(list(dataframe.column_names), plan)
+        return execute_plan(dataframe, plan)
 
     # ------------------------------------------------------------------
     # Internal: columnar execution
@@ -486,4 +488,42 @@ def _check_column_overlap(
             f"Input keys provided by both the Daft DataFrame and broadcast "
             f"values: {overlap_str}.\n\n"
             f"How to fix: Rename one side or drop the duplicate."
+        )
+
+
+def _check_output_column_collision(
+    column_names: list[str],
+    plan: list[Any],
+) -> None:
+    """Reject graph outputs that would overwrite input DataFrame columns."""
+    output_columns = set()
+    internal_columns = set()
+    for op in plan:
+        output_columns.update(op.output_columns)
+        if len(op.output_columns) > 1:
+            internal_columns.add(f"_pack_{op.node.name}")
+
+    input_columns = set(column_names)
+    output_overlap = sorted(input_columns & output_columns)
+    if output_overlap:
+        from hypergraph.graph.validation import GraphConfigError
+
+        overlap_str = ", ".join(repr(name) for name in output_overlap)
+        raise GraphConfigError(
+            f"Daft graph output column would overwrite existing DataFrame column: "
+            f"{overlap_str}.\n\n"
+            f"How to fix: Rename the node output or drop/rename the existing "
+            f"DataFrame column before calling map_dataframe."
+        )
+
+    internal_overlap = sorted(input_columns & internal_columns)
+    if internal_overlap:
+        from hypergraph.graph.validation import GraphConfigError
+
+        overlap_str = ", ".join(repr(name) for name in internal_overlap)
+        raise GraphConfigError(
+            f"Daft graph internal scratch column would overwrite existing "
+            f"DataFrame column: {overlap_str}.\n\n"
+            f"How to fix: Drop or rename the existing DataFrame column before "
+            f"calling map_dataframe."
         )

--- a/tests/test_daft_examples.py
+++ b/tests/test_daft_examples.py
@@ -7,7 +7,7 @@ pytest.importorskip("daft")
 from examples.daft.document_processing import build_document_processing_graph
 from examples.daft.quickstart_orders import build_quickstart_orders_graph
 from examples.daft.scenario_sweeps import build_scenario_sweep_graph
-from hypergraph import DaftRunner
+from hypergraph.integrations.daft import DaftRunner
 
 
 def test_quickstart_orders_example():

--- a/tests/test_examples_daft.py
+++ b/tests/test_examples_daft.py
@@ -18,6 +18,7 @@ EXAMPLE_PATHS = [
     Path("examples/daft/async_api_calls.py"),
     Path("examples/daft/ml_embeddings.py"),
     Path("examples/daft/batch_normalization.py"),
+    Path("examples/daft/advanced_udf_patterns.py"),
     Path("examples/daft/nested_document_scoring.py"),
 ]
 

--- a/tests/test_integrations_daft.py
+++ b/tests/test_integrations_daft.py
@@ -1,0 +1,274 @@
+"""Public Daft integration API tests."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("daft")
+
+import daft
+
+from hypergraph import Graph, node
+from hypergraph.integrations.daft import DaftRunner, Options, stateful
+from hypergraph.integrations.daft import node as daft_node
+from hypergraph.integrations.daft.options import Options as ReExportedOptions
+from hypergraph.runners.daft._options import Options as InternalOptions
+
+
+def test_daft_node_batch_executes_with_typed_options() -> None:
+    @daft_node(
+        output_name="word_count",
+        batch=True,
+        return_dtype=daft.DataType.int64(),
+        batch_size=2,
+    )
+    def count_words(text: daft.Series) -> list[int]:
+        return [len(value.split()) for value in text.to_pylist()]
+
+    graph = Graph([count_words], name="batch_words")
+
+    result = DaftRunner().map(
+        graph,
+        {"text": ["one fish", "two", "red blue"]},
+        map_over="text",
+    )
+
+    assert result["word_count"] == [2, 1, 2]
+
+
+def test_core_node_does_not_accept_daft_batch_option() -> None:
+    with pytest.raises(TypeError, match="batch"):
+
+        @node(output_name="word_count", batch=True)
+        def count_words(text: str) -> int:
+            return len(text.split())
+
+
+def test_stateful_batch_node_executes_with_worker_resource() -> None:
+    @stateful(max_concurrency=2)
+    class Prefixer:
+        def __init__(self) -> None:
+            self.prefix = "hg:"
+
+        def apply(self, value: str) -> str:
+            return f"{self.prefix}{value.strip().lower()}"
+
+    @daft_node(
+        output_name="normalized",
+        batch=True,
+        return_dtype=daft.DataType.string(),
+        batch_size=2,
+    )
+    def normalize(text: daft.Series, prefixer: Prefixer) -> list[str]:
+        return [prefixer.apply(value) for value in text.to_pylist()]
+
+    graph = Graph([normalize], name="stateful_batch").bind(prefixer=Prefixer())
+
+    result = DaftRunner().map(
+        graph,
+        {"text": [" Alpha ", "BETA", " Gamma"]},
+        map_over="text",
+    )
+
+    assert result["normalized"] == ["hg:alpha", "hg:beta", "hg:gamma"]
+
+
+def test_map_dataframe_rejects_output_column_collision() -> None:
+    from hypergraph.graph.validation import GraphConfigError
+
+    @node(output_name="text")
+    def normalize(raw: str) -> str:
+        return raw.strip().lower()
+
+    graph = Graph([normalize], name="collision")
+    frame = daft.from_pydict(
+        {
+            "raw": [" Alpha "],
+            "text": ["already present"],
+        }
+    )
+
+    with pytest.raises(GraphConfigError, match="output column.*text"):
+        DaftRunner().map_dataframe(graph, frame)
+
+
+def test_map_dataframe_rejects_internal_pack_column_collision() -> None:
+    from hypergraph.graph.validation import GraphConfigError
+
+    @node(output_name=("lo", "hi"))
+    def bounds(x: int) -> tuple[int, int]:
+        return x - 1, x + 1
+
+    graph = Graph([bounds], name="internal_collision")
+    frame = daft.from_pydict({"x": [2], "_pack_bounds": ["already present"]})
+
+    with pytest.raises(GraphConfigError, match="internal scratch column.*_pack_bounds"):
+        DaftRunner().map_dataframe(graph, frame)
+
+
+def test_map_dataframe_preserves_passthrough_columns_when_columns_selects_inputs() -> None:
+    @node(output_name="word_count")
+    def count_words(text: str) -> int:
+        return len(text.split())
+
+    graph = Graph([count_words], name="passthrough")
+    frame = daft.from_pydict(
+        {
+            "id": [1, 2],
+            "text": ["one fish", "red blue"],
+            "source": ["api", "csv"],
+        }
+    )
+
+    result = DaftRunner().map_dataframe(graph, frame, columns=["text"]).collect().to_pydict()
+
+    assert result == {
+        "id": [1, 2],
+        "text": ["one fish", "red blue"],
+        "source": ["api", "csv"],
+        "word_count": [2, 2],
+    }
+
+
+def test_stateful_async_node_executes_with_worker_resource() -> None:
+    @stateful
+    class Multiplier:
+        def __init__(self) -> None:
+            self.factor = 3
+
+    @daft_node(output_name="scaled")
+    async def scale(x: int, multiplier: Multiplier) -> int:
+        await asyncio.sleep(0)
+        return x * multiplier.factor
+
+    graph = Graph([scale], name="stateful_async").bind(multiplier=Multiplier())
+
+    result = DaftRunner().map(graph, {"x": [2, 4]}, map_over="x")
+
+    assert result["scaled"] == [6, 12]
+
+
+def test_async_stateless_node_uses_daft_execution_options() -> None:
+    @daft_node(output_name="doubled", max_concurrency=2)
+    async def double(x: int) -> int:
+        await asyncio.sleep(0)
+        return x * 2
+
+    graph = Graph([double], name="async_options")
+
+    result = DaftRunner().map(graph, {"x": [1, 2, 3]}, map_over="x")
+
+    assert result["doubled"] == [2, 4, 6]
+
+
+def test_async_stateless_node_can_ignore_daft_udf_errors() -> None:
+    @daft_node(output_name="status", max_concurrency=2, max_retries=0, on_error="ignore")
+    async def fail(value: str) -> str:
+        await asyncio.sleep(0)
+        raise ValueError(f"failed {value}")
+
+    graph = Graph([fail], name="async_ignore")
+
+    result = DaftRunner().map(graph, {"value": ["a", "b"]}, map_over="value")
+
+    assert result["status"] == [None, None]
+
+
+def test_map_dataframe_stateful_plan_build_does_not_eagerly_construct_resource() -> None:
+    @stateful
+    class LazyResource:
+        constructions = 0
+
+        def __init__(self) -> None:
+            type(self).constructions += 1
+
+        def transform(self, x: int) -> int:
+            return x + 1
+
+    @node(output_name="y")
+    def transform(x: int, resource: LazyResource) -> int:
+        return resource.transform(x)
+
+    graph = Graph([transform], name="lazy_stateful").bind(resource=LazyResource())
+    frame = daft.from_pydict({"x": [1, 2]})
+
+    result = DaftRunner().map_dataframe(graph, frame)
+
+    assert LazyResource.constructions == 1
+    assert result.collect().to_pydict()["y"] == [2, 3]
+
+
+def test_batch_node_requires_explicit_return_dtype() -> None:
+    from hypergraph.runners._shared.validation import IncompatibleRunnerError
+
+    @daft_node(output_name="word_count", batch=True)
+    def count_words(text: daft.Series) -> list[int]:
+        return [len(value.split()) for value in text.to_pylist()]
+
+    graph = Graph([count_words], name="batch_dtype")
+
+    with pytest.raises(IncompatibleRunnerError, match="return_dtype"):
+        DaftRunner().map(graph, {"text": ["one fish"]}, map_over="text")
+
+
+def test_batch_size_without_batch_is_rejected_before_execution() -> None:
+    from hypergraph.runners._shared.validation import IncompatibleRunnerError
+
+    @daft_node(output_name="word_count", batch_size=2)
+    def count_words(text: str) -> int:
+        return len(text.split())
+
+    graph = Graph([count_words], name="bad_batch_size")
+
+    with pytest.raises(IncompatibleRunnerError, match="batch_size"):
+        DaftRunner().map(graph, {"text": ["one fish"]}, map_over="text")
+
+
+def test_sync_stateless_max_concurrency_is_rejected_before_execution() -> None:
+    from hypergraph.runners._shared.validation import IncompatibleRunnerError
+
+    @daft_node(output_name="word_count", max_concurrency=2)
+    def count_words(text: str) -> int:
+        return len(text.split())
+
+    graph = Graph([count_words], name="bad_concurrency")
+
+    with pytest.raises(IncompatibleRunnerError, match="max_concurrency"):
+        DaftRunner().map(graph, {"text": ["one fish"]}, map_over="text")
+
+
+def test_ray_resource_options_are_rejected_at_definition_time() -> None:
+    with pytest.raises(ValueError, match="num_cpus"):
+
+        @daft_node(
+            output_name="word_count",
+            ray_options={"num_cpus": 1},
+        )
+        def count_words(text: str) -> int:
+            return len(text.split())
+
+
+def test_options_validate_current_daft_resource_rules_at_definition_time() -> None:
+    with pytest.raises(ValueError, match="on_error"):
+        Options(on_error="skip")  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="max_concurrency"):
+        Options(max_concurrency=0)
+
+    with pytest.raises(ValueError, match="gpus"):
+        Options(gpus=1.5)
+
+
+def test_options_reexports_use_one_class_identity() -> None:
+    assert Options is InternalOptions is ReExportedOptions
+
+
+def test_stateful_rejects_node_only_options() -> None:
+    with pytest.raises(ValueError, match="stateful.*return_dtype"):
+
+        @stateful(options=Options(return_dtype=daft.DataType.int64()))
+        class Resource:
+            def __init__(self) -> None:
+                pass

--- a/tests/test_integrations_daft.py
+++ b/tests/test_integrations_daft.py
@@ -213,6 +213,20 @@ def test_batch_node_requires_explicit_return_dtype() -> None:
         DaftRunner().map(graph, {"text": ["one fish"]}, map_over="text")
 
 
+def test_async_batch_node_is_rejected_before_execution() -> None:
+    from hypergraph.runners._shared.validation import IncompatibleRunnerError
+
+    @daft_node(output_name="word_count", batch=True, return_dtype=daft.DataType.int64())
+    async def count_words(text: daft.Series) -> list[int]:
+        await asyncio.sleep(0)
+        return [len(value.split()) for value in text.to_pylist()]
+
+    graph = Graph([count_words], name="async_batch")
+
+    with pytest.raises(IncompatibleRunnerError, match="Async batch"):
+        DaftRunner().map(graph, {"text": ["one fish"]}, map_over="text")
+
+
 def test_batch_size_without_batch_is_rejected_before_execution() -> None:
     from hypergraph.runners._shared.validation import IncompatibleRunnerError
 
@@ -239,6 +253,24 @@ def test_sync_stateless_max_concurrency_is_rejected_before_execution() -> None:
         DaftRunner().map(graph, {"text": ["one fish"]}, map_over="text")
 
 
+def test_stateful_node_rejects_node_level_resource_options() -> None:
+    from hypergraph.runners._shared.validation import IncompatibleRunnerError
+
+    @stateful
+    class Resource:
+        def transform(self, value: int) -> int:
+            return value + 1
+
+    @daft_node(output_name="y", max_concurrency=2)
+    def transform(x: int, resource: Resource) -> int:
+        return resource.transform(x)
+
+    graph = Graph([transform], name="bad_stateful_options").bind(resource=Resource())
+
+    with pytest.raises(IncompatibleRunnerError, match="max_concurrency.*@stateful"):
+        DaftRunner().map(graph, {"x": [1]}, map_over="x")
+
+
 def test_ray_resource_options_are_rejected_at_definition_time() -> None:
     with pytest.raises(ValueError, match="num_cpus"):
 
@@ -256,6 +288,18 @@ def test_options_validate_current_daft_resource_rules_at_definition_time() -> No
 
     with pytest.raises(ValueError, match="max_concurrency"):
         Options(max_concurrency=0)
+
+    with pytest.raises(ValueError, match="max_concurrency"):
+        Options(max_concurrency=1.5)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="max_retries"):
+        Options(max_retries=-1)
+
+    with pytest.raises(ValueError, match="batch_size"):
+        Options(batch_size=0)
+
+    with pytest.raises(ValueError, match="batch_size"):
+        Options(batch_size=1.5)  # type: ignore[arg-type]
 
     with pytest.raises(ValueError, match="gpus"):
         Options(gpus=1.5)

--- a/tests/test_runners/test_daft_operations.py
+++ b/tests/test_runners/test_daft_operations.py
@@ -9,12 +9,13 @@ pytest.importorskip("daft")
 import daft
 
 from hypergraph import Graph, node
+from hypergraph.integrations.daft import node as daft_node
+from hypergraph.integrations.daft import stateful
 from hypergraph.runners.daft.operations import (
     DaftStateful,
     create_operation,
     has_stateful_values,
     is_batch,
-    stateful,
 )
 
 # ---------------------------------------------------------------------------
@@ -97,7 +98,7 @@ class TestDaftStatefulProtocol:
 
 class TestBatchDetection:
     def test_batch_true_detected(self):
-        @node(output_name="out", batch=True)
+        @daft_node(output_name="out", batch=True, return_dtype=daft.DataType.int64())
         def batch_node(x: int) -> int:
             return x
 
@@ -134,7 +135,7 @@ class TestCreateOperation:
     def test_routes_batch_node(self):
         from hypergraph.runners.daft.operations import BatchNodeOperation
 
-        @node(output_name="out", batch=True)
+        @daft_node(output_name="out", batch=True, return_dtype=daft.DataType.int64())
         def batch_fn(x: int) -> int:
             return x
 
@@ -261,7 +262,7 @@ class TestStatefulNodeOperation:
 
 class TestBatchNodeOperation:
     def test_apply_receives_series(self):
-        @node(output_name="doubled", batch=True)
+        @daft_node(output_name="doubled", batch=True, return_dtype=daft.DataType.int64())
         def batch_double(x: daft.Series) -> daft.Series:
             values = x.to_pylist()
             return daft.Series.from_pylist([v * 2 for v in values])
@@ -274,25 +275,25 @@ class TestBatchNodeOperation:
 
 
 # ---------------------------------------------------------------------------
-# Validation: stateful + async rejection
+# Validation: stateful + async support
 # ---------------------------------------------------------------------------
 
 
-class TestStatefulAsyncRejection:
-    def test_stateful_async_node_rejected(self):
-        from hypergraph.runners._shared.validation import IncompatibleRunnerError
+class TestStatefulAsyncSupport:
+    def test_stateful_async_node_routes(self):
+        from hypergraph.runners.daft.operations import StatefulNodeOperation
 
         @node(output_name="out")
         async def async_stateful(x: int, model: MockModel) -> int:
             return x + model.value
 
         graph = Graph([async_stateful], name="test")
-        with pytest.raises(IncompatibleRunnerError, match="async"):
-            create_operation(
-                async_stateful,
-                graph,
-                bound_values={"model": MockModel()},
-            )
+        op = create_operation(
+            async_stateful,
+            graph,
+            bound_values={"model": MockModel()},
+        )
+        assert isinstance(op, StatefulNodeOperation)
 
 
 # ---------------------------------------------------------------------------
@@ -304,7 +305,7 @@ class TestBatchMultiOutputRejection:
     def test_batch_multi_output_rejected(self):
         from hypergraph.runners._shared.validation import IncompatibleRunnerError
 
-        @node(output_name=("a", "b"), batch=True)
+        @daft_node(output_name=("a", "b"), batch=True, return_dtype=daft.DataType.python())
         def bad_batch(x: int) -> tuple[int, int]:
             return (x, x)
 

--- a/tests/test_runners/test_daft_runner.py
+++ b/tests/test_runners/test_daft_runner.py
@@ -213,7 +213,7 @@ def test_daft_runner_map_dataframe_renamed_graphnode_multi_outputs():
 
 
 def test_daft_runner_map_dataframe_columns_filter():
-    """columns= parameter should select a subset of DataFrame columns."""
+    """columns= selects graph inputs while preserving passthrough columns."""
     import daft
 
     graph = Graph([double], name="col_filter")
@@ -223,8 +223,7 @@ def test_daft_runner_map_dataframe_columns_filter():
     collected = result_df.collect().to_pydict()
     assert collected["doubled"] == [2, 4]
     assert collected["x"] == [1, 2]
-    # extra column should NOT appear — it was filtered out
-    assert "extra" not in collected
+    assert collected["extra"] == ["a", "b"]
 
 
 def test_daft_runner_map_dataframe_missing_column_raises():

--- a/uv.lock
+++ b/uv.lock
@@ -758,7 +758,7 @@ wheels = [
 
 [[package]]
 name = "daft"
-version = "0.7.5"
+version = "0.7.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fsspec" },
@@ -767,13 +767,13 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/13/683623b5e62ffb50c761f14368e18a7caaab5993b7597db8f75d4ea036b2/daft-0.7.5.tar.gz", hash = "sha256:d04ee44185f280dd2735990edf01f3a60b7dde86870d4d359602a73081f08314", size = 2839832, upload-time = "2026-03-17T00:24:12.606Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/43/897f27f2cdcd8a93276fbc64fbde15d0c2131c8e656bb93be657efe85b66/daft-0.7.14.tar.gz", hash = "sha256:23b8ae24537817d40f300f71d60550fdca50a9000ddf37deffc0e303b3e6923e", size = 3224465, upload-time = "2026-05-20T03:41:05.088Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/de/8a93c014febdabd0dff987dd12a7bf69c9fa795bbe9a5c7998959b7b2775/daft-0.7.5-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:b7bbe1cfa3dcef3128443f73ccc00c37465641ab0bbf5f2bb85311eac42ef2cc", size = 56255549, upload-time = "2026-03-17T00:23:33.354Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/44/703f39c5a15e0409134f4959b848f790da7412f66bad1dceb6c9734c1a05/daft-0.7.5-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:50d50ef987d5a7d75b2db50c03f0de3e597115ad1c9c461ae4a9799e7fbdf783", size = 52213574, upload-time = "2026-03-17T00:23:37.994Z" },
-    { url = "https://files.pythonhosted.org/packages/26/0d/0e508bb591a26626ca689e556a43cac947b40b10133021c8276d9acb96b8/daft-0.7.5-cp310-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:2a2fad56e2d941d91bdb8ae1692b4e96f1fc151addb15427b67cdba5f561d36d", size = 54607974, upload-time = "2026-03-17T00:23:42.903Z" },
-    { url = "https://files.pythonhosted.org/packages/85/a2/50c137f21f30b09674774204bed1974dda7e1be9eb78da7badf969aba408/daft-0.7.5-cp310-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:cfb44d540e4e32d99c4281f69fb6c071a168bca98fcea93bd0a36e611b055e58", size = 56731547, upload-time = "2026-03-17T00:23:48.456Z" },
-    { url = "https://files.pythonhosted.org/packages/47/f7/d371d4f48818341557d9c3fad75bea5970d2f8e3b95016d13761297d2218/daft-0.7.5-cp310-abi3-win_amd64.whl", hash = "sha256:eb7b6da90fc1af2575d3a6107425db27373d14622134136f4926239db1422633", size = 57531217, upload-time = "2026-03-17T00:23:53.538Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ca/02f43d207e29383a3743ad2738aa3726419e376a3c4574e31c9399b2b011/daft-0.7.14-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:dd2328961835797cc3b1f721bea910518b8e1a090560e19088db82ec2ef8ff44", size = 61509612, upload-time = "2026-05-20T03:40:16.485Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/40/f7437c120cd9c78e8bd258d9047403ffb8371ac9b21587e8ca5c28b9e52e/daft-0.7.14-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:d372ac76beb2cd1cd8d7cb617b5c5936ddd2ade8f6d61f8b32a9b2bb14747685", size = 57069703, upload-time = "2026-05-20T03:40:22.526Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/16/b442a439004934de1140e04025e0d1ba07dd17c5fc6e6dda89bc6746723f/daft-0.7.14-cp310-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:de296328d19f3ecd5ad409583979f89b01f1d8a913d0360b4b4d3f20f5e56a09", size = 59651829, upload-time = "2026-05-20T03:40:27.904Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/19/df6465dee01e2557801d8e323a7d1ad5bae1ec11883440afebe21f6be67a/daft-0.7.14-cp310-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:5808823c3ef21dfe278d21af2540e11bc675642f617d2b51434bf2fdd827d0fa", size = 61946262, upload-time = "2026-05-20T03:40:33.309Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/13/e0efefb2cfac2b2b33d01143aaa16f832009a7516969eb42efaac723d36c/daft-0.7.14-cp310-abi3-win_amd64.whl", hash = "sha256:f7a7ae3088b234d75fa10242b181d90326eea3f7b6a9c331ec02ce07f404c706", size = 62767597, upload-time = "2026-05-20T03:40:40.416Z" },
 ]
 
 [[package]]
@@ -1467,9 +1467,9 @@ requires-dist = [
     { name = "aiosqlite", marker = "extra == 'cli'", specifier = ">=0.20.0" },
     { name = "cloudpickle", marker = "extra == 'modal'", specifier = ">=3.0.0" },
     { name = "colbert-ai", marker = "extra == 'examples'", specifier = ">=0.2.22" },
-    { name = "daft", marker = "extra == 'all'", specifier = ">=0.7.5" },
-    { name = "daft", marker = "extra == 'daft'", specifier = ">=0.7.5" },
-    { name = "daft", marker = "extra == 'examples'", specifier = ">=0.7.5" },
+    { name = "daft", marker = "extra == 'all'", specifier = ">=0.7.14" },
+    { name = "daft", marker = "extra == 'daft'", specifier = ">=0.7.14" },
+    { name = "daft", marker = "extra == 'examples'", specifier = ">=0.7.14" },
     { name = "diskcache", marker = "extra == 'cache'", specifier = ">=5.6.3" },
     { name = "diskcache", marker = "extra == 'examples'", specifier = ">=5.6.3" },
     { name = "hypercache", marker = "extra == 'all'", specifier = ">=0.2.2" },


### PR DESCRIPTION
## Problem / Bug / Challenge

Daft-specific tuning was starting to leak into core Hypergraph primitives. The integration needed a cleaner public shape where plain `@node` remains backend-neutral, while Daft-specific batch, dtype, retry, resource, and concurrency controls are opt-in through an explicit integration namespace.

This also tightens Daft runtime behavior around stateful resources, batch UDF validation, `map_dataframe` passthrough columns, and current Daft UDF APIs.

## Before / After

**Before:**

```python
from hypergraph import DaftRunner, Graph, node
from hypergraph.runners.daft import stateful

@node(output_name="normalized", batch=True)
def normalize(values):
    ...
```

Daft-specific concepts lived on core `@node`, docs/examples imported runner internals, and `map_dataframe(columns=[...])` projected away passthrough columns.

**After:**

```python
import daft

from hypergraph import Graph, node
from hypergraph.integrations.daft import DaftRunner, Options, stateful
from hypergraph.integrations.daft import node as daft_node

@node(output_name="clean")
def clean(text: str) -> str:
    return text.strip()

@daft_node(
    output_name="normalized",
    batch=True,
    return_dtype=daft.DataType.float64(),
    batch_size=64,
)
def normalize(values: daft.Series) -> list[float]:
    ...

@stateful(max_concurrency=2)
class Embedder:
    def __init__(self) -> None:
        self.model = load_heavy_model()
```

Plain Hypergraph nodes auto-lower under `DaftRunner`; Daft-only controls now live behind `hypergraph.integrations.daft`. Stateful resources lower to `daft.cls`, batch nodes lower to `daft.func.batch` / `daft.method.batch`, and `map_dataframe` preserves passthrough columns while rejecting output collisions.

## Test Plan

- [x] `uv sync --group dev --extra daft`
- [x] `uv run playwright install chromium`
- [x] `uv run --extra daft pytest -W error -W 'ignore::pytest.PytestUnraisableExceptionWarning' tests/test_integrations_daft.py tests/test_runners/test_daft_operations.py tests/test_runners/test_daft_runner.py tests/test_runners/test_daft_infrastructure.py tests/test_examples_daft.py tests/test_daft_examples.py tests/test_framework_ports.py -k 'daft or Daft'` — 96 passed
- [x] `uv run pytest -W error -W 'ignore::pytest.PytestUnraisableExceptionWarning'` — 2695 passed
- [x] `uv run ruff check src/ tests/ examples/daft examples/framework_ports/daft_workflows.py`
- [x] `uv run ruff format --check src/ tests/ examples/daft examples/framework_ports/daft_workflows.py`
- [x] `git diff --check`

## Review Prep

- Ran the repo structural sweeps for old Daft API mirrors (`daft_options`, `DaftOptions`, core `@node(..., batch=True)` docs/examples).
- Ran a thermo-nuclear maintainability pass and accepted the structural cleanup: moved typed Daft options/stateful metadata out of `operations.py` into focused private modules and added integration AGENTS guidance.
- Verified AGENTS/CLAUDE symlink hygiene after adding `src/hypergraph/integrations/AGENTS.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `@daft_node` decorator for Daft-specific batch operations with explicit `return_dtype` requirement.
  * `@stateful` decorator now accepts parameters (e.g., `max_concurrency`).
  * Added typed `Options` configuration for Daft integration settings.

* **Documentation**
  * Expanded Daft workflows guide with mental models, stateful resources, and batch patterns.
  * Added dashboard and extensions setup instructions.

* **Bug Fixes**
  * Enhanced validation to prevent DataFrame output column collisions.

* **Chores**
  * Reorganized imports: `DaftRunner` now from `hypergraph.integrations.daft`.
  * Updated minimum Daft version to 0.7.14.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gilad-rubin/hypergraph/pull/153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->