### PR TITLE
fix(viz): route mapped GraphNode boundary edges to inner nodes when expanded

### DIFF
--- a/src/hypergraph/nodes/graph_node.py
+++ b/src/hypergraph/nodes/graph_node.py
@@ -399,7 +399,10 @@ class GraphNode(HyperNode):
         """Resolve a possibly-renamed input name back to the original.
 
         Traces back through rename history to find what the input was
-        originally called in the inner graph.
+        originally called in the inner graph. Batch-aware: parallel renames
+        from one ``rename_inputs`` call (e.g. ``rename_inputs(x="y", y="x")``)
+        are treated as simultaneous transforms, matching the semantics of
+        :func:`build_reverse_rename_map` used by ``map_inputs_to_params``.
 
         Args:
             param: Current input parameter name
@@ -407,12 +410,8 @@ class GraphNode(HyperNode):
         Returns:
             Original name used in the inner graph.
         """
-        current = param
-        # Walk rename history in reverse to find original
-        for entry in reversed(self._rename_history):
-            if entry.kind == "inputs" and entry.new == current:
-                current = entry.old
-        return current
+        reverse_map = build_reverse_rename_map(self._rename_history, "inputs")
+        return reverse_map.get(param, param)
 
     def map_inputs_to_params(self, inputs: dict[str, Any]) -> dict[str, Any]:
         """Map renamed input names back to original inner graph parameter names.

--- a/src/hypergraph/nodes/graph_node.py
+++ b/src/hypergraph/nodes/graph_node.py
@@ -184,6 +184,13 @@ class GraphNode(HyperNode):
         attrs["local_inputs"] = self._local_inputs
         attrs["local_outputs"] = self._local_outputs
         attrs["namespaced"] = self._namespaced
+        # Exact boundary name maps (outer address -> original inner names).
+        # Renames from rename_inputs/rename_outputs are invisible in the flat
+        # graph otherwise, leaving consumers (viz) to guess by substring.
+        attrs["input_name_map"] = {
+            address: tuple(self._resolve_original_input_name(local) for local in self._local_inputs_for_address(address)) for address in self.inputs
+        }
+        attrs["output_name_map"] = {address: self.resolve_original_output_name(address) for address in self.outputs}
         return attrs
 
     def _refresh_projected_ports(self) -> None:

--- a/src/hypergraph/viz/AGENTS.md
+++ b/src/hypergraph/viz/AGENTS.md
@@ -172,6 +172,7 @@ Generates a scrollable gallery of all notebook visualizations with DialKit contr
 | Symptom | Likely Cause | Fix Location |
 | --- | --- | --- |
 | Edge points to container when expanded | `target_when_expanded` not populated in IR | `renderer/ir_builder.py` |
+| Dagre "setting 'rank'" crash, blank canvas | edge incident to an *expanded* container (dagre compound parent) — usually a renamed boundary param (`map_over`/`rename_inputs`/`rename_outputs`) not translated via the GRAPH node's `input_name_map`/`output_name_map` | `renderer/ir_builder.py` + `renderer/scope.py:get_deepest_consumers` |
 | Input appears outside expanded container | `ownerContainer` not derived from `deepest_owner` | `scene_builder.py` (Python + JS) |
 | Edge starts/ends with visible gap | wrong node-type offset | viz.js Section 1 |
 | Incoming edges overlap unexpectedly | dagre route or endpoint padding needs inspection | `assets/viz.js` |

--- a/src/hypergraph/viz/renderer/ir_builder.py
+++ b/src/hypergraph/viz/renderer/ir_builder.py
@@ -283,19 +283,35 @@ def _first_container_entrypoint(container_id: str, flat_graph: nx.DiGraph) -> st
     return direct_children[0]
 
 
+def _inner_output_name(container_id: str, value_name: str, flat_graph: nx.DiGraph) -> str:
+    """Translate a container-level output name to the original inner name
+    via the exact ``output_name_map`` recorded on the GRAPH node."""
+    name_map = flat_graph.nodes.get(container_id, {}).get("output_name_map") or {}
+    return name_map.get(value_name, value_name)
+
+
+def _inner_input_names(container_id: str, value_name: str, flat_graph: nx.DiGraph) -> tuple[str, ...]:
+    """Translate a container-level input name to the original inner names
+    via the exact ``input_name_map`` recorded on the GRAPH node."""
+    name_map = flat_graph.nodes.get(container_id, {}).get("input_name_map") or {}
+    return name_map.get(value_name) or (value_name,)
+
+
 def _find_deepest_internal_producer(container_id: str, value_name: str, flat_graph: nx.DiGraph) -> str | None:
     """Walk down the container tree, find the deepest descendant that
-    produces value_name as an output. Falls back to fuzzy substring
-    matching to handle the ``rename_outputs`` rename case (e.g. container
-    exposes ``recall_scores`` but the internal node produces
-    ``recall_score``)."""
+    produces value_name as an output. The exact rename recorded on the
+    GRAPH node is applied first (e.g. ``with_outputs(item_out="generated")``);
+    fuzzy substring matching remains as a fallback for renames that cross
+    several boundaries (e.g. container exposes ``recall_scores`` but the
+    internal node produces ``recall_score``)."""
+    inner_name = _inner_output_name(container_id, value_name, flat_graph)
     descendants = [(node_id, attrs) for node_id, attrs in flat_graph.nodes(data=True) if _is_descendant(node_id, container_id, flat_graph)]
 
-    candidates = [node_id for node_id, attrs in descendants if value_name in attrs.get("outputs", ())]
+    candidates = [node_id for node_id, attrs in descendants if inner_name in attrs.get("outputs", ())]
     if candidates:
         return max(candidates, key=lambda c: _depth_below(c, container_id, flat_graph))
 
-    fuzzy = [node_id for node_id, attrs in descendants for out in attrs.get("outputs", ()) if out in value_name or value_name in out]
+    fuzzy = [node_id for node_id, attrs in descendants for out in attrs.get("outputs", ()) if out in inner_name or inner_name in out]
     if fuzzy:
         return max(fuzzy, key=lambda c: _depth_below(c, container_id, flat_graph))
     return None
@@ -303,11 +319,12 @@ def _find_deepest_internal_producer(container_id: str, value_name: str, flat_gra
 
 def _find_deepest_internal_producers(container_id: str, value_name: str, flat_graph: nx.DiGraph) -> tuple[str, ...]:
     """Return all deepest internal producers for a container output."""
+    inner_name = _inner_output_name(container_id, value_name, flat_graph)
     descendants = [(node_id, attrs) for node_id, attrs in flat_graph.nodes(data=True) if _is_descendant(node_id, container_id, flat_graph)]
 
-    candidates = [node_id for node_id, attrs in descendants if value_name in attrs.get("outputs", ())]
+    candidates = [node_id for node_id, attrs in descendants if inner_name in attrs.get("outputs", ())]
     if not candidates:
-        candidates = [node_id for node_id, attrs in descendants for out in attrs.get("outputs", ()) if out in value_name or value_name in out]
+        candidates = [node_id for node_id, attrs in descendants for out in attrs.get("outputs", ()) if out in inner_name or inner_name in out]
     if not candidates:
         return ()
 
@@ -318,21 +335,22 @@ def _find_deepest_internal_producers(container_id: str, value_name: str, flat_gr
 def _find_deepest_internal_consumer(container_id: str, value_name: str, flat_graph: nx.DiGraph) -> str | None:
     """Mirror of :func:`_find_deepest_internal_producer` for inputs.
 
-    Falls back to fuzzy substring matching to handle the
-    ``map_over`` / ``rename_inputs`` rename case (e.g. the outer edge
-    carries ``eval_pairs`` but the per-item internal node consumes
-    ``eval_pair``)."""
+    Applies the exact ``input_name_map`` rename first (the
+    ``map_over`` / ``rename_inputs`` case, e.g. the outer edge carries
+    ``eval_pairs`` but the per-item internal node consumes ``eval_pair``),
+    then falls back to fuzzy substring matching."""
+    inner_names = _inner_input_names(container_id, value_name, flat_graph)
     descendants = [
         (node_id, attrs)
         for node_id, attrs in flat_graph.nodes(data=True)
         if _is_descendant(node_id, container_id, flat_graph) and attrs.get("node_type") != "GRAPH"
     ]
 
-    candidates = [node_id for node_id, attrs in descendants if value_name in attrs.get("inputs", ())]
+    candidates = [node_id for node_id, attrs in descendants if any(inner in attrs.get("inputs", ()) for inner in inner_names)]
     if candidates:
         return max(candidates, key=lambda c: _depth_below(c, container_id, flat_graph))
 
-    fuzzy = [node_id for node_id, attrs in descendants for inp in attrs.get("inputs", ()) if inp in value_name or value_name in inp]
+    fuzzy = [node_id for node_id, attrs in descendants for inp in attrs.get("inputs", ()) for inner in inner_names if inp in inner or inner in inp]
     if fuzzy:
         return max(fuzzy, key=lambda c: _depth_below(c, container_id, flat_graph))
     return None

--- a/src/hypergraph/viz/renderer/scope.py
+++ b/src/hypergraph/viz/renderer/scope.py
@@ -37,53 +37,62 @@ def get_deepest_consumers(param: str, flat_graph: nx.DiGraph) -> list[str]:
     """
     if "." in param:
         all_consumers = resolve_port_address_consumers(param, flat_graph)
-    else:
-        all_consumers = [node_id for node_id, attrs in flat_graph.nodes(data=True) if param in attrs.get("inputs", ())]
 
-    descended: list[str] = []
-    for consumer in all_consumers:
-        for deep_consumer in _descend_through_renames(consumer, param, flat_graph):
-            if deep_consumer not in descended:
-                descended.append(deep_consumer)
-    all_consumers = descended
+        if len(all_consumers) <= 1:
+            return all_consumers
 
-    if len(all_consumers) <= 1:
-        return all_consumers
+        filtered = []
+        for consumer in all_consumers:
+            is_superseded = False
+            for other in all_consumers:
+                if other == consumer:
+                    continue
+                if is_descendant_of(other, consumer, flat_graph):
+                    is_superseded = True
+                    break
+            if not is_superseded:
+                filtered.append(consumer)
 
-    filtered = []
-    for consumer in all_consumers:
-        is_superseded = False
-        for other in all_consumers:
-            if other == consumer:
-                continue
-            if is_descendant_of(other, consumer, flat_graph):
-                is_superseded = True
-                break
-        if not is_superseded:
-            filtered.append(consumer)
+        return filtered
 
-    return filtered
+    consumers: list[str] = []
+    for node_id, attrs in flat_graph.nodes(data=True):
+        if attrs.get("parent") is not None or param not in attrs.get("inputs", ()):
+            continue
+        for deep_consumer in _descend_to_inner_consumers(node_id, param, flat_graph):
+            if deep_consumer not in consumers:
+                consumers.append(deep_consumer)
+    return consumers
 
 
-def _descend_through_renames(consumer: str, param: str, flat_graph: nx.DiGraph) -> list[str]:
-    """Resolve a GRAPH consumer that renames ``param`` at its boundary to the
-    inner consumers of the renamed parameter (recursively, for nested
-    boundaries). Non-GRAPH consumers and un-renamed boundaries are returned
-    as-is — for those, the exact-name scan already sees the inner nodes."""
+def _descend_to_inner_consumers(consumer: str, param: str, flat_graph: nx.DiGraph) -> list[str]:
+    """Resolve a GRAPH consumer to the actual inner consumers of ``param``.
+
+    Walks direct children one boundary at a time, translating ``param``
+    through the container's exact ``input_name_map`` at each step
+    (``rename_inputs`` / ``map_over`` renames). Matching by direct children
+    rather than a global descendant scan means a leaf whose *local* name
+    coincides with an outer name that was renamed away at its boundary is
+    never picked up.
+
+    Terminates unconditionally: each recursive call moves to a strict
+    descendant container in the finite containment tree, regardless of how
+    boundary renames chain or swap names.
+    """
     attrs = flat_graph.nodes.get(consumer, {})
     if attrs.get("node_type") != "GRAPH":
         return [consumer]
-    inner_names = [name for name in (attrs.get("input_name_map") or {}).get(param, ()) if name != param]
-    if not inner_names:
-        return [consumer]
+    inner_names = (attrs.get("input_name_map") or {}).get(param) or (param,)
 
     inner_consumers: list[str] = []
-    for node_id, node_attrs in flat_graph.nodes(data=True):
-        if not is_descendant_of(node_id, consumer, flat_graph):
+    for child_id, child_attrs in flat_graph.nodes(data=True):
+        if child_attrs.get("parent") != consumer:
             continue
         for inner_name in inner_names:
-            if inner_name in node_attrs.get("inputs", ()):
-                inner_consumers.extend(_descend_through_renames(node_id, inner_name, flat_graph))
+            if inner_name in child_attrs.get("inputs", ()):
+                for deep_consumer in _descend_to_inner_consumers(child_id, inner_name, flat_graph):
+                    if deep_consumer not in inner_consumers:
+                        inner_consumers.append(deep_consumer)
                 break
     return inner_consumers or [consumer]
 

--- a/src/hypergraph/viz/renderer/scope.py
+++ b/src/hypergraph/viz/renderer/scope.py
@@ -26,7 +26,10 @@ def get_deepest_consumers(param: str, flat_graph: nx.DiGraph) -> list[str]:
 
     When a container (GRAPH node) and its internal nodes both list a parameter
     as an input, we return only the internal nodes - they are the "actual"
-    consumers.
+    consumers. Containers that rename the parameter at their boundary
+    (``rename_inputs`` / ``map_over``) are descended through via the exact
+    ``input_name_map`` recorded on the GRAPH node, since the inner consumers
+    list a different name.
 
     Namespaced external-input addresses (e.g. ``"middle.inner.x"``) are
     resolved through the GraphNode chain — see
@@ -36,6 +39,13 @@ def get_deepest_consumers(param: str, flat_graph: nx.DiGraph) -> list[str]:
         all_consumers = resolve_port_address_consumers(param, flat_graph)
     else:
         all_consumers = [node_id for node_id, attrs in flat_graph.nodes(data=True) if param in attrs.get("inputs", ())]
+
+    descended: list[str] = []
+    for consumer in all_consumers:
+        for deep_consumer in _descend_through_renames(consumer, param, flat_graph):
+            if deep_consumer not in descended:
+                descended.append(deep_consumer)
+    all_consumers = descended
 
     if len(all_consumers) <= 1:
         return all_consumers
@@ -53,6 +63,29 @@ def get_deepest_consumers(param: str, flat_graph: nx.DiGraph) -> list[str]:
             filtered.append(consumer)
 
     return filtered
+
+
+def _descend_through_renames(consumer: str, param: str, flat_graph: nx.DiGraph) -> list[str]:
+    """Resolve a GRAPH consumer that renames ``param`` at its boundary to the
+    inner consumers of the renamed parameter (recursively, for nested
+    boundaries). Non-GRAPH consumers and un-renamed boundaries are returned
+    as-is — for those, the exact-name scan already sees the inner nodes."""
+    attrs = flat_graph.nodes.get(consumer, {})
+    if attrs.get("node_type") != "GRAPH":
+        return [consumer]
+    inner_names = [name for name in (attrs.get("input_name_map") or {}).get(param, ()) if name != param]
+    if not inner_names:
+        return [consumer]
+
+    inner_consumers: list[str] = []
+    for node_id, node_attrs in flat_graph.nodes(data=True):
+        if not is_descendant_of(node_id, consumer, flat_graph):
+            continue
+        for inner_name in inner_names:
+            if inner_name in node_attrs.get("inputs", ()):
+                inner_consumers.extend(_descend_through_renames(node_id, inner_name, flat_graph))
+                break
+    return inner_consumers or [consumer]
 
 
 def get_ancestor_chain(node_id: str, flat_graph: nx.DiGraph) -> list[str]:

--- a/tests/viz/test_complex_nested_graphs.py
+++ b/tests/viz/test_complex_nested_graphs.py
@@ -190,7 +190,11 @@ def make_batch_recommendations_graph() -> Graph:
     )
 
 
-def test_batch_recommendations_input_group_routes_to_container() -> None:
+def test_batch_recommendations_input_group_routes_to_internal_consumers() -> None:
+    """Renamed map_over boundary inputs (results -> result, feedbacks ->
+    feedback) must route to the inner consumers when the container is
+    expanded. Routing to the expanded container hull would make the edge
+    incident to a dagre compound parent, which crashes layout."""
     graph = make_batch_recommendations_graph()
     edges = _expanded_edges(graph)
 
@@ -198,7 +202,10 @@ def test_batch_recommendations_input_group_routes_to_container() -> None:
 
     assert group_edges, "Expected grouped input edges for results/feedbacks"
     targets = {edge["target"] for edge in group_edges}
-    assert targets == {"map_recommendations"}
+    assert targets == {
+        "map_recommendations/rec_build_recommendation",
+        "map_recommendations/rec_build_chat_messages",
+    }
 
 
 def test_batch_recommendations_outputs_route_from_internal_nodes() -> None:

--- a/tests/viz/test_mapped_graphnode_expansion.py
+++ b/tests/viz/test_mapped_graphnode_expansion.py
@@ -1,0 +1,133 @@
+"""Regression tests for expanded mapped GraphNode boundaries.
+
+A ``.map_over(...)`` GraphNode renames params at its boundary: the outer
+graph wires the list param (``pages``) while the inner node consumes the
+per-item param (``page``), and ``with_outputs(item_out="generated")`` renames
+the collected output. The IR must re-route edges to the inner
+consumer/producer when the container is expanded — an edge incident to an
+expanded container becomes a dagre *compound parent* endpoint, which crashes
+layout with "Cannot set properties of undefined (setting 'rank')" and renders
+a blank canvas.
+
+https://github.com/dagrejs/dagre: edges between a cluster (compound parent)
+and any node are unsupported; ranking drops cluster nodes but keeps their
+edges, dereferencing a label-less endpoint.
+"""
+
+import pytest
+
+from hypergraph import Graph, ifelse, node
+from tests.viz.conftest import scene_for_state
+
+
+@node(output_name="exist")
+def check(store, n: int) -> bool:
+    return False
+
+
+@ifelse(when_true="create_items", when_false="load_items")
+def gate(exist: bool) -> bool:
+    return exist
+
+
+@node(output_name="items")
+def load_items(store) -> list[str]:
+    return []
+
+
+@node(output_name="item_out")
+def process(worker, page: str) -> str:
+    return page
+
+
+@node(output_name="items")
+def save(store, generated: list[str]) -> list[str]:
+    return generated
+
+
+def make_mapped_gate_graph() -> Graph:
+    """Gate routing into a mapped GraphNode whose boundary renames params."""
+    create = (
+        Graph(nodes=[process], name="process")
+        .as_node(name="create_items")
+        .with_inputs(page="pages")
+        .with_outputs(item_out="generated")
+        .map_over("pages")
+    )
+    return Graph(
+        nodes=[check, gate, load_items, create, save],
+        name="ensure_items",
+    ).bind(store=object(), worker=object())
+
+
+def assert_scene_layoutable(scene: dict) -> None:
+    """Assert the scene can be handed to dagre without crashing.
+
+    Every visible edge must reference visible nodes, and no endpoint may be
+    an *expanded* container — expanded containers become dagre compound
+    parents, and dagre does not support edges incident to compound parents.
+    """
+    nodes_by_id = {n["id"]: n for n in scene["nodes"]}
+    for edge in scene["edges"]:
+        if edge["hidden"]:
+            continue
+        for end in ("source", "target"):
+            node_id = edge[end]
+            assert node_id in nodes_by_id, f"edge {edge['id']} {end} references missing node {node_id!r}"
+            scene_node = nodes_by_id[node_id]
+            assert not scene_node["hidden"], f"edge {edge['id']} {end} references hidden node {node_id!r}"
+            data = scene_node["data"]
+            assert not (data["nodeType"] == "PIPELINE" and data.get("isExpanded")), (
+                f"edge {edge['id']} {end} references expanded container {node_id!r} (dagre compound-parent crash)"
+            )
+
+
+@pytest.mark.parametrize("expanded", [False, True])
+@pytest.mark.parametrize("show_inputs", [False, True])
+@pytest.mark.parametrize("separate_outputs", [False, True])
+def test_mapped_graphnode_scenes_are_layoutable(expanded, show_inputs, separate_outputs):
+    scene = scene_for_state(
+        make_mapped_gate_graph(),
+        expansion_state={"create_items": True} if expanded else {},
+        show_inputs=show_inputs,
+        separate_outputs=separate_outputs,
+    )
+    assert_scene_layoutable(scene)
+
+
+@pytest.mark.parametrize("show_inputs", [False, True])
+def test_mapped_graphnode_merged_edges_have_existing_endpoints(show_inputs):
+    """In merged-output mode every emitted edge — hidden ones included —
+    must reference node ids that exist in the scene node list."""
+    scene = scene_for_state(
+        make_mapped_gate_graph(),
+        expansion_state={"create_items": True},
+        show_inputs=show_inputs,
+    )
+    node_ids = {n["id"] for n in scene["nodes"]}
+    for edge in scene["edges"]:
+        assert edge["source"] in node_ids, f"edge {edge['id']} has dangling source"
+        assert edge["target"] in node_ids, f"edge {edge['id']} has dangling target"
+
+
+def test_mapped_input_edge_routes_to_inner_consumer_when_expanded():
+    """The renamed map_over input (pages -> page) must reach the inner node."""
+    scene = scene_for_state(make_mapped_gate_graph(), expansion_state={"create_items": True})
+    edges_by_id = {e["id"]: e for e in scene["edges"]}
+    assert "input_pages__create_items/process" in edges_by_id
+    assert not edges_by_id["input_pages__create_items/process"]["hidden"]
+
+
+def test_mapped_output_edge_routes_from_inner_producer_when_expanded():
+    """The renamed output (item_out -> generated) must leave from the inner node."""
+    scene = scene_for_state(make_mapped_gate_graph(), expansion_state={"create_items": True})
+    edges_by_id = {e["id"]: e for e in scene["edges"]}
+    assert "create_items/process__save" in edges_by_id
+    assert not edges_by_id["create_items/process__save"]["hidden"]
+
+
+def test_mapped_input_edge_attaches_to_collapsed_container():
+    """Collapsed view keeps the boundary edge on the container hull."""
+    scene = scene_for_state(make_mapped_gate_graph(), expansion_state={})
+    edge_pairs = {(e["source"], e["target"]) for e in scene["edges"]}
+    assert ("create_items", "save") in edge_pairs

--- a/tests/viz/test_mapped_graphnode_expansion.py
+++ b/tests/viz/test_mapped_graphnode_expansion.py
@@ -126,8 +126,40 @@ def test_mapped_output_edge_routes_from_inner_producer_when_expanded():
     assert not edges_by_id["create_items/process__save"]["hidden"]
 
 
-def test_mapped_input_edge_attaches_to_collapsed_container():
-    """Collapsed view keeps the boundary edge on the container hull."""
+def test_mapped_output_edge_attaches_to_collapsed_container():
+    """Collapsed view keeps the output boundary edge on the container hull."""
     scene = scene_for_state(make_mapped_gate_graph(), expansion_state={})
     edge_pairs = {(e["source"], e["target"]) for e in scene["edges"]}
     assert ("create_items", "save") in edge_pairs
+
+
+@node(output_name="out_a")
+def consume_x(x: int) -> int:
+    return x
+
+
+@node(output_name="out_b")
+def consume_y(y: int) -> int:
+    return y
+
+
+def test_swapped_input_renames_route_to_correct_inner_consumers():
+    """Parallel rename batches must resolve as simultaneous transforms.
+
+    ``rename_inputs(x="y", y="x")`` swaps the boundary names in one batch:
+    outer ``x`` is the inner ``y`` and vice versa. A batch-unaware resolver
+    chains through both entries and wires the outer name back to the
+    same-named inner param — the wrong consumer."""
+    swapped = Graph(nodes=[consume_x, consume_y], name="inner").as_node().rename_inputs(x="y", y="x")
+    graph = Graph(nodes=[swapped])
+
+    name_map = graph.to_flat_graph().nodes["inner"]["input_name_map"]
+    assert name_map == {"x": ("y",), "y": ("x",)}
+
+    scene = scene_for_state(graph, expansion_state={"inner": True})
+    visible_edges = {(e["source"], e["target"]) for e in scene["edges"] if not e["hidden"]}
+    assert ("input_x", "inner/consume_y") in visible_edges
+    assert ("input_y", "inner/consume_x") in visible_edges
+    assert ("input_x", "inner/consume_x") not in visible_edges
+    assert ("input_y", "inner/consume_y") not in visible_edges
+    assert_scene_layoutable(scene)


### PR DESCRIPTION
## Problem / Bug / Challenge

`graph.visualize(depth=1)` renders a **"Layout error: Cannot set properties of undefined (setting 'rank')"** toast and a blank canvas when the graph contains a `.map_over(...)` GraphNode and the mapped container is expanded.

Root cause: a `map_over` / `rename_inputs` / `rename_outputs` boundary renames params (outer `pages` list vs inner per-item `page`; `with_outputs(item_out="generated")`). The IR's producer/consumer search only had **fuzzy substring matching**, which fails for non-substring renames — so edges stayed pinned to the expanded container hull. Dagre does not support edges incident to compound parents: ranking drops compound nodes (`asNonCompoundGraph`) but keeps their edges, auto-creating a label-less endpoint and crashing on `g.node(v).rank = ...`. Verified with a 4-line minimal case against the vendored dagre: *any* edge touching a compound parent crashes; cross-boundary edges into children are fine.

Repro:

```python
from hypergraph import Graph, ifelse, node

@node(output_name="exist")
def check(store, n: int) -> bool: ...

@ifelse(when_true="create_items", when_false="load_items")
def gate(exist: bool) -> bool: ...

@node(output_name="items")
def load_items(store) -> list[str]: ...

@node(output_name="item_out")
def process(worker, page: str) -> str: ...

create = (
    Graph(nodes=[process], name="process")
    .as_node(name="create_items")
    .with_inputs(page="pages")
    .with_outputs(item_out="generated")
    .map_over("pages")
)

@node(output_name="items")
def save(store, generated: list[str]) -> list[str]: ...

g = Graph(nodes=[check, gate, load_items, create, save], name="ensure_items").bind(store=object(), worker=object())
g.visualize(depth=1, filepath="/tmp/bug.html")  # blank canvas + dagre rank error
```

## Before / After

**Before** (scene edges at depth=1 — two edges incident to the expanded container, which is a dagre compound parent):

```
gate         -> create_items/process   (control edge: rewritten correctly)
create_items -> save                   (CRASH: source is the expanded container)
input_pages  -> create_items           (CRASH: target is the expanded container)
```

Browser: `Layout error: Cannot set properties of undefined (setting 'rank')`, blank canvas. Note `show_inputs=False` at depth=1 was equally broken — `create_items -> save` alone crashes dagre.

**After** (all boundary edges route to the inner node; the `pages` INPUT nests inside the expanded container, matching how the same graph renders when nested one level deeper):

```
gate                 -> create_items/process
create_items/process -> save
input_pages          -> create_items/process
```

Collapsed view (depth=0) keeps edges on the container hull, unchanged. One intentional rendering change: at depth=0 the `pages` INPUT node is now hidden and listed as a port on the collapsed card — the existing policy for all container-owned inputs (same as an un-renamed `worker` input); previously it floated at root inconsistently.

### How

Exact rename facts instead of fuzzy guessing:

- `GraphNode.nx_attrs` now exports `input_name_map` / `output_name_map` (outer address → original inner names), built from the rename machinery the node already maintains for execution. Additive flat-graph keys; nothing outside viz consumes them.
- `renderer/ir_builder.py`: `_find_deepest_internal_producer(s)` / `_find_deepest_internal_consumer` translate value names through the container's exact map before searching; fuzzy matching kept only as fallback for multi-boundary renames.
- `renderer/scope.py`: `get_deepest_consumers` descends through GRAPH boundaries that rename a param (recursively), so external inputs reach the true inner consumer.
- `viz/AGENTS.md`: documented the dagre compound-parent failure mode.

Python-only: both scene-builder twins consume the same IR, so the JS side gets the corrected routing for free (covered by the existing parity tests).

Known adjacent gap (pre-existing, out of scope): in `separate_outputs` mode, a renamed output's DATA→consumer edge is emitted hidden with a stale id (`data_<producer>_<container_name>` vs the producer's `data_<producer>_<inner_name>` node) — no crash, but the visible connection is missing. Fixing it needs an IR schema extension synced across both scene-builder twins; tracked separately.

## Test Plan

- [x] New `tests/viz/test_mapped_graphnode_expansion.py`: builds the repro graph and, across expansion x show_inputs x separate_outputs states, asserts every visible edge references existing visible nodes **and no endpoint is an expanded container** (the dagre compound invariant), plus targeted assertions on the rewritten input/output routes and the collapsed-view hull edges. Red-verified: fails on pre-fix code.
- [x] Updated `test_complex_nested_graphs.py::test_batch_recommendations_input_group_routes_to_internal_consumers` — it previously asserted the crash-shaped contract (input group routing to the expanded container hull); now expects the inner consumers, symmetric with the existing output-side test.
- [x] Full viz suite (`uv run pytest tests/viz/`) green, including Python<->JS scene-builder parity.
- [x] CI-equivalent run green: `uv run pytest -W error -W 'ignore::pytest.PytestUnraisableExceptionWarning'`.
- [x] Manual: rendered the repro at depth=1 in headless Chromium — before: rank-error toast + blank canvas; after: full render with `pages` INPUT inside the expanded container.
- [x] Review-checklist sweeps: mirror (no stale doc refs), parity (JS twin via shared IR + parity tests), consumer grep (`input_name_map`/`output_name_map` consumed only in viz), validation-runtime N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed edge routing issues in expanded containers with renamed boundary parameters, resolving layout crashes and blank canvas scenarios.

* **Documentation**
  * Updated common failure modes documentation to describe expanded container boundary parameter scenarios and associated resolution approaches.

* **Tests**
  * Added comprehensive regression test coverage for expanded mapped nodes with renamed parameters, including layoutability and edge routing validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->