### PR TITLE
[codex] fix RAG viz shared input projection

### DIFF
--- a/src/hypergraph/viz/assets/scene_builder.js
+++ b/src/hypergraph/viz/assets/scene_builder.js
@@ -299,14 +299,18 @@
         ? 'input_group_' + ext2Ids.join('_')
         : 'input_' + ext2Ids[0];
       var consumers = ext2.consumers || [];
+      var seenTargets = {};
       for (var r = 0; r < consumers.length; r++) {
         var consumer = consumers[r];
+        var target = resolveToVisible(consumer, parentMap, visibleIds);
+        if (!target || seenTargets[target]) continue;
+        seenTargets[target] = true;
         sceneEdges.push({
-          id: inputNodeId + '__' + consumer,
+          id: inputNodeId + '__' + target,
           source: inputNodeId,
-          target: consumer,
+          target: target,
           data: { edgeType: 'input' },
-          hidden: !visibleIds[inputNodeId] || !visibleIds[consumer],
+          hidden: !visibleIds[inputNodeId] || !visibleIds[target],
         });
       }
     }

--- a/src/hypergraph/viz/assets/scene_builder.js
+++ b/src/hypergraph/viz/assets/scene_builder.js
@@ -299,12 +299,12 @@
         ? 'input_group_' + ext2Ids.join('_')
         : 'input_' + ext2Ids[0];
       var consumers = ext2.consumers || [];
-      var seenTargets = {};
+      var seenTargets = new Set();
       for (var r = 0; r < consumers.length; r++) {
         var consumer = consumers[r];
         var target = resolveToVisible(consumer, parentMap, visibleIds);
-        if (!target || seenTargets[target]) continue;
-        seenTargets[target] = true;
+        if (!target || seenTargets.has(target)) continue;
+        seenTargets.add(target);
         sceneEdges.push({
           id: inputNodeId + '__' + target,
           source: inputNodeId,

--- a/src/hypergraph/viz/assets/viz_layout.js
+++ b/src/hypergraph/viz/assets/viz_layout.js
@@ -240,6 +240,27 @@
       .filter(function(e) { return !feedbackEdgeKeys.has(e.id); })
       .map(function(e) { return { id: e.id, source: e.source, target: e.target, _original: e }; });
 
+    var containersWithNonInputExternalIncoming = new Set();
+    layoutEdges.forEach(function(other) {
+      var otherSource = visibleNodeById.get(other.source);
+      var otherSourceType = (otherSource && otherSource.data && otherSource.data.nodeType) || 'FUNCTION';
+      if (otherSourceType === 'INPUT' || otherSourceType === 'INPUT_GROUP') return;
+
+      var targetAncestor = other.target;
+      while (targetAncestor) {
+        var targetAncestorNode = visibleNodeById.get(targetAncestor);
+        if (targetAncestorNode && targetAncestorNode.data && targetAncestorNode.data.nodeType === 'PIPELINE') {
+          var targetAncestorPrefix = targetAncestor + '/';
+          if (other.source !== targetAncestor && other.source.indexOf(targetAncestorPrefix) !== 0) {
+            containersWithNonInputExternalIncoming.add(targetAncestor);
+          }
+        }
+        var slashIndex = targetAncestor.lastIndexOf('/');
+        if (slashIndex < 0) break;
+        targetAncestor = targetAncestor.slice(0, slashIndex);
+      }
+    });
+
     layoutEdges.forEach(function(e) {
       var sourceParent = displayParentById.get(e.source);
       var targetParent = displayParentById.get(e.target);
@@ -247,15 +268,7 @@
       var sourceType = (sourceNode && sourceNode.data && sourceNode.data.nodeType) || 'FUNCTION';
       var edgeLabel = {};
       if (!sourceParent && targetParent && (sourceType === 'INPUT' || sourceType === 'INPUT_GROUP')) {
-        var targetPrefix = targetParent + '/';
-        var hasExternalIncoming = layoutEdges.some(function(other) {
-          if (other.id === e.id) return false;
-          if (!(other.target === targetParent || other.target.indexOf(targetPrefix) === 0)) return false;
-          if (other.source === targetParent || other.source.indexOf(targetPrefix) === 0) return false;
-          var otherSource = visibleNodeById.get(other.source);
-          var otherSourceType = (otherSource && otherSource.data && otherSource.data.nodeType) || 'FUNCTION';
-          return otherSourceType !== 'INPUT' && otherSourceType !== 'INPUT_GROUP';
-        });
+        var hasExternalIncoming = containersWithNonInputExternalIncoming.has(targetParent);
         edgeLabel = { minlen: hasExternalIncoming ? 4 : 1, weight: 10 };
       }
       g.setEdge(e.source, e.target, edgeLabel, e.id);

--- a/src/hypergraph/viz/assets/viz_layout.js
+++ b/src/hypergraph/viz/assets/viz_layout.js
@@ -247,7 +247,16 @@
       var sourceType = (sourceNode && sourceNode.data && sourceNode.data.nodeType) || 'FUNCTION';
       var edgeLabel = {};
       if (!sourceParent && targetParent && (sourceType === 'INPUT' || sourceType === 'INPUT_GROUP')) {
-        edgeLabel = { minlen: 4, weight: 10 };
+        var targetPrefix = targetParent + '/';
+        var hasExternalIncoming = layoutEdges.some(function(other) {
+          if (other.id === e.id) return false;
+          if (!(other.target === targetParent || other.target.indexOf(targetPrefix) === 0)) return false;
+          if (other.source === targetParent || other.source.indexOf(targetPrefix) === 0) return false;
+          var otherSource = visibleNodeById.get(other.source);
+          var otherSourceType = (otherSource && otherSource.data && otherSource.data.nodeType) || 'FUNCTION';
+          return otherSourceType !== 'INPUT' && otherSourceType !== 'INPUT_GROUP';
+        });
+        edgeLabel = { minlen: hasExternalIncoming ? 4 : 1, weight: 10 };
       }
       g.setEdge(e.source, e.target, edgeLabel, e.id);
     });

--- a/src/hypergraph/viz/scene_builder.py
+++ b/src/hypergraph/viz/scene_builder.py
@@ -254,14 +254,19 @@ def build_initial_scene(
         if not show_inputs:
             continue
         input_node_id = ext.synthetic_id
+        seen_targets: set[str] = set()
         for consumer in ext.consumers:
+            target = _resolve_to_visible(consumer, parent_map, expansion_state, visible_ids)
+            if target is None or target in seen_targets:
+                continue
+            seen_targets.add(target)
             scene_edges.append(
                 {
-                    "id": f"{input_node_id}__{consumer}",
+                    "id": f"{input_node_id}__{target}",
                     "source": input_node_id,
-                    "target": consumer,
+                    "target": target,
                     "data": {"edgeType": "input"},
-                    "hidden": input_node_id not in visible_ids or consumer not in visible_ids,
+                    "hidden": input_node_id not in visible_ids or target not in visible_ids,
                 }
             )
 

--- a/tests/viz/test_graphnode_boundary_projection.py
+++ b/tests/viz/test_graphnode_boundary_projection.py
@@ -58,6 +58,59 @@ def test_exposed_shared_input_renders_once_at_parent_boundary():
     assert {edge["target"] for edge in input_edges} == {"retrieval/retrieve", "generation/generate"}
 
 
+def test_exposed_shared_input_routes_to_collapsed_graph_boundaries():
+    @node(output_name="docs")
+    def retrieve(query: str) -> str:
+        return f"docs:{query}"
+
+    @node(output_name="answer")
+    def generate(query: str) -> str:
+        return f"answer:{query}"
+
+    graph = Graph(
+        [
+            Graph([retrieve], name="retrieval").as_node(namespaced=True).expose("query"),
+            Graph([generate], name="generation").as_node(namespaced=True).expose("query"),
+        ]
+    )
+    ir = build_graph_ir(graph.to_flat_graph())
+
+    scene = build_initial_scene(ir, expansion_state={})
+    input_edges = [e for e in scene["edges"] if e["source"] == "input_query" and not e.get("hidden")]
+
+    assert {edge["target"] for edge in input_edges} == {"retrieval", "generation"}
+
+
+def test_exposed_shared_input_routes_to_visible_mixed_expansion_boundaries():
+    @node(output_name="docs")
+    def retrieve(query: str) -> str:
+        return f"docs:{query}"
+
+    @node(output_name="prompt")
+    def make_prompt(query: str) -> str:
+        return f"prompt:{query}"
+
+    @node(output_name="answer")
+    def answer(query: str, prompt: str) -> str:
+        return f"answer:{query}:{prompt}"
+
+    graph = Graph(
+        [
+            Graph([retrieve], name="retrieval").as_node(namespaced=True).expose("query"),
+            Graph([make_prompt, answer], name="generation").as_node(namespaced=True).expose("query"),
+        ]
+    )
+    ir = build_graph_ir(graph.to_flat_graph())
+
+    scene = build_initial_scene(ir, expansion_state={"retrieval": True})
+    input_edges = [e for e in scene["edges"] if e["source"] == "input_query" and not e.get("hidden")]
+
+    assert [(edge["source"], edge["target"]) for edge in input_edges] == [
+        ("input_query", "retrieval/retrieve"),
+        ("input_query", "generation"),
+    ]
+
+
 def test_mermaid_namespaced_input_label_uses_resolved_port_address():
     @node(output_name="docs")
     def retrieve(query: str) -> str:

--- a/tests/viz/test_graphnode_boundary_projection.py
+++ b/tests/viz/test_graphnode_boundary_projection.py
@@ -105,10 +105,10 @@ def test_exposed_shared_input_routes_to_visible_mixed_expansion_boundaries():
     scene = build_initial_scene(ir, expansion_state={"retrieval": True})
     input_edges = [e for e in scene["edges"] if e["source"] == "input_query" and not e.get("hidden")]
 
-    assert [(edge["source"], edge["target"]) for edge in input_edges] == [
+    assert {(edge["source"], edge["target"]) for edge in input_edges} == {
         ("input_query", "retrieval/retrieve"),
         ("input_query", "generation"),
-    ]
+    }
 
 
 def test_mermaid_namespaced_input_label_uses_resolved_port_address():

--- a/tests/viz/test_visual_layout_issues.py
+++ b/tests/viz/test_visual_layout_issues.py
@@ -246,8 +246,8 @@ class TestInputNodePosition:
         if "error" in result:
             pytest.fail(f"Setup error: {result}")
 
-        assert result["gap"] <= 180, (
-            "Question input is too far from the expanded retrieval entrypoint.\n"
+        assert 0 <= result["gap"] <= 180, (
+            "Question input should not overlap or sit too far from the expanded retrieval entrypoint.\n"
             f"Gap: {result['gap']:.1f}px\n"
             f"Question: {result['question']}\n"
             f"rewrite_question: {result['rewrite']}"

--- a/tests/viz/test_visual_layout_issues.py
+++ b/tests/viz/test_visual_layout_issues.py
@@ -55,6 +55,60 @@ def make_branch_anchor_graph() -> Graph:
     )
 
 
+@node(output_name="retrieval_query")
+def superposition_rewrite_question(question: str) -> str:
+    return question.strip()
+
+
+@node(output_name="sources")
+def superposition_retrieve_sources(
+    retrieval_query: str,
+    vector_store: object,
+    top_k: int,
+) -> list[str]:
+    return [f"{retrieval_query}:{top_k}:{vector_store!r}"]
+
+
+@node(output_name="prompt_text")
+def superposition_build_prompt(question: str, sources: list[str], prompt: str) -> str:
+    return f"{prompt}:{question}:{sources}"
+
+
+@node(output_name=("answer", "response"))
+def superposition_generate_answer(
+    question: str,
+    sources: list[str],
+    prompt_text: str,
+    answerer: object,
+) -> tuple[str, dict]:
+    return prompt_text, {"question": question, "sources": sources, "answerer": repr(answerer)}
+
+
+def make_superposition_rag_graph() -> Graph:
+    retrieval = (
+        Graph([superposition_rewrite_question, superposition_retrieve_sources], name="retrieval_graph")
+        .bind(vector_store="store", top_k=2)
+        .select("sources")
+    )
+    generation = (
+        Graph([superposition_build_prompt, superposition_generate_answer], name="generation_graph")
+        .bind(prompt="grounded", answerer="answerer")
+        .select("answer", "response")
+    )
+    return Graph(
+        [
+            retrieval.as_node(name="retrieval", namespaced=True).expose("question", sources="sources"),
+            generation.as_node(name="generation", namespaced=True).expose(
+                "question",
+                "sources",
+                answer="answer",
+                response="response",
+            ),
+        ],
+        name="rag_graph",
+    ).select("answer", "response", "sources")
+
+
 # =============================================================================
 # Test: Input nodes should be ABOVE their targets (edges flow downward)
 # =============================================================================
@@ -157,6 +211,46 @@ class TestInputNodePosition:
             f"Input bottom: {result['inputBottom']}px\n"
             f"clean_text top: {result['cleanTextTop']}px\n"
             f"Vertical distance: {result['verticalDistance']}px"
+        )
+
+    def test_superposition_rag_question_stays_close_to_expanded_retrieval(self, page, temp_html_file):
+        """Root shared input should not be separated from an expanded subgraph by multiple ranks."""
+        graph = make_superposition_rag_graph()
+        render_to_page(page, graph, depth=0, temp_path=temp_html_file, show_inputs=True)
+
+        click_to_expand_container(page, "retrieval")
+
+        result = page.evaluate("""() => {
+            const debug = window.__hypergraphVizDebug;
+            const question = debug.nodes.find(n => n.id === 'input_question');
+            const rewrite = debug.nodes.find(n => n.id === 'retrieval/superposition_rewrite_question');
+            const inputEdge = debug.edges.find(e =>
+                e.source === 'input_question' && e.target === 'retrieval/superposition_rewrite_question'
+            );
+
+            if (!question || !rewrite || !inputEdge) {
+                return {
+                    error: 'Expected nodes or edge not found',
+                    nodes: debug.nodes.map(n => n.id),
+                    edges: debug.edges.map(e => [e.source, e.target]),
+                };
+            }
+
+            return {
+                gap: rewrite.y - (question.y + question.height),
+                question: { y: question.y, height: question.height },
+                rewrite: { y: rewrite.y, height: rewrite.height },
+            };
+        }""")
+
+        if "error" in result:
+            pytest.fail(f"Setup error: {result}")
+
+        assert result["gap"] <= 180, (
+            "Question input is too far from the expanded retrieval entrypoint.\n"
+            f"Gap: {result['gap']:.1f}px\n"
+            f"Question: {result['question']}\n"
+            f"rewrite_question: {result['rewrite']}"
         )
 
 


### PR DESCRIPTION
## Problem / Bug / Challenge

Shared external inputs in the IR-driven interactive visualization could render as orphaned when their consumers lived inside collapsed graph nodes. The IR correctly records deepest leaf consumers as state-independent facts, but the scene builder emitted input edges directly to those hidden leaves. In the Superposition RAG graph, that made `question` look disconnected when `retrieval` and `generation` were collapsed.

Expanding `retrieval` also exposed a layout issue: a blanket compound-dagre `minlen: 4` hint for root input edges into expanded containers stretched the `question -> rewrite_question` edge by several ranks.

## Before / After

**Before:**

```text
collapsed scene:
input_question -> retrieval/rewrite_question  # hidden target
input_question -> generation/build_prompt     # hidden target
input_question -> generation/generate_answer  # hidden target
visible input edges: none

expanded retrieval repro:
question -> rewrite_question gap: 366px
```

**After:**

```text
collapsed scene:
input_question -> retrieval
input_question -> generation

mixed expansion scene:
input_question -> retrieval/retrieve
input_question -> generation

expanded retrieval repro:
question -> rewrite_question gap: 126px
```

## What Changed

- Project external input edges to the nearest visible graph boundary in both Python and JS scene builders.
- Deduplicate projected input targets when several hidden leaf consumers live inside the same collapsed graph.
- Make the compound-layout long-rank input hint conditional: keep extra separation when a container also has non-input incoming edges, but keep simple root-input-to-entrypoint cases compact.
- Add regressions for collapsed, mixed-expansion, and rendered Superposition-style RAG layouts.

## Test Plan

- [x] `uv run pytest -W error -W 'ignore::pytest.PytestUnraisableExceptionWarning' tests/viz`
- [x] `uv run pytest tests/viz/test_mermaid.py tests/viz/test_explicit_edges.py::TestEdgeExpectations`
- [x] `uv run ruff check src/hypergraph/viz/scene_builder.py tests/viz/test_graphnode_boundary_projection.py tests/viz/test_visual_layout_issues.py`
- [x] pre-commit/pre-push ruff + format hooks passed

## Local Hook Cleanup

Removed obsolete local Beads (`bd`) Git metadata from the shared repo checkout: `pre-commit.legacy`, `post-merge`, and the local `merge.beads.*` config entries. These lived under `.git/`, so they are not part of the PR diff; the repo itself has no tracked Beads hook setup to remove.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved edge routing for shared inputs across multiple graph boundaries—edges now resolve to appropriate visible targets and eliminate duplicates.
  * Optimized visualization layout spacing calculations to dynamically adjust based on edge configuration for better visual hierarchy.

* **Tests**
  * Added test coverage for graph boundary projection with shared inputs across namespaced subgraphs.
  * Extended layout testing for complex RAG graph visualization scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gilad-rubin/hypergraph/pull/159?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
