### PR TITLE
[codex] fix viz duplicate merged multi-value edges

### DIFF
--- a/src/hypergraph/viz/assets/scene_builder.js
+++ b/src/hypergraph/viz/assets/scene_builder.js
@@ -226,11 +226,11 @@
       if (expansionState[tgt] && irEdge.target_when_expanded) tgt = irEdge.target_when_expanded;
 
       // A data edge can carry multiple value_names (one NetworkX edge per
-      // (src,tgt) merges them). Emit one scene edge per value to mirror
-      // the legacy renderer; in separate_outputs mode each routes through
-      // its own data_<producer>_<value> node.
+      // (src,tgt) merges them). Merged-output mode should still render one
+      // visible edge per node pair; separateOutputs mode fans out through
+      // one DATA node per value.
       var valueNames = irEdge.value_names || [];
-      var valuesToEmit = (irEdge.edge_type === 'data' && valueNames.length > 0) ? valueNames : [null];
+      var valuesToEmit = (separateOutputs && irEdge.edge_type === 'data' && valueNames.length > 0) ? valueNames : [null];
 
       for (var bs = 0; bs < baseSources.length; bs++) {
         var baseSrc = baseSources[bs];

--- a/src/hypergraph/viz/scene_builder.py
+++ b/src/hypergraph/viz/scene_builder.py
@@ -195,11 +195,11 @@ def build_initial_scene(
             target = ir_edge.target_when_expanded
 
         # A data edge can carry multiple value_names (one NetworkX edge per
-        # (src,tgt) merges them). Emit one scene edge per value to mirror
-        # the legacy renderer; in separate_outputs mode each routes through
-        # its own data_<producer>_<value> node.
+        # (src,tgt) merges them). Merged-output mode should still render one
+        # visible edge per node pair; separate_outputs mode fans out through
+        # one DATA node per value.
         for base_source in base_sources:
-            if ir_edge.edge_type == "data" and ir_edge.value_names:
+            if separate_outputs and ir_edge.edge_type == "data" and ir_edge.value_names:
                 edges_to_emit = [(value_name, base_source) for value_name in ir_edge.value_names]
             else:
                 edges_to_emit = [(None, base_source)]

--- a/tests/viz/test_scene_builder.py
+++ b/tests/viz/test_scene_builder.py
@@ -191,18 +191,18 @@ def _make_multi_value_graph() -> Graph:
     return Graph(nodes=[split, merge])
 
 
-def test_multi_value_edge_emits_one_scene_edge_per_value_merged_mode():
-    """A data edge with value_names=("a","b") must produce two scene
-    edges so each value renders as a labeled connection. Mirrors the
-    legacy renderer (one edge per value)."""
+def test_multi_value_edge_emits_single_scene_edge_in_merged_mode():
+    """Merged-output mode should render one visible edge per producer/consumer
+    pair even when that edge carries multiple values."""
     flat_graph = _make_multi_value_graph().to_flat_graph()
     ir = build_graph_ir(flat_graph)
 
     scene = build_initial_scene(ir, separate_outputs=False)
 
     split_to_merge = [e for e in scene["edges"] if e["source"] == "split" and e["target"] == "merge"]
-    value_names = {e["data"]["valueName"] for e in split_to_merge}
-    assert value_names == {"a", "b"}, f"Expected one edge per value name; got {value_names}"
+    assert len(split_to_merge) == 1
+    assert split_to_merge[0]["id"] == "split__merge"
+    assert split_to_merge[0]["data"]["valueName"] is None
 
 
 def test_branch_to_end_edge_carries_label_for_when_false():


### PR DESCRIPTION
## Problem / Bug / Challenge

Merged-output graph visualization was rendering one React Flow edge per value carried by a single data edge. For graphs like `rag_eval`, `unpack_eval_item -> judge_faithfulness` carries both `context` and `ground_truth_answer`, so the default visualization showed two overlapping arcs between the same two nodes even though the flat graph has one semantic edge.

## Before / After

**Before:**

```python
if ir_edge.edge_type == "data" and ir_edge.value_names:
    edges_to_emit = [(value_name, base_source) for value_name in ir_edge.value_names]
else:
    edges_to_emit = [(None, base_source)]
```

**After:**

```python
if separate_outputs and ir_edge.edge_type == "data" and ir_edge.value_names:
    edges_to_emit = [(value_name, base_source) for value_name in ir_edge.value_names]
else:
    edges_to_emit = [(None, base_source)]
```

Default merged mode now renders one visible edge per producer/consumer pair. `separate_outputs=True` still fans out through per-value DATA nodes. The Python and JavaScript scene builders were updated together.

## Test Plan

- [x] `uv run pytest tests/viz/test_scene_builder.py tests/viz/test_parity.py -q`
- [x] `uv run pytest tests/viz/test_viz_modules_js.py tests/viz/test_render_count_tripwire.py -q`
- [x] `uv run ruff check src/hypergraph/viz/scene_builder.py tests/viz/test_scene_builder.py`
- [x] Recreated `rag_eval` from `/Users/giladrubin/python_workspace/superposition` and confirmed there are no duplicate visible source/target pairs in merged mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced visualization in merged-output mode. When displaying data connections with multiple values between nodes, the graph now renders a single consolidated edge per node pair, resulting in a cleaner and more readable visualization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->