### PR TITLE
[codex] validate runner input kwargs against graph inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,9 @@ runner.run(graph, query="hello", llm=llm)
 Rules:
 - `values` + kwargs are merged.
 - Duplicate keys across both raise `ValueError`.
+- Kwargs shorthand only accepts flat graph inputs, such as `query=...`.
+- Use `values={...}` for dotted or nested graph inputs, such as `{"inner.x": 1}`.
 - Runner option names (`select`, `map_over`, `max_concurrency`, etc.) stay reserved.
-- Passing reserved runner option names via kwargs raises `ValueError`.
 - If an input name matches an option name, pass it in `values={...}`.
 
 ## Examples

--- a/docs/06-api-reference/runners.md
+++ b/docs/06-api-reference/runners.md
@@ -87,7 +87,6 @@ Execute a graph once.
   - `"ignore"` (default): silently omit missing outputs
   - `"warn"`: warn about missing outputs, return what's available
   - `"error"`: raise error if any selected output is missing
-- `on_internal_override` - Reserved for compatibility. Internal produced values are rejected deterministically.
 - `max_iterations` - Max local iterations per cyclic execution region (SCC) (default: 1000)
 - `error_handling` - How to handle node execution errors:
   - `"raise"` (default): Re-raise the original exception (e.g., `ValueError`). Clean traceback, no wrapper.
@@ -102,7 +101,7 @@ Execute a graph once.
 - `fork_from` - Workflow ID to fork from directly (no manual checkpoint plumbing). Requires a checkpointer.
 - `retry_from` - Workflow ID to retry from directly (records retry lineage metadata). Requires a checkpointer.
 - Lineage hashing: checkpoint compatibility uses a structural hash; a separate code hash is recorded for observability/caching workflows.
-- `**input_values` - Input shorthand (merged with `values`)
+- `**input_values` - Input shorthand for flat graph input names. Use `values` for dotted/nested inputs or names that match runner options.
 
 **Returns:** `RunResult` with outputs and status
 
@@ -199,7 +198,7 @@ Execute a graph multiple times with different inputs.
   - `"continue"`: Collect all results, including failures as `RunResult` with `status=FAILED`
 - `event_processors` - Optional list of [event processors](events.md) to observe execution
 - `workflow_id` - Optional workflow identifier for checkpoint persistence and resume. Creates a parent batch run with per-item child runs (`{workflow_id}/0`, `{workflow_id}/1`, ...). On re-run, completed items are skipped. See [Resuming Batches](../05-how-to/batch-processing.md#resuming-batches).
-- `**input_values` - Input shorthand (merged with `values`)
+- `**input_values` - Input shorthand for flat graph input names. Use `values` for dotted/nested inputs or names that match runner options.
 
 **Returns:** [`MapResult`](#mapresult) wrapping per-iteration RunResults with batch metadata
 
@@ -322,7 +321,7 @@ Execute a graph once via a 1-row Daft plan.
 - `max_iterations` - Accepted for API compatibility but not used (DaftRunner does not support cycles)
 - `error_handling` - `"raise"` re-raises the original exception; `"continue"` returns a failed `RunResult`
 - `event_processors` - Accepted but ignored with a warning (DaftRunner does not support events)
-- `**input_values` - Input shorthand (merged with `values`)
+- `**input_values` - Input shorthand for flat graph input names. Use `values` for dotted/nested inputs or names that match runner options.
 
 **Example:**
 
@@ -376,7 +375,7 @@ entrypoint when your data is a Python collection.
 - `on_missing` - How to handle missing selected outputs (`"ignore"`, `"warn"`, or `"error"`)
 - `error_handling` - `"raise"` re-raises the first failed item's original exception; `"continue"` falls back to per-item execution and preserves failures inside `MapResult`
 - `event_processors` - Accepted but ignored with a warning
-- `**input_values` - Input shorthand (merged with `values`)
+- `**input_values` - Input shorthand for flat graph input names. Use `values` for dotted/nested inputs or names that match runner options.
 
 **Example:**
 
@@ -435,7 +434,7 @@ DataFrame columns without materializing rows back into Python.
 - `graph` - The graph to execute (must be a DAG)
 - `dataframe` - Daft DataFrame supplying row-wise inputs
 - `columns` - Optional subset of DataFrame columns to use as graph inputs. Defaults to all columns.
-- `values` / `**input_values` - Additional broadcast inputs merged into every row. Must not overlap with DataFrame column names.
+- `values` / `**input_values` - Additional broadcast inputs merged into every row. `**input_values` only accepts flat graph input names; use `values` for dotted/nested inputs or names that match runner options. Must not overlap with DataFrame column names.
 - `clone` - Deep-copy mutable broadcast values for each row
 
 **Returns:** Daft DataFrame with original input columns plus graph output columns.
@@ -677,7 +676,7 @@ Execute a graph asynchronously.
 - `fork_from` - Workflow ID to fork from directly (no manual checkpoint plumbing). Requires a checkpointer.
 - `retry_from` - Workflow ID to retry from directly (records retry lineage metadata). Requires a checkpointer.
 - Lineage hashing: checkpoint compatibility uses a structural hash; a separate code hash is recorded for observability/caching workflows.
-- `**input_values` - Input shorthand (merged with `values`)
+- `**input_values` - Input shorthand for flat graph input names. Use `values` for dotted/nested inputs or names that match runner options.
 
 **Returns:** `RunResult` with outputs and status
 
@@ -758,7 +757,7 @@ Execute graph multiple times concurrently.
   - `"continue"`: Collect all results, including failures as `RunResult` with `status=FAILED`
 - `event_processors` - Optional list of [event processors](events.md) to observe execution
 - `workflow_id` - Optional workflow identifier for checkpoint persistence and resume. Creates per-item child runs that can be skipped on re-run. See [Resuming Batches](../05-how-to/batch-processing.md#resuming-batches).
-- `**input_values` - Input shorthand (merged with `values`)
+- `**input_values` - Input shorthand for flat graph input names. Use `values` for dotted/nested inputs or names that match runner options.
 
 **Example:**
 
@@ -1062,13 +1061,17 @@ runner.run(graph, query="hello", llm=llm)
 Rules:
 - `values` + kwargs are merged
 - duplicate keys raise `ValueError`
+- kwargs shorthand only accepts flat graph inputs, such as `query=...`
+- use `values={...}` for dotted or nested graph inputs, such as `{"inner.x": 1}`
 - option names like `select`, `map_over`, `max_concurrency` are reserved for runner options
-- reserved option names in kwargs raise `ValueError`
 - if an input name matches an option name, pass that input through `values={...}`
 
 ```python
 # input named "select" must go through values
 runner.run(graph, values={"select": "fast"})
+
+# namespaced inputs must also go through values
+runner.run(outer, values={"inner.x": 5})
 ```
 
 ### Execution Model

--- a/src/hypergraph/runners/_shared/__init__.py
+++ b/src/hypergraph/runners/_shared/__init__.py
@@ -10,12 +10,9 @@ from hypergraph.runners._shared.helpers import (
     wrap_outputs,
 )
 from hypergraph.runners._shared.input_normalization import (
-    ASYNC_MAP_RESERVED_OPTION_NAMES,
-    ASYNC_RUN_RESERVED_OPTION_NAMES,
-    MAP_RESERVED_OPTION_NAMES,
-    RUN_RESERVED_OPTION_NAMES,
     merge_with_duplicate_check,
     normalize_inputs,
+    runner_option_names,
 )
 from hypergraph.runners._shared.protocols import (
     AsyncNodeExecutor,
@@ -63,10 +60,7 @@ __all__ = [
     "validate_map_compatible",
     "validate_node_types",
     # Input normalization
-    "RUN_RESERVED_OPTION_NAMES",
-    "ASYNC_RUN_RESERVED_OPTION_NAMES",
-    "MAP_RESERVED_OPTION_NAMES",
-    "ASYNC_MAP_RESERVED_OPTION_NAMES",
     "merge_with_duplicate_check",
     "normalize_inputs",
+    "runner_option_names",
 ]

--- a/src/hypergraph/runners/_shared/input_normalization.py
+++ b/src/hypergraph/runners/_shared/input_normalization.py
@@ -3,16 +3,25 @@
 from __future__ import annotations
 
 import inspect
+from collections.abc import Mapping
+from functools import cache
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from hypergraph.graph.core import Graph
+    from hypergraph.runners._shared.validation import _InputValidationContext
 
 _NON_OPTION_PARAMETER_NAMES = frozenset({"dataframe", "graph", "self", "values"})
 
 
 def runner_option_names(method: Any) -> frozenset[str]:
     """Return explicit runner control kwargs from a runner method signature."""
+    return _runner_option_names(getattr(method, "__func__", method))
+
+
+@cache
+def _runner_option_names(method: Any) -> frozenset[str]:
+    """Cached implementation for runner_option_names()."""
     return frozenset(
         name
         for name, param in inspect.signature(method).parameters.items()
@@ -39,8 +48,10 @@ def normalize_inputs(
     reserved_option_names: frozenset[str] | None = None,
     other_option_names: frozenset[str] | None = None,
     other_call_name: str | None = None,
+    other_option_call_names: Mapping[str, str] | None = None,
     call_name: str | None = None,
     graph: Graph | None = None,
+    validation_ctx: _InputValidationContext | None = None,
 ) -> dict[str, Any]:
     """Normalize inputs from values dict + kwargs shorthand.
 
@@ -55,12 +66,21 @@ def normalize_inputs(
     if reserved_option_names:
         conflicts = sorted(set(input_kwargs) & reserved_option_names)
         if conflicts:
-            raise ValueError(_reserved_input_error(conflicts, call_name, other_option_names, other_call_name))
+            raise ValueError(
+                _reserved_input_error(
+                    conflicts,
+                    call_name,
+                    other_option_names,
+                    other_call_name,
+                    other_option_call_names,
+                )
+            )
 
     if graph is not None and input_kwargs:
-        unexpected = _unexpected_input_kwargs(input_kwargs, graph)
+        runtime_input_names = _valid_runtime_input_names(graph, validation_ctx)
+        unexpected = _unexpected_input_kwargs(input_kwargs, runtime_input_names)
         if unexpected:
-            raise ValueError(_unexpected_input_kwarg_error(unexpected, graph, call_name))
+            raise ValueError(_unexpected_input_kwarg_error(unexpected, runtime_input_names, call_name))
 
     merged = base_values if not input_kwargs else merge_with_duplicate_check(base_values, input_kwargs)
 
@@ -76,17 +96,23 @@ def _reserved_input_error(
     call_name: str | None,
     other_option_names: frozenset[str] | None,
     other_call_name: str | None,
+    other_option_call_names: Mapping[str, str] | None,
 ) -> str:
     """Create a specific error for kwargs that collide with runner controls."""
     location = call_name or "this runner method"
     if len(conflicts) == 1:
         name = conflicts[0]
         literal = f"{name!r}"
-        if other_option_names and other_call_name and name in other_option_names:
-            other_call = other_call_name.removesuffix("()")
+        resolved_other_call_name = None
+        if other_option_call_names is not None:
+            resolved_other_call_name = other_option_call_names.get(name)
+        elif other_option_names and other_call_name and name in other_option_names:
+            resolved_other_call_name = other_call_name
+        if resolved_other_call_name is not None:
+            other_call = resolved_other_call_name.removesuffix("()")
             return (
                 f"{location} does not accept {name}=. {name}= is only for "
-                f"{other_call_name}. Use {other_call}(..., {name}=...) "
+                f"{resolved_other_call_name}. Use {other_call}(..., {name}=...) "
                 f"if that is what you meant. If your graph input is named {literal}, "
                 f"pass it through values={{{literal}: ...}}."
             )
@@ -104,29 +130,32 @@ def _reserved_input_error(
     )
 
 
-def _unexpected_input_kwargs(input_kwargs: dict[str, Any], graph: Graph) -> list[str]:
+def _unexpected_input_kwargs(input_kwargs: dict[str, Any], runtime_input_names: set[str]) -> list[str]:
     """Return kwargs that are not flat graph input names."""
-    flat_input_names = {name for name in _valid_runtime_input_names(graph) if "." not in name}
+    flat_input_names = {name for name in runtime_input_names if "." not in name}
     return sorted(name for name in input_kwargs if name not in flat_input_names)
 
 
-def _valid_runtime_input_names(graph: Graph) -> set[str]:
-    """Return graph boundary inputs plus interrupt resume keys."""
-    from hypergraph.runners._shared.validation import precompute_input_validation
+def _valid_runtime_input_names(
+    graph: Graph,
+    validation_ctx: _InputValidationContext | None = None,
+) -> set[str]:
+    """Return graph boundary inputs, bound keys, and interrupt resume keys."""
+    if validation_ctx is None:
+        from hypergraph.runners._shared.validation import precompute_input_validation
 
-    ctx = precompute_input_validation(graph)
-    return set(graph.inputs.all) | ctx.interrupt_outputs
+        validation_ctx = precompute_input_validation(graph)
+    return set(validation_ctx.input_spec.all) | set(validation_ctx.input_spec.bound) | validation_ctx.interrupt_outputs
 
 
-def _unexpected_input_kwarg_error(unexpected: list[str], graph: Graph, call_name: str | None) -> str:
+def _unexpected_input_kwarg_error(unexpected: list[str], runtime_input_names: set[str], call_name: str | None) -> str:
     """Create a helpful error for kwargs outside the flat graph input surface."""
     location = call_name or "this runner method"
-    all_inputs = _valid_runtime_input_names(graph)
-    flat_inputs = sorted(name for name in all_inputs if "." not in name)
+    flat_inputs = sorted(name for name in runtime_input_names if "." not in name)
 
     if len(unexpected) == 1:
         name = unexpected[0]
-        if "." in name and name in all_inputs:
+        if "." in name and name in runtime_input_names:
             head, leaf = name.split(".", 1)
             return (
                 f"Dotted input address {name!r} cannot be passed as a keyword argument to {location}. "

--- a/src/hypergraph/runners/_shared/input_normalization.py
+++ b/src/hypergraph/runners/_shared/input_normalization.py
@@ -2,51 +2,22 @@
 
 from __future__ import annotations
 
+import inspect
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from hypergraph.graph.core import Graph
 
-RUN_RESERVED_OPTION_NAMES = frozenset(
-    {
-        "select",
-        "max_iterations",
-        "event_processors",
-        "show_progress",
-        "on_internal_override",
-        "_parent_span_id",
-    }
-)
+_NON_OPTION_PARAMETER_NAMES = frozenset({"dataframe", "graph", "self", "values"})
 
 
-ASYNC_RUN_RESERVED_OPTION_NAMES = frozenset(
-    {
-        *RUN_RESERVED_OPTION_NAMES,
-        "max_concurrency",
-    }
-)
-
-
-MAP_RESERVED_OPTION_NAMES = frozenset(
-    {
-        "map_over",
-        "map_mode",
-        "select",
-        "error_handling",
-        "event_processors",
-        "show_progress",
-        "on_internal_override",
-        "_parent_span_id",
-    }
-)
-
-
-ASYNC_MAP_RESERVED_OPTION_NAMES = frozenset(
-    {
-        *MAP_RESERVED_OPTION_NAMES,
-        "max_concurrency",
-    }
-)
+def runner_option_names(method: Any) -> frozenset[str]:
+    """Return explicit runner control kwargs from a runner method signature."""
+    return frozenset(
+        name
+        for name, param in inspect.signature(method).parameters.items()
+        if name not in _NON_OPTION_PARAMETER_NAMES and param.kind is inspect.Parameter.KEYWORD_ONLY
+    )
 
 
 def merge_with_duplicate_check(
@@ -66,6 +37,9 @@ def normalize_inputs(
     input_kwargs: dict[str, Any],
     *,
     reserved_option_names: frozenset[str] | None = None,
+    other_option_names: frozenset[str] | None = None,
+    other_call_name: str | None = None,
+    call_name: str | None = None,
     graph: Graph | None = None,
 ) -> dict[str, Any]:
     """Normalize inputs from values dict + kwargs shorthand.
@@ -81,8 +55,12 @@ def normalize_inputs(
     if reserved_option_names:
         conflicts = sorted(set(input_kwargs) & reserved_option_names)
         if conflicts:
-            conflicts_str = ", ".join(repr(name) for name in conflicts)
-            raise ValueError(f"Input keys are reserved runner options: {conflicts_str}. Pass these keys via values={{...}}.")
+            raise ValueError(_reserved_input_error(conflicts, call_name, other_option_names, other_call_name))
+
+    if graph is not None and input_kwargs:
+        unexpected = _unexpected_input_kwargs(input_kwargs, graph)
+        if unexpected:
+            raise ValueError(_unexpected_input_kwarg_error(unexpected, graph, call_name))
 
     merged = base_values if not input_kwargs else merge_with_duplicate_check(base_values, input_kwargs)
 
@@ -91,3 +69,78 @@ def normalize_inputs(
     from hypergraph.graph._helpers import flatten_subgraph_addressing
 
     return flatten_subgraph_addressing(merged, graph)
+
+
+def _reserved_input_error(
+    conflicts: list[str],
+    call_name: str | None,
+    other_option_names: frozenset[str] | None,
+    other_call_name: str | None,
+) -> str:
+    """Create a specific error for kwargs that collide with runner controls."""
+    location = call_name or "this runner method"
+    if len(conflicts) == 1:
+        name = conflicts[0]
+        literal = f"{name!r}"
+        if other_option_names and other_call_name and name in other_option_names:
+            other_call = other_call_name.removesuffix("()")
+            return (
+                f"{location} does not accept {name}=. {name}= is only for "
+                f"{other_call_name}. Use {other_call}(..., {name}=...) "
+                f"if that is what you meant. If your graph input is named {literal}, "
+                f"pass it through values={{{literal}: ...}}."
+            )
+        return (
+            f"{location} cannot use {name}= as an input keyword because {name}= "
+            f"is a Hypergraph runner option. If your graph input is named {literal}, "
+            f"pass it through values={{{literal}: ...}}."
+        )
+
+    conflicts_str = ", ".join(repr(name) for name in conflicts)
+    return (
+        f"{location} cannot use these names as input keywords because they are "
+        f"Hypergraph runner options: {conflicts_str}. If they are graph inputs, "
+        f"pass them through values={{...}}."
+    )
+
+
+def _unexpected_input_kwargs(input_kwargs: dict[str, Any], graph: Graph) -> list[str]:
+    """Return kwargs that are not flat graph input names."""
+    flat_input_names = {name for name in _valid_runtime_input_names(graph) if "." not in name}
+    return sorted(name for name in input_kwargs if name not in flat_input_names)
+
+
+def _valid_runtime_input_names(graph: Graph) -> set[str]:
+    """Return graph boundary inputs plus interrupt resume keys."""
+    from hypergraph.runners._shared.validation import precompute_input_validation
+
+    ctx = precompute_input_validation(graph)
+    return set(graph.inputs.all) | ctx.interrupt_outputs
+
+
+def _unexpected_input_kwarg_error(unexpected: list[str], graph: Graph, call_name: str | None) -> str:
+    """Create a helpful error for kwargs outside the flat graph input surface."""
+    location = call_name or "this runner method"
+    all_inputs = _valid_runtime_input_names(graph)
+    flat_inputs = sorted(name for name in all_inputs if "." not in name)
+
+    if len(unexpected) == 1:
+        name = unexpected[0]
+        if "." in name and name in all_inputs:
+            head, leaf = name.split(".", 1)
+            return (
+                f"Dotted input address {name!r} cannot be passed as a keyword argument to {location}. "
+                f"Pass it through values={{{name!r}: ...}} or values={{{head!r}: {{{leaf!r}: ...}}}}."
+            )
+        expected = ", ".join(repr(name) for name in flat_inputs) if flat_inputs else "(none)"
+        return (
+            f"{location} got unexpected input keyword {name!r}. kwargs shorthand only accepts flat graph inputs. "
+            f"Expected input keywords: {expected}. Use values={{...}} for dotted or nested graph inputs."
+        )
+
+    unexpected_str = ", ".join(repr(name) for name in unexpected)
+    expected = ", ".join(repr(name) for name in flat_inputs) if flat_inputs else "(none)"
+    return (
+        f"{location} got unexpected input keywords: {unexpected_str}. kwargs shorthand only accepts flat graph inputs. "
+        f"Expected input keywords: {expected}. Use values={{...}} for dotted or nested graph inputs."
+    )

--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -41,9 +41,8 @@ from hypergraph.runners._shared.helpers import (
     warn_on_bind_overrides,
 )
 from hypergraph.runners._shared.input_normalization import (
-    ASYNC_MAP_RESERVED_OPTION_NAMES,
-    ASYNC_RUN_RESERVED_OPTION_NAMES,
     normalize_inputs,
+    runner_option_names,
 )
 from hypergraph.runners._shared.run_log import RunLogCollector
 from hypergraph.runners._shared.types import (
@@ -211,10 +210,15 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
         **input_values: Any,
     ) -> RunResult:
         """Execute a graph once."""
+        run_option_names = runner_option_names(self.run)
+        map_option_names = runner_option_names(self.map)
         normalized_values = normalize_inputs(
             values,
             input_values,
-            reserved_option_names=ASYNC_RUN_RESERVED_OPTION_NAMES,
+            reserved_option_names=run_option_names | map_option_names,
+            other_option_names=map_option_names - run_option_names,
+            other_call_name="runner.map()",
+            call_name="runner.run()",
             graph=graph,
         )
         # Only fire override warning at the user-initiated outer run; nested
@@ -580,10 +584,15 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
         **input_values: Any,
     ) -> MapResult:
         """Execute a graph multiple times with different inputs."""
+        run_option_names = runner_option_names(self.run)
+        map_option_names = runner_option_names(self.map)
         normalized_values = normalize_inputs(
             values,
             input_values,
-            reserved_option_names=ASYNC_MAP_RESERVED_OPTION_NAMES,
+            reserved_option_names=run_option_names | map_option_names,
+            other_option_names=run_option_names - map_option_names,
+            other_call_name="runner.run()",
+            call_name="runner.map()",
             graph=graph,
         )
         # Same parity as run(): only fire override warning at the user-initiated

--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -58,7 +58,6 @@ from hypergraph.runners._shared.validation import (
     precompute_input_validation,
     resolve_runtime_selected,
     validate_delegated_runners,
-    validate_inputs,
     validate_item_inputs,
     validate_map_compatible,
     validate_node_types,
@@ -212,6 +211,13 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
         """Execute a graph once."""
         run_option_names = runner_option_names(self.run)
         map_option_names = runner_option_names(self.map)
+        validation_ctx = _validation_ctx
+        if validation_ctx is None:
+            _validate_on_missing(on_missing)
+            _validate_error_handling(error_handling)
+            _validate_workflow_id(workflow_id, _parent_run_id)
+            effective_selected = resolve_runtime_selected(select, graph)
+            validation_ctx = precompute_input_validation(graph, entrypoint=entrypoint, selected=effective_selected)
         normalized_values = normalize_inputs(
             values,
             input_values,
@@ -220,6 +226,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
             other_call_name="runner.map()",
             call_name="runner.run()",
             graph=graph,
+            validation_ctx=validation_ctx,
         )
         # Only fire override warning at the user-initiated outer run; nested
         # GraphNode delegations propagate the same value and would re-warn.
@@ -231,9 +238,6 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
             validate_runner_compatibility(graph, self.capabilities)
             validate_node_types(graph, self.supported_node_types)
             validate_delegated_runners(graph, self.capabilities)
-            _validate_on_missing(on_missing)
-            _validate_error_handling(error_handling)
-            _validate_workflow_id(workflow_id, _parent_run_id)
 
         checkpointer = self._checkpointer
         if _validation_ctx is None and (fork_from is not None or retry_from is not None) and checkpointer is None:
@@ -305,16 +309,13 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
 
         # Value validation (after merge so checkpoint-provided params are visible)
         if _validation_ctx is None:
-            effective_selected = resolve_runtime_selected(select, graph)
-            validate_inputs(
-                graph,
+            validate_item_inputs(
+                validation_ctx,
                 validation_values,
-                entrypoint=entrypoint,
-                selected=effective_selected,
                 skip_missing_required=skip_missing_input_validation,
             )
         else:
-            validate_item_inputs(_validation_ctx, validation_values)
+            validate_item_inputs(validation_ctx, validation_values)
 
         if resume_checkpoint is not None and skip_missing_input_validation:
             resume_state = initialize_state(graph, normalized_values, checkpoint=resume_checkpoint)
@@ -586,6 +587,11 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
         """Execute a graph multiple times with different inputs."""
         run_option_names = runner_option_names(self.run)
         map_option_names = runner_option_names(self.map)
+        _validate_error_handling(error_handling)
+        _validate_workflow_id(workflow_id, _parent_run_id)
+        _validate_on_missing(on_missing)
+        effective_selected = resolve_runtime_selected(select, graph)
+        ctx = precompute_input_validation(graph, entrypoint=entrypoint, selected=effective_selected)
         normalized_values = normalize_inputs(
             values,
             input_values,
@@ -594,6 +600,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
             other_call_name="runner.run()",
             call_name="runner.map()",
             graph=graph,
+            validation_ctx=ctx,
         )
         # Same parity as run(): only fire override warning at the user-initiated
         # outer call; nested delegations would re-warn for the propagated value.
@@ -612,11 +619,6 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
         validate_node_types(graph, self.supported_node_types)
         validate_delegated_runners(graph, self.capabilities)
         validate_map_compatible(graph)
-        _validate_error_handling(error_handling)
-        _validate_workflow_id(workflow_id, _parent_run_id)
-        effective_selected = resolve_runtime_selected(select, graph)
-        _validate_on_missing(on_missing)
-        ctx = precompute_input_validation(graph, entrypoint=entrypoint, selected=effective_selected)
 
         map_over_list = [map_over] if isinstance(map_over, str) else list(map_over)
         input_variations = list(generate_map_inputs(normalized_values, map_over_list, map_mode, clone))

--- a/src/hypergraph/runners/_shared/template_sync.py
+++ b/src/hypergraph/runners/_shared/template_sync.py
@@ -49,7 +49,6 @@ from hypergraph.runners._shared.validation import (
     precompute_input_validation,
     resolve_runtime_selected,
     validate_delegated_runners,
-    validate_inputs,
     validate_item_inputs,
     validate_map_compatible,
     validate_node_types,
@@ -206,6 +205,13 @@ class SyncRunnerTemplate(BaseRunner, ABC):
         """Execute a graph once."""
         run_option_names = runner_option_names(self.run)
         map_option_names = runner_option_names(self.map)
+        validation_ctx = _validation_ctx
+        if validation_ctx is None:
+            _validate_on_missing(on_missing)
+            _validate_error_handling(error_handling)
+            _validate_workflow_id(workflow_id, _parent_run_id)
+            effective_selected = resolve_runtime_selected(select, graph)
+            validation_ctx = precompute_input_validation(graph, entrypoint=entrypoint, selected=effective_selected)
         normalized_values = normalize_inputs(
             values,
             input_values,
@@ -214,6 +220,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
             other_call_name="runner.map()",
             call_name="runner.run()",
             graph=graph,
+            validation_ctx=validation_ctx,
         )
         # Only fire override warning at the user-initiated outer run; nested
         # GraphNode delegations propagate the same value and would re-warn.
@@ -225,9 +232,6 @@ class SyncRunnerTemplate(BaseRunner, ABC):
             validate_runner_compatibility(graph, self.capabilities)
             validate_node_types(graph, self.supported_node_types)
             validate_delegated_runners(graph, self.capabilities)
-            _validate_on_missing(on_missing)
-            _validate_error_handling(error_handling)
-            _validate_workflow_id(workflow_id, _parent_run_id)
 
         if self._checkpointer is not None and _validation_ctx is None and workflow_id is None:
             workflow_id = generate_workflow_id()
@@ -298,16 +302,13 @@ class SyncRunnerTemplate(BaseRunner, ABC):
 
         # Value validation (after merge so checkpoint-provided params are visible)
         if _validation_ctx is None:
-            effective_selected = resolve_runtime_selected(select, graph)
-            validate_inputs(
-                graph,
+            validate_item_inputs(
+                validation_ctx,
                 validation_values,
-                entrypoint=entrypoint,
-                selected=effective_selected,
                 skip_missing_required=skip_missing_input_validation,
             )
         else:
-            validate_item_inputs(_validation_ctx, validation_values)
+            validate_item_inputs(validation_ctx, validation_values)
 
         if resume_checkpoint is not None and skip_missing_input_validation:
             resume_state = initialize_state(graph, normalized_values, checkpoint=resume_checkpoint)
@@ -559,6 +560,11 @@ class SyncRunnerTemplate(BaseRunner, ABC):
         """Execute a graph multiple times with different inputs."""
         run_option_names = runner_option_names(self.run)
         map_option_names = runner_option_names(self.map)
+        _validate_error_handling(error_handling)
+        _validate_workflow_id(workflow_id, _parent_run_id)
+        _validate_on_missing(on_missing)
+        effective_selected = resolve_runtime_selected(select, graph)
+        ctx = precompute_input_validation(graph, entrypoint=entrypoint, selected=effective_selected)
         normalized_values = normalize_inputs(
             values,
             input_values,
@@ -567,6 +573,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
             other_call_name="runner.run()",
             call_name="runner.map()",
             graph=graph,
+            validation_ctx=ctx,
         )
         # Same parity as run(): only fire override warning at the user-initiated
         # outer call; nested delegations would re-warn for the propagated value.
@@ -585,11 +592,6 @@ class SyncRunnerTemplate(BaseRunner, ABC):
         validate_node_types(graph, self.supported_node_types)
         validate_delegated_runners(graph, self.capabilities)
         validate_map_compatible(graph)
-        _validate_error_handling(error_handling)
-        _validate_workflow_id(workflow_id, _parent_run_id)
-        effective_selected = resolve_runtime_selected(select, graph)
-        _validate_on_missing(on_missing)
-        ctx = precompute_input_validation(graph, entrypoint=entrypoint, selected=effective_selected)
 
         map_over_list = [map_over] if isinstance(map_over, str) else list(map_over)
         input_variations = list(generate_map_inputs(normalized_values, map_over_list, map_mode, clone))

--- a/src/hypergraph/runners/_shared/template_sync.py
+++ b/src/hypergraph/runners/_shared/template_sync.py
@@ -40,9 +40,8 @@ from hypergraph.runners._shared.helpers import (
     warn_on_bind_overrides,
 )
 from hypergraph.runners._shared.input_normalization import (
-    ASYNC_MAP_RESERVED_OPTION_NAMES,
-    ASYNC_RUN_RESERVED_OPTION_NAMES,
     normalize_inputs,
+    runner_option_names,
 )
 from hypergraph.runners._shared.run_log import RunLogCollector
 from hypergraph.runners._shared.types import ErrorHandling, GraphState, MapResult, PauseExecution, RunResult, RunStatus
@@ -205,10 +204,15 @@ class SyncRunnerTemplate(BaseRunner, ABC):
         **input_values: Any,
     ) -> RunResult:
         """Execute a graph once."""
+        run_option_names = runner_option_names(self.run)
+        map_option_names = runner_option_names(self.map)
         normalized_values = normalize_inputs(
             values,
             input_values,
-            reserved_option_names=ASYNC_RUN_RESERVED_OPTION_NAMES,
+            reserved_option_names=run_option_names | map_option_names,
+            other_option_names=map_option_names - run_option_names,
+            other_call_name="runner.map()",
+            call_name="runner.run()",
             graph=graph,
         )
         # Only fire override warning at the user-initiated outer run; nested
@@ -553,10 +557,15 @@ class SyncRunnerTemplate(BaseRunner, ABC):
         **input_values: Any,
     ) -> MapResult:
         """Execute a graph multiple times with different inputs."""
+        run_option_names = runner_option_names(self.run)
+        map_option_names = runner_option_names(self.map)
         normalized_values = normalize_inputs(
             values,
             input_values,
-            reserved_option_names=ASYNC_MAP_RESERVED_OPTION_NAMES,
+            reserved_option_names=run_option_names | map_option_names,
+            other_option_names=run_option_names - map_option_names,
+            other_call_name="runner.run()",
+            call_name="runner.map()",
             graph=graph,
         )
         # Same parity as run(): only fire override warning at the user-initiated

--- a/src/hypergraph/runners/base.py
+++ b/src/hypergraph/runners/base.py
@@ -65,7 +65,8 @@ class BaseRunner(ABC):
             event_processors: Optional list of event processors to receive execution events
             show_progress: Override runner-level show_progress for this call.
                 None = use runner default, True/False = explicit override.
-            **input_values: Input values shorthand (merged with values)
+            **input_values: Input values shorthand for flat graph input names.
+                Use values for dotted/nested inputs or names that match runner options.
 
         Returns:
             RunResult with output values and status
@@ -103,7 +104,8 @@ class BaseRunner(ABC):
             event_processors: Optional list of event processors to receive execution events
             show_progress: Override runner-level show_progress for this call.
                 None = use runner default, True/False = explicit override.
-            **input_values: Input values shorthand (merged with values)
+            **input_values: Input values shorthand for flat graph input names.
+                Use values for dotted/nested inputs or names that match runner options.
 
         Returns:
             MapResult wrapping per-iteration RunResults with batch metadata

--- a/src/hypergraph/runners/daft/runner.py
+++ b/src/hypergraph/runners/daft/runner.py
@@ -19,9 +19,8 @@ from hypergraph.runners._shared.helpers import (
     generate_map_inputs,
 )
 from hypergraph.runners._shared.input_normalization import (
-    MAP_RESERVED_OPTION_NAMES,
-    RUN_RESERVED_OPTION_NAMES,
     normalize_inputs,
+    runner_option_names,
 )
 from hypergraph.runners._shared.types import (
     GraphState,
@@ -113,10 +112,16 @@ class DaftRunner(BaseRunner):
         **input_values: Any,
     ) -> RunResult:
         """Execute graph once via a 1-row Daft plan."""
+        run_option_names = runner_option_names(self.run)
+        map_option_names = runner_option_names(self.map)
         normalized = normalize_inputs(
             values,
             input_values,
-            reserved_option_names=RUN_RESERVED_OPTION_NAMES,
+            reserved_option_names=run_option_names | map_option_names,
+            other_option_names=map_option_names - run_option_names,
+            other_call_name="runner.map()",
+            call_name="runner.run()",
+            graph=graph,
         )
         self._warn_ignored(event_processors=event_processors, show_progress=show_progress)
 
@@ -175,10 +180,16 @@ class DaftRunner(BaseRunner):
         **input_values: Any,
     ) -> MapResult:
         """Execute graph for each item via Daft columnar execution."""
+        run_option_names = runner_option_names(self.run)
+        map_option_names = runner_option_names(self.map)
         normalized = normalize_inputs(
             values,
             input_values,
-            reserved_option_names=MAP_RESERVED_OPTION_NAMES,
+            reserved_option_names=run_option_names | map_option_names,
+            other_option_names=run_option_names - map_option_names,
+            other_call_name="runner.run()",
+            call_name="runner.map()",
+            graph=graph,
         )
         self._warn_ignored(event_processors=event_processors, show_progress=show_progress)
 
@@ -273,7 +284,8 @@ class DaftRunner(BaseRunner):
                     UDF closures, not added as DataFrame columns).
             clone: Deep-copy strategy (generally not needed — Daft provides
                    row isolation).
-            **input_values: Additional broadcast values (merged with ``values``).
+            **input_values: Additional broadcast values for flat graph input names.
+                Use values for dotted/nested inputs or names that match runner options.
 
         Returns:
             Daft DataFrame with original input columns plus output columns
@@ -281,10 +293,17 @@ class DaftRunner(BaseRunner):
         """
         from hypergraph.runners.daft.engine import build_execution_plan, execute_plan
 
+        run_option_names = runner_option_names(self.run)
+        map_option_names = runner_option_names(self.map)
+        map_dataframe_option_names = runner_option_names(self.map_dataframe)
         normalized = normalize_inputs(
             values,
             input_values,
-            reserved_option_names=MAP_RESERVED_OPTION_NAMES,
+            reserved_option_names=run_option_names | map_option_names | map_dataframe_option_names,
+            other_option_names=map_option_names - map_dataframe_option_names,
+            other_call_name="runner.map()",
+            call_name="runner.map_dataframe()",
+            graph=graph,
         )
 
         validate_runner_compatibility(graph, self.capabilities)

--- a/src/hypergraph/runners/daft/runner.py
+++ b/src/hypergraph/runners/daft/runner.py
@@ -114,6 +114,14 @@ class DaftRunner(BaseRunner):
         """Execute graph once via a 1-row Daft plan."""
         run_option_names = runner_option_names(self.run)
         map_option_names = runner_option_names(self.map)
+        _validate_error_handling(error_handling)
+        _validate_on_missing(on_missing)
+        effective_selected = resolve_runtime_selected(select, graph)
+        ctx = precompute_input_validation(
+            graph,
+            entrypoint=entrypoint,
+            selected=effective_selected,
+        )
         normalized = normalize_inputs(
             values,
             input_values,
@@ -122,19 +130,12 @@ class DaftRunner(BaseRunner):
             other_call_name="runner.map()",
             call_name="runner.run()",
             graph=graph,
+            validation_ctx=ctx,
         )
         self._warn_ignored(event_processors=event_processors, show_progress=show_progress)
 
         validate_runner_compatibility(graph, self.capabilities)
         _validate_no_runner_overrides(graph)
-        _validate_error_handling(error_handling)
-        effective_selected = resolve_runtime_selected(select, graph)
-        _validate_on_missing(on_missing)
-        ctx = precompute_input_validation(
-            graph,
-            entrypoint=entrypoint,
-            selected=effective_selected,
-        )
         validate_item_inputs(ctx, normalized)
 
         try:
@@ -182,6 +183,14 @@ class DaftRunner(BaseRunner):
         """Execute graph for each item via Daft columnar execution."""
         run_option_names = runner_option_names(self.run)
         map_option_names = runner_option_names(self.map)
+        _validate_error_handling(error_handling)
+        _validate_on_missing(on_missing)
+        effective_selected = resolve_runtime_selected(select, graph)
+        ctx = precompute_input_validation(
+            graph,
+            entrypoint=None,
+            selected=effective_selected,
+        )
         normalized = normalize_inputs(
             values,
             input_values,
@@ -190,19 +199,12 @@ class DaftRunner(BaseRunner):
             other_call_name="runner.run()",
             call_name="runner.map()",
             graph=graph,
+            validation_ctx=ctx,
         )
         self._warn_ignored(event_processors=event_processors, show_progress=show_progress)
 
         validate_runner_compatibility(graph, self.capabilities)
         _validate_no_runner_overrides(graph)
-        _validate_error_handling(error_handling)
-        effective_selected = resolve_runtime_selected(select, graph)
-        _validate_on_missing(on_missing)
-        ctx = precompute_input_validation(
-            graph,
-            entrypoint=None,
-            selected=effective_selected,
-        )
         validate_item_inputs(ctx, normalized)
 
         map_over_list = [map_over] if isinstance(map_over, str) else list(map_over)
@@ -296,14 +298,21 @@ class DaftRunner(BaseRunner):
         run_option_names = runner_option_names(self.run)
         map_option_names = runner_option_names(self.map)
         map_dataframe_option_names = runner_option_names(self.map_dataframe)
+        ctx = precompute_input_validation(graph, entrypoint=None, selected=graph.selected)
+        run_only_options = run_option_names - map_option_names - map_dataframe_option_names
+        map_only_options = map_option_names - run_option_names - map_dataframe_option_names
+        other_option_call_names = {
+            **dict.fromkeys(run_only_options, "runner.run()"),
+            **dict.fromkeys(map_only_options, "runner.map()"),
+        }
         normalized = normalize_inputs(
             values,
             input_values,
             reserved_option_names=run_option_names | map_option_names | map_dataframe_option_names,
-            other_option_names=map_option_names - map_dataframe_option_names,
-            other_call_name="runner.map()",
+            other_option_call_names=other_option_call_names,
             call_name="runner.map_dataframe()",
             graph=graph,
+            validation_ctx=ctx,
         )
 
         validate_runner_compatibility(graph, self.capabilities)
@@ -317,7 +326,6 @@ class DaftRunner(BaseRunner):
         all_bound = {**bound, **normalized}
         validation_values = {name: None for name in column_names}
         validation_values.update(all_bound)
-        ctx = precompute_input_validation(graph, entrypoint=None, selected=graph.selected)
         # DataFrames often carry passthrough columns that are not graph inputs.
         # Keep stale-address and missing-input validation, but do not warn for
         # extra columns that Daft will preserve untouched.

--- a/tests/test_runners/test_async_runner.py
+++ b/tests/test_runners/test_async_runner.py
@@ -162,6 +162,28 @@ class TestAsyncRunnerRun:
 
         assert result["result"] == "fast"
 
+    async def test_run_input_named_map_over_requires_values_dict(self):
+        """A map_over input is accepted through values, not kwargs."""
+
+        @node(output_name="result")
+        def echo_map_over(map_over: str) -> str:
+            return map_over
+
+        graph = Graph([echo_map_over])
+        runner = AsyncRunner()
+
+        result = await runner.run(graph, values={"map_over": "items"})
+
+        assert result["result"] == "items"
+
+    async def test_run_rejects_map_over_kwarg(self):
+        """run() treats map_over as reserved for runner.map()."""
+        graph = Graph([double])
+        runner = AsyncRunner()
+
+        with pytest.raises(ValueError, match="runner\\.run\\(\\) does not accept map_over=.*runner\\.map"):
+            await runner.run(graph, x=1, map_over="x")
+
     async def test_fan_out_graph(self):
         """Multiple nodes consume same input."""
 
@@ -358,11 +380,11 @@ class TestAsyncRunnerRun:
             await runner.run(graph, {"left": 100, "right": 200})
 
     async def test_removed_internal_override_argument_is_rejected(self):
-        """run() treats on_internal_override as a reserved runner option."""
+        """run() rejects removed runner options as unexpected kwargs."""
         graph = Graph([double])
         runner = AsyncRunner()
 
-        with pytest.raises(ValueError, match="reserved runner options"):
+        with pytest.raises(ValueError, match="runner\\.run\\(\\) got unexpected input keyword 'on_internal_override'"):
             await runner.run(graph, {"x": 1}, on_internal_override="warn")  # type: ignore[call-arg]
 
     # Cycles
@@ -471,6 +493,23 @@ class TestAsyncRunnerMap:
 
         assert [r["doubled"] for r in results] == [2, 4, 6]
 
+    async def test_map_unknown_kwarg_input_raises(self):
+        """map kwargs shorthand only accepts flat graph input names."""
+        graph = Graph([double])
+        runner = AsyncRunner()
+
+        with pytest.raises(ValueError, match="runner\\.map\\(\\) got unexpected input keyword 'typo'"):
+            await runner.map(graph, map_over="x", x=[1], typo=2)
+
+    async def test_map_dotted_kwarg_input_raises(self):
+        """Dotted input addresses in map() must go through values."""
+        inner = Graph([double], name="inner")
+        outer = Graph([inner.as_node(namespaced=True)])
+        runner = AsyncRunner()
+
+        with pytest.raises(ValueError, match="Dotted input address 'inner\\.x'.*values=\\{'inner\\.x':"):
+            await runner.map(outer, map_over="inner.x", **{"inner.x": [1]})
+
     async def test_map_merges_values_and_kwargs(self):
         """map merges values dict with kwargs when keys are disjoint."""
         graph = Graph([add])
@@ -511,6 +550,24 @@ class TestAsyncRunnerMap:
 
         assert [r["sum"] for r in results] == [11, 12]
 
+    async def test_map_input_named_max_iterations_requires_values_dict(self):
+        """Run-only option names remain valid map inputs through values."""
+
+        @node(output_name="sum")
+        def add_with_reserved_name(x: int, max_iterations: int) -> int:
+            return x + max_iterations
+
+        graph = Graph([add_with_reserved_name])
+        runner = AsyncRunner()
+
+        results = await runner.map(
+            graph,
+            values={"x": [1, 2], "max_iterations": 10},
+            map_over="x",
+        )
+
+        assert [r["sum"] for r in results] == [11, 12]
+
     async def test_map_rejects_internal_edge_produced_overrides(self):
         """Internal edge-produced overrides are rejected in map()."""
 
@@ -537,11 +594,11 @@ class TestAsyncRunnerMap:
             )
 
     async def test_map_removed_internal_override_argument_is_rejected(self):
-        """map() treats on_internal_override as a reserved runner option."""
+        """map() rejects removed runner options as unexpected kwargs."""
         graph = Graph([double])
         runner = AsyncRunner()
 
-        with pytest.raises(ValueError, match="reserved runner options"):
+        with pytest.raises(ValueError, match="runner\\.map\\(\\) got unexpected input keyword 'on_internal_override'"):
             await runner.map(graph, {"x": [1]}, map_over="x", on_internal_override="warn")  # type: ignore[call-arg]
 
     async def test_map_runs_concurrently(self):

--- a/tests/test_runners/test_async_runner.py
+++ b/tests/test_runners/test_async_runner.py
@@ -148,6 +148,25 @@ class TestAsyncRunnerRun:
 
         assert result["top_k"] == 5
 
+    async def test_run_bound_input_outside_active_scope_allowed_as_kwarg(self):
+        """Bound input names stay valid kwargs even when inactive after select()."""
+
+        @node(output_name="b_out")
+        def make_b(seed: int) -> int:
+            return seed + 1
+
+        @node(output_name="c_out")
+        def make_c(other: int) -> int:
+            return other * 3
+
+        graph = Graph([make_b, make_c]).bind(seed=5).select("c_out")
+        runner = AsyncRunner()
+
+        with pytest.warns(UserWarning, match="seed"):
+            result = await runner.run(graph, other=2, seed=10)
+
+        assert result["c_out"] == 6
+
     async def test_run_input_named_select_requires_values_dict(self):
         """Input names matching options are only accepted via values dict."""
 

--- a/tests/test_runners/test_daft_runner.py
+++ b/tests/test_runners/test_daft_runner.py
@@ -199,6 +199,16 @@ def test_daft_runner_map_dataframe_rejects_map_option_kwarg():
         DaftRunner().map_dataframe(graph, df, map_over="x")
 
 
+def test_daft_runner_map_dataframe_rejects_run_option_kwarg():
+    import daft
+
+    graph = Graph([double], name="df_run_reserved")
+    df = daft.from_pydict({"x": [1]})
+
+    with pytest.raises(ValueError, match="runner\\.map_dataframe\\(\\) does not accept max_iterations=.*runner\\.run"):
+        DaftRunner().map_dataframe(graph, df, max_iterations=10)
+
+
 def test_daft_runner_map_dataframe_with_broadcast_values():
     """Broadcast values should be captured in UDF closures."""
     import daft

--- a/tests/test_runners/test_daft_runner.py
+++ b/tests/test_runners/test_daft_runner.py
@@ -29,6 +29,28 @@ def test_daft_runner_map_matches_sync_runner_for_basic_batches():
     assert daft_results.status == RunStatus.COMPLETED
 
 
+def test_daft_runner_run_rejects_map_only_option_kwarg():
+    graph = Graph([double], name="run_reserved")
+
+    with pytest.raises(ValueError, match="runner\\.run\\(\\) does not accept map_over=.*runner\\.map"):
+        DaftRunner().run(graph, x=1, map_over="x")
+
+
+def test_daft_runner_run_dotted_kwarg_input_raises():
+    inner = Graph([double], name="inner")
+    outer = Graph([inner.as_node(namespaced=True)], name="outer")
+
+    with pytest.raises(ValueError, match="Dotted input address 'inner\\.x'.*values=\\{'inner\\.x':"):
+        DaftRunner().run(outer, **{"inner.x": 1})
+
+
+def test_daft_runner_map_rejects_run_only_option_kwarg():
+    graph = Graph([double], name="map_reserved")
+
+    with pytest.raises(ValueError, match="runner\\.map\\(\\) does not accept max_iterations=.*runner\\.run"):
+        DaftRunner().map(graph, {"x": [1]}, map_over="x", max_iterations=10)
+
+
 def test_daft_runner_supports_product_mode():
     graph = Graph([combine], name="product_batch")
 
@@ -165,6 +187,16 @@ def test_daft_runner_map_dataframe_returns_dataframe():
     collected = result_df.collect().to_pydict()
     assert collected["doubled"] == [2, 4, 6]
     assert collected["x"] == [1, 2, 3]
+
+
+def test_daft_runner_map_dataframe_rejects_map_option_kwarg():
+    import daft
+
+    graph = Graph([double], name="df_reserved")
+    df = daft.from_pydict({"x": [1]})
+
+    with pytest.raises(ValueError, match="runner\\.map_dataframe\\(\\) does not accept map_over=.*runner\\.map"):
+        DaftRunner().map_dataframe(graph, df, map_over="x")
 
 
 def test_daft_runner_map_dataframe_with_broadcast_values():

--- a/tests/test_runners/test_sync_runner.py
+++ b/tests/test_runners/test_sync_runner.py
@@ -229,6 +229,30 @@ class TestSyncRunnerRun:
         with pytest.raises(ValueError, match="runner\\.run\\(\\) got unexpected input keyword 'typo'"):
             runner.run(graph, x=1, typo=2)
 
+    def test_run_kwargs_reuses_precomputed_input_validation(self, monkeypatch):
+        """Kwarg validation and value validation share one graph traversal."""
+        from hypergraph.runners._shared import template_sync as template_sync_module
+        from hypergraph.runners._shared import validation as validation_module
+
+        calls = 0
+        real_precompute = template_sync_module.precompute_input_validation
+
+        def spy_precompute(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            return real_precompute(*args, **kwargs)
+
+        def fail_precompute(*args, **kwargs):  # pragma: no cover - assertion helper
+            pytest.fail("normalize_inputs recomputed input validation instead of reusing the runner context")
+
+        monkeypatch.setattr(template_sync_module, "precompute_input_validation", spy_precompute)
+        monkeypatch.setattr(validation_module, "precompute_input_validation", fail_precompute)
+
+        result = SyncRunner().run(Graph([double]), x=1)
+
+        assert result["doubled"] == 2
+        assert calls == 1
+
     def test_run_dotted_kwarg_input_raises(self):
         """Dotted input addresses must go through values, not kwargs."""
         inner = Graph([double], name="inner")
@@ -237,6 +261,25 @@ class TestSyncRunnerRun:
 
         with pytest.raises(ValueError, match="Dotted input address 'inner\\.x'.*values=\\{'inner\\.x':"):
             runner.run(outer, **{"inner.x": 1})
+
+    def test_run_bound_input_outside_active_scope_allowed_as_kwarg(self):
+        """Bound input names stay valid kwargs even when inactive after select()."""
+
+        @node(output_name="b_out")
+        def make_b(seed: int) -> int:
+            return seed + 1
+
+        @node(output_name="c_out")
+        def make_c(other: int) -> int:
+            return other * 3
+
+        graph = Graph([make_b, make_c]).bind(seed=5).select("c_out")
+        runner = SyncRunner()
+
+        with pytest.warns(UserWarning, match="seed"):
+            result = runner.run(graph, other=2, seed=10)
+
+        assert result["c_out"] == 6
 
     def test_run_input_named_select_requires_values_dict(self):
         """Input names matching options are only accepted via values dict."""

--- a/tests/test_runners/test_sync_runner.py
+++ b/tests/test_runners/test_sync_runner.py
@@ -221,6 +221,23 @@ class TestSyncRunnerRun:
 
         assert result["top_k"] == 5
 
+    def test_run_unknown_kwarg_input_raises(self):
+        """kwargs shorthand only accepts flat graph input names."""
+        graph = Graph([double])
+        runner = SyncRunner()
+
+        with pytest.raises(ValueError, match="runner\\.run\\(\\) got unexpected input keyword 'typo'"):
+            runner.run(graph, x=1, typo=2)
+
+    def test_run_dotted_kwarg_input_raises(self):
+        """Dotted input addresses must go through values, not kwargs."""
+        inner = Graph([double], name="inner")
+        outer = Graph([inner.as_node(namespaced=True)])
+        runner = SyncRunner()
+
+        with pytest.raises(ValueError, match="Dotted input address 'inner\\.x'.*values=\\{'inner\\.x':"):
+            runner.run(outer, **{"inner.x": 1})
+
     def test_run_input_named_select_requires_values_dict(self):
         """Input names matching options are only accepted via values dict."""
 
@@ -235,13 +252,44 @@ class TestSyncRunnerRun:
 
         assert result["result"] == "fast"
 
+    def test_run_input_named_map_over_requires_values_dict(self):
+        """A map_over input is accepted through values, not kwargs."""
+
+        @node(output_name="result")
+        def echo_map_over(map_over: str) -> str:
+            return map_over
+
+        graph = Graph([echo_map_over])
+        runner = SyncRunner()
+
+        result = runner.run(graph, values={"map_over": "items"})
+
+        assert result["result"] == "items"
+
     def test_run_reserved_option_name_in_kwargs_raises(self):
         """Reserved option names cannot be passed via kwargs shorthand."""
         graph = Graph([double])
         runner = SyncRunner()
 
-        with pytest.raises(ValueError, match="reserved runner options"):
+        with pytest.raises(ValueError, match="runner\\.run\\(\\) got unexpected input keyword 'max_concurrency'"):
             runner.run(graph, x=1, max_concurrency=1)
+
+    def test_run_rejects_map_over_kwarg(self):
+        """run() treats map_over as reserved for runner.map()."""
+        graph = Graph([double])
+        runner = SyncRunner()
+
+        with pytest.raises(ValueError, match="runner\\.run\\(\\) does not accept map_over=.*runner\\.map"):
+            runner.run(graph, x=1, map_over="x")
+
+    @pytest.mark.parametrize("option_name", ["map_mode", "clone"])
+    def test_run_rejects_map_only_option_kwargs(self, option_name: str):
+        """run() rejects map-only option names instead of ignoring them."""
+        graph = Graph([double])
+        runner = SyncRunner()
+
+        with pytest.raises(ValueError, match=f"runner\\.run\\(\\) does not accept {option_name}="):
+            runner.run(graph, {"x": 1}, **{option_name: "bad"})
 
     def test_uses_bound_values(self):
         """Bound values are used when input not provided."""
@@ -283,11 +331,11 @@ class TestSyncRunnerRun:
             runner.run(graph, {"left": 100, "right": 200})
 
     def test_removed_internal_override_argument_is_rejected(self):
-        """run() treats on_internal_override as a reserved runner option."""
+        """run() rejects removed runner options as unexpected kwargs."""
         graph = Graph([double])
         runner = SyncRunner()
 
-        with pytest.raises(ValueError, match="reserved runner options"):
+        with pytest.raises(ValueError, match="runner\\.run\\(\\) got unexpected input keyword 'on_internal_override'"):
             runner.run(graph, {"x": 1}, on_internal_override="warn")  # type: ignore[call-arg]
 
     def test_input_overrides_bound(self):
@@ -522,6 +570,23 @@ class TestSyncRunnerMap:
 
         assert [r["doubled"] for r in results] == [2, 4, 6]
 
+    def test_map_unknown_kwarg_input_raises(self):
+        """map kwargs shorthand only accepts flat graph input names."""
+        graph = Graph([double])
+        runner = SyncRunner()
+
+        with pytest.raises(ValueError, match="runner\\.map\\(\\) got unexpected input keyword 'typo'"):
+            runner.map(graph, map_over="x", x=[1], typo=2)
+
+    def test_map_dotted_kwarg_input_raises(self):
+        """Dotted input addresses in map() must go through values."""
+        inner = Graph([double], name="inner")
+        outer = Graph([inner.as_node(namespaced=True)])
+        runner = SyncRunner()
+
+        with pytest.raises(ValueError, match="Dotted input address 'inner\\.x'.*values=\\{'inner\\.x':"):
+            runner.map(outer, map_over="inner.x", **{"inner.x": [1]})
+
     def test_map_merges_values_and_kwargs(self):
         """map merges values dict with kwargs when keys are disjoint."""
         graph = Graph([add])
@@ -562,12 +627,30 @@ class TestSyncRunnerMap:
 
         assert [r["sum"] for r in results] == [11, 12]
 
+    def test_map_input_named_max_iterations_requires_values_dict(self):
+        """Run-only option names remain valid map inputs through values."""
+
+        @node(output_name="sum")
+        def add_with_reserved_name(x: int, max_iterations: int) -> int:
+            return x + max_iterations
+
+        graph = Graph([add_with_reserved_name])
+        runner = SyncRunner()
+
+        results = runner.map(
+            graph,
+            values={"x": [1, 2], "max_iterations": 10},
+            map_over="x",
+        )
+
+        assert [r["sum"] for r in results] == [11, 12]
+
     def test_map_reserved_option_name_in_kwargs_raises(self):
         """Reserved map option names cannot be passed via kwargs shorthand."""
         graph = Graph([double])
         runner = SyncRunner()
 
-        with pytest.raises(ValueError, match="reserved runner options"):
+        with pytest.raises(ValueError, match="runner\\.map\\(\\) got unexpected input keyword 'max_concurrency'"):
             runner.map(graph, map_over="x", x=[1, 2], max_concurrency=1)
 
     def test_map_rejects_internal_edge_produced_overrides(self):
@@ -596,12 +679,24 @@ class TestSyncRunnerMap:
             )
 
     def test_map_removed_internal_override_argument_is_rejected(self):
-        """map() treats on_internal_override as a reserved runner option."""
+        """map() rejects removed runner options as unexpected kwargs."""
         graph = Graph([double])
         runner = SyncRunner()
 
-        with pytest.raises(ValueError, match="reserved runner options"):
+        with pytest.raises(ValueError, match="runner\\.map\\(\\) got unexpected input keyword 'on_internal_override'"):
             runner.map(graph, {"x": [1]}, map_over="x", on_internal_override="warn")  # type: ignore[call-arg]
+
+    @pytest.mark.parametrize(
+        "option_name",
+        ["max_iterations", "checkpoint", "override_workflow", "fork_from", "retry_from"],
+    )
+    def test_map_rejects_run_only_option_kwargs(self, option_name: str):
+        """map() rejects run-only option names instead of ignoring them."""
+        graph = Graph([double])
+        runner = SyncRunner()
+
+        with pytest.raises(ValueError, match=f"runner\\.map\\(\\) does not accept {option_name}="):
+            runner.map(graph, {"x": [1]}, map_over="x", **{option_name: "bad"})
 
     def test_map_over_returns_list_of_results(self):
         """Map returns list of RunResult."""

--- a/tests/test_runners/test_validation.py
+++ b/tests/test_runners/test_validation.py
@@ -222,6 +222,30 @@ class TestNormalizeInputs:
                 reserved_option_names=frozenset({"select"}),
             )
 
+    def test_runner_option_names_memoizes_signature_inspection(self, monkeypatch):
+        """runner_option_names should not inspect the same method repeatedly."""
+        from hypergraph.runners import SyncRunner
+        from hypergraph.runners._shared import input_normalization as input_norm
+
+        input_norm._runner_option_names.cache_clear()
+        real_signature = input_norm.inspect.signature
+        calls = 0
+
+        def spy_signature(method):
+            nonlocal calls
+            calls += 1
+            return real_signature(method)
+
+        monkeypatch.setattr(input_norm.inspect, "signature", spy_signature)
+        runner = SyncRunner()
+
+        try:
+            assert "max_iterations" in input_norm.runner_option_names(runner.run)
+            assert "max_iterations" in input_norm.runner_option_names(runner.run)
+            assert calls == 1
+        finally:
+            input_norm._runner_option_names.cache_clear()
+
 
 class TestValidateRunnerCompatibility:
     """Tests for validate_runner_compatibility function."""

--- a/tests/test_runners/test_validation.py
+++ b/tests/test_runners/test_validation.py
@@ -215,7 +215,7 @@ class TestNormalizeInputs:
 
     def test_reserved_option_names_raise(self):
         """Reserved option names in kwargs raise ValueError."""
-        with pytest.raises(ValueError, match="reserved runner options"):
+        with pytest.raises(ValueError, match="Hypergraph runner option"):
             normalize_inputs(
                 {"x": 1},
                 {"select": "bad"},


### PR DESCRIPTION
## Problem / Bug / Challenge

Runner kwargs were doing double duty: explicit runner options and graph-input shorthand. That let method-specific options drift or produce misleading errors. For example, `runner.run(..., map_over=...)` could be treated like an input-ish validation failure instead of clearly saying `map_over` belongs to `runner.map()`. Unknown kwargs could also slip through to later, more generic validation.

This tightens runner input normalization so kwargs shorthand only accepts flat graph inputs, while `values={...}` remains the escape hatch for dotted/nested inputs or graph inputs whose names collide with runner options.

## Before / After

**Before:**

```python
runner.run(graph, x=1, map_over="x")
# generic/wrong validation error instead of pointing at runner.map(...)

runner.run(outer, **{"inner.x": 1})
# dotted input address accepted via kwargs shorthand path
```

**After:**

```python
runner.run(graph, x=1, map_over="x")
# ValueError: runner.run() does not accept map_over=. map_over= is only for runner.map().

runner.run(outer, **{"inner.x": 1})
# ValueError: Dotted input address 'inner.x' cannot be passed as a keyword argument to runner.run().

runner.run(outer, values={"inner.x": 1})
# still valid
```

## What changed

- Derive reserved runner option names from method signatures with `runner_option_names(...)` to avoid manual drift.
- Validate `.run()`, `.map()`, and Daft `.map_dataframe()` kwargs against the active graph's flat input surface.
- Add method-aware errors for sibling runner options, such as `map_over` on `.run()` and `max_iterations` on `.map()`.
- Keep `values={...}` valid for option-name collisions and dotted/nested graph inputs.
- Update runner docs and tests across sync, async, and Daft runner surfaces.

## Test Plan

- [x] `uv sync --group dev --extra daft`
- [x] `uv run playwright install chromium`
- [x] `uv run pytest tests/test_runners/test_daft_runner.py`
- [x] `uv run pytest -W error -W 'ignore::pytest.PytestUnraisableExceptionWarning'` (`2720 passed`)
- [x] `uv run ruff check src/ tests/`
- [x] `uv run ruff format --check src/ tests/`
- [x] `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that kwargs shorthand for runner inputs only supports flat graph names; dotted/nested inputs must be passed via values={...}
  * Updated guidance when input names conflict with runner option names to require values={...}; removed an outdated internal parameter note

* **Bug Fixes**
  * Improved and more specific error messages for invalid/ambiguous input kwargs and reserved-option conflicts

* **Tests**
  * Added/expanded tests across runners to verify input validation and reserved-option handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gilad-rubin/hypergraph/pull/157?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->