### PR TITLE
[codex] add stateful resource scopes

### DIFF
--- a/docs/05-how-to/daft-workflows.md
+++ b/docs/05-how-to/daft-workflows.md
@@ -258,8 +258,8 @@ Prefer `SyncRunner` or `AsyncRunner` when:
 ## Stateful UDFs
 
 Heavy resources (ML models, DB connections) can be initialized once per Daft
-worker instead of once per row. Use the `@stateful` decorator and bind the
-instance to the graph:
+worker instead of once per row. Use the `@stateful` decorator and bind the lazy
+handle to the graph:
 
 ```python
 from hypergraph import Graph, node
@@ -267,8 +267,8 @@ from hypergraph.integrations.daft import DaftRunner, stateful
 
 @stateful(max_concurrency=2)
 class Embedder:
-    def __init__(self):
-        self.model = load_heavy_model()
+    def __init__(self, model_name: str):
+        self.model = load_heavy_model(model_name)
 
     def embed(self, text: str) -> list[float]:
         return self.model.encode(text)
@@ -277,16 +277,15 @@ class Embedder:
 def embed(text: str, embedder: Embedder) -> list[float]:
     return embedder.embed(text)
 
-graph = Graph([embed]).bind(embedder=Embedder())
+graph = Graph([embed]).bind(embedder=Embedder("all-MiniLM-L6-v2"))
 runner = DaftRunner()
 results = runner.map(graph, {"text": texts}, map_over="text")
 ```
 
 DaftRunner wraps stateful objects with `@daft.cls` so `__init__` runs once per
-worker process. The class must support zero-argument construction. Hypergraph
-validates that contract by signature during plan build, then constructs the
-resource inside the Daft worker on first use so expensive model/client setup is
-not accidentally triggered while building a lazy plan.
+worker process. The constructor arguments are captured by the lazy handle and
+used inside the Daft worker, so expensive model/client setup is not accidentally
+triggered while defining the graph or building a lazy plan.
 See `examples/daft/ml_embeddings.py` for a complete example.
 
 ## Vectorized Batch UDFs

--- a/docs/05-how-to/daft-workflows.md
+++ b/docs/05-how-to/daft-workflows.md
@@ -318,32 +318,30 @@ See `examples/daft/batch_normalization.py` for a complete example.
 
 ## Daft Options
 
-Pass common Daft UDF controls directly to `daft_node`, or reuse a typed
-`Options` value when several nodes share the same settings:
+Pass Daft UDF controls directly to `daft_node` as keyword arguments:
 
 ```python
 import daft
-from hypergraph.integrations.daft import Options
 from hypergraph.integrations.daft import node as daft_node
 
-embedding_options = Options(
+@daft_node(
+    output_name="embedding",
     return_dtype=daft.DataType.list(daft.DataType.float64()),
     batch=True,
     batch_size=64,
     max_retries=2,
     on_error="log",
 )
-
-@daft_node(output_name="embedding", options=embedding_options)
 def embed_batch(text: daft.Series) -> list[list[float] | None]:
     return embed_many(text.to_pylist())
 ```
 
-`Options` validates Daft's current public rules early: `on_error` is one of
-`"raise"`, `"log"`, or `"ignore"`; `max_concurrency` must be positive; `gpus`
-above `1.0` must be whole numbers; and `ray_options` cannot include
-`"num_cpus"`, `"num_gpus"`, or `"memory"`. Put class-level resource controls on
-`@stateful(...)`; put dtype, batch, and unnest settings on `daft_node(...)`.
+These options are validated against Daft's current public rules at definition
+time: `on_error` is one of `"raise"`, `"log"`, or `"ignore"`; `max_concurrency`
+must be positive; `gpus` above `1.0` must be whole numbers; and `ray_options`
+cannot include `"num_cpus"`, `"num_gpus"`, or `"memory"`. Put class-level
+resource controls (`cpus`, `gpus`, `max_concurrency`, ...) on `@stateful(...)`;
+put dtype, batch, and unnest settings on `daft_node(...)`.
 
 ## Dashboard and Extensions
 

--- a/docs/05-how-to/integrate-with-llms.md
+++ b/docs/05-how-to/integrate-with-llms.md
@@ -318,6 +318,11 @@ def safe_generate(prompt: str, max_retries: int = 3) -> str:
 
 **Best practice**: Use `.bind()` to provide shared LLM clients at the graph level instead of global variables or function defaults.
 
+When the client should be opened lazily and closed by Hypergraph, decorate the
+client class with `@stateful(resource=True)` and run the graph inside
+`graph.resources()`. See [Manage Stateful Resources](manage-stateful-resources.md)
+for lifecycle and FastAPI examples.
+
 ```python
 from anthropic import Anthropic
 

--- a/docs/05-how-to/manage-stateful-resources.md
+++ b/docs/05-how-to/manage-stateful-resources.md
@@ -45,6 +45,9 @@ async with graph.resources() as ready_graph:
 `LLM(...)` creates a lazy handle. The real `LLM` object is constructed when the
 resource scope opens, not when the graph is defined.
 
+Runners do not auto-open resource scopes. Run the graph returned by
+`graph.resources()`, not the original graph with lazy handles still bound.
+
 ## Cleanup Rules
 
 `graph.resources()` follows the cleanup method that matches the scope:

--- a/docs/05-how-to/manage-stateful-resources.md
+++ b/docs/05-how-to/manage-stateful-resources.md
@@ -1,0 +1,219 @@
+# Manage Stateful Resources
+
+Use `@stateful` and `graph.resources()` when a graph depends on objects that
+should be constructed lazily and closed deterministically.
+
+Good examples are LLM clients, embedders, vector stores, HTTP clients, database
+pools, and SDK objects that open sockets or hold locks.
+
+## One Graph
+
+```python
+from hypergraph import AsyncRunner, Graph, node, stateful
+
+
+@stateful(resource=True)
+class LLM:
+    def __init__(self, api_key: str, model: str):
+        self.api_key = api_key
+        self.model = model
+        self.client = open_client(api_key)
+
+    async def generate(self, prompt: str) -> str:
+        return await self.client.generate(model=self.model, prompt=prompt)
+
+    async def aclose(self) -> None:
+        await self.client.close()
+
+
+@node(output_name="answer")
+async def answer_question(question: str, llm: LLM) -> str:
+    return await llm.generate(question)
+
+
+graph = Graph([answer_question]).bind(
+    llm=LLM(api_key="...", model="gpt-5"),
+)
+
+async with graph.resources() as ready_graph:
+    result = await AsyncRunner().run(
+        ready_graph,
+        {"question": "What changed?"},
+    )
+```
+
+`LLM(...)` creates a lazy handle. The real `LLM` object is constructed when the
+resource scope opens, not when the graph is defined.
+
+## Cleanup Rules
+
+`graph.resources()` follows the cleanup method that matches the scope:
+
+| Resource class | `with graph.resources()` | `async with graph.resources()` |
+| --- | --- | --- |
+| `close()` only | calls `close()` | calls `close()` |
+| `aclose()` only | raises before opening | awaits `aclose()` |
+| both | calls `close()` | awaits `aclose()` |
+| neither | invalid with `resource=True` | invalid with `resource=True` |
+
+When a class uses a different method name, declare it:
+
+```python
+@stateful(resource=True, close="shutdown")
+class SearchClient:
+    def shutdown(self) -> None:
+        ...
+```
+
+Use `resource=False` for lazy state that does not need cleanup:
+
+```python
+@stateful(resource=False)
+class PromptFormatter:
+    ...
+```
+
+## Sharing
+
+Sharing is explicit.
+
+```python
+shared_llm = LLM(api_key="...", model="gpt-5")
+
+graph = Graph([draft, revise]).bind(
+    draft_llm=shared_llm,
+    revise_llm=shared_llm,
+)
+```
+
+The same lazy handle materializes once and closes once.
+
+Different handles stay different resources, even when their constructor
+arguments are equal:
+
+```python
+graph = Graph([draft, revise]).bind(
+    draft_llm=LLM(api_key="...", model="gpt-5"),
+    revise_llm=LLM(api_key="...", model="gpt-5"),
+)
+```
+
+Hypergraph does not deduplicate resources by constructor arguments. If a class
+can safely pool lower-level transports, implement that inside the class.
+
+## Parent Graph With Subgraphs
+
+Subgraphs can bind their own resources and remain runnable on their own:
+
+```python
+@node(output_name="validation")
+async def validate(query: str, validation_llm: LLM) -> bool:
+    ...
+
+
+def validation_graph() -> Graph:
+    return Graph([validate], name="validation").bind(
+        validation_llm=LLM(api_key="...", model="gpt-5-mini"),
+    )
+
+
+@node(output_name="answer")
+async def generate(query: str, generation_llm: LLM) -> str:
+    ...
+
+
+def generation_graph() -> Graph:
+    return Graph([generate], name="generation").bind(
+        generation_llm=LLM(api_key="...", model="gpt-5"),
+    )
+```
+
+The parent opens one scope over the whole graph tree:
+
+```python
+parent = Graph(
+    [
+        validation_graph().as_node(name="validation", namespaced=True),
+        generation_graph().as_node(name="generation", namespaced=True),
+    ],
+    name="rag",
+)
+
+async with parent.resources() as ready_parent:
+    result = await AsyncRunner().run(
+        ready_parent,
+        {"validation.query": query, "generation.query": query},
+    )
+```
+
+Those two LLM handles are different resources. That is the safe default.
+
+If two subgraphs should truly share the same LLM configuration, pass the same
+handle into both graphs before composing:
+
+```python
+shared = LLM(api_key="...", model="gpt-5")
+
+validation = Graph([validate], name="validation").bind(validation_llm=shared)
+generation = Graph([generate], name="generation").bind(generation_llm=shared)
+```
+
+## FastAPI Lifespan
+
+For a web app, open resources once during startup and close them at shutdown:
+
+```python
+from contextlib import asynccontextmanager
+from fastapi import FastAPI, Request
+
+from hypergraph import AsyncRunner
+
+
+graph = Graph([answer_question]).bind(
+    llm=LLM(api_key="...", model="gpt-5"),
+)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    async with graph.resources() as ready_graph:
+        app.state.graph = ready_graph
+        app.state.runner = AsyncRunner()
+        yield
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+@app.post("/answer")
+async def answer(request: Request, body: dict):
+    result = await request.app.state.runner.run(
+        request.app.state.graph,
+        {"question": body["question"]},
+    )
+    return {"answer": result.values["answer"]}
+```
+
+## Optional Hypster Pattern
+
+Hypergraph does not depend on Hypster. Advanced users can still create lazy
+handles from Hypster configs because they are ordinary Python values:
+
+```python
+def llm_config(hp):
+    model = hp.text("gpt-5", name="model")
+    effort = hp.select(["low", "medium", "high"], name="reasoning_effort")
+    return LLM(api_key="...", model=model, reasoning_effort=effort)
+
+
+def generation_graph_config(hp):
+    llm = hp.nest(
+        llm_config,
+        name="llm",
+        values={"reasoning_effort": "high"},
+    )
+    return Graph([generate], name="generation").bind(llm=llm)
+```
+
+This keeps configuration hierarchical without making Hypergraph import or know
+about Hypster.

--- a/docs/06-api-reference/graph.md
+++ b/docs/06-api-reference/graph.md
@@ -434,6 +434,53 @@ runner.run(graph, {"query": "test"})
 
 The error message explains why copying is needed for signature defaults and suggests using `.bind()` for shared state.
 
+### `resources()`
+
+Open a resource scope for lazy stateful values bound with `.bind()`.
+
+```python
+from hypergraph import Graph, SyncRunner, node, stateful
+
+@stateful(resource=True)
+class Client:
+    def __init__(self, endpoint: str):
+        self.endpoint = endpoint
+
+    def close(self) -> None:
+        ...
+
+@node(output_name="answer")
+def answer(query: str, client: Client) -> str:
+    ...
+
+graph = Graph([answer]).bind(client=Client(endpoint="https://api.example"))
+
+with graph.resources() as ready_graph:
+    result = SyncRunner().run(ready_graph, {"query": "hello"})
+```
+
+`Client(...)` returns a lazy handle. The real `Client` is constructed when the
+scope opens and is closed when the scope exits.
+
+Use an async scope for async resources:
+
+```python
+async with graph.resources() as ready_graph:
+    result = await AsyncRunner().run(ready_graph, {"query": "hello"})
+```
+
+Cleanup follows these rules:
+
+| Resource class | Sync scope | Async scope |
+| --- | --- | --- |
+| `close()` only | calls `close()` | calls `close()` |
+| `aclose()` only | raises before opening | awaits `aclose()` |
+| both | calls `close()` | awaits `aclose()` |
+| neither | invalid with `resource=True` | invalid with `resource=True` |
+
+The same lazy handle bound in multiple places materializes once per scope.
+Different handles are not deduplicated by constructor arguments.
+
 ### `unbind(*names) -> Graph`
 
 Remove specific bindings. Returns a new Graph.

--- a/docs/06-api-reference/runners.md
+++ b/docs/06-api-reference/runners.md
@@ -531,10 +531,16 @@ results = runner.map(graph, {"text": texts}, map_over="text")
 The constructor is captured by the lazy handle. Daft workers construct the
 resource from the captured arguments when execution runs.
 
-Use `resource=True` when the same stateful class should also be managed by
-`graph.resources()` in SyncRunner or AsyncRunner workflows:
+Resource lifecycle (`resource=True` with `close`/`aclose`) is **not** part of
+`hypergraph.integrations.daft.stateful`. Daft constructs resources per worker
+and has no deterministic teardown hook, so a `resource=True` stateful is
+rejected by `DaftRunner`. Declare lifecycle-managed resources with the core
+`hypergraph.stateful` and run them under `SyncRunner`/`AsyncRunner` via
+`graph.resources()`:
 
 ```python
+from hypergraph import stateful
+
 @stateful(resource=True)
 class Client:
     async def aclose(self) -> None:
@@ -567,33 +573,29 @@ runner = DaftRunner()
 results = runner.map(graph, {"values": [10.0, 20.0, 30.0]}, map_over="values")
 ```
 
-### Options
+### Daft lowering options
 
-Typed Daft lowering options can be passed directly to `daft_node` or reused via
-`Options`:
+Daft lowering options are passed directly to `daft_node` as keyword arguments:
 
 ```python
 import daft
-from hypergraph.integrations.daft import Options
 from hypergraph.integrations.daft import node as daft_node
 
-batch_options = Options(
+@daft_node(
+    output_name="token_count",
     return_dtype=daft.DataType.int64(),
     batch=True,
     batch_size=128,
     max_retries=2,
     on_error="log",
 )
-
-@daft_node(output_name="token_count", options=batch_options)
 def count_tokens(text: daft.Series) -> list[int | None]:
     return [len(value.split()) for value in text.to_pylist()]
 ```
 
 Use `@stateful(cpus=..., gpus=..., max_concurrency=...)` for class-level
-`@daft.cls` controls. `stateful(options=...)` accepts only class resource,
-retry, and error-handling settings; dtype, batch, and unnest settings belong on
-`daft_node(...)`.
+`@daft.cls` controls (worker placement and actor-pool concurrency). Dtype,
+batch, and unnest settings belong on `daft_node(...)`.
 
 ### Dashboard and Extensions
 

--- a/docs/06-api-reference/runners.md
+++ b/docs/06-api-reference/runners.md
@@ -502,10 +502,10 @@ caps.supports_checkpointing   # False
 
 ### @stateful
 
-Decorator to mark a class for once-per-worker initialization. DaftRunner wraps
-stateful objects with `@daft.cls` instead of `@daft.func`, so heavy resources
-(ML models, DB connections) are created once per worker process rather than
-once per row.
+Decorator to mark a class for lazy construction. With DaftRunner, stateful
+handles are wrapped with `@daft.cls` instead of `@daft.func`, so heavy
+resources (ML models, DB connections) are created once per worker process
+rather than once per row.
 
 ```python
 from hypergraph import Graph, node
@@ -513,8 +513,8 @@ from hypergraph.integrations.daft import DaftRunner, stateful
 
 @stateful(max_concurrency=2)
 class Embedder:
-    def __init__(self):
-        self.model = load_heavy_model()
+    def __init__(self, model_name: str):
+        self.model = load_heavy_model(model_name)
 
     def embed(self, text: str) -> list[float]:
         return self.model.encode(text)
@@ -523,13 +523,23 @@ class Embedder:
 def embed(text: str, embedder: Embedder) -> list[float]:
     return embedder.embed(text)
 
-graph = Graph([embed]).bind(embedder=Embedder())
+graph = Graph([embed]).bind(embedder=Embedder("all-MiniLM-L6-v2"))
 runner = DaftRunner()
 results = runner.map(graph, {"text": texts}, map_over="text")
 ```
 
-The class must support zero-argument construction (`__init__()` with no
-required args) so Daft can re-create it on each worker.
+The constructor is captured by the lazy handle. Daft workers construct the
+resource from the captured arguments when execution runs.
+
+Use `resource=True` when the same stateful class should also be managed by
+`graph.resources()` in SyncRunner or AsyncRunner workflows:
+
+```python
+@stateful(resource=True)
+class Client:
+    async def aclose(self) -> None:
+        ...
+```
 
 ### daft_node(..., batch=True)
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -38,6 +38,7 @@
 * [Batch Processing](05-how-to/batch-processing.md)
 * [Rename and Adapt](05-how-to/rename-and-adapt.md)
 * [Integrate with LLMs](05-how-to/integrate-with-llms.md)
+* [Manage Stateful Resources](05-how-to/manage-stateful-resources.md)
 * [Test Without Framework](05-how-to/test-without-framework.md)
 * [Observe Execution](05-how-to/observe-execution.md)
 * [Visualize Graphs](05-how-to/visualize-graphs.md)

--- a/specs/not_reviewed/stateful-resource-lifecycle-prd.md
+++ b/specs/not_reviewed/stateful-resource-lifecycle-prd.md
@@ -1,0 +1,130 @@
+# Stateful Resource Lifecycle
+
+## Problem Statement
+
+Hypergraph users often bind expensive, stateful objects such as LLM clients, vector stores, embedders, database pools, and HTTP clients into graphs. Today `.bind()` can inject those objects, but it does not provide a first-class lifecycle: users must decide where construction happens, remember to close resources, and avoid accidentally opening production connections while inspecting or visualizing a graph locally.
+
+This becomes more visible with nested graphs. A subgraph should be able to declare the resources it needs in place, stay runnable on its own, and still compose cleanly into a parent graph. The parent graph should be able to open and close the resources used by the whole nested graph tree without requiring Hypergraph to know about Hypster or any other configuration framework.
+
+The current Daft `@stateful` support also points in this direction. Daft already has a lazy class model where initialization happens on workers. Hypergraph should align with that concept while keeping the core graph API decoupled from Daft and Hypster.
+
+## Solution
+
+Introduce lazy `@stateful` handles and a graph resource scope.
+
+Users will mark classes that should be constructed lazily:
+
+```python
+@stateful(resource=True)
+class LLM:
+    async def aclose(self) -> None:
+        ...
+```
+
+Calling a stateful class will return a lazy handle instead of opening the underlying resource immediately. Binding that handle to a graph will make the graph input optional, just like any existing `.bind()` value, but the resource will not be constructed until a resource scope opens:
+
+```python
+graph = Graph([generate]).bind(llm=LLM(model="gpt-5"))
+
+async with graph.resources() as ready_graph:
+    result = await AsyncRunner().run(ready_graph, {"query": "hello"})
+```
+
+The resource scope will materialize each distinct handle once, replace the bound handles with live instances for the duration of the scope, and close owned resources when the scope exits. The same handle bound in multiple places will be shared and closed once. Different handles, even if constructed with the same arguments, will remain different resources.
+
+Cleanup semantics will be deterministic:
+
+| Resource shape | Sync scope | Async scope |
+| --- | --- | --- |
+| `close()` only | construct and call `close()` on exit | construct and call `close()` on exit |
+| `aclose()` only | error before opening | construct and await `aclose()` on exit |
+| both `close()` and `aclose()` | construct and call `close()` | construct and await `aclose()` |
+| neither | invalid for `resource=True` | invalid for `resource=True` |
+
+`resource=False` remains lazy state without lifecycle ownership.
+
+## User Stories
+
+1. As a graph author, I want to bind a stateful LLM lazily, so that graph construction does not open network connections.
+2. As a graph author, I want to visualize or inspect a graph with stateful resources, so that local development does not require production credentials or services.
+3. As an async application developer, I want to use `async with graph.resources()`, so that async resources are opened and closed deterministically.
+4. As a sync application developer, I want to use `with graph.resources()`, so that sync resources are opened and closed deterministically.
+5. As a sync application developer, I want a clear error when a graph contains an async-only resource, so that I do not accidentally leak a resource that requires `await`.
+6. As a resource class author, I want `resource=True` to validate that cleanup exists, so that lifecycle bugs are caught early.
+7. As a resource class author, I want to support classes with `close()`, so that common sync clients work naturally.
+8. As a resource class author, I want to support classes with `aclose()`, so that async clients work naturally.
+9. As a resource class author, I want classes with both `close()` and `aclose()` to use the cleanup method that matches the scope, so that double-close bugs are avoided.
+10. As a graph author, I want resources with no cleanup to be invalid when `resource=True`, so that the lifecycle contract remains meaningful.
+11. As a graph author, I want `resource=False` to allow lazy state with no cleanup, so that stateful non-resource objects are still supported.
+12. As a nested graph author, I want subgraphs to declare their own resources, so that each subgraph remains standalone.
+13. As a parent graph author, I want a parent resource scope to open resources across nested subgraphs, so that the whole composed workflow has one lifecycle boundary.
+14. As a parent graph author, I want the same lazy handle used in multiple bindings to become one live instance, so that explicit sharing is possible.
+15. As a parent graph author, I want different lazy handles to remain different resources, so that Hypergraph does not infer unsafe sharing from constructor arguments.
+16. As an advanced user, I want to implement pooling inside my own resource class if needed, so that Hypergraph does not need provider-specific singleton logic.
+17. As a FastAPI user, I want to open graph resources in the app lifespan, so that long-lived clients are created once and closed at shutdown.
+18. As a FastAPI user, I want request handlers to receive a ready graph, so that request execution does not repeatedly open expensive resources.
+19. As a Daft user, I want `@stateful` constructor arguments to be captured lazily, so that Daft workers construct resources where execution happens.
+20. As a Daft user, I want existing class-level Daft options to continue working, so that `max_concurrency`, CPU/GPU, and retry controls remain available.
+21. As a maintainer, I want this feature to live in Hypergraph core, so that Hypster remains optional and decoupled.
+22. As a Hypster user, I want an advanced composition pattern using `hp.nest(...)`, so that lazy handles can be produced by configs without adding Hypergraph-Hypster coupling.
+23. As a test author, I want behavior tests through public graph and runner APIs, so that the implementation can be refactored without brittle tests.
+
+## Implementation Decisions
+
+- `@stateful` becomes the public lazy-constructor decorator for classes.
+- `@stateful(resource=True)` marks the lazy handle as an owned graph resource that must support deterministic cleanup.
+- `@stateful(resource=False)` marks lazy state without lifecycle ownership.
+- Calling a decorated class returns a lazy handle that captures the original class, positional arguments, keyword arguments, Daft options, and resource metadata.
+- The original class is not instantiated when the lazy handle is created.
+- A graph resource scope materializes handles and returns a graph with live instances bound in place of the handles.
+- The same lazy handle identity materializes once per scope and is reused anywhere that handle appears.
+- Different lazy handle identities materialize as distinct live resources, even if their constructor arguments are equal.
+- Hypergraph will not provide constructor-field deduping such as `share_by=("endpoint", "api_key")`.
+- Hypergraph will not provide a graph-level singleton/multiton pool for different handles in this implementation.
+- Sync scopes reject async-only resources before opening anything.
+- Async scopes can manage both sync and async cleanup.
+- When a resource has both `close()` and `aclose()`, sync scope uses `close()` and async scope uses `aclose()`.
+- Cleanup runs once per materialized handle in reverse materialization order.
+- Cleanup errors should propagate from scope exit using Python context manager semantics.
+- `Graph.resources()` is the intended lifecycle boundary for sync and async runners.
+- `Graph.bind(...)` remains the injection mechanism; no separate `bind_resource(...)` API is introduced.
+- Runtime inputs should not be used as a resource ownership mechanism. Resources should be bound before opening a resource scope.
+- Daft lowering should use the lazy handle metadata to construct worker-side resources with captured constructor arguments.
+- Hypster examples are documentation-only. Hypergraph will not import or depend on Hypster.
+
+## Testing Decisions
+
+- Tests should exercise behavior through public interfaces: `@stateful`, `Graph.bind(...)`, `Graph.resources()`, `SyncRunner`, and `AsyncRunner`.
+- Tests should avoid checking private registries or implementation-specific helper structures.
+- The tracer-bullet test will prove that a bound stateful resource is not constructed at bind time, is constructed inside the resource scope, is usable by a runner, and is closed on scope exit.
+- Additional tests will cover sync vs async cleanup behavior, invalid resource declarations, same-handle sharing, separate-handle separation, and nested graph resource scope behavior.
+- Daft tests should cover that lazy handles lower to Daft stateful operations without requiring zero-argument constructors.
+- Existing bind and nested graph tests provide prior art for public Graph behavior.
+- Existing Daft stateful tests provide prior art for stateful lowering behavior, but should be updated away from eager instance construction.
+
+## Out of Scope
+
+- Automatic resource deduplication based on constructor arguments.
+- `share_by=...` or other constructor-field identity APIs.
+- Built-in singleton/multiton transport pooling for LLM clients.
+- Hypster API changes.
+- FastAPI integration package code.
+- Automatic per-run resource scope opening in runners.
+- Lifecycle management for values provided directly at `runner.run(...)` time.
+- Support for async constructors.
+- Public resource override APIs beyond ordinary graph composition and binding.
+
+## Further Notes
+
+The design intentionally follows the spirit of FastAPI lifespan/dependency cleanup, Dishka scopes, Dependency Injector resource providers, and Python `ExitStack`/`AsyncExitStack`: lifecycle belongs to an explicit owner/scope, not to arbitrary object equality.
+
+This keeps the Hypergraph API small:
+
+```python
+graph = Graph([generate]).bind(llm=LLM(model="gpt-5"))
+
+async with graph.resources() as ready_graph:
+    await AsyncRunner().run(ready_graph, {"query": "hello"})
+```
+
+For nested graphs, subgraphs can bind their own handles and parent graphs can open one resource scope over the composed graph. Advanced Hypster users can produce those handles with `hp.nest(...)`, but Hypergraph only sees ordinary Python objects and graph bindings.

--- a/src/hypergraph/__init__.py
+++ b/src/hypergraph/__init__.py
@@ -69,6 +69,7 @@ from hypergraph.runners import (
     SyncRunner,
 )
 from hypergraph.runners._shared.node_context import NodeContext
+from hypergraph.stateful import StatefulHandle, stateful
 
 __all__ = [
     # Decorators and node types
@@ -135,6 +136,8 @@ __all__ = [
     "RichProgressProcessor",
     # Context
     "NodeContext",
+    "stateful",
+    "StatefulHandle",
     # Cache
     "CacheBackend",
     "InMemoryCache",

--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -1010,6 +1010,12 @@ class Graph:
         new_graph._bound = {**self._bound, **canonical}
         return new_graph
 
+    def resources(self):
+        """Open a resource scope for lazy stateful bound values."""
+        from hypergraph.graph.resources import GraphResourceScope
+
+        return GraphResourceScope(self)
+
     def unbind(self, *keys: str) -> Graph:
         """Remove specific bindings. Returns new Graph."""
         new_graph = self._shallow_copy()

--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -19,6 +19,7 @@ from hypergraph.nodes.base import HyperNode
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+    from hypergraph.graph.resources import GraphResourceScope
     from hypergraph.nodes.graph_node import GraphNode
     from hypergraph.viz.debug import VizDebugger
 
@@ -1010,7 +1011,7 @@ class Graph:
         new_graph._bound = {**self._bound, **canonical}
         return new_graph
 
-    def resources(self):
+    def resources(self) -> GraphResourceScope:
         """Open a resource scope for lazy stateful bound values."""
         from hypergraph.graph.resources import GraphResourceScope
 

--- a/src/hypergraph/graph/resources.py
+++ b/src/hypergraph/graph/resources.py
@@ -1,0 +1,137 @@
+"""Graph resource scope support."""
+
+from __future__ import annotations
+
+import inspect
+import sys
+from contextlib import AsyncExitStack, ExitStack
+from typing import TYPE_CHECKING, Any
+
+from hypergraph.stateful import StatefulHandle, is_stateful_handle
+
+if TYPE_CHECKING:
+    from hypergraph.graph import Graph
+
+
+class GraphResourceScope:
+    """Materialize lazy stateful handles for a graph scope."""
+
+    def __init__(self, graph: Graph) -> None:
+        self._graph = graph
+        self._instances: dict[StatefulHandle, Any] = {}
+        self._stack: ExitStack | None = None
+        self._astack: AsyncExitStack | None = None
+
+    def __enter__(self) -> Graph:
+        handles = list(_iter_stateful_handles(self._graph))
+        _validate_sync_scope(handles)
+        self._stack = ExitStack()
+        try:
+            return self._materialize_graph(async_scope=False)
+        except BaseException:
+            self.__exit__(*sys.exc_info())
+            raise
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> bool | None:
+        if self._stack is None:
+            return None
+        return self._stack.__exit__(exc_type, exc, tb)
+
+    async def __aenter__(self) -> Graph:
+        self._astack = AsyncExitStack()
+        try:
+            return self._materialize_graph(async_scope=True)
+        except BaseException:
+            await self.__aexit__(*sys.exc_info())
+            raise
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> bool | None:
+        if self._astack is None:
+            return None
+        return await self._astack.__aexit__(exc_type, exc, tb)
+
+    def _materialize_graph(self, graph: Graph | None = None, *, async_scope: bool) -> Graph:
+        from hypergraph.nodes.graph_node import GraphNode
+
+        graph = self._graph if graph is None else graph
+        new_graph = graph._shallow_copy()
+        new_graph._bound = {name: self._materialize_value(value, async_scope=async_scope) for name, value in graph._bound.items()}
+
+        nodes_changed = False
+        new_nodes = dict(graph._nodes)
+        for name, node in graph._nodes.items():
+            if not isinstance(node, GraphNode):
+                continue
+            inner = self._materialize_graph(node.graph, async_scope=async_scope)
+            copied = node._copy()
+            copied._graph = inner
+            new_nodes[name] = copied
+            nodes_changed = True
+
+        if nodes_changed:
+            new_graph._nodes = new_nodes
+        new_graph.__dict__.pop("inputs", None)
+        return new_graph
+
+    def _materialize_value(self, value: Any, *, async_scope: bool) -> Any:
+        if not is_stateful_handle(value):
+            return value
+
+        if value in self._instances:
+            return self._instances[value]
+
+        instance = value.materialize()
+        self._instances[value] = instance
+        self._register_cleanup(value, instance, async_scope=async_scope)
+        return instance
+
+    def _register_cleanup(self, handle: StatefulHandle, instance: Any, *, async_scope: bool) -> None:
+        policy = handle.policy
+        if not policy.resource:
+            return
+
+        if async_scope:
+            if policy.aclose is not None:
+                assert self._astack is not None
+                self._astack.push_async_callback(_call_async_cleanup, instance, policy.aclose)
+            elif policy.close is not None:
+                assert self._astack is not None
+                self._astack.callback(_call_sync_cleanup, instance, policy.close)
+            return
+
+        if policy.close is None:
+            raise TypeError(f"{handle.cls.__name__} requires async cleanup via aclose(); use async with graph.resources().")
+        assert self._stack is not None
+        self._stack.callback(_call_sync_cleanup, instance, policy.close)
+
+
+def _iter_stateful_handles(graph: Graph) -> list[StatefulHandle]:
+    from hypergraph.nodes.graph_node import GraphNode
+
+    handles: list[StatefulHandle] = []
+    for value in graph._bound.values():
+        if is_stateful_handle(value):
+            handles.append(value)
+
+    for node in graph._nodes.values():
+        if isinstance(node, GraphNode):
+            handles.extend(_iter_stateful_handles(node.graph))
+    return handles
+
+
+def _validate_sync_scope(handles: list[StatefulHandle]) -> None:
+    for handle in handles:
+        if handle.policy.async_only:
+            raise TypeError(f"{handle.cls.__name__} requires async cleanup via aclose(); use async with graph.resources().")
+
+
+def _call_sync_cleanup(instance: Any, method_name: str) -> None:
+    result = getattr(instance, method_name)()
+    if inspect.isawaitable(result):
+        raise TypeError(f"{type(instance).__name__}.{method_name} returned an awaitable during sync cleanup")
+
+
+async def _call_async_cleanup(instance: Any, method_name: str) -> None:
+    result = getattr(instance, method_name)()
+    if inspect.isawaitable(result):
+        await result

--- a/src/hypergraph/graph/resources.py
+++ b/src/hypergraph/graph/resources.py
@@ -23,6 +23,10 @@ class GraphResourceScope:
         self._astack: AsyncExitStack | None = None
 
     def __enter__(self) -> Graph:
+        if self._stack is not None or self._astack is not None:
+            raise RuntimeError("GraphResourceScope is already active")
+        self._instances = {}
+        self._astack = None
         handles = list(_iter_stateful_handles(self._graph))
         _validate_sync_scope(handles)
         self._stack = ExitStack()
@@ -35,9 +39,17 @@ class GraphResourceScope:
     def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> bool | None:
         if self._stack is None:
             return None
-        return self._stack.__exit__(exc_type, exc, tb)
+        try:
+            return self._stack.__exit__(exc_type, exc, tb)
+        finally:
+            self._instances = {}
+            self._stack = None
 
     async def __aenter__(self) -> Graph:
+        if self._stack is not None or self._astack is not None:
+            raise RuntimeError("GraphResourceScope is already active")
+        self._instances = {}
+        self._stack = None
         self._astack = AsyncExitStack()
         try:
             return self._materialize_graph(async_scope=True)
@@ -48,7 +60,11 @@ class GraphResourceScope:
     async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> bool | None:
         if self._astack is None:
             return None
-        return await self._astack.__aexit__(exc_type, exc, tb)
+        try:
+            return await self._astack.__aexit__(exc_type, exc, tb)
+        finally:
+            self._instances = {}
+            self._astack = None
 
     def _materialize_graph(self, graph: Graph | None = None, *, async_scope: bool) -> Graph:
         from hypergraph.nodes.graph_node import GraphNode
@@ -135,3 +151,5 @@ async def _call_async_cleanup(instance: Any, method_name: str) -> None:
     result = getattr(instance, method_name)()
     if inspect.isawaitable(result):
         await result
+        return
+    raise TypeError(f"{type(instance).__name__}.{method_name} returned a non-awaitable value during async cleanup")

--- a/src/hypergraph/integrations/daft/__init__.py
+++ b/src/hypergraph/integrations/daft/__init__.py
@@ -1,7 +1,6 @@
 """Public Daft integration surface."""
 
 from hypergraph.integrations.daft.decorators import node, stateful
-from hypergraph.integrations.daft.options import Options
 from hypergraph.runners.daft.runner import DaftRunner
 
-__all__ = ["DaftRunner", "Options", "node", "stateful"]
+__all__ = ["DaftRunner", "node", "stateful"]

--- a/src/hypergraph/integrations/daft/decorators.py
+++ b/src/hypergraph/integrations/daft/decorators.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import replace
 from typing import Any, Literal
 
 from hypergraph.nodes.function import FunctionNode
@@ -22,7 +21,6 @@ def node(
     hide: bool = False,
     emit: str | tuple[str, ...] | None = None,
     wait_for: str | tuple[str, ...] | None = None,
-    options: Options | None = None,
     batch: bool = False,
     return_dtype: Any | None = None,
     batch_size: int | None = None,
@@ -37,10 +35,9 @@ def node(
 ) -> FunctionNode | Callable[[Callable], FunctionNode]:
     """Wrap a function as a Hypergraph node with Daft-specific lowering hints."""
 
-    daft_options = _merge_options(
-        options,
-        batch=batch,
+    daft_options = Options(
         return_dtype=return_dtype,
+        batch=batch,
         batch_size=batch_size,
         unnest=unnest,
         cpus=cpus,
@@ -69,54 +66,3 @@ def node(
     if source is not None:
         return decorator(source)
     return decorator
-
-
-def _merge_options(
-    options: Options | None,
-    *,
-    batch: bool,
-    return_dtype: Any | None,
-    batch_size: int | None,
-    unnest: bool | None,
-    cpus: float | None,
-    use_process: bool | None,
-    max_concurrency: int | None,
-    max_retries: int | None,
-    on_error: Literal["raise", "log", "ignore"] | None,
-    gpus: float | None,
-    ray_options: dict[str, Any] | None,
-) -> Options:
-    if options is not None and any(
-        value is not None
-        for value in (
-            return_dtype,
-            batch_size,
-            unnest,
-            cpus,
-            use_process,
-            max_concurrency,
-            max_retries,
-            on_error,
-            gpus,
-            ray_options,
-        )
-    ):
-        raise TypeError("Pass either options=Options(...) or direct Daft option keywords, not both")
-
-    if options is None:
-        return Options(
-            return_dtype=return_dtype,
-            batch=batch,
-            batch_size=batch_size,
-            unnest=unnest,
-            cpus=cpus,
-            use_process=use_process,
-            max_concurrency=max_concurrency,
-            max_retries=max_retries,
-            on_error=on_error,
-            gpus=gpus,
-            ray_options=ray_options,
-        )
-    if batch and not options.batch:
-        return replace(options, batch=True)
-    return options

--- a/src/hypergraph/integrations/daft/options.py
+++ b/src/hypergraph/integrations/daft/options.py
@@ -1,5 +1,0 @@
-"""Compatibility import for typed Daft integration options."""
-
-from hypergraph.runners.daft._options import DEFAULT_OPTIONS, Options
-
-__all__ = ["DEFAULT_OPTIONS", "Options"]

--- a/src/hypergraph/runners/_shared/helpers.py
+++ b/src/hypergraph/runners/_shared/helpers.py
@@ -335,6 +335,25 @@ def warn_on_bind_overrides(graph: Graph, provided_values: dict[str, Any]) -> Non
         warnings.warn(msg, UserWarning, stacklevel=4)
 
 
+def validate_no_unmaterialized_stateful_handles(graph: Graph, provided_values: dict[str, Any]) -> None:
+    """Reject bound lazy handles before SyncRunner/AsyncRunner execution."""
+    from hypergraph.stateful import is_stateful_handle
+
+    for name, value in graph.inputs.bound.items():
+        if name in provided_values or not is_stateful_handle(value):
+            continue
+        raise GraphConfigError(
+            f"Bound input {name!r} is a lazy stateful handle and has not been materialized.\n\n"
+            f"How to fix:\n"
+            f"  Open a graph resource scope before running:\n"
+            f"    with graph.resources() as ready_graph:\n"
+            f"        runner.run(ready_graph, ...)\n"
+            f"  or, for async resources:\n"
+            f"    async with graph.resources() as ready_graph:\n"
+            f"        await runner.run(ready_graph, ...)"
+        )
+
+
 def _safe_deepcopy(value: Any, param_name: str = "<unknown>") -> Any:
     """Deep-copy a value, falling back gracefully for non-copyable objects.
 

--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -38,6 +38,7 @@ from hypergraph.runners._shared.helpers import (
     generate_workflow_id,
     initialize_state,
     is_interrupt_resume_payload,
+    validate_no_unmaterialized_stateful_handles,
     warn_on_bind_overrides,
 )
 from hypergraph.runners._shared.input_normalization import (
@@ -228,6 +229,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
             graph=graph,
             validation_ctx=validation_ctx,
         )
+        validate_no_unmaterialized_stateful_handles(graph, normalized_values)
         # Only fire override warning at the user-initiated outer run; nested
         # GraphNode delegations propagate the same value and would re-warn.
         if _parent_span_id is None and _parent_run_id is None:

--- a/src/hypergraph/runners/_shared/template_sync.py
+++ b/src/hypergraph/runners/_shared/template_sync.py
@@ -37,6 +37,7 @@ from hypergraph.runners._shared.helpers import (
     generate_workflow_id,
     initialize_state,
     is_interrupt_resume_payload,
+    validate_no_unmaterialized_stateful_handles,
     warn_on_bind_overrides,
 )
 from hypergraph.runners._shared.input_normalization import (
@@ -222,6 +223,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
             graph=graph,
             validation_ctx=validation_ctx,
         )
+        validate_no_unmaterialized_stateful_handles(graph, normalized_values)
         # Only fire override warning at the user-initiated outer run; nested
         # GraphNode delegations propagate the same value and would re-warn.
         if _parent_span_id is None and _parent_run_id is None:

--- a/src/hypergraph/runners/daft/AGENTS.md
+++ b/src/hypergraph/runners/daft/AGENTS.md
@@ -20,6 +20,11 @@ DataFrame plan is built.
   option-merging policy.
 - When adding a Daft lowering option, update the typed option model, operation
   validation, docs/examples, and at least one runtime test together.
+- `daft.stateful`/`daft_node` expose only `daft.cls`/`daft.func` placement
+  controls as flat kwargs (no public `Options` object). Resource lifecycle
+  (`resource`/`close`/`aclose`) stays on core `@stateful` + Sync/Async; Daft has
+  no deterministic teardown hook, so DaftRunner rejects any `resource=True`
+  stateful. Do not re-add lifecycle args to the Daft decorators.
 
 ## GraphNode Outputs
 

--- a/src/hypergraph/runners/daft/_options.py
+++ b/src/hypergraph/runners/daft/_options.py
@@ -43,21 +43,6 @@ class Options:
                 names = ", ".join(repr(name) for name in unsupported)
                 raise ValueError(f"ray_options cannot include {names}; use cpus/gpus instead")
 
-    def validate_stateful_class_options(self) -> None:
-        """Reject node/method-only settings when options are used for ``stateful``."""
-        unsupported = []
-        if self.return_dtype is not None:
-            unsupported.append("return_dtype")
-        if self.batch:
-            unsupported.append("batch")
-        if self.batch_size is not None:
-            unsupported.append("batch_size")
-        if self.unnest is not None:
-            unsupported.append("unnest")
-        if unsupported:
-            names = ", ".join(unsupported)
-            raise ValueError(f"stateful Options cannot include {names}; put node/method options on daft_node(...)")
-
     def for_func(self) -> dict[str, Any]:
         """Keyword arguments accepted by ``daft.func``."""
         return _drop_none(

--- a/src/hypergraph/runners/daft/_stateful.py
+++ b/src/hypergraph/runners/daft/_stateful.py
@@ -6,9 +6,20 @@ from collections.abc import Callable
 from typing import Any, ClassVar, Literal, Protocol, runtime_checkable
 
 from hypergraph.runners.daft._options import DEFAULT_OPTIONS, Options
+from hypergraph.stateful import (
+    _INFER,
+    DAFT_OPTIONS_ATTR,
+    StatefulHandle,
+)
+from hypergraph.stateful import (
+    is_stateful as _is_stateful,
+)
+from hypergraph.stateful import (
+    stateful as _core_stateful,
+)
 
 STATEFUL_ATTR = "__daft_stateful__"
-STATEFUL_OPTIONS_ATTR = "__daft_options__"
+STATEFUL_OPTIONS_ATTR = DAFT_OPTIONS_ATTR
 
 
 @runtime_checkable
@@ -21,6 +32,9 @@ class DaftStateful(Protocol):
 def stateful(
     cls: type | None = None,
     *,
+    resource: bool = False,
+    close: str | None | object = _INFER,
+    aclose: str | None | object = _INFER,
     options: Options | None = None,
     cpus: float | None = None,
     gpus: float | None = None,
@@ -43,9 +57,13 @@ def stateful(
     )
 
     def decorate(class_: type) -> type:
-        setattr(class_, STATEFUL_ATTR, True)
-        setattr(class_, STATEFUL_OPTIONS_ATTR, daft_options)
-        return class_
+        return _core_stateful(
+            class_,
+            resource=resource,
+            close=close,
+            aclose=aclose,
+            _daft_options=daft_options,
+        )
 
     if cls is not None:
         return decorate(cls)
@@ -54,7 +72,7 @@ def stateful(
 
 def is_stateful(value: Any) -> bool:
     """Return whether ``value`` is marked as a Daft stateful resource."""
-    return getattr(type(value), STATEFUL_ATTR, False) is True
+    return _is_stateful(value)
 
 
 def has_stateful_values(bound_values: dict[str, Any]) -> bool:
@@ -64,6 +82,8 @@ def has_stateful_values(bound_values: dict[str, Any]) -> bool:
 
 def get_stateful_options(value: Any) -> Options:
     """Return Daft class options attached to a stateful resource."""
+    if isinstance(value, StatefulHandle):
+        return value.metadata.daft_options or DEFAULT_OPTIONS
     return getattr(type(value), STATEFUL_OPTIONS_ATTR, DEFAULT_OPTIONS)
 
 

--- a/src/hypergraph/runners/daft/_stateful.py
+++ b/src/hypergraph/runners/daft/_stateful.py
@@ -7,8 +7,8 @@ from typing import Any, ClassVar, Literal, Protocol, runtime_checkable
 
 from hypergraph.runners.daft._options import DEFAULT_OPTIONS, Options
 from hypergraph.stateful import (
-    _INFER,
     DAFT_OPTIONS_ATTR,
+    STATEFUL_METADATA_ATTR,
     StatefulHandle,
 )
 from hypergraph.stateful import (
@@ -32,10 +32,6 @@ class DaftStateful(Protocol):
 def stateful(
     cls: type | None = None,
     *,
-    resource: bool = False,
-    close: str | None | object = _INFER,
-    aclose: str | None | object = _INFER,
-    options: Options | None = None,
     cpus: float | None = None,
     gpus: float | None = None,
     use_process: bool | None = None,
@@ -44,9 +40,14 @@ def stateful(
     on_error: Literal["raise", "log", "ignore"] | None = None,
     ray_options: dict[str, Any] | None = None,
 ) -> type | Callable[[type], type]:
-    """Mark a class for per-worker initialization in DaftRunner."""
-    daft_options = _merge_stateful_options(
-        options,
+    """Mark a class for per-worker construction in DaftRunner.
+
+    Accepts only ``daft.cls`` placement controls. Resource lifecycle
+    (``resource``/``close``/``aclose``) is a core ``@stateful`` + Sync/Async
+    concern: Daft constructs resources per worker and exposes no deterministic
+    teardown hook, so this decorator intentionally does not own that lifecycle.
+    """
+    daft_options = Options(
         cpus=cpus,
         gpus=gpus,
         use_process=use_process,
@@ -57,13 +58,7 @@ def stateful(
     )
 
     def decorate(class_: type) -> type:
-        return _core_stateful(
-            class_,
-            resource=resource,
-            close=close,
-            aclose=aclose,
-            _daft_options=daft_options,
-        )
+        return _core_stateful(class_, _daft_options=daft_options)
 
     if cls is not None:
         return decorate(cls)
@@ -73,6 +68,14 @@ def stateful(
 def is_stateful(value: Any) -> bool:
     """Return whether ``value`` is marked as a Daft stateful resource."""
     return _is_stateful(value) or getattr(type(value), STATEFUL_ATTR, False) is True
+
+
+def is_resource_stateful(value: Any) -> bool:
+    """Return whether a stateful value declares ``resource=True`` lifecycle."""
+    if isinstance(value, StatefulHandle):
+        return value.policy.resource
+    metadata = getattr(type(value), STATEFUL_METADATA_ATTR, None)
+    return bool(metadata is not None and metadata.policy.resource)
 
 
 def has_stateful_values(bound_values: dict[str, Any]) -> bool:
@@ -85,33 +88,3 @@ def get_stateful_options(value: Any) -> Options:
     if isinstance(value, StatefulHandle):
         return value.metadata.daft_options or DEFAULT_OPTIONS
     return getattr(type(value), STATEFUL_OPTIONS_ATTR, DEFAULT_OPTIONS)
-
-
-def _merge_stateful_options(
-    options: Options | None,
-    *,
-    cpus: float | None,
-    gpus: float | None,
-    use_process: bool | None,
-    max_concurrency: int | None,
-    max_retries: int | None,
-    on_error: Literal["raise", "log", "ignore"] | None,
-    ray_options: dict[str, Any] | None,
-) -> Options:
-    direct_values = (cpus, gpus, use_process, max_concurrency, max_retries, on_error, ray_options)
-    if options is not None and any(value is not None for value in direct_values):
-        raise TypeError("Pass either options=Options(...) or direct Daft option keywords, not both")
-
-    if options is not None:
-        options.validate_stateful_class_options()
-        return options
-
-    return Options(
-        cpus=cpus,
-        gpus=gpus,
-        use_process=use_process,
-        max_concurrency=max_concurrency,
-        max_retries=max_retries,
-        on_error=on_error,
-        ray_options=ray_options,
-    )

--- a/src/hypergraph/runners/daft/_stateful.py
+++ b/src/hypergraph/runners/daft/_stateful.py
@@ -72,7 +72,7 @@ def stateful(
 
 def is_stateful(value: Any) -> bool:
     """Return whether ``value`` is marked as a Daft stateful resource."""
-    return _is_stateful(value)
+    return _is_stateful(value) or getattr(type(value), STATEFUL_ATTR, False) is True
 
 
 def has_stateful_values(bound_values: dict[str, Any]) -> bool:

--- a/src/hypergraph/runners/daft/operations.py
+++ b/src/hypergraph/runners/daft/operations.py
@@ -9,7 +9,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from hypergraph.runners.daft._options import DEFAULT_OPTIONS, Options, get_node_options
-from hypergraph.runners.daft._stateful import DaftStateful, get_stateful_options, has_stateful_values, is_stateful
+from hypergraph.runners.daft._stateful import DaftStateful, get_stateful_options, has_stateful_values, is_resource_stateful, is_stateful
 from hypergraph.stateful import StatefulHandle
 
 if TYPE_CHECKING:
@@ -348,6 +348,7 @@ def create_operation(
         if is_batch(node):
             _validate_batch_options(node, output_cols)
         if has_stateful_values(node_bound):
+            _validate_stateful_no_resource(node_bound)
             _validate_stateful_constructable(node_bound)
             _validate_stateful_node_options(node)
             return StatefulNodeOperation(
@@ -385,6 +386,23 @@ def create_operation(
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _validate_stateful_no_resource(bound_values: dict[str, Any]) -> None:
+    """Reject ``resource=True`` stateful values, which Daft cannot deterministically close."""
+    from hypergraph.runners._shared.validation import IncompatibleRunnerError
+
+    for name, value in bound_values.items():
+        if not is_stateful(value) or not is_resource_stateful(value):
+            continue
+        cls_name = value.cls.__name__ if isinstance(value, StatefulHandle) else type(value).__name__
+        raise IncompatibleRunnerError(
+            f"@stateful(resource=True) ({cls_name}, bound as {name!r}) cannot run on DaftRunner: "
+            f"Daft constructs resources per worker and has no deterministic teardown hook, so "
+            f"close()/aclose() would never be called. Use resource=False for worker-local state, "
+            f"or run resource scopes with SyncRunner/AsyncRunner via graph.resources().",
+            capability="node_types",
+        )
 
 
 def _validate_stateful_constructable(bound_values: dict[str, Any]) -> None:

--- a/src/hypergraph/runners/daft/operations.py
+++ b/src/hypergraph/runners/daft/operations.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 from hypergraph.runners.daft._options import DEFAULT_OPTIONS, Options, get_node_options
 from hypergraph.runners.daft._stateful import DaftStateful, get_stateful_options, has_stateful_values, is_stateful
+from hypergraph.stateful import StatefulHandle
 
 if TYPE_CHECKING:
     import daft
@@ -127,7 +128,6 @@ class StatefulNodeOperation(DaftOperation):
 
         # Separate stateful from plain bound values
         stateful_vals = {k: v for k, v in bound.items() if is_stateful(v)}
-        stateful_types = {k: type(v) for k, v in stateful_vals.items()}
         plain_vals = {k: v for k, v in bound.items() if not is_stateful(v)}
 
         class_options = _stateful_options(stateful_vals)
@@ -140,7 +140,7 @@ class StatefulNodeOperation(DaftOperation):
 
             def _stateful_values(self) -> dict[str, Any]:
                 if self._stateful is None:
-                    self._stateful = {k: cls() for k, cls in stateful_types.items()}
+                    self._stateful = {k: _materialize_stateful(v) for k, v in stateful_vals.items()}
                 return self._stateful
 
             def _call_kwargs(self, *args: Any) -> dict[str, Any]:
@@ -390,6 +390,8 @@ def create_operation(
 def _validate_stateful_constructable(bound_values: dict[str, Any]) -> None:
     """Validate that DaftStateful objects support zero-arg construction."""
     for k, v in bound_values.items():
+        if isinstance(v, StatefulHandle):
+            continue
         if not isinstance(v, DaftStateful):
             continue
         try:
@@ -400,6 +402,12 @@ def _validate_stateful_constructable(bound_values: dict[str, Any]) -> None:
                 f"zero-arg construction for per-worker re-initialization. Got: {e}\n\n"
                 f"How to fix: Ensure {type(v).__name__}.__init__() works with no arguments."
             ) from e
+
+
+def _materialize_stateful(value: Any) -> Any:
+    if isinstance(value, StatefulHandle):
+        return value.materialize()
+    return type(value)()
 
 
 def _validate_batch_options(node: HyperNode, output_cols: list[str]) -> None:

--- a/src/hypergraph/runners/daft/operations.py
+++ b/src/hypergraph/runners/daft/operations.py
@@ -140,7 +140,7 @@ class StatefulNodeOperation(DaftOperation):
 
             def _stateful_values(self) -> dict[str, Any]:
                 if self._stateful is None:
-                    self._stateful = {k: _materialize_stateful(v) for k, v in stateful_vals.items()}
+                    self._stateful = _materialize_stateful_values(stateful_vals)
                 return self._stateful
 
             def _call_kwargs(self, *args: Any) -> dict[str, Any]:
@@ -408,6 +408,19 @@ def _materialize_stateful(value: Any) -> Any:
     if isinstance(value, StatefulHandle):
         return value.materialize()
     return type(value)()
+
+
+def _materialize_stateful_values(stateful_vals: dict[str, Any]) -> dict[str, Any]:
+    materialized_handles: dict[StatefulHandle, Any] = {}
+    materialized: dict[str, Any] = {}
+    for name, value in stateful_vals.items():
+        if isinstance(value, StatefulHandle):
+            if value not in materialized_handles:
+                materialized_handles[value] = value.materialize()
+            materialized[name] = materialized_handles[value]
+        else:
+            materialized[name] = _materialize_stateful(value)
+    return materialized
 
 
 def _validate_batch_options(node: HyperNode, output_cols: list[str]) -> None:

--- a/src/hypergraph/stateful.py
+++ b/src/hypergraph/stateful.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import inspect
+from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import Any
 
@@ -12,6 +13,10 @@ DAFT_STATEFUL_ATTR = "__daft_stateful__"
 DAFT_OPTIONS_ATTR = "__daft_options__"
 
 _INFER = object()
+_MATERIALIZING_CLASSES: ContextVar[frozenset[type]] = ContextVar(
+    "_MATERIALIZING_CLASSES",
+    default=frozenset(),
+)
 
 
 @dataclass(frozen=True)
@@ -47,10 +52,12 @@ class StatefulHandle:
         metadata: StatefulMetadata,
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
+        stateful_cls: type | None = None,
     ) -> None:
         self.metadata = metadata
         self.args = args
         self.kwargs = dict(kwargs)
+        self.stateful_cls = stateful_cls
         self.__daft_options__ = metadata.daft_options
 
     @property
@@ -63,10 +70,29 @@ class StatefulHandle:
 
     def materialize(self) -> Any:
         """Construct the wrapped object."""
+        if self.stateful_cls is not None:
+            return self.stateful_cls.__hypergraph_materialize__(*self.args, **self.kwargs)
         return self.cls(*self.args, **self.kwargs)
+
+    def __reduce__(self) -> Any:
+        if self.stateful_cls is None:
+            return (_rebuild_legacy_stateful_handle, (self.metadata, self.args, self.kwargs))
+        return (_rebuild_stateful_handle, (self.stateful_cls, self.args, self.kwargs))
 
     def __repr__(self) -> str:
         return f"StatefulHandle({self.cls.__name__})"
+
+
+def _rebuild_stateful_handle(stateful_cls: type, args: tuple[Any, ...], kwargs: dict[str, Any]) -> StatefulHandle:
+    return stateful_cls(*args, **kwargs)
+
+
+def _rebuild_legacy_stateful_handle(
+    metadata: StatefulMetadata,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> StatefulHandle:
+    return StatefulHandle(metadata, args, kwargs)
 
 
 def stateful(
@@ -90,10 +116,19 @@ def stateful(
             __daft_stateful__ = True
             __daft_options__ = _daft_options
 
-            def __new__(proxy_cls, *args: Any, **kwargs: Any) -> StatefulHandle:  # noqa: N804
-                if proxy_cls is StatefulClass:
-                    return StatefulHandle(metadata, args, kwargs)
+            def __new__(proxy_cls, *args: Any, **kwargs: Any) -> Any:  # noqa: N804
+                if proxy_cls is StatefulClass and StatefulClass not in _MATERIALIZING_CLASSES.get():
+                    return StatefulHandle(metadata, args, kwargs, StatefulClass)
                 return super().__new__(proxy_cls)
+
+            @classmethod
+            def __hypergraph_materialize__(stateful_cls, *args: Any, **kwargs: Any) -> Any:
+                materializing = _MATERIALIZING_CLASSES.get()
+                token = _MATERIALIZING_CLASSES.set(materializing | {stateful_cls})
+                try:
+                    return stateful_cls(*args, **kwargs)
+                finally:
+                    _MATERIALIZING_CLASSES.reset(token)
 
         StatefulClass.__name__ = class_.__name__
         StatefulClass.__qualname__ = class_.__qualname__

--- a/src/hypergraph/stateful.py
+++ b/src/hypergraph/stateful.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import inspect
-from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import Any
 
@@ -13,10 +12,6 @@ DAFT_STATEFUL_ATTR = "__daft_stateful__"
 DAFT_OPTIONS_ATTR = "__daft_options__"
 
 _INFER = object()
-_MATERIALIZING_CLASSES: ContextVar[frozenset[type]] = ContextVar(
-    "_MATERIALIZING_CLASSES",
-    default=frozenset(),
-)
 
 
 @dataclass(frozen=True)
@@ -117,18 +112,13 @@ def stateful(
             __daft_options__ = _daft_options
 
             def __new__(proxy_cls, *args: Any, **kwargs: Any) -> Any:  # noqa: N804
-                if proxy_cls is StatefulClass and StatefulClass not in _MATERIALIZING_CLASSES.get():
+                if proxy_cls is StatefulClass:
                     return StatefulHandle(metadata, args, kwargs, StatefulClass)
                 return super().__new__(proxy_cls)
 
             @classmethod
             def __hypergraph_materialize__(stateful_cls, *args: Any, **kwargs: Any) -> Any:
-                materializing = _MATERIALIZING_CLASSES.get()
-                token = _MATERIALIZING_CLASSES.set(materializing | {stateful_cls})
-                try:
-                    return stateful_cls(*args, **kwargs)
-                finally:
-                    _MATERIALIZING_CLASSES.reset(token)
+                return _construct_stateful_instance(class_, stateful_cls, args, kwargs)
 
         StatefulClass.__name__ = class_.__name__
         StatefulClass.__qualname__ = class_.__qualname__
@@ -139,6 +129,21 @@ def stateful(
     if cls is not None:
         return decorate(cls)
     return decorate
+
+
+def _construct_stateful_instance(
+    original_cls: type,
+    stateful_cls: type,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> Any:
+    """Construct the proxy instance without producing another lazy handle."""
+    new = original_cls.__new__
+    instance = object.__new__(stateful_cls) if new is object.__new__ else new(stateful_cls, *args, **kwargs)
+
+    if isinstance(instance, stateful_cls):
+        original_cls.__init__(instance, *args, **kwargs)
+    return instance
 
 
 def is_stateful(value: Any) -> bool:

--- a/src/hypergraph/stateful.py
+++ b/src/hypergraph/stateful.py
@@ -1,0 +1,169 @@
+"""Lazy stateful object handles."""
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass
+from typing import Any
+
+STATEFUL_ATTR = "__hypergraph_stateful__"
+STATEFUL_METADATA_ATTR = "__hypergraph_stateful_metadata__"
+DAFT_STATEFUL_ATTR = "__daft_stateful__"
+DAFT_OPTIONS_ATTR = "__daft_options__"
+
+_INFER = object()
+
+
+@dataclass(frozen=True)
+class StatefulResourcePolicy:
+    """Lifecycle policy for a stateful handle."""
+
+    resource: bool
+    close: str | None = None
+    aclose: str | None = None
+
+    @property
+    def async_only(self) -> bool:
+        return self.resource and self.close is None and self.aclose is not None
+
+
+@dataclass(frozen=True)
+class StatefulMetadata:
+    """Metadata captured by ``@stateful``."""
+
+    cls: type
+    policy: StatefulResourcePolicy
+    daft_options: Any = None
+
+
+class StatefulHandle:
+    """Lazy constructor call produced by a ``@stateful`` class."""
+
+    __hypergraph_stateful__ = True
+    __daft_stateful__ = True
+
+    def __init__(
+        self,
+        metadata: StatefulMetadata,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> None:
+        self.metadata = metadata
+        self.args = args
+        self.kwargs = dict(kwargs)
+        self.__daft_options__ = metadata.daft_options
+
+    @property
+    def cls(self) -> type:
+        return self.metadata.cls
+
+    @property
+    def policy(self) -> StatefulResourcePolicy:
+        return self.metadata.policy
+
+    def materialize(self) -> Any:
+        """Construct the wrapped object."""
+        return self.cls(*self.args, **self.kwargs)
+
+    def __repr__(self) -> str:
+        return f"StatefulHandle({self.cls.__name__})"
+
+
+def stateful(
+    cls: type | None = None,
+    *,
+    resource: bool = False,
+    close: str | None | object = _INFER,
+    aclose: str | None | object = _INFER,
+    _daft_options: Any = None,
+) -> type | Any:
+    """Decorate a class so construction produces a lazy handle."""
+
+    def decorate(class_: type) -> type:
+        policy = _resource_policy(class_, resource=resource, close=close, aclose=aclose)
+        metadata = StatefulMetadata(class_, policy, _daft_options)
+
+        class StatefulClass(class_):  # type: ignore[misc, valid-type]
+            __wrapped__ = class_
+            __hypergraph_stateful__ = True
+            __hypergraph_stateful_metadata__ = metadata
+            __daft_stateful__ = True
+            __daft_options__ = _daft_options
+
+            def __new__(proxy_cls, *args: Any, **kwargs: Any) -> StatefulHandle:  # noqa: N804
+                if proxy_cls is StatefulClass:
+                    return StatefulHandle(metadata, args, kwargs)
+                return super().__new__(proxy_cls)
+
+        StatefulClass.__name__ = class_.__name__
+        StatefulClass.__qualname__ = class_.__qualname__
+        StatefulClass.__module__ = class_.__module__
+        StatefulClass.__doc__ = class_.__doc__
+        return StatefulClass
+
+    if cls is not None:
+        return decorate(cls)
+    return decorate
+
+
+def is_stateful(value: Any) -> bool:
+    """Return whether ``value`` is a lazy stateful handle."""
+    return isinstance(value, StatefulHandle) or getattr(value, STATEFUL_ATTR, False) is True
+
+
+def is_stateful_handle(value: Any) -> bool:
+    """Return whether ``value`` is a lazy constructor handle."""
+    return isinstance(value, StatefulHandle)
+
+
+def _resource_policy(
+    cls: type,
+    *,
+    resource: bool,
+    close: str | None | object,
+    aclose: str | None | object,
+) -> StatefulResourcePolicy:
+    if not resource:
+        return StatefulResourcePolicy(resource=False)
+
+    close_name = _resolve_cleanup_name(cls, close, default="close", sync=True)
+    aclose_name = _resolve_cleanup_name(cls, aclose, default="aclose", sync=False)
+
+    if close_name is None and aclose_name is None:
+        raise TypeError(
+            f"{cls.__name__} is marked resource=True but has no close()/aclose() cleanup method. "
+            "Add close(), add async aclose(), or use resource=False for lazy state without lifecycle ownership."
+        )
+
+    return StatefulResourcePolicy(resource=True, close=close_name, aclose=aclose_name)
+
+
+def _resolve_cleanup_name(
+    cls: type,
+    value: str | None | object,
+    *,
+    default: str,
+    sync: bool,
+) -> str | None:
+    if value is None:
+        return None
+
+    if value is _INFER:
+        name = default if callable(getattr(cls, default, None)) else None
+    else:
+        if not isinstance(value, str):
+            raise TypeError("close/aclose must be method names, None, or omitted")
+        name = value
+        if not callable(getattr(cls, name, None)):
+            raise TypeError(f"{cls.__name__} has no cleanup method {name!r}")
+
+    if name is None:
+        return None
+
+    method = getattr(cls, name)
+    is_async = inspect.iscoroutinefunction(method)
+    if sync and is_async:
+        raise TypeError(f"{cls.__name__}.{name} is async; pass it as aclose={name!r}")
+    if not sync and not is_async:
+        raise TypeError(f"{cls.__name__}.{name} is sync; pass it as close={name!r}")
+    return name

--- a/tests/test_integrations_daft.py
+++ b/tests/test_integrations_daft.py
@@ -11,9 +11,8 @@ pytest.importorskip("daft")
 import daft
 
 from hypergraph import Graph, node
-from hypergraph.integrations.daft import DaftRunner, Options, stateful
+from hypergraph.integrations.daft import DaftRunner, stateful
 from hypergraph.integrations.daft import node as daft_node
-from hypergraph.integrations.daft.options import Options as ReExportedOptions
 from hypergraph.runners.daft._options import Options as InternalOptions
 
 
@@ -284,35 +283,75 @@ def test_ray_resource_options_are_rejected_at_definition_time() -> None:
 
 def test_options_validate_current_daft_resource_rules_at_definition_time() -> None:
     with pytest.raises(ValueError, match="on_error"):
-        Options(on_error="skip")  # type: ignore[arg-type]
+        InternalOptions(on_error="skip")  # type: ignore[arg-type]
 
     with pytest.raises(ValueError, match="max_concurrency"):
-        Options(max_concurrency=0)
+        InternalOptions(max_concurrency=0)
 
     with pytest.raises(ValueError, match="max_concurrency"):
-        Options(max_concurrency=1.5)  # type: ignore[arg-type]
+        InternalOptions(max_concurrency=1.5)  # type: ignore[arg-type]
 
     with pytest.raises(ValueError, match="max_retries"):
-        Options(max_retries=-1)
+        InternalOptions(max_retries=-1)
 
     with pytest.raises(ValueError, match="batch_size"):
-        Options(batch_size=0)
+        InternalOptions(batch_size=0)
 
     with pytest.raises(ValueError, match="batch_size"):
-        Options(batch_size=1.5)  # type: ignore[arg-type]
+        InternalOptions(batch_size=1.5)  # type: ignore[arg-type]
 
     with pytest.raises(ValueError, match="gpus"):
-        Options(gpus=1.5)
+        InternalOptions(gpus=1.5)
 
 
-def test_options_reexports_use_one_class_identity() -> None:
-    assert Options is InternalOptions is ReExportedOptions
+def test_options_is_not_part_of_public_integration_surface() -> None:
+    import hypergraph.integrations.daft as daft_integration
+
+    assert not hasattr(daft_integration, "Options")
+
+    with pytest.raises(ImportError):
+        from hypergraph.integrations.daft import Options  # noqa: F401
+
+    with pytest.raises(ModuleNotFoundError):
+        import hypergraph.integrations.daft.options  # noqa: F401
 
 
-def test_stateful_rejects_node_only_options() -> None:
-    with pytest.raises(ValueError, match="stateful.*return_dtype"):
+def test_daft_stateful_does_not_own_resource_lifecycle() -> None:
+    # Lifecycle (resource/close/aclose) is a core @stateful + Sync/Async concept.
+    # Daft has no deterministic teardown hook, so daft.stateful must not advertise it.
+    for kwargs in ({"resource": True}, {"close": "shutdown"}, {"aclose": "aclose"}):
+        with pytest.raises(TypeError):
+            stateful(**kwargs)
 
-        @stateful(options=Options(return_dtype=daft.DataType.int64()))
-        class Resource:
-            def __init__(self) -> None:
-                pass
+
+def test_daft_decorators_reject_options_keyword() -> None:
+    # Flat kwargs only; the typed Options model is an internal detail now.
+    with pytest.raises(TypeError):
+        daft_node(options=InternalOptions())
+    with pytest.raises(TypeError):
+        stateful(options=InternalOptions())
+
+
+def test_daft_runner_rejects_resource_true_stateful() -> None:
+    from hypergraph import stateful as core_stateful
+    from hypergraph.runners._shared.validation import IncompatibleRunnerError
+
+    @core_stateful(resource=True)
+    class Client:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def transform(self, x: int) -> int:
+            return x + 1
+
+        def close(self) -> None:
+            self.closed = True
+
+    @node(output_name="y")
+    def transform(x: int, client: Client) -> int:
+        return client.transform(x)
+
+    graph = Graph([transform], name="resource_on_daft").bind(client=Client())
+
+    with pytest.raises(IncompatibleRunnerError, match="resource=True"):
+        DaftRunner().map(graph, {"x": [1, 2]}, map_over="x")

--- a/tests/test_integrations_daft.py
+++ b/tests/test_integrations_daft.py
@@ -196,7 +196,7 @@ def test_map_dataframe_stateful_plan_build_does_not_eagerly_construct_resource()
 
     result = DaftRunner().map_dataframe(graph, frame)
 
-    assert LazyResource.constructions == 1
+    assert LazyResource.constructions == 0
     assert result.collect().to_pydict()["y"] == [2, 3]
 
 

--- a/tests/test_runners/test_daft_operations.py
+++ b/tests/test_runners/test_daft_operations.py
@@ -315,25 +315,28 @@ class TestBatchMultiOutputRejection:
 
 
 # ---------------------------------------------------------------------------
-# Validation: _validate_stateful_constructable
+# Validation: stateful constructor capture
 # ---------------------------------------------------------------------------
 
 
 class TestStatefulConstructable:
-    def test_non_constructable_stateful_rejected(self):
+    def test_stateful_constructor_args_are_captured(self):
         @stateful
         class NeedsArgs:
             def __init__(self, required_arg: str):
                 self.value = required_arg
 
         @node(output_name="out")
-        def use_it(x: int, model: NeedsArgs) -> int:
-            return x
+        def use_it(x: int, model: NeedsArgs) -> str:
+            return f"{model.value}:{x}"
 
         graph = Graph([use_it], name="test")
-        with pytest.raises(TypeError, match="zero-arg construction"):
-            create_operation(
-                use_it,
-                graph,
-                bound_values={"model": NeedsArgs("hello")},
-            )
+        op = create_operation(
+            use_it,
+            graph,
+            bound_values={"model": NeedsArgs("hello")},
+        )
+
+        df = daft.from_pydict({"x": [1]})
+        result = op.apply(df).collect().to_pydict()
+        assert result["out"] == ["hello:1"]

--- a/tests/test_runners/test_daft_operations.py
+++ b/tests/test_runners/test_daft_operations.py
@@ -90,6 +90,14 @@ class TestDaftStatefulProtocol:
 
         assert not has_stateful_values({"obj": NotStateful()})
 
+    def test_manual_daft_stateful_attribute_detected(self):
+        """Legacy objects marked with __daft_stateful__ are still supported."""
+
+        class LegacyStateful:
+            __daft_stateful__ = True
+
+        assert has_stateful_values({"obj": LegacyStateful()})
+
 
 # ---------------------------------------------------------------------------
 # Batch detection
@@ -253,6 +261,22 @@ class TestStatefulNodeOperation:
         df = daft.from_pydict({"text": ["hi", "hello"]})
         result = op.apply(df).collect().to_pydict()
         assert result["score"] == [2 * 42, 5 * 42]
+
+    def test_repeated_stateful_handle_materializes_once(self):
+        @node(output_name="same")
+        def compare_models(x: int, left: MockModel, right: MockModel) -> bool:
+            return left is right
+
+        handle = MockModel()
+        graph = Graph([compare_models], name="test")
+        op = create_operation(
+            compare_models,
+            graph,
+            bound_values={"left": handle, "right": handle},
+        )
+        df = daft.from_pydict({"x": [1, 2]})
+        result = op.apply(df).collect().to_pydict()
+        assert result["same"] == [True, True]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_stateful_resources.py
+++ b/tests/test_stateful_resources.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import pytest
+
+from hypergraph import AsyncRunner, Graph, SyncRunner, node, stateful
+
+
+def test_sync_resource_scope_materializes_bound_stateful_resource() -> None:
+    events: list[tuple[str, str]] = []
+
+    @stateful(resource=True)
+    class Prefixer:
+        def __init__(self, prefix: str) -> None:
+            events.append(("init", prefix))
+            self.prefix = prefix
+
+        def format(self, text: str) -> str:
+            return f"{self.prefix}:{text}"
+
+        def close(self) -> None:
+            events.append(("close", self.prefix))
+
+    @node(output_name="formatted")
+    def format_text(text: str, prefixer: Prefixer) -> str:
+        return prefixer.format(text)
+
+    prefixer = Prefixer("prod")
+    graph = Graph([format_text]).bind(prefixer=prefixer)
+
+    assert events == []
+
+    with graph.resources() as ready_graph:
+        assert events == [("init", "prod")]
+        result = SyncRunner().run(ready_graph, {"text": "hello"})
+        assert result.values["formatted"] == "prod:hello"
+
+    assert events == [("init", "prod"), ("close", "prod")]
+
+
+def test_sync_resource_scope_rejects_async_only_resource_before_opening() -> None:
+    events: list[str] = []
+
+    @stateful(resource=True)
+    class AsyncOnly:
+        def __init__(self) -> None:
+            events.append("init")
+
+        async def aclose(self) -> None:
+            events.append("aclose")
+
+    @node(output_name="out")
+    def use_resource(resource: AsyncOnly) -> str:
+        return "ok"
+
+    graph = Graph([use_resource]).bind(resource=AsyncOnly())
+
+    with pytest.raises(TypeError, match="async cleanup"), graph.resources():
+        pass
+
+    assert events == []
+
+
+@pytest.mark.asyncio
+async def test_async_resource_scope_handles_sync_async_and_dual_cleanup() -> None:
+    events: list[str] = []
+
+    @stateful(resource=True)
+    class CloseOnly:
+        def __init__(self) -> None:
+            events.append("close:init")
+
+        def close(self) -> None:
+            events.append("close:close")
+
+    @stateful(resource=True)
+    class ACloseOnly:
+        def __init__(self) -> None:
+            events.append("aclose:init")
+
+        async def aclose(self) -> None:
+            events.append("aclose:aclose")
+
+    @stateful(resource=True)
+    class Both:
+        def __init__(self) -> None:
+            events.append("both:init")
+
+        def close(self) -> None:
+            events.append("both:close")
+
+        async def aclose(self) -> None:
+            events.append("both:aclose")
+
+    @node(output_name="out")
+    async def use_resources(close_only: CloseOnly, aclose_only: ACloseOnly, both: Both) -> str:
+        return "ok"
+
+    graph = Graph([use_resources]).bind(
+        close_only=CloseOnly(),
+        aclose_only=ACloseOnly(),
+        both=Both(),
+    )
+
+    async with graph.resources() as ready_graph:
+        result = await AsyncRunner().run(ready_graph)
+        assert result.values["out"] == "ok"
+
+    assert events == [
+        "close:init",
+        "aclose:init",
+        "both:init",
+        "both:aclose",
+        "aclose:aclose",
+        "close:close",
+    ]
+
+
+def test_resource_true_requires_cleanup_unless_resource_false() -> None:
+    with pytest.raises(TypeError, match="resource=True"):
+
+        @stateful(resource=True)
+        class MissingCleanup:
+            pass
+
+    @stateful(resource=False)
+    class PlainState:
+        def __init__(self, value: str) -> None:
+            self.value = value
+
+    @node(output_name="out")
+    def use_state(state: PlainState) -> str:
+        return state.value
+
+    graph = Graph([use_state]).bind(state=PlainState("ok"))
+
+    with graph.resources() as ready_graph:
+        result = SyncRunner().run(ready_graph)
+
+    assert result.values["out"] == "ok"
+
+
+def test_resource_cleanup_method_names_can_be_explicit() -> None:
+    events: list[str] = []
+
+    @stateful(resource=True, close="shutdown")
+    class CustomShutdown:
+        def __init__(self) -> None:
+            events.append("init")
+
+        def shutdown(self) -> None:
+            events.append("shutdown")
+
+    @node(output_name="out")
+    def use_resource(resource: CustomShutdown) -> str:
+        return "ok"
+
+    graph = Graph([use_resource]).bind(resource=CustomShutdown())
+
+    with graph.resources() as ready_graph:
+        result = SyncRunner().run(ready_graph)
+        assert result.values["out"] == "ok"
+
+    assert events == ["init", "shutdown"]
+
+
+def test_same_stateful_handle_is_materialized_once_per_scope() -> None:
+    events: list[str] = []
+
+    @stateful(resource=True)
+    class Resource:
+        def __init__(self, name: str) -> None:
+            events.append(f"init:{name}")
+            self.name = name
+
+        def close(self) -> None:
+            events.append(f"close:{self.name}")
+
+    @node(output_name="shared")
+    def compare_resources(left: Resource, right: Resource) -> bool:
+        return left is right
+
+    handle = Resource("shared")
+    graph = Graph([compare_resources]).bind(left=handle, right=handle)
+
+    with graph.resources() as ready_graph:
+        result = SyncRunner().run(ready_graph)
+        assert result.values["shared"] is True
+
+    assert events == ["init:shared", "close:shared"]
+
+
+def test_parent_resource_scope_materializes_nested_graph_resources() -> None:
+    events: list[str] = []
+
+    @stateful(resource=True)
+    class Resource:
+        def __init__(self, name: str) -> None:
+            events.append(f"init:{name}")
+            self.name = name
+
+        def close(self) -> None:
+            events.append(f"close:{self.name}")
+
+    @node(output_name="left_value")
+    def use_left(resource: Resource) -> str:
+        return resource.name
+
+    @node(output_name="right_value")
+    def use_right(resource: Resource) -> str:
+        return resource.name
+
+    left = Graph([use_left], name="left").bind(resource=Resource("left"))
+    right = Graph([use_right], name="right").bind(resource=Resource("right"))
+    parent = Graph(
+        [
+            left.as_node(name="left", namespaced=True),
+            right.as_node(name="right", namespaced=True),
+        ],
+        name="parent",
+    )
+
+    with parent.resources() as ready_graph:
+        result = SyncRunner().run(ready_graph)
+        assert result.values["left.left_value"] == "left"
+        assert result.values["right.right_value"] == "right"
+
+    assert events == [
+        "init:left",
+        "init:right",
+        "close:right",
+        "close:left",
+    ]
+
+
+def test_different_stateful_handles_are_not_deduplicated_by_constructor_args() -> None:
+    events: list[str] = []
+
+    @stateful(resource=True)
+    class Resource:
+        def __init__(self, name: str) -> None:
+            events.append(f"init:{name}")
+            self.name = name
+
+        def close(self) -> None:
+            events.append(f"close:{self.name}")
+
+    @node(output_name="same")
+    def compare_resources(left: Resource, right: Resource) -> bool:
+        return left is right
+
+    graph = Graph([compare_resources]).bind(left=Resource("same"), right=Resource("same"))
+
+    with graph.resources() as ready_graph:
+        result = SyncRunner().run(ready_graph)
+        assert result.values["same"] is False
+
+    assert events == [
+        "init:same",
+        "init:same",
+        "close:same",
+        "close:same",
+    ]

--- a/tests/test_stateful_resources.py
+++ b/tests/test_stateful_resources.py
@@ -1,8 +1,19 @@
 from __future__ import annotations
 
+import pickle
+
 import pytest
 
-from hypergraph import AsyncRunner, Graph, SyncRunner, node, stateful
+from hypergraph import AsyncRunner, Graph, GraphConfigError, SyncRunner, node, stateful
+
+
+@stateful(resource=True)
+class PickleResource:
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+    def close(self) -> None:
+        pass
 
 
 def test_sync_resource_scope_materializes_bound_stateful_resource() -> None:
@@ -260,3 +271,83 @@ def test_different_stateful_handles_are_not_deduplicated_by_constructor_args() -
         "close:same",
         "close:same",
     ]
+
+
+def test_materialized_resource_is_instance_of_decorated_class() -> None:
+    @stateful(resource=True)
+    class Resource:
+        def close(self) -> None:
+            pass
+
+    @node(output_name="is_resource")
+    def check_resource(resource: Resource) -> bool:
+        return isinstance(resource, Resource)
+
+    graph = Graph([check_resource]).bind(resource=Resource())
+
+    with graph.resources() as ready_graph:
+        result = SyncRunner().run(ready_graph)
+
+    assert result.values["is_resource"] is True
+
+
+def test_resource_scope_can_be_reentered_with_fresh_instances() -> None:
+    events: list[str] = []
+
+    @stateful(resource=True)
+    class Resource:
+        def __init__(self) -> None:
+            events.append("init")
+
+        def close(self) -> None:
+            events.append("close")
+
+    @node(output_name="ok")
+    def use_resource(resource: Resource) -> bool:
+        return isinstance(resource, Resource)
+
+    graph = Graph([use_resource]).bind(resource=Resource())
+    scope = graph.resources()
+
+    with scope as ready_graph:
+        assert SyncRunner().run(ready_graph).values["ok"] is True
+
+    with scope as ready_graph:
+        assert SyncRunner().run(ready_graph).values["ok"] is True
+
+    assert events == ["init", "close", "init", "close"]
+
+
+def test_runner_explains_stateful_handle_needs_resource_scope() -> None:
+    @stateful(resource=True)
+    class Resource:
+        def close(self) -> None:
+            pass
+
+        def value(self) -> str:
+            return "ok"
+
+    @node(output_name="value")
+    def use_resource(resource: Resource) -> str:
+        return resource.value()
+
+    graph = Graph([use_resource]).bind(resource=Resource())
+
+    with pytest.raises(GraphConfigError, match=r"graph\.resources\(\)"):
+        SyncRunner().run(graph)
+
+
+def test_stateful_handle_round_trips_with_standard_pickle() -> None:
+    handle = PickleResource("ok")
+    restored = pickle.loads(pickle.dumps(handle))
+
+    @node(output_name="value")
+    def use_resource(resource: PickleResource) -> str:
+        return resource.value
+
+    graph = Graph([use_resource]).bind(resource=restored)
+
+    with graph.resources() as ready_graph:
+        result = SyncRunner().run(ready_graph)
+
+    assert result.values["value"] == "ok"


### PR DESCRIPTION
## Problem / Bug / Challenge

Graphs can bind expensive stateful objects, but Hypergraph did not have a first-class lifecycle boundary for lazy construction and deterministic cleanup. This made nested graph composition, FastAPI lifespan use, local visualization without production connections, and Daft `@stateful` constructor arguments awkward.

## Before / After

**Before:**

```python
graph = Graph([generate]).bind(llm=LLM(...))
# LLM construction/cleanup was owned by user code.
```

**After:**

```python
@stateful(resource=True)
class LLM:
    async def aclose(self) -> None: ...

graph = Graph([generate]).bind(llm=LLM(...))

async with graph.resources() as ready_graph:
    await AsyncRunner().run(ready_graph, inputs)
```

This adds lazy `@stateful` handles, `Graph.resources()` sync/async scopes, nested graph materialization, and explicit cleanup semantics for `close()` / `aclose()` / both. The same lazy handle is materialized once per scope; different handles remain separate resources.

Also updates Daft stateful lowering so constructor args are captured by lazy handles instead of requiring zero-arg construction.

## Test Plan

- [x] `uv run ruff check src/hypergraph/stateful.py src/hypergraph/graph/resources.py src/hypergraph/graph/core.py src/hypergraph/__init__.py src/hypergraph/runners/daft/_stateful.py src/hypergraph/runners/daft/operations.py tests/test_stateful_resources.py tests/test_runners/test_daft_operations.py`
- [x] `uv run pytest tests/test_stateful_resources.py tests/test_graph.py::TestGraphBind tests/test_bind_defaults.py tests/test_runners/test_value_resolution.py -q`
- [x] `uv run pytest -W error -W 'ignore::pytest.PytestUnraisableExceptionWarning'`

Result: `2638 passed, 15 skipped`.

Note: Daft tests skip locally because `daft` is not installed in this worktree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Graph.resources() resource scopes for lazily materializing and deterministically cleaning up stateful objects (sync/async).
  * stateful decorator now returns lazy handles that capture constructor args, enabling richer resource initialization.

* **Documentation**
  * New "Manage Stateful Resources" guide and updates showing lifecycle, DI patterns, and Daft lowering guidance.

* **Behavior Changes**
  * Daft integration: prefer passing node options as kwargs (no Options object); Daft rejects resource=True statefuls.

* **Tests**
  * Added/expanded tests covering resource lifecycle, materialization, and Daft behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gilad-rubin/hypergraph/pull/158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->