### PR TITLE
fix(materialization): fail loud on manifestless indexes and swallowed LanceDB search errors

### DIFF
--- a/docs/08-hypertable/implementing-a-store.md
+++ b/docs/08-hypertable/implementing-a-store.md
@@ -31,6 +31,15 @@ class MyStore(TableStore):
 `search`, `save_manifest`, and `load_manifest` are optional (they default to
 "not supported" / no-op) — implement them only if your backend offers them.
 
+**Named indexes need both manifest hooks.** `save_manifest` / `load_manifest`
+persist a table's index specs. They stay optional for any store that never uses
+indexes, but a store that *is* asked to `create_index` without implementing them
+fails loud at use time — `HyperTable.create_index` checks the pair and raises
+`NotImplementedError` naming your store and `save_manifest`, rather than
+"succeeding" silently and then having `list_indexes()` return nothing. So
+implement **both** hooks (not just one) if you want named indexes; leave both as
+the base no-op if you don't.
+
 ## The invariants that aren't obvious
 
 Most of the interface is self-explanatory. These few are not, and a store that

--- a/src/hypergraph/materialization/_hypertable.py
+++ b/src/hypergraph/materialization/_hypertable.py
@@ -722,6 +722,12 @@ class HyperTable:
     ) -> dict[str, Any]:
         """Record a named query spec: which table, which vector column, which row slice."""
         self._ensure_analyzed()
+        if not self._store.supports_manifests():
+            raise NotImplementedError(
+                f"{type(self._store).__name__} does not implement save_manifest/load_manifest, "
+                "so it cannot persist named indexes. Implement both manifest hooks to support "
+                "create_index, or use a store that does (e.g. LanceDBStore)."
+            )
         spec = self._resolve_index_table(on)
         if vector is None:
             raise ValueError("create_index requires vector=<column>: v1 indexes are vector-search specs")

--- a/src/hypergraph/materialization/_lancedb_store.py
+++ b/src/hypergraph/materialization/_lancedb_store.py
@@ -51,18 +51,6 @@ def _sql_literal(val: Any) -> str:
     return str(val)
 
 
-def _is_table_absent(exc: Exception, table_name: str) -> bool:
-    """True when ``exc`` is LanceDB's "table not found" signal for ``table_name``.
-
-    LanceDB 0.33 raises a plain ``ValueError`` whose message reads
-    ``Table '<name>' was not found``. There is no dedicated exception class, so
-    we match the message narrowly — the table name plus "not found" — to avoid
-    treating an unrelated ValueError as an absent table.
-    """
-    message = str(exc).lower()
-    return "not found" in message and table_name.lower() in message
-
-
 def _build_lance_filter(where: RowPredicate) -> str:
     """Convert RowPredicate to a LanceDB SQL-like filter string."""
     op_map = {"eq": "=", "ne": "!=", "lt": "<", "lte": "<=", "gt": ">", "gte": ">="}
@@ -193,18 +181,17 @@ class LanceDBStore(TableStore):
             raise ValueError("LanceDBStore.search requires query_vector (text-only search is not supported in v1)")
         tbl = self._tables.get(table_name)
         if tbl is None:
-            try:
-                tbl = self._db.open_table(table_name)
-            except ValueError as exc:
-                # An absent table means "no rows have ever been written" — a
-                # documented empty result (mirrors max_write_gen's absent -> 0).
-                # LanceDB signals this with a ValueError whose message names the
-                # missing table. Any OTHER error (corruption, permissions, a
-                # different ValueError) is a real failure and must re-raise, not
-                # be swallowed into an empty result.
-                if _is_table_absent(exc, table_name):
-                    return []
-                raise
+            # A table LanceDB never created has no on-disk directory: that means
+            # "no rows have ever been written" — a documented empty result
+            # (mirrors max_write_gen's absent -> 0). But a table whose directory
+            # exists yet fails to open is corrupt / unreadable / permission-denied
+            # — a real failure that must surface, NOT be swallowed into []. The
+            # error message alone can't tell these apart (LanceDB raises the same
+            # "Table '<name>' was not found" ValueError for a corrupt table), so
+            # we key off the on-disk directory, which a corrupt table still has.
+            if not self._table_dir_exists(table_name):
+                return []
+            tbl = self._db.open_table(table_name)
             self._tables[table_name] = tbl
         q = tbl.search(list(query_vector), vector_column_name=vector_column)
         if where:
@@ -242,6 +229,15 @@ class LanceDBStore(TableStore):
 
     def _manifest_path(self, table_name: str) -> Path:
         return self._path / f"{table_name}__manifest.json"
+
+    def _table_dir_exists(self, table_name: str) -> bool:
+        """Whether LanceDB has ever created this table on disk.
+
+        LanceDB stores each table as a ``<name>.lance`` directory under the
+        connection path. Absent directory = never created (no rows ever
+        written); present directory that still fails to open = corrupt.
+        """
+        return (self._path / f"{table_name}.lance").exists()
 
     def _ensure_table(self, spec: TableSpec) -> None:
         try:

--- a/src/hypergraph/materialization/_lancedb_store.py
+++ b/src/hypergraph/materialization/_lancedb_store.py
@@ -51,6 +51,18 @@ def _sql_literal(val: Any) -> str:
     return str(val)
 
 
+def _is_table_absent(exc: Exception, table_name: str) -> bool:
+    """True when ``exc`` is LanceDB's "table not found" signal for ``table_name``.
+
+    LanceDB 0.33 raises a plain ``ValueError`` whose message reads
+    ``Table '<name>' was not found``. There is no dedicated exception class, so
+    we match the message narrowly — the table name plus "not found" — to avoid
+    treating an unrelated ValueError as an absent table.
+    """
+    message = str(exc).lower()
+    return "not found" in message and table_name.lower() in message
+
+
 def _build_lance_filter(where: RowPredicate) -> str:
     """Convert RowPredicate to a LanceDB SQL-like filter string."""
     op_map = {"eq": "=", "ne": "!=", "lt": "<", "lte": "<=", "gt": ">", "gte": ">="}
@@ -183,8 +195,16 @@ class LanceDBStore(TableStore):
         if tbl is None:
             try:
                 tbl = self._db.open_table(table_name)
-            except Exception:
-                return []
+            except ValueError as exc:
+                # An absent table means "no rows have ever been written" — a
+                # documented empty result (mirrors max_write_gen's absent -> 0).
+                # LanceDB signals this with a ValueError whose message names the
+                # missing table. Any OTHER error (corruption, permissions, a
+                # different ValueError) is a real failure and must re-raise, not
+                # be swallowed into an empty result.
+                if _is_table_absent(exc, table_name):
+                    return []
+                raise
             self._tables[table_name] = tbl
         q = tbl.search(list(query_vector), vector_column_name=vector_column)
         if where:

--- a/src/hypergraph/materialization/_table_store.py
+++ b/src/hypergraph/materialization/_table_store.py
@@ -73,12 +73,28 @@ class TableStore(ABC):
         raise NotImplementedError("This store does not support search")
 
     def save_manifest(self, table_name: str, manifest: dict[str, Any]) -> None:
-        """Persist table metadata when the backend supports manifests."""
+        """Persist table metadata when the backend supports manifests.
+
+        Manifests are OPTIONAL: a store that never uses named indexes never
+        touches them and can leave this base no-op in place. The loud failure
+        for a store that *does* get asked to persist an index lives at the call
+        site (``HyperTable.create_index`` checks ``supports_manifests`` and
+        raises, naming the store and this method) so it fires exactly when the
+        capability is used — not silently at ``list_indexes``-returns-nothing.
+        """
         return None
 
     def load_manifest(self, table_name: str) -> dict[str, Any] | None:
         """Load table metadata when the backend supports manifests."""
         return None
+
+    def supports_manifests(self) -> bool:
+        """True when the store overrides the manifest hooks (index persistence).
+
+        A store must implement both ``save_manifest`` and ``load_manifest`` to
+        support named indexes; the base no-ops do not count.
+        """
+        return type(self).save_manifest is not TableStore.save_manifest and type(self).load_manifest is not TableStore.load_manifest
 
 
 def validate_store(store: Any) -> TableStore:

--- a/tests/test_hypertable_indexes.py
+++ b/tests/test_hypertable_indexes.py
@@ -12,7 +12,7 @@ from typing import TypedDict
 import pytest
 
 from hypergraph import Graph, node
-from hypergraph.materialization import HyperTable
+from hypergraph.materialization import HyperTable, TableStore
 from hypergraph.materialization._lancedb_store import LanceDBStore
 from hypergraph.runners import SyncRunner
 
@@ -178,3 +178,111 @@ class TestRecipeCurrency:
 
         rebound = make_table(store, embedder=Embedder("embed-b"))
         assert rebound.list_indexes()[0]["current"] is False
+
+
+class TestLanceDBStoreSearchAbsentVsError:
+    """LanceDBStore.search: absent table is an empty result; any other error re-raises.
+
+    An absent table means "no rows have ever been written" — a documented empty
+    result. But the catch must NOT swallow corruption/permission errors into the
+    same ``[]``; those are real failures and must surface.
+    """
+
+    def test_absent_table_returns_empty(self, tmp_path):
+        store = LanceDBStore(str(tmp_path / "absent_store"))
+        # Never opened/written this table -> genuinely absent.
+        assert store.search("never_written", query_vector=[1.0, 0.0, 0.0]) == []
+
+    def test_non_absence_error_reraises(self, tmp_path, monkeypatch):
+        store = LanceDBStore(str(tmp_path / "err_store"))
+
+        class BoomDB:
+            def open_table(self, name):
+                raise RuntimeError("disk corruption / permission denied")
+
+        monkeypatch.setattr(store, "_db", BoomDB())
+        with pytest.raises(RuntimeError, match="corruption"):
+            store.search("some_table", query_vector=[1.0, 0.0, 0.0])
+
+    def test_unrelated_valueerror_reraises(self, tmp_path, monkeypatch):
+        """A ValueError that is NOT 'table not found' must not be swallowed."""
+        store = LanceDBStore(str(tmp_path / "verr_store"))
+
+        class BadValueDB:
+            def open_table(self, name):
+                raise ValueError("invalid vector column dtype")
+
+        monkeypatch.setattr(store, "_db", BadValueDB())
+        with pytest.raises(ValueError, match="dtype"):
+            store.search("some_table", query_vector=[1.0, 0.0, 0.0])
+
+
+class ManifestlessStore(TableStore):
+    """A store that supports rows but leaves the manifest hooks as base no-ops.
+
+    Legitimate for a backend that never uses indexes. But if such a store is
+    asked to ``create_index``, it must fail loud at use time instead of
+    silently "succeeding" and having ``list_indexes`` return nothing.
+    """
+
+    def __init__(self) -> None:
+        self._tables: dict[str, list[dict]] = {}
+
+    def open(self, spec, children):
+        result = {spec.name: [c.name for c in spec.columns]}
+        self._tables.setdefault(spec.name, [])
+        for child in children:
+            result[child.name] = [c.name for c in child.columns]
+            self._tables.setdefault(child.name, [])
+        return result
+
+    def count(self, table_name):
+        return len(self._tables.get(table_name, []))
+
+    def read_rows(self, table_name, where=None, *, limit=None):
+        rows = list(self._tables.get(table_name, []))
+        return rows[:limit] if limit is not None else rows
+
+    def read_one(self, table_name, identity_column, identity_value):
+        matches = [r for r in self._tables.get(table_name, []) if r.get(identity_column) == identity_value]
+        return max(matches, key=lambda r: r.get("_write_gen", 0)) if matches else None
+
+    def write_rows(self, table_name, rows):
+        self._tables.setdefault(table_name, []).extend(rows)
+
+    def delete_rows(self, table_name, where):
+        return 0
+
+    def max_write_gen(self, table_name):
+        rows = self._tables.get(table_name, [])
+        return max((r.get("_write_gen", 0) for r in rows), default=0)
+
+    def evolve_schema(self, table_name, new_columns):
+        return list(new_columns.keys())
+
+    # NOTE: save_manifest / load_manifest are intentionally NOT overridden.
+
+
+class TestManifestlessStoreFailsLoudOnCreateIndex:
+    def _table(self):
+        store = ManifestlessStore()
+        table = make_table(store)
+        table.insert(DOCS)
+        return store, table
+
+    def test_create_index_raises_naming_store_and_capability(self):
+        _store, table = self._table()
+
+        with pytest.raises(NotImplementedError, match="ManifestlessStore") as exc:
+            table.create_index("main", vector="vec")
+        assert "save_manifest" in str(exc.value)
+
+    def test_no_index_is_silently_recorded(self):
+        """The failure must fire before the index is half-written."""
+        store, table = self._table()
+
+        with pytest.raises(NotImplementedError):
+            table.create_index("main", vector="vec")
+        # A fresh instance over the same store sees no phantom index.
+        fresh = make_table(store)
+        assert fresh.list_indexes() == []

--- a/tests/test_hypertable_indexes.py
+++ b/tests/test_hypertable_indexes.py
@@ -181,39 +181,47 @@ class TestRecipeCurrency:
 
 
 class TestLanceDBStoreSearchAbsentVsError:
-    """LanceDBStore.search: absent table is an empty result; any other error re-raises.
+    """LanceDBStore.search: an absent table is an empty result; a corrupt or
+    unreadable one re-raises.
 
-    An absent table means "no rows have ever been written" — a documented empty
-    result. But the catch must NOT swallow corruption/permission errors into the
-    same ``[]``; those are real failures and must surface.
+    A table LanceDB never created (no on-disk ``<name>.lance`` directory) means
+    "no rows have ever been written" — a documented empty result. But a table
+    whose directory exists yet fails to open is corrupt / permission-denied — a
+    real failure that must surface, not be swallowed into ``[]``. The error
+    message can't tell them apart (LanceDB raises the same "was not found"
+    ValueError for a corrupt table), so the store keys off the directory.
     """
 
     def test_absent_table_returns_empty(self, tmp_path):
         store = LanceDBStore(str(tmp_path / "absent_store"))
-        # Never opened/written this table -> genuinely absent.
+        # Never created -> no <name>.lance directory -> genuinely absent.
         assert store.search("never_written", query_vector=[1.0, 0.0, 0.0]) == []
 
-    def test_non_absence_error_reraises(self, tmp_path, monkeypatch):
-        store = LanceDBStore(str(tmp_path / "err_store"))
+    def test_corrupt_table_reraises(self, tmp_path, monkeypatch):
+        """A table whose directory exists but won't open is corrupt -> re-raise."""
+        store = LanceDBStore(str(tmp_path / "corrupt_store"))
+        # Simulate the on-disk directory being present (table was created)...
+        (store._path / "some_table.lance").mkdir(parents=True)
 
-        class BoomDB:
-            def open_table(self, name):
-                raise RuntimeError("disk corruption / permission denied")
+        # ...but open_table fails as LanceDB does for a corrupt table: the same
+        # "was not found" ValueError it also raises for a truly absent table.
+        def boom(name):
+            raise ValueError(f"Table '{name}' was not found")
 
-        monkeypatch.setattr(store, "_db", BoomDB())
-        with pytest.raises(RuntimeError, match="corruption"):
+        monkeypatch.setattr(store._db, "open_table", boom)
+        with pytest.raises(ValueError, match="was not found"):
             store.search("some_table", query_vector=[1.0, 0.0, 0.0])
 
-    def test_unrelated_valueerror_reraises(self, tmp_path, monkeypatch):
-        """A ValueError that is NOT 'table not found' must not be swallowed."""
-        store = LanceDBStore(str(tmp_path / "verr_store"))
+    def test_permission_error_reraises(self, tmp_path, monkeypatch):
+        """A non-ValueError open failure (permissions, etc.) must re-raise too."""
+        store = LanceDBStore(str(tmp_path / "perm_store"))
+        (store._path / "some_table.lance").mkdir(parents=True)
 
-        class BadValueDB:
-            def open_table(self, name):
-                raise ValueError("invalid vector column dtype")
+        def boom(name):
+            raise RuntimeError("permission denied")
 
-        monkeypatch.setattr(store, "_db", BadValueDB())
-        with pytest.raises(ValueError, match="dtype"):
+        monkeypatch.setattr(store._db, "open_table", boom)
+        with pytest.raises(RuntimeError, match="permission denied"):
             store.search("some_table", query_vector=[1.0, 0.0, 0.0])
 
 


### PR DESCRIPTION
## Problem / Bug / Challenge

The review bot parked two silent-fallback flags on #166. The owner's standing rule is **no silent fallbacks — fail loudly, naming what's unsupported.** Both were paths where a real capability gap or error got quietly turned into an empty result:

1. **`create_index` over a store that never implemented manifests "succeeded" silently.** A `TableStore` persists its index specs through `save_manifest`/`load_manifest`. Those are optional no-ops in the base class (a store that never uses indexes legitimately skips them). But a store that *does* get asked to `create_index` without implementing them used to return a fully-formed index spec — and then `list_indexes()` returned nothing, because the write went into the no-op. The failure surfaced far from its cause, at read time.

2. **`LanceDBStore.search` swallowed every table-open failure into `return []`.** The `except Exception: return []` caught a genuinely-absent table (fine) *and* corruption / permission errors / any other failure (not fine) — all collapsed into the same empty result.

## Before / After

**Manifestless store fails loud at `create_index` time, not silently at `list_indexes`**

*Before:*

```python
store = ManifestlessStore()          # implements row ops, leaves manifests as base no-op
table = HyperTable(..., store=store)
table.create_index("main", vector="vec")   # returns an index spec — looks fine
table.list_indexes()                        # []  <- silently gone
```

*After:*

```python
table.create_index("main", vector="vec")
# NotImplementedError: ManifestlessStore does not implement
# save_manifest/load_manifest, so it cannot persist named indexes.
# Implement both manifest hooks to support create_index, or use a
# store that does (e.g. LanceDBStore).
```

**Placement decision:** the base `save_manifest`/`load_manifest` stay OPTIONAL no-ops — `docs/08-hypertable/implementing-a-store.md` and the conformance harness both document them as optional, and a store that never uses indexes must not be forced to implement them. Making the base method raise would break those legitimate stores. So the loud failure lives at the **call site**: `HyperTable.create_index` checks a new `TableStore.supports_manifests()` (both hooks overridden — not just one) and raises `NotImplementedError` naming the store and `save_manifest`. It fires exactly when the capability is USED, and only then.

**LanceDB search: absent table is empty; a corrupt/unreadable one re-raises**

*Before:*

```python
except Exception:
    return []          # absent table AND corruption/permission errors -> [] silently
```

*After:*

```python
# Absent = LanceDB never created the table = no <name>.lance directory
# = "no rows ever written" (mirrors max_write_gen's absent -> 0).
if not self._table_dir_exists(table_name):
    return []
tbl = self._db.open_table(table_name)   # dir exists but won't open -> corrupt -> re-raises
```

**Semantics chosen:** an absent table stays a documented empty result — it means "no rows have ever been written," the same convention `max_write_gen` uses (absent → 0). The distinction is keyed off the **on-disk table directory**, not the error message. This matters because (confirmed against LanceDB 0.33) a *corrupt* table — directory present, internals gone — raises the **identical** `Table '<name>' was not found` ValueError as a truly absent table, so the message alone cannot tell them apart. A corrupt/unreadable/permission-denied table still has its `<name>.lance` directory, so `open_table`'s failure re-raises and surfaces. (This addresses Greptile's P1 on the first revision, which used message-matching.)

## Tests

TDD — failing tests first, then the fix. +5 tests over the #166 baseline (2931 → 2936):
- `create_index` on a manifestless store raises `NotImplementedError` naming the store + `save_manifest`; no phantom index is recorded.
- `LanceDBStore.search` returns `[]` for a genuinely-absent table (no directory); re-raises when the directory exists but `open_table` fails (corrupt) and on a non-ValueError open failure (permissions).

Full suite green with CI flags (`--extra daft`, `-W error`): **2936 passed, 0 skipped, 0 warnings.** `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)