### PR TITLE
feat(materialization): HyperTable — per-column provenance, status() dry-run, named indexes + in-node span observability

### DIFF
--- a/docs/03-patterns/08-caching.md
+++ b/docs/03-patterns/08-caching.md
@@ -182,6 +182,43 @@ def classify_query(query: str) -> str:
 
 On cache hit, the runner replays the cached routing decision without calling the function again. Downstream routing still works correctly — the cached decision is restored into the graph state.
 
+## Caching in Batch Runs
+
+Caching works per item inside mapped subgraphs. Each iteration of a `map_over` (or `runner.map()`) runs the inner graph with that item's inputs, so a `cache=True` node inside it gets a cache key derived from the per-item input values:
+
+```python
+from hypergraph import Graph, node, SyncRunner, InMemoryCache
+
+@node(output_name="embedding", cache=True)
+def embed(text: str) -> list[float]:
+    return model.embed(text)  # expensive — cached per text
+
+@node(output_name="answer")
+def generate(embedding: list[float], temperature: float) -> str:
+    return llm.generate(embedding, temperature=temperature)
+
+inner = Graph([embed, generate], name="pipeline")
+outer = Graph([inner.as_node().map_over("text")])
+
+runner = SyncRunner(cache=InMemoryCache())
+
+# First batch: embed runs once per unique text
+runner.run(outer, {"text": ["a", "b", "c"], "temperature": 0.0})
+
+# Change a downstream parameter and re-run the batch:
+# all three embed calls hit the cache, only generate re-executes
+runner.run(outer, {"text": ["a", "b", "c"], "temperature": 1.0})
+
+# Add one new item: only "d" is embedded, "a"/"b"/"c" come from cache
+runner.run(outer, {"text": ["a", "b", "c", "d"], "temperature": 1.0})
+```
+
+The cache backend lives on the runner and is shared by all nested per-item runs, so hits carry across batches, across runs, and (with `DiskCache`) across processes.
+
+This is what makes eval loops cheap: re-running a batch after changing one parameter recomputes only the nodes downstream of that parameter — every cached upstream result is reused per item. A 500-item eval where you only tweaked the generation prompt pays for 500 generations, not 500 embeddings plus 500 retrievals plus 500 generations.
+
+Broadcast (non-mapped) inputs participate in the cache key like any other input: if a cached node consumes a broadcast value and you change it, every item recomputes that node — which is exactly right, since its inputs changed.
+
 ## Restrictions
 
 These node types reject `cache=True` at build time:

--- a/docs/05-how-to/declare-edges-explicitly.md
+++ b/docs/05-how-to/declare-edges-explicitly.md
@@ -1,0 +1,128 @@
+# How to Declare Edges Explicitly
+
+Control graph topology directly instead of relying on name matching. Hypergraph has three wiring modes — automatic, explicit, and additive — and picking the right one makes the difference between a graph that rewires itself silently and a topology you can review in a diff.
+
+## The Three Wiring Modes
+
+| Mode | Constructor | Data edges come from |
+|------|-------------|----------------------|
+| Automatic (default) | `Graph([a, b, c])` | Name matching: output `x` feeds input `x` |
+| Explicit | `Graph([...], edges=[...])` | Your declared edges only — auto-inference is disabled |
+| Additive | `Graph([...], edges=[...], shared=[...])` | Auto-inference for non-shared params, plus your declared edges on top |
+
+In **all three modes**, two kinds of edges are always auto-wired:
+
+- **Control edges** from gate nodes (`@route`, `@ifelse`) to their targets
+- **Ordering edges** from `emit`/`wait_for` declarations
+
+You never declare those by hand. Don't declare edges from a gate to its targets — the explicit edge would override the auto-wired control edge type.
+
+## Automatic Mode (Default)
+
+The default you already know: matching output/input names create edges.
+
+```python
+from hypergraph import Graph, node
+
+@node(output_name="embedding")
+def embed(text: str) -> list[float]: ...
+
+@node(output_name="docs")
+def retrieve(embedding: list[float]) -> list[str]: ...
+
+graph = Graph([embed, retrieve])  # embed -> retrieve, inferred from "embedding"
+```
+
+This is the right mode for small pipelines: zero wiring code, and renaming an output deliberately rewires every consumer.
+
+## Explicit Mode: `edges=` Without `shared=`
+
+Pass `edges` to take over data wiring completely. Auto-inference is disabled; the edges you declare are the **only** data edges in the graph.
+
+```python
+@node(output_name="messages")
+def add_query(messages: list, query: str) -> list:
+    return [*messages, {"role": "user", "content": query}]
+
+@node(output_name="response")
+def generate(messages: list) -> str:
+    return llm.chat(messages)
+
+@node(output_name="messages")
+def add_response(messages: list, response: str) -> list:
+    return [*messages, {"role": "assistant", "content": response}]
+
+chat = Graph(
+    [add_query, generate, add_response],
+    edges=[
+        (add_query, generate),         # carries: messages
+        (generate, add_response),      # carries: response
+        (add_response, add_query),     # carries: messages (cycle)
+    ],
+)
+```
+
+Each edge is a 2-tuple or 3-tuple:
+
+| Form | Behavior |
+|------|----------|
+| `(a, b)` | Value names auto-detected from the intersection of `a`'s outputs and `b`'s inputs |
+| `(a, b, "x")` | Pins exactly which value flows; build fails if `x` is not an output of `a` and an input of `b` |
+| `(a, b, ["x", "y"])` | Pins multiple values |
+| `(a, b)` with no name overlap | Ordering-only edge — a structural dependency with no data flow |
+
+Source and target can be node objects or string names. Inputs not fed by any declared edge become graph inputs, provided at `run()` time or via `bind()`.
+
+## Additive Mode: `edges=` With `shared=`
+
+When `shared=` is present, the semantics flip: auto-inference **still runs** for all non-shared params, and your explicit edges are added on top. This is the chat-loop/cycle pattern — shared state flows through run state, and you only declare the ordering that name matching can't determine:
+
+```python
+from hypergraph import Graph, node, route, END
+
+@node(output_name="messages")
+def add_user_message(messages: list, user_input: str) -> list: ...
+
+@node(output_name="response")
+def generate(messages: list) -> str: ...
+
+@node(output_name="messages")
+def add_response(messages: list, response: str) -> list: ...
+
+@route(targets=["add_user_message", END])
+def should_continue(messages: list) -> str: ...
+
+graph = Graph(
+    [add_user_message, generate, add_response, should_continue],
+    shared=["messages"],
+    entrypoint="add_user_message",
+    edges=[
+        (add_user_message, generate),   # ordering only: "messages" is shared
+        (add_response, should_continue),
+    ],
+)
+```
+
+Here `response` is still auto-wired from `generate` to `add_response` by name. The two declared edges only impose ordering: since `messages` is shared, no data flows on them — nodes read the latest `messages` from run state. Edges whose only overlapping values are shared params become ordering-only edges automatically.
+
+See [Shared State](../06-api-reference/graph.md#shared-state) for shared-param rules and [Agentic Loops](../03-patterns/03-agentic-loops.md) for the full pattern.
+
+## When to Prefer Explicit Edges
+
+Automatic wiring is the right default, but reach for explicit `edges=` when:
+
+- **The graph has more than ~5 nodes.** At that size, the topology is no longer obvious from reading node signatures, and an explicit edge list doubles as documentation.
+- **The graph is reviewed in PRs.** With explicit edges, topology changes show up in the diff. With auto-inference, renaming an output can silently rewire consumers across the file — in explicit mode a rename can never attach a consumer to a new producer, and pinned 3-tuple values fail loudly at build time.
+- **Multiple nodes produce the same output.** Auto-inference rejects this as ambiguous; explicit edges (or `shared=`) make the intent unambiguous.
+- **You need ordering without data flow** and `emit`/`wait_for` would be more ceremony than a single ordering-only edge.
+
+Two restrictions to know about:
+
+- `add_nodes()` raises on a graph with explicit edges — create a new `Graph` with the complete node and edge lists instead.
+- Explicit and automatic data wiring don't mix without `shared=`. If you want "mostly automatic plus a few extra edges", that's exactly what additive mode is for.
+
+## What's Next?
+
+- [Graph API Reference](../06-api-reference/graph.md#explicit-edges) — full edge format and validation rules
+- [Agentic Loops](../03-patterns/03-agentic-loops.md) — cycles, shared outputs, and gates
+- [Rename and Adapt](rename-and-adapt.md) — reusing nodes under different names

--- a/docs/05-how-to/declare-edges-explicitly.md
+++ b/docs/05-how-to/declare-edges-explicitly.md
@@ -10,6 +10,8 @@ Control graph topology directly instead of relying on name matching. Hypergraph 
 | Explicit | `Graph([...], edges=[...])` | Your declared edges only — auto-inference is disabled |
 | Additive | `Graph([...], edges=[...], shared=[...])` | Auto-inference for non-shared params, plus your declared edges on top |
 
+> **The mode is chosen implicitly.** There is no `mode=` parameter: passing `edges=` alone means *replace* auto-wiring, while passing `edges=` together with `shared=` means *add to* auto-wiring. The same `edges=` list changes meaning depending on whether `shared=` is present. If your explicit-mode graph later gains a `shared=` param, auto-inference silently turns back on for everything else — re-check your edge list when you add `shared=`.
+
 In **all three modes**, two kinds of edges are always auto-wired:
 
 - **Control edges** from gate nodes (`@route`, `@ifelse`) to their targets

--- a/docs/05-how-to/nodes-from-component-methods.md
+++ b/docs/05-how-to/nodes-from-component-methods.md
@@ -1,0 +1,75 @@
+# How to Build Nodes from Component Methods
+
+Most real pipelines delegate the heavy lifting to configured components — an LLM client, a retriever, a reranker. The usual pattern wraps each call in a thin function node:
+
+```python
+@node(output_name="answer")
+def generate(llm: LLM, question: str) -> str:
+    return llm.generate(question)
+```
+
+That works, and it makes the component a graph input (late binding). But when the component is already constructed at graph-build time, the wrapper adds nothing — you can pass the **bound method** to `FunctionNode` directly:
+
+```python
+from hypergraph.nodes.function import FunctionNode
+
+llm = LLM(model="gpt-5.5-mini")
+
+generate = FunctionNode(llm.generate, name="generate", output_name="answer")
+```
+
+`inspect.signature` strips `self`, so the node's inputs are exactly the method's remaining parameters (`question`). The instance travels with the node — no wrapper function, no component input port.
+
+## Two Instances, Two Nodes
+
+Because the instance is bound, the same class can appear in one graph under different configurations:
+
+```python
+class Summarizer:
+    def __init__(self, model: str):
+        self.model = model
+
+    def summarize(self, text: str) -> str:
+        return call_llm(self.model, f"Summarize: {text}")
+
+fast = Summarizer(model="gpt-5.5-mini")
+deep = Summarizer(model="gpt-5.5")
+
+draft = FunctionNode(fast.summarize, name="draft", output_name="draft")
+final = FunctionNode(
+    deep.summarize, name="final", output_name="final"
+).rename_inputs(text="draft")
+
+graph = Graph([draft, final])
+```
+
+Each node carries its own instance state. Combined with `rename_inputs` / `rename_outputs` at the boundaries, this removes most "wrapper" nodes whose only job was to call a method on a component.
+
+## When to Prefer Which Binding
+
+| | Bound method (early binding) | Component as input (late binding) |
+|---|---|---|
+| Component is chosen | at graph construction | at `run()` time |
+| Component appears in `graph.inputs` | no | yes |
+| Same graph, different component per run | rebuild the graph | pass a different input |
+| Wrapper function needed | no | yes |
+
+If a config factory builds both the components and the graph in one place, early binding is natural — the configuration already decided which instance to use. Reach for late binding when the *same compiled graph* must serve differently-configured components at run time.
+
+## Caching Caveat
+
+`definition_hash` for a bound method includes an **instance fingerprint**: a `cache_key()` method on the instance if it defines one, otherwise a deterministic serialization of `vars(instance)`. Two differently-configured instances therefore hash differently, and `cache=True` on bound-method nodes is safe.
+
+The fingerprint is captured when the node is constructed. If you mutate instance state after constructing the node, the hash does not track it — construct nodes from fully-configured instances.
+
+```python
+node_fast = FunctionNode(fast.summarize, name="s", output_name="out")
+node_deep = FunctionNode(deep.summarize, name="s", output_name="out")
+assert node_fast.definition_hash != node_deep.definition_hash  # different model attrs
+```
+
+## What's Next?
+
+- [Rename and Adapt](rename-and-adapt.md) — wiring reused nodes under different names
+- [Declare Edges Explicitly](declare-edges-explicitly.md) — making topology reviewable
+- [Caching](../03-patterns/08-caching.md) — cache keys, batch runs, and invalidation

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -36,6 +36,7 @@
 ## How-To Guides
 
 * [Batch Processing](05-how-to/batch-processing.md)
+* [Declare Edges Explicitly](05-how-to/declare-edges-explicitly.md)
 * [Rename and Adapt](05-how-to/rename-and-adapt.md)
 * [Integrate with LLMs](05-how-to/integrate-with-llms.md)
 * [Test Without Framework](05-how-to/test-without-framework.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -37,6 +37,7 @@
 
 * [Batch Processing](05-how-to/batch-processing.md)
 * [Declare Edges Explicitly](05-how-to/declare-edges-explicitly.md)
+* [Nodes from Component Methods](05-how-to/nodes-from-component-methods.md)
 * [Rename and Adapt](05-how-to/rename-and-adapt.md)
 * [Integrate with LLMs](05-how-to/integrate-with-llms.md)
 * [Test Without Framework](05-how-to/test-without-framework.md)

--- a/src/hypergraph/__init__.py
+++ b/src/hypergraph/__init__.py
@@ -69,6 +69,7 @@ from hypergraph.runners import (
     SyncRunner,
 )
 from hypergraph.runners._shared.node_context import NodeContext
+from hypergraph.runners._shared.observability import NodeSpanRef, current_node_span
 
 __all__ = [
     # Decorators and node types
@@ -135,6 +136,9 @@ __all__ = [
     "RichProgressProcessor",
     # Context
     "NodeContext",
+    # Observability
+    "NodeSpanRef",
+    "current_node_span",
     # Cache
     "CacheBackend",
     "InMemoryCache",

--- a/src/hypergraph/_utils.py
+++ b/src/hypergraph/_utils.py
@@ -6,6 +6,7 @@ import hashlib
 import inspect
 from collections.abc import Callable
 from datetime import datetime
+from typing import Any
 
 
 def ensure_tuple(value: str | tuple[str, ...]) -> tuple[str, ...]:
@@ -88,6 +89,15 @@ def hash_definition(func: Callable) -> str:
     bytecode for dynamically created functions (exec/eval), and finally to
     qualified name for builtins/C extensions.
 
+    For bound methods, an instance fingerprint is mixed into the hash so the
+    same method on two differently-configured instances hashes differently
+    (e.g. two ``Summarizer`` instances with different ``model`` attributes).
+    The fingerprint prefers the instance's ``cache_key()`` method when one is
+    defined (mirroring hypercache's convention), falling back to a
+    deterministic serialization of ``vars(instance)``. The fingerprint is
+    captured when the hash is computed — node construction — so mutating
+    instance state after construction is not tracked.
+
     Args:
         func: Function to hash
 
@@ -99,6 +109,42 @@ def hash_definition(func: Callable) -> str:
         >>> len(hash_definition(foo))
         64
     """
+    code_hash = _hash_code(func)
+
+    # Bound methods: mix in instance state so differently-configured
+    # instances of the same class do not share a hash (and a cache).
+    instance = getattr(func, "__self__", None)
+    if instance is None or isinstance(instance, type):
+        # Plain function, or classmethod (class-level state is not
+        # deterministic across processes — keep code-only hashing).
+        return code_hash
+
+    fingerprint = _instance_fingerprint(instance)
+    if fingerprint is None:
+        return code_hash
+    return hashlib.sha256(f"{code_hash}:{fingerprint}".encode()).hexdigest()
+
+
+def _instance_fingerprint(instance: Any) -> str | None:
+    """Deterministic fingerprint of a bound method's instance state.
+
+    Prefers the instance's ``cache_key()`` method when defined. Falls back
+    to a sorted serialization of ``vars(instance)``. Returns None when no
+    state is accessible (e.g. ``__slots__`` without ``__dict__``).
+    """
+    cache_key = getattr(instance, "cache_key", None)
+    if callable(cache_key):
+        return repr(cache_key())
+
+    try:
+        state = vars(instance)
+    except TypeError:
+        return None
+    return repr(tuple((key, repr(value)) for key, value in sorted(state.items())))
+
+
+def _hash_code(func: Callable) -> str:
+    """Hash a callable's code: source, bytecode, or qualified-name fallback."""
     # Prefer source code — most precise, captures comments and formatting
     try:
         source = inspect.getsource(func)

--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -159,7 +159,12 @@ class Graph:
                 edge. If omitted on a 2-tuple, values are auto-detected from
                 the intersection of source outputs and target inputs. Edges
                 with no matching values become ordering-only edges.
-                When ``edges`` is provided, auto-inference is disabled.
+                When ``edges`` is provided WITHOUT ``shared``, auto-inference
+                is disabled and the declared edges are the only data edges
+                (explicit mode). When ``shared`` is also provided, auto-inference
+                still runs for non-shared params and the declared edges are
+                added on top, typically as ordering-only edges (additive mode).
+                See :doc:`/05-how-to/declare-edges-explicitly`.
             entrypoint: Convenience shortcut for ``with_entrypoint(...)``.
                 Accepts a node name/object or a list/tuple of node names/objects
                 and applies the same validation and semantics as

--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -6,7 +6,7 @@ import functools
 import hashlib
 import types
 import warnings
-from typing import TYPE_CHECKING, Any, Union, get_args, get_origin
+from typing import TYPE_CHECKING, Annotated, Any, Union, get_args, get_origin
 
 import networkx as nx
 
@@ -77,6 +77,9 @@ def _format_type_hint(type_hint: Any) -> str:
     """Format a type annotation for human-readable summaries."""
     if type_hint is type(None):
         return "None"
+
+    if get_origin(type_hint) is Annotated:
+        return _format_type_hint(get_args(type_hint)[0])
 
     origin = get_origin(type_hint)
     if origin in (types.UnionType, Union):

--- a/src/hypergraph/materialization/__init__.py
+++ b/src/hypergraph/materialization/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from hypergraph.materialization._hypertable import HyperTable
 from hypergraph.materialization._table_store import TableStore, validate_store
-from hypergraph.materialization._types import ErrorRow, SyncResult
+from hypergraph.materialization._types import ErrorRow, SyncResult, TableStatus
 
 __all__ = [
     "HyperTable",
@@ -12,6 +12,7 @@ __all__ = [
     "validate_store",
     "ErrorRow",
     "SyncResult",
+    "TableStatus",
     "check_store_conformance",
 ]
 

--- a/src/hypergraph/materialization/_fingerprint.py
+++ b/src/hypergraph/materialization/_fingerprint.py
@@ -62,6 +62,23 @@ def compute_child_fingerprint(child_graph: Any, components: dict[str, Any], chil
     return _fingerprint(child_inputs, _node_definition_hashes(child_graph), _component_config_hashes(components, valid_inputs))
 
 
+def compute_recipe_fingerprint(node_fn: Any, component_hashes: dict[str, str]) -> str:
+    """Recipe identity for a column's producing node: hash(node code + consumed component configs).
+
+    Unlike ``compute_column_provenance`` this excludes input values — it names
+    HOW a column is derived, not what it was derived from. A named index records
+    it so a rebound component (e.g. a different embedder) flips the index stale.
+    """
+    payload = json.dumps(
+        {
+            "node": compute_definition_hash(node_fn),
+            "components": component_hashes,
+        },
+        sort_keys=True,
+    )
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
 def compute_column_provenance(node_fn: Any, inputs: dict[str, Any], component_hashes: dict[str, str]) -> str:
     """Per-column provenance: hash(producing node's code + its direct input values + consumed component configs).
 

--- a/src/hypergraph/materialization/_fingerprint.py
+++ b/src/hypergraph/materialization/_fingerprint.py
@@ -62,10 +62,18 @@ def compute_child_fingerprint(child_graph: Any, components: dict[str, Any], chil
     return _fingerprint(child_inputs, _node_definition_hashes(child_graph), _component_config_hashes(components, valid_inputs))
 
 
-def compute_provenance(col_name: str, inputs: dict[str, Any]) -> str:
-    """Per-column provenance hash over the inputs that produced it."""
+def compute_column_provenance(node_fn: Any, inputs: dict[str, Any], component_hashes: dict[str, str]) -> str:
+    """Per-column provenance: hash(producing node's code + its direct input values + consumed component configs).
+
+    Direct inputs are themselves stored columns, so transitivity is value-based:
+    an upstream change that yields the same value stops the cascade here.
+    """
     payload = json.dumps(
-        {"column": col_name, "inputs": {k: str(v) for k, v in sorted(inputs.items())}},
+        {
+            "node": compute_definition_hash(node_fn),
+            "inputs": {k: f"{type(v).__name__}:{v}" for k, v in sorted(inputs.items())},
+            "components": component_hashes,
+        },
         sort_keys=True,
     )
     return hashlib.sha256(payload.encode()).hexdigest()

--- a/src/hypergraph/materialization/_hypertable.py
+++ b/src/hypergraph/materialization/_hypertable.py
@@ -95,6 +95,17 @@ def _where_predicate(where: Any) -> list[tuple[str, str, Any]]:
     return list(where)
 
 
+def _split_boundary_provenance(value: Any) -> tuple[str | None, int | None]:
+    """Parse a stored boundary provenance ("<hash>#<item count>") into its parts."""
+    if not isinstance(value, str) or "#" not in value:
+        return None, None
+    prov, _, count = value.rpartition("#")
+    try:
+        return prov, int(count)
+    except ValueError:
+        return None, None
+
+
 class HyperTable:
     """A Hypergraph graph where each node output is a stored column."""
 
@@ -228,8 +239,15 @@ class HyperTable:
         if provenances is None:
             values = {**{k: v for k, v in item.items() if k != self._identity}, **outputs}
             provenances = {c.name: self._node_provenance(c.produced_by, values) for c in derived_cols}
-        for col in derived_cols:
-            row[f"_provenance_{col.name}"] = provenances.get(col.name)
+            for child_spec in self._spec.children:
+                bnode = self._boundary_node(child_spec)
+                if bnode is None:
+                    continue
+                prov = self._node_provenance(bnode, values)
+                if prov is not None:
+                    provenances[child_spec.map_input] = self._boundary_provenance_value(prov, outputs.get(child_spec.map_input))
+        for name, prov in provenances.items():
+            row[f"_provenance_{name}"] = prov
 
         return row
 
@@ -286,14 +304,15 @@ class HyperTable:
 
     # --- Per-column provenance (config-aware, value-chained) ---
 
-    def _derived_columns(self) -> list:
-        return [c for c in self._spec.columns if c.role == "derived"]
+    def _derived_columns(self, spec: TableSpec | None = None) -> list:
+        spec = spec or self._spec
+        return [c for c in spec.columns if c.role == "derived"]
 
     def _node_params(self, node: Any) -> Any:
         return inspect.signature(node_func(node)).parameters
 
-    def _node_columns(self, node: Any) -> list:
-        return [c for c in self._derived_columns() if c.produced_by is node]
+    def _node_columns(self, node: Any, spec: TableSpec | None = None) -> list:
+        return [c for c in self._derived_columns(spec) if c.produced_by is node]
 
     def _producing_node(self, column: str) -> Any:
         for c in self._derived_columns():
@@ -301,9 +320,9 @@ class HyperTable:
                 return c.produced_by
         raise KeyError(f"{column!r} is not a derived column")
 
-    def _nodes_in_dependency_order(self) -> list:
+    def _nodes_in_dependency_order(self, spec: TableSpec | None = None) -> list:
         """Producing nodes ordered so every node's column inputs are produced before it."""
-        derived = self._derived_columns()
+        derived = self._derived_columns(spec)
         nodes: list = []
         seen: set[int] = set()
         for col in derived:
@@ -320,7 +339,7 @@ class HyperTable:
                 deps = {p for p in self._node_params(n) if p in derived_names}
                 if deps <= placed:
                     ordered.append(n)
-                    placed.update(c.name for c in self._node_columns(n))
+                    placed.update(c.name for c in self._node_columns(n, spec))
                     remaining.remove(n)
                     progressed = True
             if not progressed:
@@ -365,14 +384,60 @@ class HyperTable:
     def _stored_values(self, row: dict[str, Any]) -> dict[str, Any]:
         return {k: _normalize_value(v) for k, v in row.items() if not is_internal_column(k)}
 
-    def _node_is_fresh(self, node: Any, prov: str, existing: dict[str, Any]) -> bool:
-        return all(existing.get(f"_provenance_{c.name}") == prov and not self._column_is_null(existing.get(c.name)) for c in self._node_columns(node))
+    def _node_is_fresh(self, node: Any, prov: str, existing: dict[str, Any], spec: TableSpec | None = None) -> bool:
+        return all(
+            existing.get(f"_provenance_{c.name}") == prov and not self._column_is_null(existing.get(c.name)) for c in self._node_columns(node, spec)
+        )
 
-    def _reconcile_columns(self, item: dict[str, Any], existing: dict[str, Any]) -> tuple[dict[str, Any], dict[str, str]] | None:
+    def _boundary_node(self, child_spec: TableSpec) -> Any:
+        """The root-graph node whose output is the child spec's mapped-items list."""
+        if not child_spec.map_input:
+            return None
+        nodes_dict = self._graph.nodes if isinstance(self._graph.nodes, dict) else {}
+        for n in nodes_dict.values():
+            if child_spec.map_input in (n.data_outputs if hasattr(n, "data_outputs") else ()):
+                return n
+        return None
+
+    def _stored_child_count(self, child_spec: TableSpec, parent_id: Any) -> int:
+        rows = self._store.read_rows(child_spec.name, [("_parent_id", "eq", parent_id)])
+        return len(_dedup_child_rows(rows, child_spec.identity))
+
+    def _boundary_provenance_value(self, prov: str, items: Any) -> str:
+        """Stored boundary provenance: recipe hash + how many items it produced.
+
+        The count is checked against the stored child rows on reconcile, so a
+        lost child row (crash leftover) forces the boundary node to re-run.
+        """
+        count = len(items) if isinstance(items, list) else 0
+        return f"{prov}#{count}"
+
+    def _boundary_freshness(
+        self, child_spec: TableSpec, item: dict[str, Any], existing: dict[str, Any], values: dict[str, Any]
+    ) -> tuple[Any, str, Any, bool] | None:
+        """Decide whether stored child rows can stand in for a boundary-node run.
+
+        Returns ``(boundary_node, provenance, stored_value, fresh)``, or None when
+        the boundary can't be reconciled column-scoped (full-run fallback).
+        """
+        bnode = self._boundary_node(child_spec)
+        if bnode is None or any(c.produced_by is bnode for c in self._derived_columns()):
+            return None
+        prov = self._node_provenance(bnode, values)
+        if prov is None:
+            return None
+        stored = existing.get(f"_provenance_{child_spec.map_input}")
+        stored_prov, stored_count = _split_boundary_provenance(stored)
+        fresh = stored_prov == prov and stored_count == self._stored_child_count(child_spec, item[self._identity])
+        return bnode, prov, stored, fresh
+
+    def _reconcile_columns(self, item: dict[str, Any], existing: dict[str, Any]) -> tuple[dict[str, Any], dict[str, str], dict[str, Any]] | None:
         """Column-scoped upsert: reuse fresh columns, re-derive stale ones from stored upstream values.
 
-        Returns (outputs, provenances), or None when a required input is
-        unavailable — the caller falls back to a full graph run.
+        Returns (outputs, provenances, child_plan), or None when a required input
+        is unavailable — the caller falls back to a full graph run. A child_plan
+        entry of None means: rebuild the mapped items from stored child rows
+        instead of re-running the boundary node.
         """
         values = self._stored_values(existing)
         values.update({k: v for k, v in item.items() if k != self._identity})
@@ -391,9 +456,25 @@ class HyperTable:
                     outputs[c.name] = node_outputs[c.name]
                     values[c.name] = node_outputs[c.name]
                 provenances[c.name] = prov
-        return outputs, provenances
+        child_plan: dict[str, Any] = {}
+        for child_spec in self._spec.children:
+            state = self._boundary_freshness(child_spec, item, existing, values)
+            if state is None:
+                return None
+            bnode, prov, stored, fresh = state
+            if fresh:
+                provenances[child_spec.map_input] = stored
+                child_plan[child_spec.name] = None
+            else:
+                items = self._run_column_node(bnode, values).get(child_spec.map_input)
+                items = items if isinstance(items, list) else []
+                provenances[child_spec.map_input] = self._boundary_provenance_value(prov, items)
+                child_plan[child_spec.name] = items
+        return outputs, provenances, child_plan
 
-    async def _reconcile_columns_async(self, item: dict[str, Any], existing: dict[str, Any]) -> tuple[dict[str, Any], dict[str, str]] | None:
+    async def _reconcile_columns_async(
+        self, item: dict[str, Any], existing: dict[str, Any]
+    ) -> tuple[dict[str, Any], dict[str, str], dict[str, Any]] | None:
         """Async twin of ``_reconcile_columns`` — identical except the awaited node runs."""
         values = self._stored_values(existing)
         values.update({k: v for k, v in item.items() if k != self._identity})
@@ -412,7 +493,22 @@ class HyperTable:
                     outputs[c.name] = node_outputs[c.name]
                     values[c.name] = node_outputs[c.name]
                 provenances[c.name] = prov
-        return outputs, provenances
+        child_plan: dict[str, Any] = {}
+        for child_spec in self._spec.children:
+            state = self._boundary_freshness(child_spec, item, existing, values)
+            if state is None:
+                return None
+            bnode, prov, stored, fresh = state
+            if fresh:
+                provenances[child_spec.map_input] = stored
+                child_plan[child_spec.name] = None
+            else:
+                boundary_outputs = await self._run_column_node_async(bnode, values)
+                items = boundary_outputs.get(child_spec.map_input)
+                items = items if isinstance(items, list) else []
+                provenances[child_spec.map_input] = self._boundary_provenance_value(prov, items)
+                child_plan[child_spec.name] = items
+        return outputs, provenances, child_plan
 
     def _row_converged(self, row: dict[str, Any]) -> bool:
         """All derived columns present with provenance matching the current recipe."""
@@ -477,23 +573,25 @@ class HyperTable:
             **root,
         )
 
-    def _count_stale_columns(self, row: dict[str, Any], counts: dict[str, int]) -> None:
+    def _count_stale_columns(self, row: dict[str, Any], counts: dict[str, int], spec: TableSpec | None = None) -> None:
         """Attribute a stale row to the specific columns whose provenance no longer matches."""
         values = self._stored_values(row)
-        for node in self._nodes_in_dependency_order():
+        for node in self._nodes_in_dependency_order(spec):
             prov = self._node_provenance(node, values)
-            for c in self._node_columns(node):
+            for c in self._node_columns(node, spec):
                 if prov is None or self._column_is_null(row.get(c.name)) or row.get(f"_provenance_{c.name}") != prov:
                     counts[c.name] = counts.get(c.name, 0) + 1
 
     def _child_status(self, child_spec: TableSpec) -> TableStatus:
         rows = _dedup_child_rows(self._store.read_rows(child_spec.name), child_spec.identity)
+        stale_column_counts: dict[str, int] = {}
         counts = self._classify_rows(
             rows,
             identity=child_spec.identity,
             fingerprint_of=lambda row: self._compute_child_fingerprint(self._child_source_inputs_from_row(row, child_spec), child_spec),
+            on_stale=lambda row: self._count_stale_columns(row, stale_column_counts, spec=child_spec),
         )
-        return TableStatus(table=child_spec.name, **counts)
+        return TableStatus(table=child_spec.name, stale_columns=tuple(sorted(stale_column_counts.items())), **counts)
 
     def _classify_rows(self, rows: list[dict[str, Any]], *, identity: str, fingerprint_of: Any, on_stale: Any = None) -> dict[str, Any]:
         """Split stored rows into fresh / stale / errored for a status report."""
@@ -705,24 +803,70 @@ class HyperTable:
                 [("_parent_id", "eq", identity_value), ("_write_gen", "lt", write_gen)],
             )
 
-    def _can_reconcile(self, existing: dict[str, Any] | None, parent_skipped: bool) -> bool:
-        """Column-scoped reconcile applies to complete prior rows of childless tables."""
-        return existing is not None and not parent_skipped and not self._spec.children and existing.get("_status") != "error"
+    def _can_reconcile(self, existing: dict[str, Any] | None) -> bool:
+        """Column-scoped reconcile applies to any complete (non-error) prior row."""
+        return existing is not None and existing.get("_status") != "error"
 
-    def _write_reconciled_row(
+    def _apply_reconciled(
         self,
         item: dict[str, Any],
         graph_inputs: dict[str, Any],
-        reconciled: tuple[dict[str, Any], dict[str, str]],
+        existing: dict[str, Any],
+        reconciled: tuple[dict[str, Any], dict[str, str], dict[str, Any]],
+        parent_skipped: bool,
         write_gen: int,
-    ) -> None:
-        outputs, provenances = reconciled
-        self._evolve_for_metadata(item)
-        row = self._build_row(item, graph_inputs, outputs, write_gen, provenances=provenances)
-        row["_status"] = "complete"
-        row["_error"] = None
-        self._store.write_rows(self._spec.name, [row])
-        self._cleanup_old_parent_gens(item[self._identity], write_gen)
+    ) -> str:
+        """Persist a reconciled row: children first, then the parent row that vouches for them.
+
+        The parent row is rewritten only when it changed (or when a provenance
+        column must be persisted for a pre-provenance row); a skipped parent's
+        stored row is left untouched so its old generation is never cleaned away.
+        """
+        outputs, provenances, child_plan = reconciled
+        identity_value = item[self._identity]
+        for child_spec in self._spec.children:
+            items = child_plan.get(child_spec.name)
+            if items is None:
+                items = self._rebuild_child_items(child_spec, identity_value)
+            self._insert_children_items(identity_value, items, child_spec, write_gen)
+        prov_changed = any(existing.get(f"_provenance_{name}") != prov for name, prov in provenances.items())
+        if not parent_skipped or prov_changed:
+            self._evolve_for_metadata(item)
+            row = self._build_row(item, graph_inputs, outputs, write_gen, provenances=provenances)
+            row["_status"] = "complete"
+            row["_error"] = None
+            self._store.write_rows(self._spec.name, [row])
+            self._cleanup_old_parent_gens(identity_value, write_gen)
+        self._cleanup_old_child_gens(identity_value, write_gen)
+        return "skipped" if parent_skipped else "updated"
+
+    async def _apply_reconciled_async(
+        self,
+        item: dict[str, Any],
+        graph_inputs: dict[str, Any],
+        existing: dict[str, Any],
+        reconciled: tuple[dict[str, Any], dict[str, str], dict[str, Any]],
+        parent_skipped: bool,
+        write_gen: int,
+    ) -> str:
+        """Async twin of ``_apply_reconciled`` — identical except the awaited child runs."""
+        outputs, provenances, child_plan = reconciled
+        identity_value = item[self._identity]
+        for child_spec in self._spec.children:
+            items = child_plan.get(child_spec.name)
+            if items is None:
+                items = self._rebuild_child_items(child_spec, identity_value)
+            await self._insert_children_items_async(identity_value, items, child_spec, write_gen)
+        prov_changed = any(existing.get(f"_provenance_{name}") != prov for name, prov in provenances.items())
+        if not parent_skipped or prov_changed:
+            self._evolve_for_metadata(item)
+            row = self._build_row(item, graph_inputs, outputs, write_gen, provenances=provenances)
+            row["_status"] = "complete"
+            row["_error"] = None
+            self._store.write_rows(self._spec.name, [row])
+            self._cleanup_old_parent_gens(identity_value, write_gen)
+        self._cleanup_old_child_gens(identity_value, write_gen)
+        return "skipped" if parent_skipped else "updated"
 
     def _insert_one(self, item: dict[str, Any], write_gen: int) -> str:
         """Insert or upsert a single row. Returns 'inserted', 'updated', 'skipped', or 'errored'."""
@@ -732,17 +876,21 @@ class HyperTable:
         if parent_skipped and not self._spec.children:
             return "skipped"
 
-        if self._can_reconcile(existing, parent_skipped):
+        if self._can_reconcile(existing):
             try:
                 reconciled = self._reconcile_columns(item, existing)
             except Exception as e:
                 if self._on_error == "raise":
                     raise
+                if parent_skipped:
+                    # Parent is complete and unchanged; a transient failure while
+                    # reconciling solely for the children must not downgrade the
+                    # stored-complete parent to an error row.
+                    return "skipped"
                 self._write_error_row(item, graph_inputs, write_gen, e, existing)
                 return "errored"
             if reconciled is not None:
-                self._write_reconciled_row(item, graph_inputs, reconciled, write_gen)
-                return "updated"
+                return self._apply_reconciled(item, graph_inputs, existing, reconciled, parent_skipped, write_gen)
 
         try:
             outputs = self._extract_outputs(self._runner.run(self._graph, **graph_inputs))
@@ -764,9 +912,11 @@ class HyperTable:
             self._cleanup_old_child_gens(identity_value, write_gen)
             return "skipped"
 
-        self._write_parent_row(item, graph_inputs, outputs, write_gen)
+        # Children before the parent row: the parent row carries the boundary
+        # provenance that vouches for the stored child set, so it must land last.
         for child_spec in self._spec.children:
             self._insert_children(identity_value, outputs, child_spec, write_gen)
+        self._write_parent_row(item, graph_inputs, outputs, write_gen)
         if existing is not None:
             self._cleanup_old_parent_gens(identity_value, write_gen)
             self._cleanup_old_child_gens(identity_value, write_gen)
@@ -780,17 +930,21 @@ class HyperTable:
         if parent_skipped and not self._spec.children:
             return "skipped"
 
-        if self._can_reconcile(existing, parent_skipped):
+        if self._can_reconcile(existing):
             try:
                 reconciled = await self._reconcile_columns_async(item, existing)
             except Exception as e:
                 if self._on_error == "raise":
                     raise
+                if parent_skipped:
+                    # Parent is complete and unchanged; a transient failure while
+                    # reconciling solely for the children must not downgrade the
+                    # stored-complete parent to an error row.
+                    return "skipped"
                 self._write_error_row(item, graph_inputs, write_gen, e, existing)
                 return "errored"
             if reconciled is not None:
-                self._write_reconciled_row(item, graph_inputs, reconciled, write_gen)
-                return "updated"
+                return await self._apply_reconciled_async(item, graph_inputs, existing, reconciled, parent_skipped, write_gen)
 
         try:
             outputs = self._extract_outputs(await self._runner.run(self._graph, **graph_inputs))
@@ -811,9 +965,11 @@ class HyperTable:
             self._cleanup_old_child_gens(identity_value, write_gen)
             return "skipped"
 
-        self._write_parent_row(item, graph_inputs, outputs, write_gen)
+        # Children before the parent row: the parent row carries the boundary
+        # provenance that vouches for the stored child set, so it must land last.
         for child_spec in self._spec.children:
             await self._insert_children_async(identity_value, outputs, child_spec, write_gen)
+        self._write_parent_row(item, graph_inputs, outputs, write_gen)
         if existing is not None:
             self._cleanup_old_parent_gens(identity_value, write_gen)
             self._cleanup_old_child_gens(identity_value, write_gen)
@@ -837,8 +993,8 @@ class HyperTable:
 
     def _plan_child(
         self, child_spec: TableSpec, child_item: dict[str, Any], parent_id: str, write_gen: int
-    ) -> tuple[str, dict[str, Any], str] | None:
-        """Compute ``(child_identity, child_inputs, fingerprint)`` for a child item.
+    ) -> tuple[str, dict[str, Any], str, dict[str, Any] | None] | None:
+        """Compute ``(child_identity, child_inputs, fingerprint, existing_child)`` for a child item.
 
         If the child is unchanged and complete, bump its ``_write_gen`` so it
         survives cleanup and return None to signal a skip.
@@ -861,7 +1017,7 @@ class HyperTable:
                 bumped["_write_gen"] = write_gen
                 self._store.write_rows(child_spec.name, [bumped])
                 return None
-        return child_identity, child_inputs, new_fingerprint
+        return child_identity, child_inputs, new_fingerprint, existing_child
 
     def _child_row(
         self,
@@ -875,6 +1031,7 @@ class HyperTable:
         status: str,
         error: str | None,
         outputs: dict[str, Any] | None = None,
+        provenances: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         """Assemble a child row from its source item plus (on success) its derived outputs."""
         row = {
@@ -890,11 +1047,128 @@ class HyperTable:
                 row[k] = v
         for k, v in (outputs or {}).items():
             row[k] = v
+        for name, prov in (provenances or {}).items():
+            row[f"_provenance_{name}"] = prov
         return row
+
+    def _child_provenances(self, child_spec: TableSpec, values: dict[str, Any]) -> dict[str, str]:
+        """Per-column provenance for a child row, from the inner graph's nodes."""
+        provenances: dict[str, str] = {}
+        for node in self._nodes_in_dependency_order(child_spec):
+            prov = self._node_provenance(node, values)
+            for c in self._node_columns(node, child_spec):
+                provenances[c.name] = prov
+        return provenances
+
+    def _rebuild_child_items(self, child_spec: TableSpec, parent_id: str) -> list[dict[str, Any]]:
+        """Reconstruct the mapped items from stored child rows (source + metadata columns).
+
+        Error child rows are included — their source columns are preserved — so
+        they naturally retry.
+        """
+        rows = _dedup_child_rows(
+            self._store.read_rows(child_spec.name, [("_parent_id", "eq", parent_id)]),
+            child_spec.identity,
+        )
+        derived = {c.name for c in child_spec.columns if c.role == "derived"}
+        return [
+            {k: _normalize_value(v) for k, v in row.items() if k not in derived and k != "_parent_id" and not is_internal_column(k)} for row in rows
+        ]
+
+    def _reconcile_child_row(
+        self,
+        child_spec: TableSpec,
+        child_item: dict[str, Any],
+        existing_child: dict[str, Any],
+        parent_id: str,
+        new_fingerprint: str,
+        write_gen: int,
+    ) -> dict[str, Any] | None:
+        """Column-scoped child upsert: reuse fresh columns, re-derive stale ones.
+
+        Returns the new child row, or None when a required input is unavailable —
+        the caller falls back to a full child-graph run.
+        """
+        values = self._stored_values(existing_child)
+        values.update(child_item)
+        outputs: dict[str, Any] = {}
+        provenances: dict[str, str] = {}
+        for node in self._nodes_in_dependency_order(child_spec):
+            prov = self._node_provenance(node, values)
+            if prov is None:
+                return None
+            if self._node_is_fresh(node, prov, existing_child, child_spec):
+                node_outputs = {c.name: _normalize_value(existing_child[c.name]) for c in self._node_columns(node, child_spec)}
+            else:
+                node_outputs = self._run_column_node(node, values)
+            for c in self._node_columns(node, child_spec):
+                if c.name in node_outputs:
+                    outputs[c.name] = node_outputs[c.name]
+                    values[c.name] = node_outputs[c.name]
+                provenances[c.name] = prov
+        child_identity = child_item.get(child_spec.identity, "")
+        return self._child_row(
+            child_spec,
+            child_item,
+            child_identity,
+            parent_id,
+            new_fingerprint,
+            write_gen,
+            status="complete",
+            error=None,
+            outputs=outputs,
+            provenances=provenances,
+        )
+
+    async def _reconcile_child_row_async(
+        self,
+        child_spec: TableSpec,
+        child_item: dict[str, Any],
+        existing_child: dict[str, Any],
+        parent_id: str,
+        new_fingerprint: str,
+        write_gen: int,
+    ) -> dict[str, Any] | None:
+        """Async twin of ``_reconcile_child_row`` — identical except the awaited node runs."""
+        values = self._stored_values(existing_child)
+        values.update(child_item)
+        outputs: dict[str, Any] = {}
+        provenances: dict[str, str] = {}
+        for node in self._nodes_in_dependency_order(child_spec):
+            prov = self._node_provenance(node, values)
+            if prov is None:
+                return None
+            if self._node_is_fresh(node, prov, existing_child, child_spec):
+                node_outputs = {c.name: _normalize_value(existing_child[c.name]) for c in self._node_columns(node, child_spec)}
+            else:
+                node_outputs = await self._run_column_node_async(node, values)
+            for c in self._node_columns(node, child_spec):
+                if c.name in node_outputs:
+                    outputs[c.name] = node_outputs[c.name]
+                    values[c.name] = node_outputs[c.name]
+                provenances[c.name] = prov
+        child_identity = child_item.get(child_spec.identity, "")
+        return self._child_row(
+            child_spec,
+            child_item,
+            child_identity,
+            parent_id,
+            new_fingerprint,
+            write_gen,
+            status="complete",
+            error=None,
+            outputs=outputs,
+            provenances=provenances,
+        )
 
     def _insert_children(self, parent_id: str, outputs: dict, child_spec: TableSpec, write_gen: int) -> None:
         child_items = self._child_items(outputs, child_spec)
         if child_items is None:
+            return
+        self._insert_children_items(parent_id, child_items, child_spec, write_gen)
+
+    def _insert_children_items(self, parent_id: str, child_items: list, child_spec: TableSpec, write_gen: int) -> None:
+        if child_spec.child_graph is None:
             return
         bound_graph = self._bind_child_components(child_spec.child_graph)
         for raw_item in child_items:
@@ -902,46 +1176,125 @@ class HyperTable:
             plan = self._plan_child(child_spec, child_item, parent_id, write_gen)
             if plan is None:
                 continue
-            child_identity, child_inputs, new_fingerprint = plan
-            try:
-                child_outputs = self._extract_outputs(self._runner.run(bound_graph, **child_inputs))
-            except Exception as e:
-                if self._on_error == "raise":
-                    raise
+            child_identity, child_inputs, new_fingerprint, existing_child = plan
+            row = None
+            if existing_child is not None and existing_child.get("_status") in (None, "complete"):
+                try:
+                    row = self._reconcile_child_row(child_spec, child_item, existing_child, parent_id, new_fingerprint, write_gen)
+                except Exception as e:
+                    if self._on_error == "raise":
+                        raise
+                    row = self._child_row(
+                        child_spec,
+                        child_item,
+                        child_identity,
+                        parent_id,
+                        new_fingerprint,
+                        write_gen,
+                        status="error",
+                        error=f"{type(e).__name__}: {e}",
+                    )
+                    self._store.write_rows(child_spec.name, [row])
+                    continue
+            if row is None:
+                try:
+                    child_outputs = self._extract_outputs(self._runner.run(bound_graph, **child_inputs))
+                except Exception as e:
+                    if self._on_error == "raise":
+                        raise
+                    row = self._child_row(
+                        child_spec,
+                        child_item,
+                        child_identity,
+                        parent_id,
+                        new_fingerprint,
+                        write_gen,
+                        status="error",
+                        error=f"{type(e).__name__}: {e}",
+                    )
+                    self._store.write_rows(child_spec.name, [row])
+                    continue
+                child_values = {**child_item, **child_outputs}
                 row = self._child_row(
-                    child_spec, child_item, child_identity, parent_id, new_fingerprint, write_gen, status="error", error=f"{type(e).__name__}: {e}"
+                    child_spec,
+                    child_item,
+                    child_identity,
+                    parent_id,
+                    new_fingerprint,
+                    write_gen,
+                    status="complete",
+                    error=None,
+                    outputs=child_outputs,
+                    provenances=self._child_provenances(child_spec, child_values),
                 )
-                self._store.write_rows(child_spec.name, [row])
-                continue
-            row = self._child_row(
-                child_spec, child_item, child_identity, parent_id, new_fingerprint, write_gen, status="complete", error=None, outputs=child_outputs
-            )
             self._store.write_rows(child_spec.name, [row])
 
     async def _insert_children_async(self, parent_id: str, outputs: dict, child_spec: TableSpec, write_gen: int) -> None:
         child_items = self._child_items(outputs, child_spec)
         if child_items is None:
             return
+        await self._insert_children_items_async(parent_id, child_items, child_spec, write_gen)
+
+    async def _insert_children_items_async(self, parent_id: str, child_items: list, child_spec: TableSpec, write_gen: int) -> None:
+        if child_spec.child_graph is None:
+            return
         bound_graph = self._bind_child_components(child_spec.child_graph)
         for raw_item in child_items:
             child_item = _normalize_to_dict(raw_item)
             plan = self._plan_child(child_spec, child_item, parent_id, write_gen)
             if plan is None:
                 continue
-            child_identity, child_inputs, new_fingerprint = plan
-            try:
-                child_outputs = self._extract_outputs(await self._runner.run(bound_graph, **child_inputs))
-            except Exception as e:
-                if self._on_error == "raise":
-                    raise
+            child_identity, child_inputs, new_fingerprint, existing_child = plan
+            row = None
+            if existing_child is not None and existing_child.get("_status") in (None, "complete"):
+                try:
+                    row = await self._reconcile_child_row_async(child_spec, child_item, existing_child, parent_id, new_fingerprint, write_gen)
+                except Exception as e:
+                    if self._on_error == "raise":
+                        raise
+                    row = self._child_row(
+                        child_spec,
+                        child_item,
+                        child_identity,
+                        parent_id,
+                        new_fingerprint,
+                        write_gen,
+                        status="error",
+                        error=f"{type(e).__name__}: {e}",
+                    )
+                    self._store.write_rows(child_spec.name, [row])
+                    continue
+            if row is None:
+                try:
+                    child_outputs = self._extract_outputs(await self._runner.run(bound_graph, **child_inputs))
+                except Exception as e:
+                    if self._on_error == "raise":
+                        raise
+                    row = self._child_row(
+                        child_spec,
+                        child_item,
+                        child_identity,
+                        parent_id,
+                        new_fingerprint,
+                        write_gen,
+                        status="error",
+                        error=f"{type(e).__name__}: {e}",
+                    )
+                    self._store.write_rows(child_spec.name, [row])
+                    continue
+                child_values = {**child_item, **child_outputs}
                 row = self._child_row(
-                    child_spec, child_item, child_identity, parent_id, new_fingerprint, write_gen, status="error", error=f"{type(e).__name__}: {e}"
+                    child_spec,
+                    child_item,
+                    child_identity,
+                    parent_id,
+                    new_fingerprint,
+                    write_gen,
+                    status="complete",
+                    error=None,
+                    outputs=child_outputs,
+                    provenances=self._child_provenances(child_spec, child_values),
                 )
-                self._store.write_rows(child_spec.name, [row])
-                continue
-            row = self._child_row(
-                child_spec, child_item, child_identity, parent_id, new_fingerprint, write_gen, status="complete", error=None, outputs=child_outputs
-            )
             self._store.write_rows(child_spec.name, [row])
 
     def update(self, identity_value: str, **changes: Any) -> Any:
@@ -983,53 +1336,58 @@ class HyperTable:
 
     def _update_sync(self, identity_value: str, **changes: Any) -> None:
         item, needs_rederive, write_gen = self._prepare_update(identity_value, changes)
-        if needs_rederive:
-            graph_inputs = self._extract_graph_inputs(item)
-            existing = self._store.read_one(self._spec.name, self._identity, identity_value)
-            if self._can_reconcile(existing, False):
-                reconciled = self._reconcile_columns(item, existing)
-                if reconciled is not None:
-                    self._write_reconciled_row(item, graph_inputs, reconciled, write_gen)
-                    return
-            outputs = self._extract_outputs(self._runner.run(self._graph, **graph_inputs))
-            self._evolve_for_metadata(item)
-            row = self._build_row(item, graph_inputs, outputs, write_gen)
-        else:
-            outputs = None
+        if not needs_rederive:
             row = self._row_with_changes(identity_value, changes, write_gen)
+            self._store.write_rows(self._spec.name, [row])
+            self._cleanup_old_parent_gens(identity_value, write_gen)
+            return
 
+        graph_inputs = self._extract_graph_inputs(item)
+        existing = self._store.read_one(self._spec.name, self._identity, identity_value)
+        if self._can_reconcile(existing):
+            reconciled = self._reconcile_columns(item, existing)
+            if reconciled is not None:
+                self._apply_reconciled(item, graph_inputs, existing, reconciled, parent_skipped=False, write_gen=write_gen)
+                return
+
+        outputs = self._extract_outputs(self._runner.run(self._graph, **graph_inputs))
+        self._evolve_for_metadata(item)
+        row = self._build_row(item, graph_inputs, outputs, write_gen)
+        # Write new children BEFORE the parent row and old-gen cleanup — crash-safe
+        # ordering: the parent row carries the boundary provenance that vouches
+        # for the stored child set.
+        for child_spec in self._spec.children:
+            self._insert_children(identity_value, outputs, child_spec, write_gen)
         self._store.write_rows(self._spec.name, [row])
-
-        if needs_rederive:
-            # Write new children BEFORE deleting old ones — crash-safe ordering.
-            for child_spec in self._spec.children:
-                self._insert_children(identity_value, outputs, child_spec, write_gen)
-            self._cleanup_old_child_gens(identity_value, write_gen)
+        self._cleanup_old_child_gens(identity_value, write_gen)
         self._cleanup_old_parent_gens(identity_value, write_gen)
 
     async def _update_async(self, identity_value: str, **changes: Any) -> None:
         item, needs_rederive, write_gen = self._prepare_update(identity_value, changes)
-        if needs_rederive:
-            graph_inputs = self._extract_graph_inputs(item)
-            existing = self._store.read_one(self._spec.name, self._identity, identity_value)
-            if self._can_reconcile(existing, False):
-                reconciled = await self._reconcile_columns_async(item, existing)
-                if reconciled is not None:
-                    self._write_reconciled_row(item, graph_inputs, reconciled, write_gen)
-                    return
-            outputs = self._extract_outputs(await self._runner.run(self._graph, **graph_inputs))
-            self._evolve_for_metadata(item)
-            row = self._build_row(item, graph_inputs, outputs, write_gen)
-        else:
-            outputs = None
+        if not needs_rederive:
             row = self._row_with_changes(identity_value, changes, write_gen)
+            self._store.write_rows(self._spec.name, [row])
+            self._cleanup_old_parent_gens(identity_value, write_gen)
+            return
 
+        graph_inputs = self._extract_graph_inputs(item)
+        existing = self._store.read_one(self._spec.name, self._identity, identity_value)
+        if self._can_reconcile(existing):
+            reconciled = await self._reconcile_columns_async(item, existing)
+            if reconciled is not None:
+                await self._apply_reconciled_async(item, graph_inputs, existing, reconciled, parent_skipped=False, write_gen=write_gen)
+                return
+
+        outputs = self._extract_outputs(await self._runner.run(self._graph, **graph_inputs))
+        self._evolve_for_metadata(item)
+        row = self._build_row(item, graph_inputs, outputs, write_gen)
+        # Write new children BEFORE the parent row and old-gen cleanup — crash-safe
+        # ordering: the parent row carries the boundary provenance that vouches
+        # for the stored child set.
+        for child_spec in self._spec.children:
+            await self._insert_children_async(identity_value, outputs, child_spec, write_gen)
         self._store.write_rows(self._spec.name, [row])
-
-        if needs_rederive:
-            for child_spec in self._spec.children:
-                await self._insert_children_async(identity_value, outputs, child_spec, write_gen)
-            self._cleanup_old_child_gens(identity_value, write_gen)
+        self._cleanup_old_child_gens(identity_value, write_gen)
         self._cleanup_old_parent_gens(identity_value, write_gen)
 
     def delete(self, identity_value: str) -> Any:

--- a/src/hypergraph/materialization/_hypertable.py
+++ b/src/hypergraph/materialization/_hypertable.py
@@ -2,21 +2,28 @@
 
 from __future__ import annotations
 
+import inspect
 import math
 from typing import Any
 
 from hypergraph import Graph
-from hypergraph.materialization._fingerprint import compute_child_fingerprint, compute_provenance, compute_row_fingerprint
+from hypergraph.materialization._fingerprint import (
+    _component_config_hashes,
+    compute_child_fingerprint,
+    compute_column_provenance,
+    compute_row_fingerprint,
+)
 from hypergraph.materialization._schema import (
     STATUS_COLUMNS,
     TableSpec,
     analyze_table,
     input_names,
     is_internal_column,
+    node_func,
     python_type_to_arrow,
     return_type,
 )
-from hypergraph.materialization._types import ErrorRow, SyncResult
+from hypergraph.materialization._types import ErrorRow, SyncResult, TableStatus
 
 
 def _normalize_to_dict(item: Any) -> dict[str, Any]:
@@ -113,6 +120,7 @@ class HyperTable:
         self._graph = _graph
         self._spec: TableSpec | None = None
         self._analyzed = False
+        self._column_graphs: dict[int, Any] = {}
 
     def bind(self, **components: Any) -> HyperTable:
         merged = {**self._components, **components}
@@ -203,6 +211,7 @@ class HyperTable:
         graph_inputs: dict[str, Any],
         outputs: dict[str, Any],
         write_gen: int,
+        provenances: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         identity_value = item[self._identity]
         row: dict[str, Any] = {self._identity: identity_value}
@@ -216,8 +225,11 @@ class HyperTable:
         row["_row_fingerprint"] = self._compute_row_fingerprint(graph_inputs)
         row["_write_gen"] = write_gen
 
+        if provenances is None:
+            values = {**{k: v for k, v in item.items() if k != self._identity}, **outputs}
+            provenances = {c.name: self._node_provenance(c.produced_by, values) for c in derived_cols}
         for col in derived_cols:
-            row[f"_provenance_{col.name}"] = compute_provenance(col.name, graph_inputs)
+            row[f"_provenance_{col.name}"] = provenances.get(col.name)
 
         return row
 
@@ -272,6 +284,146 @@ class HyperTable:
                 return return_type(c.produced_by)
         return str
 
+    # --- Per-column provenance (config-aware, value-chained) ---
+
+    def _derived_columns(self) -> list:
+        return [c for c in self._spec.columns if c.role == "derived"]
+
+    def _node_params(self, node: Any) -> Any:
+        return inspect.signature(node_func(node)).parameters
+
+    def _node_columns(self, node: Any) -> list:
+        return [c for c in self._derived_columns() if c.produced_by is node]
+
+    def _producing_node(self, column: str) -> Any:
+        for c in self._derived_columns():
+            if c.name == column:
+                return c.produced_by
+        raise KeyError(f"{column!r} is not a derived column")
+
+    def _nodes_in_dependency_order(self) -> list:
+        """Producing nodes ordered so every node's column inputs are produced before it."""
+        derived = self._derived_columns()
+        nodes: list = []
+        seen: set[int] = set()
+        for col in derived:
+            if id(col.produced_by) not in seen:
+                seen.add(id(col.produced_by))
+                nodes.append(col.produced_by)
+        derived_names = {c.name for c in derived}
+        placed: set[str] = set()
+        ordered: list = []
+        remaining = list(nodes)
+        while remaining:
+            progressed = False
+            for n in list(remaining):
+                deps = {p for p in self._node_params(n) if p in derived_names}
+                if deps <= placed:
+                    ordered.append(n)
+                    placed.update(c.name for c in self._node_columns(n))
+                    remaining.remove(n)
+                    progressed = True
+            if not progressed:
+                ordered.extend(remaining)
+                break
+        return ordered
+
+    def _node_provenance(self, node: Any, values: dict[str, Any]) -> str | None:
+        """Provenance for a node's output columns; None if a required input is unavailable."""
+        params = self._node_params(node)
+        comp = {k: v for k, v in self._components.items() if k in params}
+        inputs: dict[str, Any] = {}
+        for name, param in params.items():
+            if name in comp:
+                continue
+            if name in values:
+                inputs[name] = values[name]
+            elif param.default is inspect.Parameter.empty:
+                return None
+        return compute_column_provenance(node_func(node), inputs, _component_config_hashes(comp))
+
+    def _column_graph(self, node: Any) -> Any:
+        """A cached single-node graph for column-scoped execution."""
+        graph = self._column_graphs.get(id(node))
+        if graph is None:
+            graph = Graph([node], name=f"{self._spec.name}__{node_func(node).__name__}")
+            binds = {k: v for k, v in self._components.items() if k in set(graph.inputs.all)}
+            if binds:
+                graph = graph.bind(**binds)
+            self._column_graphs[id(node)] = graph
+        return graph
+
+    def _node_inputs(self, node: Any, values: dict[str, Any]) -> dict[str, Any]:
+        return {name: values[name] for name in self._node_params(node) if name not in self._components and name in values}
+
+    def _run_column_node(self, node: Any, values: dict[str, Any]) -> dict[str, Any]:
+        return self._extract_outputs(self._runner.run(self._column_graph(node), **self._node_inputs(node, values)))
+
+    async def _run_column_node_async(self, node: Any, values: dict[str, Any]) -> dict[str, Any]:
+        return self._extract_outputs(await self._runner.run(self._column_graph(node), **self._node_inputs(node, values)))
+
+    def _stored_values(self, row: dict[str, Any]) -> dict[str, Any]:
+        return {k: _normalize_value(v) for k, v in row.items() if not is_internal_column(k)}
+
+    def _node_is_fresh(self, node: Any, prov: str, existing: dict[str, Any]) -> bool:
+        return all(existing.get(f"_provenance_{c.name}") == prov and not self._column_is_null(existing.get(c.name)) for c in self._node_columns(node))
+
+    def _reconcile_columns(self, item: dict[str, Any], existing: dict[str, Any]) -> tuple[dict[str, Any], dict[str, str]] | None:
+        """Column-scoped upsert: reuse fresh columns, re-derive stale ones from stored upstream values.
+
+        Returns (outputs, provenances), or None when a required input is
+        unavailable — the caller falls back to a full graph run.
+        """
+        values = self._stored_values(existing)
+        values.update({k: v for k, v in item.items() if k != self._identity})
+        outputs: dict[str, Any] = {}
+        provenances: dict[str, str] = {}
+        for node in self._nodes_in_dependency_order():
+            prov = self._node_provenance(node, values)
+            if prov is None:
+                return None
+            if self._node_is_fresh(node, prov, existing):
+                node_outputs = {c.name: _normalize_value(existing[c.name]) for c in self._node_columns(node)}
+            else:
+                node_outputs = self._run_column_node(node, values)
+            for c in self._node_columns(node):
+                if c.name in node_outputs:
+                    outputs[c.name] = node_outputs[c.name]
+                    values[c.name] = node_outputs[c.name]
+                provenances[c.name] = prov
+        return outputs, provenances
+
+    async def _reconcile_columns_async(self, item: dict[str, Any], existing: dict[str, Any]) -> tuple[dict[str, Any], dict[str, str]] | None:
+        """Async twin of ``_reconcile_columns`` — identical except the awaited node runs."""
+        values = self._stored_values(existing)
+        values.update({k: v for k, v in item.items() if k != self._identity})
+        outputs: dict[str, Any] = {}
+        provenances: dict[str, str] = {}
+        for node in self._nodes_in_dependency_order():
+            prov = self._node_provenance(node, values)
+            if prov is None:
+                return None
+            if self._node_is_fresh(node, prov, existing):
+                node_outputs = {c.name: _normalize_value(existing[c.name]) for c in self._node_columns(node)}
+            else:
+                node_outputs = await self._run_column_node_async(node, values)
+            for c in self._node_columns(node):
+                if c.name in node_outputs:
+                    outputs[c.name] = node_outputs[c.name]
+                    values[c.name] = node_outputs[c.name]
+                provenances[c.name] = prov
+        return outputs, provenances
+
+    def _row_converged(self, row: dict[str, Any]) -> bool:
+        """All derived columns present with provenance matching the current recipe."""
+        values = self._stored_values(row)
+        for node in self._nodes_in_dependency_order():
+            prov = self._node_provenance(node, values)
+            for c in self._node_columns(node):
+                if prov is None or self._column_is_null(row.get(c.name)) or row.get(f"_provenance_{c.name}") != prov:
+                    return False
+        return True
+
     # --- Public API ---
 
     def visualize(self, *, include_children: bool = True, **kwargs) -> Any:
@@ -299,6 +451,79 @@ class HyperTable:
                     return len(_dedup_child_rows(self._store.read_rows(child.name), child.identity))
             return 0
         return len(_dedup_rows(self._store.read_rows(self._spec.name), self._identity))
+
+    def status(self) -> TableStatus:
+        """Report which stored rows would re-derive if sync ran now, without deriving anything.
+
+        Read-only and runner-free: recomputes each row's fingerprint from its
+        stored source values plus the *current* node code and component configs,
+        and compares it with the fingerprint stored when the row was written.
+        Child tables are checked with their scoped child fingerprints.
+        """
+        self._ensure_analyzed()
+        rows = _dedup_rows(self._store.read_rows(self._spec.name), self._identity)
+        stale_column_counts: dict[str, int] = {}
+        root = self._classify_rows(
+            rows,
+            identity=self._identity,
+            fingerprint_of=lambda row: self._compute_row_fingerprint(self._source_inputs_from_row(row)),
+            on_stale=lambda row: self._count_stale_columns(row, stale_column_counts),
+        )
+        children = tuple(self._child_status(child_spec) for child_spec in self._spec.children)
+        return TableStatus(
+            table=self._spec.name,
+            children=children,
+            stale_columns=tuple(sorted(stale_column_counts.items())),
+            **root,
+        )
+
+    def _count_stale_columns(self, row: dict[str, Any], counts: dict[str, int]) -> None:
+        """Attribute a stale row to the specific columns whose provenance no longer matches."""
+        values = self._stored_values(row)
+        for node in self._nodes_in_dependency_order():
+            prov = self._node_provenance(node, values)
+            for c in self._node_columns(node):
+                if prov is None or self._column_is_null(row.get(c.name)) or row.get(f"_provenance_{c.name}") != prov:
+                    counts[c.name] = counts.get(c.name, 0) + 1
+
+    def _child_status(self, child_spec: TableSpec) -> TableStatus:
+        rows = _dedup_child_rows(self._store.read_rows(child_spec.name), child_spec.identity)
+        counts = self._classify_rows(
+            rows,
+            identity=child_spec.identity,
+            fingerprint_of=lambda row: self._compute_child_fingerprint(self._child_source_inputs_from_row(row, child_spec), child_spec),
+        )
+        return TableStatus(table=child_spec.name, **counts)
+
+    def _classify_rows(self, rows: list[dict[str, Any]], *, identity: str, fingerprint_of: Any, on_stale: Any = None) -> dict[str, Any]:
+        """Split stored rows into fresh / stale / errored for a status report."""
+        fresh = stale = errored = 0
+        stale_ids: list[str] = []
+        errored_ids: list[str] = []
+        for row in rows:
+            id_val = str(row.get(identity, ""))
+            if row.get("_status") == "error":
+                errored += 1
+                errored_ids.append(id_val)
+            elif row.get("_row_fingerprint") == fingerprint_of(row):
+                fresh += 1
+            else:
+                stale += 1
+                stale_ids.append(id_val)
+                if on_stale is not None:
+                    on_stale(row)
+        return {
+            "total": len(rows),
+            "fresh": fresh,
+            "stale": stale,
+            "errored": errored,
+            "stale_ids": tuple(sorted(stale_ids)),
+            "errored_ids": tuple(sorted(errored_ids)),
+        }
+
+    def _child_source_inputs_from_row(self, row: dict[str, Any], child_spec: TableSpec) -> dict[str, Any]:
+        """Reconstruct a child's content-key inputs from its stored row (mirrors _plan_child)."""
+        return {c.name: _normalize_value(row[c.name]) for c in child_spec.columns if c.role == "source" and c.content_key and c.name in row}
 
     def get(self, identity_value: str, *, include_status: bool = False) -> dict[str, Any] | None:
         self._ensure_analyzed()
@@ -480,6 +705,25 @@ class HyperTable:
                 [("_parent_id", "eq", identity_value), ("_write_gen", "lt", write_gen)],
             )
 
+    def _can_reconcile(self, existing: dict[str, Any] | None, parent_skipped: bool) -> bool:
+        """Column-scoped reconcile applies to complete prior rows of childless tables."""
+        return existing is not None and not parent_skipped and not self._spec.children and existing.get("_status") != "error"
+
+    def _write_reconciled_row(
+        self,
+        item: dict[str, Any],
+        graph_inputs: dict[str, Any],
+        reconciled: tuple[dict[str, Any], dict[str, str]],
+        write_gen: int,
+    ) -> None:
+        outputs, provenances = reconciled
+        self._evolve_for_metadata(item)
+        row = self._build_row(item, graph_inputs, outputs, write_gen, provenances=provenances)
+        row["_status"] = "complete"
+        row["_error"] = None
+        self._store.write_rows(self._spec.name, [row])
+        self._cleanup_old_parent_gens(item[self._identity], write_gen)
+
     def _insert_one(self, item: dict[str, Any], write_gen: int) -> str:
         """Insert or upsert a single row. Returns 'inserted', 'updated', 'skipped', or 'errored'."""
         identity_value = item[self._identity]
@@ -487,6 +731,18 @@ class HyperTable:
         existing, parent_skipped = self._plan_insert(item, graph_inputs)
         if parent_skipped and not self._spec.children:
             return "skipped"
+
+        if self._can_reconcile(existing, parent_skipped):
+            try:
+                reconciled = self._reconcile_columns(item, existing)
+            except Exception as e:
+                if self._on_error == "raise":
+                    raise
+                self._write_error_row(item, graph_inputs, write_gen, e, existing)
+                return "errored"
+            if reconciled is not None:
+                self._write_reconciled_row(item, graph_inputs, reconciled, write_gen)
+                return "updated"
 
         try:
             outputs = self._extract_outputs(self._runner.run(self._graph, **graph_inputs))
@@ -523,6 +779,18 @@ class HyperTable:
         existing, parent_skipped = self._plan_insert(item, graph_inputs)
         if parent_skipped and not self._spec.children:
             return "skipped"
+
+        if self._can_reconcile(existing, parent_skipped):
+            try:
+                reconciled = await self._reconcile_columns_async(item, existing)
+            except Exception as e:
+                if self._on_error == "raise":
+                    raise
+                self._write_error_row(item, graph_inputs, write_gen, e, existing)
+                return "errored"
+            if reconciled is not None:
+                self._write_reconciled_row(item, graph_inputs, reconciled, write_gen)
+                return "updated"
 
         try:
             outputs = self._extract_outputs(await self._runner.run(self._graph, **graph_inputs))
@@ -717,6 +985,12 @@ class HyperTable:
         item, needs_rederive, write_gen = self._prepare_update(identity_value, changes)
         if needs_rederive:
             graph_inputs = self._extract_graph_inputs(item)
+            existing = self._store.read_one(self._spec.name, self._identity, identity_value)
+            if self._can_reconcile(existing, False):
+                reconciled = self._reconcile_columns(item, existing)
+                if reconciled is not None:
+                    self._write_reconciled_row(item, graph_inputs, reconciled, write_gen)
+                    return
             outputs = self._extract_outputs(self._runner.run(self._graph, **graph_inputs))
             self._evolve_for_metadata(item)
             row = self._build_row(item, graph_inputs, outputs, write_gen)
@@ -737,6 +1011,12 @@ class HyperTable:
         item, needs_rederive, write_gen = self._prepare_update(identity_value, changes)
         if needs_rederive:
             graph_inputs = self._extract_graph_inputs(item)
+            existing = self._store.read_one(self._spec.name, self._identity, identity_value)
+            if self._can_reconcile(existing, False):
+                reconciled = await self._reconcile_columns_async(item, existing)
+                if reconciled is not None:
+                    self._write_reconciled_row(item, graph_inputs, reconciled, write_gen)
+                    return
             outputs = self._extract_outputs(await self._runner.run(self._graph, **graph_inputs))
             self._evolve_for_metadata(item)
             row = self._build_row(item, graph_inputs, outputs, write_gen)
@@ -871,20 +1151,23 @@ class HyperTable:
         """Reconstruct graph inputs from a stored row's source columns."""
         return {c.name: _normalize_value(existing[c.name]) for c in self._spec.columns if c.role == "source" and c.name in existing}
 
-    def _persist_rederived_column(
-        self,
-        existing: dict[str, Any],
-        column: str,
-        graph_inputs: dict[str, Any],
-        outputs: dict[str, Any],
-        write_gen: int,
-    ) -> None:
-        """Write a new generation of one row with `column` re-derived, then drop the old one."""
+    def _persist_node_outputs(self, existing: dict[str, Any], node: Any, node_outputs: dict[str, Any], write_gen: int) -> None:
+        """Write a new generation of one row with the node's columns re-derived, then drop the old one.
+
+        The row fingerprint is refreshed only when every derived column now
+        matches the current recipe — a partially-current row must keep reporting
+        stale so the pending cascade stays visible.
+        """
         new_row = {k: _normalize_value(v) for k, v in existing.items()}
-        if column in outputs:
-            new_row[column] = outputs[column]
+        for c in self._node_columns(node):
+            if c.name in node_outputs:
+                new_row[c.name] = node_outputs[c.name]
+        prov = self._node_provenance(node, self._stored_values(new_row))
+        for c in self._node_columns(node):
+            new_row[f"_provenance_{c.name}"] = prov
         new_row["_write_gen"] = write_gen
-        new_row[f"_provenance_{column}"] = compute_provenance(column, graph_inputs)
+        if self._row_converged(new_row):
+            new_row["_row_fingerprint"] = self._compute_row_fingerprint(self._source_inputs_from_row(new_row))
 
         self._store.write_rows(self._spec.name, [new_row])
         self._store.delete_rows(
@@ -918,18 +1201,18 @@ class HyperTable:
         return self._recompute_sync(column)
 
     def _recompute_sync(self, column: str) -> None:
+        node = self._producing_node(column)
         write_gen = self._store.max_write_gen(self._spec.name) + 1
         for existing in _dedup_rows(self._store.read_rows(self._spec.name), self._identity):
-            graph_inputs = self._source_inputs_from_row(existing)
-            outputs = self._extract_outputs(self._runner.run(self._graph, **graph_inputs))
-            self._persist_rederived_column(existing, column, graph_inputs, outputs, write_gen)
+            node_outputs = self._run_column_node(node, self._stored_values(existing))
+            self._persist_node_outputs(existing, node, node_outputs, write_gen)
 
     async def _recompute_async(self, column: str) -> None:
+        node = self._producing_node(column)
         write_gen = self._store.max_write_gen(self._spec.name) + 1
         for existing in _dedup_rows(self._store.read_rows(self._spec.name), self._identity):
-            graph_inputs = self._source_inputs_from_row(existing)
-            outputs = self._extract_outputs(await self._runner.run(self._graph, **graph_inputs))
-            self._persist_rederived_column(existing, column, graph_inputs, outputs, write_gen)
+            node_outputs = await self._run_column_node_async(node, self._stored_values(existing))
+            self._persist_node_outputs(existing, node, node_outputs, write_gen)
 
     def backfill(self, column: str) -> Any:
         """Derive a new column for existing rows that have NULL."""
@@ -941,23 +1224,23 @@ class HyperTable:
 
     def _backfill_sync(self, column: str) -> None:
         self._evolve_for_backfill_column(column)
+        node = self._producing_node(column)
         write_gen = self._store.max_write_gen(self._spec.name) + 1
         for existing in _dedup_rows(self._store.read_rows(self._spec.name), self._identity):
             if not self._column_is_null(existing.get(column)):
                 continue
-            graph_inputs = self._source_inputs_from_row(existing)
-            outputs = self._extract_outputs(self._runner.run(self._graph, **graph_inputs))
-            self._persist_rederived_column(existing, column, graph_inputs, outputs, write_gen)
+            node_outputs = self._run_column_node(node, self._stored_values(existing))
+            self._persist_node_outputs(existing, node, node_outputs, write_gen)
 
     async def _backfill_async(self, column: str) -> None:
         self._evolve_for_backfill_column(column)
+        node = self._producing_node(column)
         write_gen = self._store.max_write_gen(self._spec.name) + 1
         for existing in _dedup_rows(self._store.read_rows(self._spec.name), self._identity):
             if not self._column_is_null(existing.get(column)):
                 continue
-            graph_inputs = self._source_inputs_from_row(existing)
-            outputs = self._extract_outputs(await self._runner.run(self._graph, **graph_inputs))
-            self._persist_rederived_column(existing, column, graph_inputs, outputs, write_gen)
+            node_outputs = await self._run_column_node_async(node, self._stored_values(existing))
+            self._persist_node_outputs(existing, node, node_outputs, write_gen)
 
     # --- Fingerprint and provenance ---
 

--- a/src/hypergraph/materialization/_hypertable.py
+++ b/src/hypergraph/materialization/_hypertable.py
@@ -11,6 +11,7 @@ from hypergraph.materialization._fingerprint import (
     _component_config_hashes,
     compute_child_fingerprint,
     compute_column_provenance,
+    compute_recipe_fingerprint,
     compute_row_fingerprint,
 )
 from hypergraph.materialization._schema import (
@@ -361,6 +362,12 @@ class HyperTable:
                 return None
         return compute_column_provenance(node_func(node), inputs, _component_config_hashes(comp))
 
+    def _node_recipe(self, node: Any) -> str:
+        """Recipe identity for a node: hash(node code + consumed component configs), no input values."""
+        params = self._node_params(node)
+        comp = {k: v for k, v in self._components.items() if k in params}
+        return compute_recipe_fingerprint(node_func(node), _component_config_hashes(comp))
+
     def _column_graph(self, node: Any) -> Any:
         """A cached single-node graph for column-scoped execution."""
         graph = self._column_graphs.get(id(node))
@@ -663,6 +670,120 @@ class HyperTable:
         rows = self._store.read_rows(child_spec.name, _where_predicate(where), limit=limit)
         rows = _dedup_child_rows(rows, child_spec.identity)
         return [_public_row(row, include_status=include_status) for row in rows]
+
+    # --- Named indexes (persisted query specs) ---
+    #
+    # An index is a projection, not a table: a named, persisted query spec over
+    # a vector column that already lives in the (root or child) table. The
+    # LanceDB store ANN-searches that column directly — no separate artifact.
+    # Materializing into external backends (Chroma, Azure Search) is an
+    # application-layer concern, out of scope here.
+
+    def _resolve_index_table(self, on: str | None) -> TableSpec:
+        if on is None or on == self._spec.name:
+            return self._spec
+        for cs in self._spec.children:
+            if cs.name == on:
+                return cs
+        known = [self._spec.name, *(cs.name for cs in self._spec.children)]
+        raise ValueError(f"unknown table {on!r} for index; expected one of {known}")
+
+    def _index_recipe_fingerprint(self, spec: TableSpec, vector: str) -> str | None:
+        """The component-config + node-definition basis of the vector column's producing node."""
+        for c in self._derived_columns(spec):
+            if c.name == vector and c.produced_by is not None:
+                return self._node_recipe(c.produced_by)
+        return None
+
+    def _index_queryable_columns(self, spec: TableSpec) -> set[str]:
+        """Columns an index may reference: spec columns plus physical (metadata-evolved) ones."""
+        columns = {c.name for c in spec.columns if c.role != "internal"}
+        physical = self._store.open(self._spec, self._spec.children).get(spec.name, [])
+        columns.update(name for name in physical if not is_internal_column(name))
+        return columns
+
+    def _load_indexes(self) -> dict[str, dict[str, Any]]:
+        manifest = self._store.load_manifest(self._spec.name) or {}
+        return dict(manifest.get("indexes", {}))
+
+    def _save_indexes(self, indexes: dict[str, dict[str, Any]]) -> None:
+        manifest = self._store.load_manifest(self._spec.name) or {}
+        manifest["indexes"] = indexes
+        self._store.save_manifest(self._spec.name, manifest)
+
+    def create_index(
+        self,
+        name: str,
+        *,
+        on: str | None = None,
+        rows: Any = None,
+        text: str | None = None,
+        vector: str | None = None,
+    ) -> dict[str, Any]:
+        """Record a named query spec: which table, which vector column, which row slice."""
+        self._ensure_analyzed()
+        spec = self._resolve_index_table(on)
+        if vector is None:
+            raise ValueError("create_index requires vector=<column>: v1 indexes are vector-search specs")
+        columns = self._index_queryable_columns(spec)
+        for label, col in (("vector", vector), ("text", text)):
+            if col is not None and col not in columns:
+                raise ValueError(f"{label} column {col!r} does not exist on table {spec.name!r}; known columns: {sorted(columns)}")
+        for col, _op, _val in _where_predicate(rows):
+            if col not in columns:
+                raise ValueError(f"rows filter column {col!r} does not exist on table {spec.name!r}; known columns: {sorted(columns)}")
+        index_spec = {
+            "name": name,
+            "on": spec.name,
+            "rows": rows,
+            "text": text,
+            "vector": vector,
+            "recipe_fingerprint": self._index_recipe_fingerprint(spec, vector),
+        }
+        indexes = self._load_indexes()
+        indexes[name] = index_spec
+        self._save_indexes(indexes)
+        return dict(index_spec)
+
+    def list_indexes(self) -> list[dict[str, Any]]:
+        """The persisted index specs, each with ``current``: does its recorded recipe match the recipe now?"""
+        self._ensure_analyzed()
+        specs = []
+        for index_spec in self._load_indexes().values():
+            spec = self._resolve_index_table(index_spec.get("on"))
+            now = self._index_recipe_fingerprint(spec, index_spec["vector"])
+            specs.append({**index_spec, "current": now == index_spec.get("recipe_fingerprint")})
+        return specs
+
+    def drop_index(self, name: str) -> None:
+        self._ensure_analyzed()
+        indexes = self._load_indexes()
+        if name not in indexes:
+            raise KeyError(f"no index named {name!r}")
+        del indexes[name]
+        self._save_indexes(indexes)
+
+    def search(self, query_vector: list[float], *, index: str, limit: int = 10, include_status: bool = False) -> list[dict[str, Any]]:
+        """Vector search through a named index: public rows plus a ``_distance`` field."""
+        self._ensure_analyzed()
+        indexes = self._load_indexes()
+        if index not in indexes:
+            raise KeyError(f"no index named {index!r}; known indexes: {sorted(indexes)}")
+        index_spec = indexes[index]
+        hits = self._store.search(
+            index_spec["on"],
+            query_vector=list(query_vector),
+            vector_column=index_spec["vector"],
+            where=_where_predicate(index_spec.get("rows")) or None,
+            limit=limit,
+        )
+        results = []
+        for row in hits:
+            distance = row.pop("_distance", None)
+            public = _public_row(row, include_status=include_status)
+            public["_distance"] = _normalize_value(distance)
+            results.append(public)
+        return results
 
     def set_children(self, where: Any = None, **fields: Any) -> int:
         """Bulk metadata update for child rows matching a predicate."""

--- a/src/hypergraph/materialization/_lancedb_store.py
+++ b/src/hypergraph/materialization/_lancedb_store.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import Any
 
 import lancedb
@@ -66,6 +68,7 @@ class LanceDBStore(TableStore):
     """LanceDB-backed TableStore implementation."""
 
     def __init__(self, path: str):
+        self._path = Path(path)
         self._db = lancedb.connect(path)
         self._tables: dict[str, Any] = {}
         self._schemas: dict[str, pa.Schema] = {}
@@ -163,6 +166,44 @@ class LanceDBStore(TableStore):
             return 0
         return pc.max(at.column("_write_gen")).as_py()
 
+    def search(
+        self,
+        table_name: str,
+        *,
+        query: str | None = None,
+        query_vector: list[float] | None = None,
+        vector_column: str | None = None,
+        where: RowPredicate | None = None,
+        limit: int | None = None,
+        **kwargs: Any,
+    ) -> list[dict[str, Any]]:
+        if query_vector is None:
+            raise ValueError("LanceDBStore.search requires query_vector (text-only search is not supported in v1)")
+        tbl = self._tables.get(table_name)
+        if tbl is None:
+            try:
+                tbl = self._db.open_table(table_name)
+            except Exception:
+                return []
+            self._tables[table_name] = tbl
+        q = tbl.search(list(query_vector), vector_column_name=vector_column)
+        if where:
+            q = q.where(_build_lance_filter(where), prefilter=True)
+        if limit is not None:
+            q = q.limit(limit)
+        return q.to_list()
+
+    def save_manifest(self, table_name: str, manifest: dict[str, Any]) -> None:
+        path = self._manifest_path(table_name)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(manifest, indent=2, sort_keys=True))
+
+    def load_manifest(self, table_name: str) -> dict[str, Any] | None:
+        path = self._manifest_path(table_name)
+        if not path.exists():
+            return None
+        return json.loads(path.read_text())
+
     def evolve_schema(self, table_name: str, new_columns: dict[str, pa.DataType]) -> list[str]:
         tbl = self._tables[table_name]
         existing_data = tbl.to_arrow()
@@ -178,6 +219,9 @@ class LanceDBStore(TableStore):
         return [f.name for f in new_schema]
 
     # --- Internal ---
+
+    def _manifest_path(self, table_name: str) -> Path:
+        return self._path / f"{table_name}__manifest.json"
 
     def _ensure_table(self, spec: TableSpec) -> None:
         try:

--- a/src/hypergraph/materialization/_schema.py
+++ b/src/hypergraph/materialization/_schema.py
@@ -162,10 +162,14 @@ def analyze_table(graph: Any, identity: str, components: dict[str, Any], map_ove
 
     derived_cols = [c for c in root_columns if c.role == "derived"]
     prov_cols = [_column(f"{PROVENANCE_PREFIX}{c.name}", role="internal") for c in derived_cols]
+    # One boundary provenance column per child spec: the recipe hash (+ item count)
+    # of the node producing the mapped items. The items list itself is never stored.
+    boundary_prov_cols = [_column(f"{PROVENANCE_PREFIX}{cs.map_input}", role="internal") for cs in child_specs if cs.map_input]
     final_columns = [
         *root_columns,
         _column("_row_fingerprint", role="internal"),
         *prov_cols,
+        *boundary_prov_cols,
         _column("_write_gen", role="internal", python_type=int),
         _column("_status", role="internal"),
         _column("_error", role="internal"),
@@ -195,6 +199,8 @@ def _analyze_map_over(map_node: Any, components: dict[str, Any]) -> TableSpec | 
             for out_name in n.data_outputs if hasattr(n, "data_outputs") else []:
                 _validate_column_name(out_name, "derived")
                 child_columns.append(_column(out_name, role="derived", produced_by=n, python_type=return_type(n)))
+        derived_child_cols = [c for c in child_columns if c.role == "derived"]
+        child_columns.extend(_column(f"{PROVENANCE_PREFIX}{c.name}", role="internal") for c in derived_child_cols)
 
     child_columns.extend(_internal_columns())
 

--- a/src/hypergraph/materialization/_table_store.py
+++ b/src/hypergraph/materialization/_table_store.py
@@ -54,8 +54,22 @@ class TableStore(ABC):
         conversion — the HyperTable layer does it once before calling here.
         """
 
-    def search(self, table_name: str, *, query: str, query_vector: list[float], **kwargs: Any) -> list[dict[str, Any]]:
-        """Search is optional because not every TableStore is a retrieval adapter."""
+    def search(
+        self,
+        table_name: str,
+        *,
+        query: str | None = None,
+        query_vector: list[float] | None = None,
+        vector_column: str | None = None,
+        where: RowPredicate | None = None,
+        limit: int | None = None,
+        **kwargs: Any,
+    ) -> list[dict[str, Any]]:
+        """Search is optional because not every TableStore is a retrieval adapter.
+
+        Implementations run a vector search on ``vector_column`` with ``where``
+        applied as a pre-filter, and include a ``_distance`` field per hit.
+        """
         raise NotImplementedError("This store does not support search")
 
     def save_manifest(self, table_name: str, manifest: dict[str, Any]) -> None:

--- a/src/hypergraph/materialization/_types.py
+++ b/src/hypergraph/materialization/_types.py
@@ -24,3 +24,29 @@ class SyncResult:
     skipped: int
     errored: int
     errors: tuple[ErrorRow, ...] = ()
+
+
+@dataclass(frozen=True)
+class TableStatus:
+    """Dry-run staleness report for one table, returned by status().
+
+    A row is stale when its stored fingerprint no longer matches
+    hash(stored source values + current node code + current component
+    configs) — the recipe or the content changed after the row was written.
+    Errored rows are reported separately; both re-derive on the next sync.
+    """
+
+    table: str
+    total: int
+    fresh: int
+    stale: int
+    errored: int
+    stale_ids: tuple[str, ...] = ()
+    errored_ids: tuple[str, ...] = ()
+    stale_columns: tuple[tuple[str, int], ...] = ()
+    children: tuple[TableStatus, ...] = ()
+
+    @property
+    def is_fresh(self) -> bool:
+        """True when no row here or in any child table would re-derive."""
+        return self.stale == 0 and self.errored == 0 and all(child.is_fresh for child in self.children)

--- a/src/hypergraph/nodes/_callable.py
+++ b/src/hypergraph/nodes/_callable.py
@@ -99,10 +99,12 @@ class CallableMixin:
         Returns:
             dict mapping parameter names (using current/renamed input names) to their
             type annotations. Only includes parameters that have annotations.
+            ``Annotated`` metadata (e.g. port metadata consumed by external
+            tools) is preserved; type checks already unwrap it.
             Returns empty dict if get_type_hints fails (e.g., forward references).
         """
         try:
-            hints = get_type_hints(self.func)
+            hints = get_type_hints(self.func, include_extras=True)
         except Exception:
             return {}
 

--- a/src/hypergraph/nodes/graph_node.py
+++ b/src/hypergraph/nodes/graph_node.py
@@ -667,9 +667,21 @@ class GraphNode(HyperNode):
                   equal-length lists. First values together, second together, etc.
                 - "product": Cartesian product. All combinations of values.
             error_handling: How to handle failures during map execution:
-                - "raise": Stop on first failure and raise the error (default).
-                - "continue": Collect all results; failed items become None
-                  placeholders to preserve list length.
+                - "raise": Stop on first failure and re-raise the original
+                  error (default). The parent graph run fails with that error.
+                - "continue": Run every iteration; for each failed item,
+                  EVERY output of this GraphNode gets a None placeholder at
+                  that item's position, preserving list length and alignment
+                  with the mapped inputs. The parent run completes normally,
+                  so downstream nodes receive lists that may contain None and
+                  must handle those entries:
+
+                      inner = Graph([double], name="inner")  # fails on x=3
+                      gn = inner.as_node().map_over("x", error_handling="continue")
+                      outer = Graph([gn, summarize])
+                      result = runner.run(outer, {"x": [1, 2, 3]})
+                      # summarize received doubled=[2, 4, None]
+                      # result.status is COMPLETED
             clone: Control deep-copying of broadcast (non-mapped) values per
                 iteration. Useful when nodes mutate broadcast inputs.
                 - False (default): share by reference (efficient, backward compatible)

--- a/src/hypergraph/runners/_shared/observability.py
+++ b/src/hypergraph/runners/_shared/observability.py
@@ -1,0 +1,45 @@
+"""Current-node-span context for external observability tools.
+
+While a node executes, the runner publishes the node's span identity in a
+``ContextVar``. Code that runs *inside* the node — an LLM client, a vector
+store, any instrumented component — can call :func:`current_node_span` to
+attribute its own telemetry (model calls, token usage, cache lookups) to the
+exact node span that triggered it, even when many nodes run concurrently.
+
+Zero coupling, mirroring ``cache_observer``: hypergraph knows nothing about
+the consumers; consumers soft-import this accessor and tolerate ``None``
+(no graph running, or a runner that does not publish spans).
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar, Token
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class NodeSpanRef:
+    """Identity of the node span currently executing in this context."""
+
+    run_id: str
+    span_id: str
+    node_name: str
+    graph_name: str
+
+
+_current_node_span: ContextVar[NodeSpanRef | None] = ContextVar("hypergraph_current_node_span", default=None)
+
+
+def current_node_span() -> NodeSpanRef | None:
+    """Return the span identity of the node executing in this context, if any."""
+    return _current_node_span.get()
+
+
+def set_current_node_span(ref: NodeSpanRef) -> Token:
+    """Publish the executing node's span (runner-internal); returns a reset token."""
+    return _current_node_span.set(ref)
+
+
+def reset_current_node_span(token: Token) -> None:
+    """Restore the previous span context (runner-internal)."""
+    _current_node_span.reset(token)

--- a/src/hypergraph/runners/async_/superstep.py
+++ b/src/hypergraph/runners/async_/superstep.py
@@ -23,6 +23,11 @@ from hypergraph.runners._shared.event_helpers import (
     build_route_decision_event,
 )
 from hypergraph.runners._shared.helpers import address_for_node_input, apply_node_result, collect_inputs_for_node
+from hypergraph.runners._shared.observability import (
+    NodeSpanRef,
+    reset_current_node_span,
+    set_current_node_span,
+)
 from hypergraph.runners._shared.types import ExecutionContext, GraphState, PauseExecution
 
 if TYPE_CHECKING:
@@ -197,8 +202,14 @@ async def run_superstep_async(
                 on_inner_log=inner_logs.append,
             )
 
-            # Pass new_state so routing decisions are stored in the updated state
-            outputs = await executor(node, new_state, inputs, ctx)
+            # Publish the node span so in-node telemetry (LLM clients, stores)
+            # can attribute itself to this exact span even under concurrency.
+            span_token = set_current_node_span(NodeSpanRef(run_id=run_id, span_id=node_span_id, node_name=node.name, graph_name=graph.name))
+            try:
+                # Pass new_state so routing decisions are stored in the updated state
+                outputs = await executor(node, new_state, inputs, ctx)
+            finally:
+                reset_current_node_span(span_token)
 
             duration_ms = (time.time() - node_start) * 1000
 

--- a/src/hypergraph/runners/sync/superstep.py
+++ b/src/hypergraph/runners/sync/superstep.py
@@ -21,6 +21,11 @@ from hypergraph.runners._shared.event_helpers import (
     build_route_decision_event,
 )
 from hypergraph.runners._shared.helpers import address_for_node_input, apply_node_result, collect_inputs_for_node
+from hypergraph.runners._shared.observability import (
+    NodeSpanRef,
+    reset_current_node_span,
+    set_current_node_span,
+)
 from hypergraph.runners._shared.types import ExecutionContext, GraphState, PauseExecution
 
 if TYPE_CHECKING:
@@ -171,8 +176,14 @@ def run_superstep_sync(
                     on_inner_log=inner_logs.append,
                 )
 
-                # Execute node
-                outputs = executor(node, new_state, inputs, ctx)
+                # Publish the node span so in-node telemetry (LLM clients, stores)
+                # can attribute itself to this exact span.
+                span_token = set_current_node_span(NodeSpanRef(run_id=run_id, span_id=node_span_id, node_name=node.name, graph_name=graph.name))
+                try:
+                    # Execute node
+                    outputs = executor(node, new_state, inputs, ctx)
+                finally:
+                    reset_current_node_span(span_token)
 
                 duration_ms = (time.time() - node_start) * 1000
 

--- a/tests/test_hypertable_child_column_provenance.py
+++ b/tests/test_hypertable_child_column_provenance.py
@@ -1,0 +1,171 @@
+"""Tests for per-column provenance across the parent/child (map_over) boundary.
+
+The scenario: one document row fans out to page rows; the per-page pipeline is
+enrich (expensive LLM stand-in) -> embed. Swapping the embedder must re-run
+ONLY embed per page — not the document split, not the enrichment.
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+import pytest
+
+from hypergraph import Graph, node
+from hypergraph.materialization._lancedb_store import LanceDBStore
+from hypergraph.runners import SyncRunner
+
+CALLS = {"split": 0, "split_v2": 0, "enrich": 0, "embed": 0}
+
+
+class Enricher:
+    def __init__(self, name: str = "enrich-a"):
+        self.name = name
+
+    def _config(self):
+        return {"name": self.name}
+
+    def summarize(self, text: str) -> str:
+        return f"{self.name}:{text[:5]}"
+
+
+class Embedder:
+    def __init__(self, model: str = "embed-a"):
+        self.model = model
+
+    def _config(self):
+        return {"model": self.model}
+
+    def embed(self, text: str) -> list[float]:
+        return [float(len(self.model)), float(len(text))]
+
+
+class Page(TypedDict):
+    page_id: str
+    page_text: str
+
+
+@node(output_name="pages")
+def split_pages(text: str) -> list[Page]:
+    CALLS["split"] += 1
+    return [Page(page_id=f"p{i}", page_text=part) for i, part in enumerate(text.split("|"))]
+
+
+@node(output_name="pages")
+def split_pages_v2(text: str) -> list[Page]:
+    CALLS["split_v2"] += 1
+    parts = text.split("|")  # different code, same pages
+    return [Page(page_id=f"p{i}", page_text=part) for i, part in enumerate(parts)]
+
+
+@node(output_name="summary")
+def enrich_page(page_text: str, enricher: Enricher) -> str:
+    CALLS["enrich"] += 1
+    return enricher.summarize(page_text)
+
+
+@node(output_name="page_vector")
+def embed_page(page_text: str, embedder: Embedder) -> list[float]:
+    CALLS["embed"] += 1
+    return embedder.embed(page_text)
+
+
+process_page = Graph([enrich_page, embed_page], name="process_page")
+
+
+@pytest.fixture(autouse=True)
+def reset_calls():
+    for key in CALLS:
+        CALLS[key] = 0
+
+
+@pytest.fixture
+def store(tmp_path):
+    return LanceDBStore(str(tmp_path / "child_prov_store"))
+
+
+def make_table(store, embedder=None, enricher=None, split_node=split_pages):
+    from hypergraph.materialization import HyperTable
+
+    pages_node = process_page.as_node().map_over("pages", identity="page_id")
+    return (
+        HyperTable([split_node, pages_node], identity="doc_id", store=store)
+        .bind(embedder=embedder or Embedder(), enricher=enricher or Enricher())
+        .with_runner(SyncRunner())
+    )
+
+
+DOCS = [
+    {"doc_id": "d1", "text": "alpha|beta"},
+    {"doc_id": "d2", "text": "gamma|delta|epsilon"},
+]  # 2 docs, 5 pages
+
+
+class TestRecipeChanges:
+    def test_embedder_swap_rederives_only_embeddings(self, store):
+        make_table(store).insert(DOCS)
+        assert (CALLS["split"], CALLS["enrich"], CALLS["embed"]) == (2, 5, 5)
+
+        swapped = make_table(store, embedder=Embedder("embed-b"))
+        swapped.sync(DOCS)
+
+        assert CALLS["split"] == 2, "document split must not re-run on an embedder swap"
+        assert CALLS["enrich"] == 5, "per-page enrichment (the LLM) must not re-run"
+        assert CALLS["embed"] == 10, "embeddings must re-run for all 5 pages"
+        assert swapped.children("d1")[0]["page_vector"][0] == float(len("embed-b"))
+        assert swapped.status().is_fresh
+
+    def test_enricher_swap_leaves_embeddings_alone(self, store):
+        make_table(store).insert(DOCS)
+
+        swapped = make_table(store, enricher=Enricher("enrich-b"))
+        swapped.sync(DOCS)
+
+        assert CALLS["split"] == 2
+        assert CALLS["enrich"] == 10
+        assert CALLS["embed"] == 5, "embeddings must not re-run on an enricher swap"
+        assert swapped.children("d1")[0]["summary"].startswith("enrich-b:")
+        assert swapped.status().is_fresh
+
+    def test_split_code_change_with_same_pages_skips_children(self, store):
+        make_table(store).insert(DOCS)
+
+        variant = make_table(store, split_node=split_pages_v2)
+        variant.sync(DOCS)
+
+        assert CALLS["split_v2"] == 2, "changed split must re-run"
+        assert CALLS["enrich"] == 5, "identical pages must not re-enrich"
+        assert CALLS["embed"] == 5, "identical pages must not re-embed"
+        assert variant.status().is_fresh
+
+
+class TestContentChanges:
+    def test_reinsert_unchanged_runs_nothing(self, store):
+        table = make_table(store)
+        table.insert(DOCS)
+        calls_before = dict(CALLS)
+
+        table.insert(DOCS)
+        assert dict(CALLS) == calls_before, "unchanged re-insert must execute nothing, not even split"
+
+    def test_content_change_rederives_only_the_changed_page(self, store):
+        table = make_table(store)
+        table.insert(DOCS)
+
+        table.sync([{"doc_id": "d1", "text": "alpha|zeta"}, DOCS[1]])
+
+        assert CALLS["split"] == 3, "d1 must re-split (its text changed)"
+        assert CALLS["enrich"] == 6, "only the changed page re-enriches"
+        assert CALLS["embed"] == 6, "only the changed page re-embeds"
+        texts = {c["page_text"] for c in table.children("d1")}
+        assert texts == {"alpha", "zeta"}
+
+
+class TestChildStatus:
+    def test_child_status_reports_stale_columns(self, store):
+        make_table(store).insert(DOCS)
+
+        report = make_table(store, embedder=Embedder("embed-b")).status()
+        child = report.children[0]
+        assert child.stale == 5
+        assert child.stale_columns == (("page_vector", 5),)

--- a/tests/test_hypertable_column_provenance.py
+++ b/tests/test_hypertable_column_provenance.py
@@ -1,0 +1,195 @@
+"""Tests for config-aware per-column provenance and column-scoped re-derivation.
+
+A column's provenance = hash(producing node's code + configs of the components
+it consumes + values of its direct inputs). Direct inputs are stored columns,
+so transitivity is value-based: an upstream code change that produces the same
+value stops the cascade; a changed value propagates.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hypergraph import node
+from hypergraph.materialization._lancedb_store import LanceDBStore
+from hypergraph.runners import SyncRunner
+
+# ---------------------------------------------------------------------------
+# Test nodes and components (with execution counters)
+# ---------------------------------------------------------------------------
+
+CALLS = {"clean": 0, "clean_same": 0, "clean_diff": 0, "embed": 0, "embed_v2": 0}
+
+
+class Embedder:
+    def __init__(self, model_name: str = "embed-a"):
+        self.model_name = model_name
+
+    def _config(self):
+        return {"model": self.model_name}
+
+    def embed(self, text: str) -> list[float]:
+        return [float(len(self.model_name)), float(len(text))]
+
+
+@node(output_name="clean_text")
+def clean(text: str) -> str:
+    CALLS["clean"] += 1
+    return text.strip().lower()
+
+
+@node(output_name="clean_text")
+def clean_same_value(text: str) -> str:
+    CALLS["clean_same"] += 1
+    result = text.strip().lower()
+    return result  # different code, same value
+
+
+@node(output_name="clean_text")
+def clean_diff_value(text: str) -> str:
+    CALLS["clean_diff"] += 1
+    return text.strip().lower() + "!"
+
+
+@node(output_name="vector")
+def embed_text(clean_text: str, embedder: Embedder) -> list[float]:
+    CALLS["embed"] += 1
+    return embedder.embed(clean_text)
+
+
+@node(output_name="vector_v2")
+def embed_text_v2(clean_text: str, embedder_v2: Embedder) -> list[float]:
+    CALLS["embed_v2"] += 1
+    return embedder_v2.embed(clean_text)
+
+
+@pytest.fixture(autouse=True)
+def reset_calls():
+    for key in CALLS:
+        CALLS[key] = 0
+
+
+@pytest.fixture
+def store(tmp_path):
+    return LanceDBStore(str(tmp_path / "prov_store"))
+
+
+def make_table(store, embedder, nodes=None):
+    from hypergraph.materialization import HyperTable
+
+    return HyperTable(nodes or [clean, embed_text], identity="doc_id", store=store).bind(embedder=embedder).with_runner(SyncRunner())
+
+
+DOCS = [{"doc_id": "d1", "text": "Chest pain"}, {"doc_id": "d2", "text": "Stroke triage"}]
+
+
+# ---------------------------------------------------------------------------
+# Column-scoped re-derivation (value-chaining)
+# ---------------------------------------------------------------------------
+
+
+class TestComponentSwap:
+    def test_component_swap_rederives_only_consuming_column(self, store):
+        table = make_table(store, Embedder("embed-a"))
+        table.insert(DOCS)
+        assert (CALLS["clean"], CALLS["embed"]) == (2, 2)
+
+        rebound = make_table(store, Embedder("embed-b-longer"))
+        rebound.sync(DOCS)
+
+        assert CALLS["clean"] == 2, "clean() must not re-run on an embedder swap"
+        assert CALLS["embed"] == 4, "embed must re-run for both rows"
+        assert rebound.get("d1")["vector"][0] == float(len("embed-b-longer"))
+        assert rebound.status().is_fresh
+
+    def test_unconsumed_component_swap_heals_without_execution(self, store):
+        table = make_table(store, Embedder("embed-a")).bind(unused=Embedder("x")).with_runner(SyncRunner())
+        table.insert(DOCS)
+        calls_before = dict(CALLS)
+
+        rebound = make_table(store, Embedder("embed-a")).bind(unused=Embedder("y")).with_runner(SyncRunner())
+        assert rebound.status().stale == 2
+        assert rebound.status().stale_columns == ()
+
+        rebound.sync(DOCS)
+        assert dict(CALLS) == calls_before, "no node may execute for an unconsumed component swap"
+        assert rebound.status().is_fresh
+
+
+class TestValueChaining:
+    def test_code_change_with_same_value_stops_cascade(self, store):
+        make_table(store, Embedder()).insert(DOCS)
+        embed_before = CALLS["embed"]
+
+        variant = make_table(store, Embedder(), nodes=[clean_same_value, embed_text])
+        variant.sync(DOCS)
+
+        assert CALLS["clean_same"] == 2, "changed node must re-run"
+        assert CALLS["embed"] == embed_before, "same upstream value must stop the cascade"
+        assert variant.status().is_fresh
+
+    def test_code_change_with_new_value_cascades(self, store):
+        make_table(store, Embedder()).insert(DOCS)
+        embed_before = CALLS["embed"]
+
+        variant = make_table(store, Embedder(), nodes=[clean_diff_value, embed_text])
+        variant.sync(DOCS)
+
+        assert CALLS["clean_diff"] == 2
+        assert CALLS["embed"] == embed_before + 2, "changed upstream value must cascade"
+        assert variant.get("d1")["clean_text"] == "chest pain!"
+        assert variant.status().is_fresh
+
+
+# ---------------------------------------------------------------------------
+# status() column breakdown
+# ---------------------------------------------------------------------------
+
+
+class TestStatusColumns:
+    def test_status_reports_stale_columns(self, store):
+        make_table(store, Embedder("embed-a")).insert(DOCS)
+
+        report = make_table(store, Embedder("embed-b")).status()
+        assert report.stale == 2
+        assert report.stale_columns == (("vector", 2),)
+
+    def test_fresh_table_has_no_stale_columns(self, store):
+        table = make_table(store, Embedder())
+        table.insert(DOCS)
+        assert table.status().stale_columns == ()
+
+
+# ---------------------------------------------------------------------------
+# Column-scoped recompute / backfill
+# ---------------------------------------------------------------------------
+
+
+class TestRecomputeBackfill:
+    def test_recompute_is_column_scoped_and_converges(self, store):
+        make_table(store, Embedder("embed-a")).insert(DOCS)
+        clean_before = CALLS["clean"]
+
+        rebound = make_table(store, Embedder("embed-b"))
+        rebound.recompute("vector")
+
+        assert CALLS["clean"] == clean_before, "recompute('vector') must not run clean()"
+        assert CALLS["embed"] == 4
+        assert rebound.status().is_fresh, "converged recompute must refresh freshness"
+
+    def test_backfill_new_column_executes_only_its_node(self, store):
+        make_table(store, Embedder("embed-a")).insert(DOCS)
+        calls_before = dict(CALLS)
+
+        extended = (
+            make_table(store, Embedder("embed-a"), nodes=[clean, embed_text, embed_text_v2])
+            .bind(embedder_v2=Embedder("embed-v2"))
+            .with_runner(SyncRunner())
+        )
+        extended.backfill("vector_v2")
+
+        assert CALLS["clean"] == calls_before["clean"], "backfill must not re-run clean()"
+        assert CALLS["embed"] == calls_before["embed"], "backfill must not re-run embed()"
+        assert CALLS["embed_v2"] == 2
+        assert extended.get("d1")["vector_v2"][0] == float(len("embed-v2"))
+        assert extended.status().is_fresh, "backfilled table with unchanged siblings must be fresh"

--- a/tests/test_hypertable_indexes.py
+++ b/tests/test_hypertable_indexes.py
@@ -1,0 +1,180 @@
+"""Tests for named indexes as persisted query specs (create_index / search).
+
+An index is a projection, not a table: a named, persisted query spec over a
+vector column that already lives in the table. For the LanceDB store there is
+no separate materialized artifact — LanceDB ANN-searches the column directly.
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+import pytest
+
+from hypergraph import Graph, node
+from hypergraph.materialization import HyperTable
+from hypergraph.materialization._lancedb_store import LanceDBStore
+from hypergraph.runners import SyncRunner
+
+VECTORS = {
+    "alpha": [1.0, 0.0, 0.0],
+    "beta": [0.0, 1.0, 0.0],
+    "gamma": [0.0, 0.0, 1.0],
+}
+
+
+class Embedder:
+    def __init__(self, model: str = "embed-a"):
+        self.model = model
+
+    def _config(self):
+        return {"model": self.model}
+
+    def embed(self, text: str) -> list[float]:
+        return VECTORS.get(text, [0.5, 0.5, 0.5])
+
+
+@node(output_name="vec")
+def embed_doc(text: str, embedder: Embedder) -> list[float]:
+    return embedder.embed(text)
+
+
+def make_table(store, embedder=None):
+    return HyperTable([embed_doc], identity="doc_id", store=store).bind(embedder=embedder or Embedder()).with_runner(SyncRunner())
+
+
+DOCS = [
+    {"doc_id": "d1", "text": "alpha", "active": True},
+    {"doc_id": "d2", "text": "beta", "active": True},
+    {"doc_id": "d3", "text": "gamma", "active": False},
+]
+
+
+@pytest.fixture
+def store(tmp_path):
+    return LanceDBStore(str(tmp_path / "index_store"))
+
+
+@pytest.fixture
+def table(store):
+    t = make_table(store)
+    t.insert(DOCS)
+    return t
+
+
+class TestCreateListDrop:
+    def test_create_and_list(self, table):
+        table.create_index("main", vector="vec", text="text")
+
+        specs = table.list_indexes()
+        assert len(specs) == 1
+        spec = specs[0]
+        assert spec["name"] == "main"
+        assert spec["on"] == "doc"
+        assert spec["vector"] == "vec"
+        assert spec["text"] == "text"
+        assert spec["recipe_fingerprint"]
+        assert spec["current"] is True
+
+    def test_drop(self, table):
+        table.create_index("main", vector="vec")
+        table.drop_index("main")
+        assert table.list_indexes() == []
+
+    def test_drop_unknown_raises(self, table):
+        with pytest.raises(KeyError, match="no index named"):
+            table.drop_index("nope")
+
+    def test_unknown_vector_column_raises(self, table):
+        with pytest.raises(ValueError, match="nope"):
+            table.create_index("main", vector="nope")
+
+    def test_unknown_rows_column_raises(self, table):
+        with pytest.raises(ValueError, match="missing_col"):
+            table.create_index("main", vector="vec", rows={"missing_col": True})
+
+    def test_unknown_table_raises(self, table):
+        with pytest.raises(ValueError, match="not_a_table"):
+            table.create_index("main", on="not_a_table", vector="vec")
+
+    def test_vector_is_required(self, table):
+        with pytest.raises(ValueError, match="vector"):
+            table.create_index("main")
+
+
+class TestPersistence:
+    def test_index_survives_a_fresh_instance_over_the_same_store(self, store, table):
+        table.create_index("main", vector="vec", rows={"active": True})
+
+        fresh = make_table(store)
+        specs = fresh.list_indexes()
+        assert [s["name"] for s in specs] == ["main"]
+        assert specs[0]["rows"] == {"active": True}
+        assert specs[0]["current"] is True
+
+
+class TestSearch:
+    def test_search_returns_the_nearest_row(self, table):
+        table.create_index("main", vector="vec")
+
+        hits = table.search([0.9, 0.1, 0.0], index="main", limit=1)
+        assert len(hits) == 1
+        assert hits[0]["doc_id"] == "d1"
+        assert hits[0]["text"] == "alpha"
+        assert "_distance" in hits[0]
+
+    def test_search_honors_the_row_filter(self, table):
+        table.create_index("active_only", vector="vec", rows={"active": True})
+
+        hits = table.search([0.0, 0.1, 0.9], index="active_only", limit=1)
+        # d3 (gamma) is the true nearest but inactive; the filter excludes it.
+        assert hits[0]["doc_id"] == "d2"
+
+    def test_search_unknown_index_raises(self, table):
+        with pytest.raises(KeyError, match="no index named"):
+            table.search([1.0, 0.0, 0.0], index="nope")
+
+
+class Page(TypedDict):
+    page_id: str
+    page_text: str
+
+
+@node(output_name="pages")
+def split_pages(text: str) -> list[Page]:
+    return [Page(page_id=f"p{i}", page_text=part) for i, part in enumerate(text.split("|"))]
+
+
+@node(output_name="page_vector")
+def embed_page(page_text: str, embedder: Embedder) -> list[float]:
+    return embedder.embed(page_text)
+
+
+process_page = Graph([embed_page], name="process_page")
+
+
+def make_child_table(store, embedder=None):
+    pages_node = process_page.as_node().map_over("pages", identity="page_id")
+    return HyperTable([split_pages, pages_node], identity="doc_id", store=store).bind(embedder=embedder or Embedder()).with_runner(SyncRunner())
+
+
+class TestChildTableIndex:
+    def test_index_on_child_pages(self, tmp_path):
+        store = LanceDBStore(str(tmp_path / "child_index_store"))
+        table = make_child_table(store)
+        table.insert([{"doc_id": "d1", "text": "alpha|beta"}, {"doc_id": "d2", "text": "gamma"}])
+
+        table.create_index("pages_idx", on="page", vector="page_vector")
+
+        hits = table.search([0.0, 0.95, 0.05], index="pages_idx", limit=1)
+        assert hits[0]["page_text"] == "beta"
+        assert hits[0]["_parent_id"] == "d1"
+
+
+class TestRecipeCurrency:
+    def test_current_flips_after_rebinding_a_different_embedder(self, store, table):
+        table.create_index("main", vector="vec")
+        assert table.list_indexes()[0]["current"] is True
+
+        rebound = make_table(store, embedder=Embedder("embed-b"))
+        assert rebound.list_indexes()[0]["current"] is False

--- a/tests/test_hypertable_status.py
+++ b/tests/test_hypertable_status.py
@@ -1,0 +1,189 @@
+"""Tests for HyperTable.status(): the read-only staleness dry-run."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+import pytest
+
+from hypergraph import Graph, node
+from hypergraph.materialization._lancedb_store import LanceDBStore
+from hypergraph.runners import SyncRunner
+
+# ---------------------------------------------------------------------------
+# Test nodes and components
+# ---------------------------------------------------------------------------
+
+
+class Embedder:
+    def __init__(self, model_name: str = "test-embed", dim: int = 3):
+        self.model_name = model_name
+        self.dim = dim
+
+    def _config(self):
+        return {"model": self.model_name, "dim": self.dim}
+
+    def embed(self, text: str) -> list[float]:
+        vec = [0.0] * self.dim
+        for i, c in enumerate(text[: self.dim]):
+            vec[i] = float(ord(c)) / 122.0
+        return vec
+
+
+@node(output_name="clean_text")
+def clean(text: str) -> str:
+    return text.strip().lower()
+
+
+@node(output_name="vector")
+def embed_text(clean_text: str, embedder: Embedder) -> list[float]:
+    return embedder.embed(clean_text)
+
+
+@node(output_name="clean_text")
+def clean_variant(text: str) -> str:
+    return text.strip().lower().replace("-", " ")
+
+
+@node(output_name="length")
+def measure(text: str) -> int:
+    if "boom" in text:
+        raise ValueError("boom row")
+    return len(text)
+
+
+class Page(TypedDict):
+    page_id: str
+    page_text: str
+
+
+@node(output_name="pages")
+def split_pages(text: str) -> list[Page]:
+    return [Page(page_id=f"p{i}", page_text=part) for i, part in enumerate(text.split("|"))]
+
+
+@node(output_name="page_vector")
+def embed_page(page_text: str, embedder: Embedder) -> list[float]:
+    return embedder.embed(page_text)
+
+
+process_page = Graph([embed_page], name="process_page")
+
+
+@pytest.fixture
+def store(tmp_path):
+    return LanceDBStore(str(tmp_path / "status_store"))
+
+
+@pytest.fixture
+def embedder():
+    return Embedder()
+
+
+def make_table(store, embedder):
+    from hypergraph.materialization import HyperTable
+
+    return HyperTable([clean, embed_text], identity="doc_id", store=store).bind(embedder=embedder).with_runner(SyncRunner())
+
+
+# ---------------------------------------------------------------------------
+# Root-row staleness
+# ---------------------------------------------------------------------------
+
+
+class TestStatusRoot:
+    def test_fresh_after_insert(self, store, embedder):
+        table = make_table(store, embedder)
+        table.insert([{"doc_id": "d1", "text": "hello"}, {"doc_id": "d2", "text": "world"}])
+
+        report = table.status()
+        assert report.table == "doc"
+        assert (report.total, report.fresh, report.stale, report.errored) == (2, 2, 0, 0)
+        assert report.is_fresh
+
+    def test_component_config_change_marks_all_stale(self, store, embedder):
+        table = make_table(store, embedder)
+        table.insert([{"doc_id": "d1", "text": "hello"}, {"doc_id": "d2", "text": "world"}])
+
+        rebound = table.bind(embedder=Embedder(model_name="new-embed")).with_runner(SyncRunner())
+        report = rebound.status()
+        assert (report.fresh, report.stale) == (0, 2)
+        assert report.stale_ids == ("d1", "d2")
+        assert not report.is_fresh
+
+    def test_node_definition_change_marks_stale(self, store, embedder):
+        from hypergraph.materialization import HyperTable
+
+        make_table(store, embedder).insert(doc_id="d1", text="a-b")
+
+        variant = HyperTable([clean_variant, embed_text], identity="doc_id", store=store).bind(embedder=embedder).with_runner(SyncRunner())
+        report = variant.status()
+        assert (report.fresh, report.stale) == (0, 1)
+
+    def test_status_requires_no_runner(self, store, embedder):
+        from hypergraph.materialization import HyperTable
+
+        make_table(store, embedder).insert(doc_id="d1", text="hello")
+
+        readonly = HyperTable([clean, embed_text], identity="doc_id", store=store).bind(embedder=embedder)
+        report = readonly.status()
+        assert report.is_fresh
+
+    def test_sync_heals_stale_rows(self, store, embedder):
+        table = make_table(store, embedder)
+        items = [{"doc_id": "d1", "text": "hello"}, {"doc_id": "d2", "text": "world"}]
+        table.insert(items)
+
+        rebound = table.bind(embedder=Embedder(model_name="new-embed")).with_runner(SyncRunner())
+        assert rebound.status().stale == 2
+        rebound.sync(items)
+        assert rebound.status().is_fresh
+
+    def test_errored_rows_reported_separately(self, store):
+        from hypergraph.materialization import HyperTable
+
+        table = HyperTable([measure], identity="doc_id", store=store, on_error="store").with_runner(SyncRunner())
+        table.insert([{"doc_id": "ok", "text": "fine"}, {"doc_id": "bad", "text": "boom"}])
+
+        report = table.status()
+        assert (report.fresh, report.stale, report.errored) == (1, 0, 1)
+        assert report.errored_ids == ("bad",)
+        assert not report.is_fresh
+
+    def test_metadata_set_does_not_stale(self, store, embedder):
+        table = make_table(store, embedder)
+        table.insert(doc_id="d1", text="hello", station="north")
+        table.set({"doc_id": "d1"}, station="south")
+        assert table.status().is_fresh
+
+
+# ---------------------------------------------------------------------------
+# Child-table staleness
+# ---------------------------------------------------------------------------
+
+
+class TestStatusChildren:
+    def make_parent_child(self, store, embedder):
+        from hypergraph.materialization import HyperTable
+
+        pages_node = process_page.as_node().map_over("pages", identity="page_id")
+        return HyperTable([split_pages, pages_node], identity="doc_id", store=store).bind(embedder=embedder).with_runner(SyncRunner())
+
+    def test_children_fresh_after_insert(self, store, embedder):
+        table = self.make_parent_child(store, embedder)
+        table.insert(doc_id="d1", text="alpha|beta")
+
+        report = table.status()
+        assert report.is_fresh
+        assert len(report.children) == 1
+        child = report.children[0]
+        assert (child.total, child.fresh, child.stale) == (2, 2, 0)
+
+    def test_child_component_change_marks_children_stale(self, store, embedder):
+        table = self.make_parent_child(store, embedder)
+        table.insert(doc_id="d1", text="alpha|beta")
+
+        rebound = table.bind(embedder=Embedder(model_name="new-embed")).with_runner(SyncRunner())
+        child = rebound.status().children[0]
+        assert (child.fresh, child.stale) == (0, 2)
+        assert not rebound.status().is_fresh

--- a/tests/test_nodes_function.py
+++ b/tests/test_nodes_function.py
@@ -1081,3 +1081,64 @@ class TestGeneratorExecution:
         # At len=3, we stop adding (limit reached)
         # Final should stabilize at [0,1,2]
         assert len(result["items"]) <= 3
+
+
+class TestFunctionNodeBoundMethods:
+    """FunctionNode wrapping bound methods of configured instances."""
+
+    class Summarizer:
+        """Configurable component with a method used as a node."""
+
+        def __init__(self, model: str):
+            self.model = model
+
+        def summarize(self, text: str) -> str:
+            return f"{self.model}: {text}"
+
+    def test_bound_method_strips_self_and_runs(self):
+        """Bound-method node: self excluded from inputs, runs in a graph."""
+        from hypergraph import Graph
+        from hypergraph.runners.sync import SyncRunner
+
+        component = self.Summarizer(model="gpt-4")
+        fn = FunctionNode(component.summarize, name="summarize", output_name="summary")
+
+        assert fn.inputs == ("text",)
+        assert fn.outputs == ("summary",)
+
+        graph = Graph([fn])
+        result = SyncRunner().run(graph, {"text": "hello"})
+
+        assert result["summary"] == "gpt-4: hello"
+
+    def test_differently_configured_instances_different_hash(self):
+        """Two differently-configured instances → different definition_hash."""
+        a = FunctionNode(self.Summarizer(model="gpt-4").summarize, name="a", output_name="summary")
+        b = FunctionNode(self.Summarizer(model="haiku").summarize, name="b", output_name="summary")
+
+        assert a.definition_hash != b.definition_hash
+
+    def test_same_instance_stable_hash(self):
+        """Same instance, same method → stable definition_hash."""
+        component = self.Summarizer(model="gpt-4")
+
+        a = FunctionNode(component.summarize, name="a", output_name="summary")
+        b = FunctionNode(component.summarize, name="b", output_name="summary")
+
+        assert a.definition_hash == b.definition_hash
+
+    def test_rename_inputs_on_bound_method_node(self):
+        """rename_inputs works on a bound-method node."""
+        from hypergraph import Graph
+        from hypergraph.runners.sync import SyncRunner
+
+        component = self.Summarizer(model="gpt-4")
+        fn = FunctionNode(component.summarize, name="summarize", output_name="summary")
+        renamed = fn.rename_inputs({"text": "document"})
+
+        assert renamed.inputs == ("document",)
+
+        graph = Graph([renamed])
+        result = SyncRunner().run(graph, {"document": "report"})
+
+        assert result["summary"] == "gpt-4: report"

--- a/tests/test_observability_current_span.py
+++ b/tests/test_observability_current_span.py
@@ -1,0 +1,89 @@
+"""current_node_span(): in-node telemetry can identify the executing node span."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from hypergraph import AsyncRunner, Graph, SyncRunner, current_node_span, node
+from hypergraph.events import EventProcessor, NodeStartEvent
+
+
+class _SpanIndex(EventProcessor):
+    """Record node span ids exactly as the event stream reports them."""
+
+    def __init__(self) -> None:
+        self.by_node: dict[str, list[str]] = {}
+
+    def on_event(self, event) -> None:
+        if isinstance(event, NodeStartEvent):
+            self.by_node.setdefault(event.node_name, []).append(event.span_id)
+
+
+def test_no_span_outside_graph_execution():
+    assert current_node_span() is None
+
+
+def test_sync_runner_publishes_node_span():
+    seen: list = []
+
+    @node(output_name="out")
+    def observe(value: int) -> int:
+        seen.append(current_node_span())
+        return value
+
+    index = _SpanIndex()
+    graph = Graph([observe], name="obs_graph")
+    SyncRunner().run(graph, {"value": 1}, event_processors=[index])
+
+    assert current_node_span() is None
+    (ref,) = seen
+    assert ref is not None
+    assert ref.node_name == "observe"
+    assert ref.graph_name == "obs_graph"
+    assert ref.span_id in index.by_node["observe"]
+
+
+@pytest.mark.asyncio
+async def test_async_concurrent_nodes_see_their_own_span():
+    """Concurrently executing nodes each observe their own span, not a sibling's."""
+    observed: dict[str, str] = {}
+
+    @node(output_name="a_out")
+    async def node_a(value: int) -> int:
+        await asyncio.sleep(0.01)
+        observed["node_a"] = current_node_span().span_id
+        return value
+
+    @node(output_name="b_out")
+    async def node_b(value: int) -> int:
+        await asyncio.sleep(0.01)
+        observed["node_b"] = current_node_span().span_id
+        return value
+
+    index = _SpanIndex()
+    graph = Graph([node_a, node_b], name="parallel_graph")
+    await AsyncRunner().run(graph, {"value": 1}, event_processors=[index])
+
+    assert observed["node_a"] != observed["node_b"]
+    assert observed["node_a"] in index.by_node["node_a"]
+    assert observed["node_b"] in index.by_node["node_b"]
+
+
+@pytest.mark.asyncio
+async def test_mapped_items_see_distinct_spans():
+    """Each .map_over item execution observes a distinct span id."""
+    span_ids: list[str] = []
+
+    @node(output_name="doubled")
+    async def double(value: int) -> int:
+        await asyncio.sleep(0.01)
+        span_ids.append(current_node_span().span_id)
+        return value * 2
+
+    graph = Graph([double], name="map_graph")
+    await AsyncRunner().map(graph, {"value": [1, 2, 3]}, map_over="value")
+
+    assert len(span_ids) == 3
+    assert len(set(span_ids)) == 3

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -170,3 +170,94 @@ class TestHashDefinition:
         result = hash_definition(fn)
         assert len(result) == 64
         assert all(c in "0123456789abcdef" for c in result)
+
+
+class _Summarizer:
+    """Configurable component used by bound-method hashing tests."""
+
+    def __init__(self, model: str):
+        self.model = model
+
+    def summarize(self, text: str) -> str:
+        return f"{self.model}: {text}"
+
+
+class TestHashDefinitionBoundMethods:
+    """Bound methods mix instance state into the hash.
+
+    The fingerprint is captured when the hash is computed (node construction),
+    so post-construction mutation of instance state is not tracked.
+    """
+
+    def test_differently_configured_instances_different_hash(self):
+        """Same method, different instance state → different hash."""
+        a = _Summarizer(model="gpt-4")
+        b = _Summarizer(model="haiku")
+
+        assert hash_definition(a.summarize) != hash_definition(b.summarize)
+
+    def test_same_instance_stable_hash(self):
+        """Same instance, same method → stable hash across calls."""
+        obj = _Summarizer(model="gpt-4")
+
+        assert hash_definition(obj.summarize) == hash_definition(obj.summarize)
+
+    def test_identically_configured_instances_same_hash(self):
+        """Two instances with identical state hash the same."""
+        a = _Summarizer(model="gpt-4")
+        b = _Summarizer(model="gpt-4")
+
+        assert hash_definition(a.summarize) == hash_definition(b.summarize)
+
+    def test_cache_key_method_takes_precedence(self):
+        """A callable cache_key() defines the fingerprint (hypercache convention)."""
+
+        class Component:
+            def __init__(self, model: str, client: object):
+                self.model = model
+                self.client = client  # not part of identity
+
+            def cache_key(self) -> dict:
+                return {"model": self.model}
+
+            def run(self, x: int) -> int:
+                return x
+
+        a = Component("gpt-4", client=object())
+        b = Component("gpt-4", client=object())  # different client, same key
+        c = Component("haiku", client=object())
+
+        assert hash_definition(a.run) == hash_definition(b.run)
+        assert hash_definition(a.run) != hash_definition(c.run)
+
+    def test_slots_instance_falls_back_to_code_hash(self):
+        """Instances without __dict__ fall back to code-only hashing."""
+
+        class Slotted:
+            __slots__ = ("model",)
+
+            def __init__(self, model: str):
+                self.model = model
+
+            def run(self, x: int) -> int:
+                return x
+
+        a = Slotted("gpt-4")
+        b = Slotted("haiku")
+
+        result = hash_definition(a.run)
+        assert len(result) == 64
+        # No accessible state — same as pre-fix behavior
+        assert result == hash_definition(b.run)
+
+    def test_classmethod_keeps_code_only_hash(self):
+        """Classmethods are not fingerprinted (class dicts are not stable)."""
+
+        class WithClassmethod:
+            @classmethod
+            def run(cls, x: int) -> int:
+                return x
+
+        result = hash_definition(WithClassmethod.run)
+        assert len(result) == 64
+        assert result == hash_definition(WithClassmethod.run)


### PR DESCRIPTION
## Problem / Bug / Challenge

PR #165 landed HyperTable's first cut: graph-native incremental tables that sync a graph over a store, fingerprint each row, and re-derive only what changed. But at the row grain it was still coarse — a stale row re-ran its whole recipe, `map_over` children were opaque, there was no way to ask "what would re-derive if I synced now?" without actually syncing, and a KB's vector column had no persisted, identity-tracked query spec. This PR closes those gaps and folds in the in-node observability + hashing fixes that the same downstream work (Superposition's KB/retrieval PRDs) depends on.

## Before / After

**Per-column provenance — swap the embedder, keep the enrichment**

*Before:* any stale row re-ran its entire producing recipe. Rebinding the embedder re-ran parse + enrich + embed for every touched row.

*After:* each column stores its own provenance = `hash(producing node's code + its direct input values + consumed component configs)`. `insert`/`sync`/`update` reconcile column-by-column, running only the nodes whose provenance mismatches.

```python
# Rebind only the embedder on an existing table, then:
table.sync(...)     # re-derives the `embedding` column; parse/enrich columns untouched
```

Transitivity is value-based: because direct inputs are stored columns, an upstream code change that yields the *same* value stops the cascade; a changed value propagates. `recompute(col)` / `backfill(col)` run only the producing node and refresh the row fingerprint only once the whole row converges to the current recipe (a partially-current row keeps reporting stale).

**`status()` — a runner-free staleness dry-run**

*Before:* the only way to learn what was stale was to sync and watch what moved.

*After:*

```python
report = table.status()          # reads only; runs nothing
report.stale, report.errored     # counts
report.stale_ids                 # which rows
report.stale_columns             # ("embedding", 42) — per-column attribution
report.children                  # nested TableStatus per child table
report.is_fresh                  # True when nothing here or in any child would re-derive
```

`TableStatus` is a new frozen dataclass, exported from `hypergraph.materialization`.

**Per-column provenance across the `map_over` child boundary**

*Before:* a child-bearing table re-ran the parent graph just to regenerate the child-items list, and any stale child full-ran.

*After:* two savings —
1. Each parent row stores a boundary provenance for the node that produces the mapped items; when it's unchanged and the stored child-row count matches, mapped items are rebuilt from stored child rows instead of running the graph.
2. Child rows carry per-column provenance, so an embedder swap re-embeds pages without re-running enrichment; a changed split whose pages come out identical skips children entirely. `status()` on children attributes staleness per column too.

**Named indexes as persisted query specs**

*Before:* no first-class notion of a searchable index over a table's vector column.

*After:* an index is a projection, not a table — v1 stores no separate artifact. `create_index` records a **named, persisted query spec** (target table, row filter, optional content column, vector column) plus a `recipe_fingerprint` = `hash(vector column's producing-node code + its consumed component configs)`.

```python
table.create_index("pages_vec", on="pages", text="content")
table.list_indexes()            # each spec reports `current` — flips False after an embedder rebind
hits = table.search(query_vector, index="pages_vec")   # pre-filters by the recorded predicate; returns rows + _distance
```

Specs persist via `TableStore.save_manifest`/`load_manifest` (LanceDBStore writes a JSON manifest inside the LanceDB directory), so they survive fresh `HyperTable` instances over the same store. v1 scope: LanceDB virtual indexes; hybrid text-query search and materialization into external backends (Chroma, Azure Search) are application-level and out of scope.

**In-node observability — `current_node_span()`** (merged from `sp-observability`)

While a node executes, the sync and async runners publish its span identity (`run_id`, `span_id`, `node_name`, `graph_name`) in a `ContextVar`:

```python
from hypergraph import current_node_span
ref = current_node_span()   # NodeSpanRef | None
```

Telemetry running *inside* a node — an LLM client, a vector store — can attribute its own spans to the exact node span, correct under concurrent `map_over`. Zero-coupling, mirroring the hypercache observer precedent: consumers soft-import and tolerate `None`.

**Two correctness fixes folded in**

- `fix(nodes)`: bound-method definition hashes now mix in instance state (prefers `cache_key()`, else a deterministic `vars(instance)` serialization). Previously two differently-configured instances of the same class produced identical definition hashes, cross-contaminating the `@node(cache=True)` cache between instances.
- `Preserve Annotated metadata`: `parameter_annotations` now uses `get_type_hints(include_extras=True)`, so port metadata (`Annotated` extras) survives node boundaries — including renamed and mapped `GraphNode` inputs, where external tools derive run-input surfaces from `get_input_type`.

## New public API

- `hypergraph.current_node_span`, `hypergraph.NodeSpanRef`
- `hypergraph.materialization.TableStatus`
- `HyperTable.status()`, `HyperTable.create_index()`, `HyperTable.list_indexes()`, `HyperTable.search()`, `recompute(col)` / `backfill(col)`
- `TableStore.save_manifest` / `load_manifest` (implemented by `LanceDBStore`)

## Test Plan

- [x] Full CI-equivalent suite locally: `uv run pytest -W error -W 'ignore::pytest.PytestUnraisableExceptionWarning'` → **2931 passed, 0 failed, 0 skipped, 0 warnings** (CI enforces zero skips/zero warnings).
- [x] `uv run ruff check .` and `uv run ruff format --check .` clean.
- [x] New coverage: `tests/test_hypertable_status.py`, `tests/test_hypertable_column_provenance.py`, `tests/test_hypertable_child_column_provenance.py`, `tests/test_hypertable_indexes.py`, `tests/test_observability_current_span.py`, `tests/test_nodes_function.py`, `tests/test_utils.py` (976 new test lines).
- [x] Docs updated in-tree: new how-to guides (`declare-edges-explicitly`, `nodes-from-component-methods`), caching/nodes pattern docs, and `docs/SUMMARY.md` registrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
