### PR TITLE
fix(viz): translate renamed value names for separate-outputs DATA edges

### DIFF
--- a/src/hypergraph/viz/assets/scene_builder.js
+++ b/src/hypergraph/viz/assets/scene_builder.js
@@ -217,7 +217,9 @@
     for (var p = 0; p < ir.edges.length; p++) {
       var irEdge = ir.edges[p];
       var baseSources = [irEdge.source];
+      var sourceRewritten = false;
       if (expansionState[irEdge.source] && irEdge.source_when_expanded) {
+        sourceRewritten = true;
         baseSources = Array.isArray(irEdge.source_when_expanded)
           ? irEdge.source_when_expanded.slice()
           : [irEdge.source_when_expanded];
@@ -228,9 +230,13 @@
       // A data edge can carry multiple value_names (one NetworkX edge per
       // (src,tgt) merges them). Merged-output mode should still render one
       // visible edge per node pair; separateOutputs mode fans out through
-      // one DATA node per value.
+      // one DATA node per value. When the source rewrite fired, DATA ids
+      // must use the producer's local output names (boundary renames).
       var valueNames = irEdge.value_names || [];
-      var valuesToEmit = (separateOutputs && irEdge.edge_type === 'data' && valueNames.length > 0) ? valueNames : [null];
+      var emitNames = (sourceRewritten && irEdge.value_names_when_expanded && irEdge.value_names_when_expanded.length > 0)
+        ? irEdge.value_names_when_expanded
+        : valueNames;
+      var valuesToEmit = (separateOutputs && irEdge.edge_type === 'data' && valueNames.length > 0) ? emitNames : [null];
 
       for (var bs = 0; bs < baseSources.length; bs++) {
         var baseSrc = baseSources[bs];

--- a/src/hypergraph/viz/ir_schema.py
+++ b/src/hypergraph/viz/ir_schema.py
@@ -39,6 +39,14 @@ class IREdge:
     # the data flow goes producer -> data_node -> consumer instead of
     # producer -> consumer directly).
     value_names: tuple[str, ...] = ()
+    # Local value names at the rewritten producer: when the source container
+    # is expanded and renames an output at its boundary (rename_outputs /
+    # with_outputs), separate_outputs DATA ids must use the producer's own
+    # output name (e.g. container exposes "generated" but the inner node
+    # produces "item_out"). Aligned index-wise with value_names; None when
+    # no boundary rename applies. Optional and ignorable — old scene
+    # builders fall back to value_names, so no schema_version bump.
+    value_names_when_expanded: tuple[str, ...] | None = None
     # Branch label for control edges originating from a gate (e.g. "True"
     # / "False" for an ifelse, or the route key for a route).
     label: str | None = None

--- a/src/hypergraph/viz/renderer/ir_builder.py
+++ b/src/hypergraph/viz/renderer/ir_builder.py
@@ -151,12 +151,16 @@ def _build_ir_edge(
     value_names = tuple(attrs.get("value_names", ()))
 
     src_attrs = flat_graph.nodes.get(src, {})
+    value_names_when_expanded: tuple[str, ...] | None = None
     if src_attrs.get("node_type") == "GRAPH":
         for value_name in value_names:
             internal = _find_deepest_internal_producers(src, value_name, flat_graph)
             if internal:
                 source_when_expanded = internal[0] if len(internal) == 1 else internal
                 break
+        translated = tuple(_inner_output_name(src, value_name, flat_graph) for value_name in value_names)
+        if translated != value_names:
+            value_names_when_expanded = translated
 
     tgt_attrs = flat_graph.nodes.get(tgt, {})
     if tgt_attrs.get("node_type") == "GRAPH":
@@ -188,6 +192,7 @@ def _build_ir_edge(
         source_when_expanded=source_when_expanded,
         target_when_expanded=target_when_expanded,
         value_names=value_names,
+        value_names_when_expanded=value_names_when_expanded,
         label=label,
         exclusive=exclusive,
         is_back_edge=(src, tgt) in back_edges,

--- a/src/hypergraph/viz/scene_builder.py
+++ b/src/hypergraph/viz/scene_builder.py
@@ -187,7 +187,9 @@ def build_initial_scene(
         # expanded, route the edge to the deepest internal producer/consumer
         # instead of the container hull.
         base_sources = [ir_edge.source]
+        source_rewritten = False
         if expansion_state.get(ir_edge.source) and ir_edge.source_when_expanded:
+            source_rewritten = True
             expanded_sources = ir_edge.source_when_expanded
             base_sources = list(expanded_sources) if isinstance(expanded_sources, tuple) else [expanded_sources]
         target = ir_edge.target
@@ -197,10 +199,14 @@ def build_initial_scene(
         # A data edge can carry multiple value_names (one NetworkX edge per
         # (src,tgt) merges them). Merged-output mode should still render one
         # visible edge per node pair; separate_outputs mode fans out through
-        # one DATA node per value.
+        # one DATA node per value. When the source rewrite fired, DATA ids
+        # must use the producer's local output names (boundary renames).
+        emit_value_names = ir_edge.value_names
+        if source_rewritten and ir_edge.value_names_when_expanded:
+            emit_value_names = ir_edge.value_names_when_expanded
         for base_source in base_sources:
             if separate_outputs and ir_edge.edge_type == "data" and ir_edge.value_names:
-                edges_to_emit = [(value_name, base_source) for value_name in ir_edge.value_names]
+                edges_to_emit = [(value_name, base_source) for value_name in emit_value_names]
             else:
                 edges_to_emit = [(None, base_source)]
 

--- a/tests/viz/conftest.py
+++ b/tests/viz/conftest.py
@@ -17,7 +17,7 @@ import tempfile
 
 import pytest
 
-from hypergraph import Graph, node
+from hypergraph import Graph, ifelse, node
 from hypergraph.viz._common import get_expandable_nodes
 from hypergraph.viz.html import generate_widget_html
 from hypergraph.viz.renderer import render_graph
@@ -169,6 +169,52 @@ def make_outer() -> Graph:
     inner = Graph(nodes=[step1, step2], name="inner")
     middle = Graph(nodes=[inner.as_node(), validate], name="middle")
     return Graph(nodes=[middle.as_node(), log_result])
+
+
+# --- Mapped GraphNode with renamed boundary (gate + map_over) ---
+@node(output_name="exist")
+def check(store, n: int) -> bool:
+    return False
+
+
+@ifelse(when_true="create_items", when_false="load_items")
+def gate(exist: bool) -> bool:
+    return exist
+
+
+@node(output_name="items")
+def load_items(store) -> list[str]:
+    return []
+
+
+@node(output_name="item_out")
+def process(worker, page: str) -> str:
+    return page
+
+
+@node(output_name="items")
+def save(store, generated: list[str]) -> list[str]:
+    return generated
+
+
+def make_mapped_gate_graph() -> Graph:
+    """Gate routing into a mapped GraphNode whose boundary renames params.
+
+    The map boundary renames both directions: outer ``pages`` (list) vs
+    inner per-item ``page``, and inner ``item_out`` vs outer ``generated``
+    via ``with_outputs``. Exercises boundary-rename edge rewriting.
+    """
+    create = (
+        Graph(nodes=[process], name="process")
+        .as_node(name="create_items")
+        .with_inputs(page="pages")
+        .with_outputs(item_out="generated")
+        .map_over("pages")
+    )
+    return Graph(
+        nodes=[check, gate, load_items, create, save],
+        name="ensure_items",
+    ).bind(store=object(), worker=object())
 
 
 # =============================================================================

--- a/tests/viz/test_mapped_graphnode_expansion.py
+++ b/tests/viz/test_mapped_graphnode_expansion.py
@@ -16,48 +16,8 @@ edges, dereferencing a label-less endpoint.
 
 import pytest
 
-from hypergraph import Graph, ifelse, node
-from tests.viz.conftest import scene_for_state
-
-
-@node(output_name="exist")
-def check(store, n: int) -> bool:
-    return False
-
-
-@ifelse(when_true="create_items", when_false="load_items")
-def gate(exist: bool) -> bool:
-    return exist
-
-
-@node(output_name="items")
-def load_items(store) -> list[str]:
-    return []
-
-
-@node(output_name="item_out")
-def process(worker, page: str) -> str:
-    return page
-
-
-@node(output_name="items")
-def save(store, generated: list[str]) -> list[str]:
-    return generated
-
-
-def make_mapped_gate_graph() -> Graph:
-    """Gate routing into a mapped GraphNode whose boundary renames params."""
-    create = (
-        Graph(nodes=[process], name="process")
-        .as_node(name="create_items")
-        .with_inputs(page="pages")
-        .with_outputs(item_out="generated")
-        .map_over("pages")
-    )
-    return Graph(
-        nodes=[check, gate, load_items, create, save],
-        name="ensure_items",
-    ).bind(store=object(), worker=object())
+from hypergraph import Graph, node
+from tests.viz.conftest import make_mapped_gate_graph, scene_for_state
 
 
 def assert_scene_layoutable(scene: dict) -> None:
@@ -163,3 +123,34 @@ def test_swapped_input_renames_route_to_correct_inner_consumers():
     assert ("input_x", "inner/consume_x") not in visible_edges
     assert ("input_y", "inner/consume_y") not in visible_edges
     assert_scene_layoutable(scene)
+
+
+def test_separate_outputs_renamed_data_edge_uses_inner_output_name():
+    """separate_outputs + expanded container: the DATA edge to the consumer
+    must use the producer's local output name (item_out), not the renamed
+    container-level name (generated) — otherwise the edge references a
+    nonexistent DATA node id and the visible scene loses the connection."""
+    scene = scene_for_state(
+        make_mapped_gate_graph(),
+        expansion_state={"create_items": True},
+        separate_outputs=True,
+    )
+    visible_edges = {(e["source"], e["target"]) for e in scene["edges"] if not e["hidden"]}
+    assert ("data_create_items/process_item_out", "save") in visible_edges
+    assert ("create_items/process", "data_create_items/process_item_out") in visible_edges
+
+    node_ids = {n["id"] for n in scene["nodes"]}
+    for edge in scene["edges"]:
+        if edge["hidden"]:
+            continue
+        assert edge["source"] in node_ids, f"edge {edge['id']} has dangling source"
+        assert edge["target"] in node_ids, f"edge {edge['id']} has dangling target"
+
+
+def test_separate_outputs_collapsed_data_edge_keeps_container_name():
+    """Collapsed view still flows through the container-level DATA node
+    under the renamed (outer) value name."""
+    scene = scene_for_state(make_mapped_gate_graph(), expansion_state={}, separate_outputs=True)
+    visible_edges = {(e["source"], e["target"]) for e in scene["edges"] if not e["hidden"]}
+    assert ("data_create_items_generated", "save") in visible_edges
+    assert ("create_items", "data_create_items_generated") in visible_edges

--- a/tests/viz/test_parity.py
+++ b/tests/viz/test_parity.py
@@ -22,6 +22,7 @@ from hypergraph.viz.renderer.ir_builder import build_graph_ir
 from hypergraph.viz.scene_builder import build_initial_scene
 from tests.viz.conftest import (
     make_chain_graph,
+    make_mapped_gate_graph,
     make_outer,
     make_simple_graph,
     make_workflow,
@@ -182,6 +183,7 @@ FIXTURES = {
     "outer": make_outer,
     "bound": make_bound_graph,
     "unordered_entrypoint": make_unordered_nested_entrypoint_graph,
+    "mapped_gate": make_mapped_gate_graph,
 }
 
 


### PR DESCRIPTION
> Stacked on #163 (depends on the `output_name_map` nx_attrs introduced there). Review/merge #163 first; GitHub will retarget this PR to master automatically when the base branch merges.

## Problem / Bug / Challenge

In `separate_outputs=True` mode, when an expanded GraphNode renames an output at its boundary (`.with_outputs(item_out="generated")`), the DATA→consumer edge silently disappears: the producer's DATA node dangles with no outgoing edge, and the consumer has no incoming edge.

Root cause: when `IREdge.source_when_expanded` rewrites the edge source to the inner producer, both scene-builder twins construct the DATA id as `data_{source}_{value_name}` using the **container-level** value name → `data_create_items/process_generated`. But the DATA node created from the producer's own outputs is `data_create_items/process_item_out`. The endpoint doesn't exist, so the edge ships `hidden=True` and the visible connection is lost. (Pre-existing for all boundary renames; #163's exact-map rewrites made it reachable for non-substring renames too, and its PR body flagged this as a known gap.)

Repro:

```python
scene = scene_for_state(
    make_mapped_gate_graph(),               # tests/viz/conftest.py
    expansion_state={"create_items": True},
    separate_outputs=True,
)
```

## Before / After

**Before** (visible scene, container expanded):

```
create_items/process -> data_create_items/process_item_out      (DATA node dangles)
data_create_items/process_generated -> save                     (hidden: source id doesn't exist)
                                                                 save has NO incoming edge
```

**After:**

```
create_items/process -> data_create_items/process_item_out
data_create_items/process_item_out -> save
```

Collapsed view unchanged: `create_items -> data_create_items_generated -> save` still flows through the container-level DATA node under the renamed outer name.

### How

`IREdge` gains `value_names_when_expanded` — producer-local value names translated via the GRAPH node's exact `output_name_map`, aligned index-wise with `value_names` and `None` when no rename applies. Both twins (`scene_builder.py` + `assets/scene_builder.js`) use them for DATA ids and edge ids when the source rewrite fires. The field is optional and ignorable by older scene builders (they fall back to `value_names`, reproducing today's hidden-edge behavior at worst), so **no `schema_version` bump** per the policy in `ir_schema.py`.

The IR keeps carrying all expansion rewrites eagerly — scene builders stay dumb lookups, no graph re-walking in JS.

## Test Plan

- [x] New regression tests in `tests/viz/test_mapped_graphnode_expansion.py`: expanded + separate_outputs scene must contain visible `create_items/process → data_create_items/process_item_out → save` edges and no visible edge with a dangling endpoint; collapsed view keeps the container-level DATA route. Red-verified: the expanded-mode test fails without the fix.
- [x] `make_mapped_gate_graph` moved to `tests/viz/conftest.py` and added to the `test_parity.py` fixture matrix — the renamed-boundary path is now covered by the Python↔JS parity merge gate (all expansion states × separate_outputs × show_inputs × show_bounded_inputs).
- [x] Full viz suite green; CI-equivalent run green (`uv run pytest -W error -W 'ignore::pytest.PytestUnraisableExceptionWarning'`).
- [x] Manual: rendered the repro at depth=1 with separate_outputs in headless Chromium — before: `item_out` DATA node dangling, `save` floating disconnected; after: connected flow through the DATA node.
- [x] Sweeps: consumer grep (`valueName` consumed only by scene builders; no edge-id format dependencies elsewhere), mirror (schema docstring documents the new field), parity (covered by the matrix above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)