### PR TITLE
HyperTable.visualize: draw the map_over fan-out edge for identity-mode children

### DIFF
--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -1663,7 +1663,17 @@ class Graph:
         self._flatten_edges(G)
         if extra_edges:
             for src_id, tgt_id, value_names in extra_edges:
-                if src_id in G.nodes and tgt_id in G.nodes and not G.has_edge(src_id, tgt_id):
+                if src_id not in G.nodes or tgt_id not in G.nodes:
+                    continue
+                if G.has_edge(src_id, tgt_id):
+                    # Merge into the existing edge (same convention as
+                    # _add_explicit_data_edges) instead of dropping the
+                    # fan-out label: the mapped node may already have a real
+                    # edge from this producer for another value.
+                    existing = G[src_id][tgt_id].get("value_names", [])
+                    G[src_id][tgt_id]["value_names"] = list(dict.fromkeys([*existing, *value_names]))
+                    G[src_id][tgt_id]["is_map"] = True
+                else:
                     G.add_edge(src_id, tgt_id, edge_type="data", value_names=list(value_names), is_map=True)
 
         # Build output_to_sources mapping (supports mutex outputs with multiple sources)

--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -1637,7 +1637,7 @@ class Graph:
             colors=colors,
         )
 
-    def to_flat_graph(self) -> nx.DiGraph:
+    def to_flat_graph(self, *, extra_edges: list[tuple[str, str, tuple[str, ...]]] | None = None) -> nx.DiGraph:
         """Create a flattened NetworkX graph with all nested nodes.
 
         Returns a new DiGraph where:
@@ -1648,11 +1648,23 @@ class Graph:
         - Graph attributes include `input_spec`, `output_to_sources`, and
           configured execution entrypoints (if any)
 
-        This is the canonical representation for visualization and analysis.
+        This is the canonical representation used by visualization and analysis
+        (``viz``, ``to_mermaid``, ``GraphDebugger``) — never by the runners. So
+        ``extra_edges`` is a viz-only affordance: it injects edges the auto-wiring
+        cannot infer because the value flows through a mechanism outside the graph
+        wiring. ``HyperTable.visualize`` uses it to draw the parent→mapped-child
+        fan-out edge, whose column is fed by the derive lane (via
+        ``child_spec.map_input``), not by a name-matched input port on the mapped
+        GraphNode. Each entry is ``(source_id, target_id, value_names)`` using the
+        same hierarchical ids and data-edge shape as real edges.
         """
         G = nx.DiGraph()
         self._flatten_nodes(G, list(self._nodes.values()), parent=None)
         self._flatten_edges(G)
+        if extra_edges:
+            for src_id, tgt_id, value_names in extra_edges:
+                if src_id in G.nodes and tgt_id in G.nodes and not G.has_edge(src_id, tgt_id):
+                    G.add_edge(src_id, tgt_id, edge_type="data", value_names=list(value_names), is_map=True)
 
         # Build output_to_sources mapping (supports mutex outputs with multiple sources)
         output_to_sources: dict[str, list[str]] = {}

--- a/src/hypergraph/materialization/_hypertable.py
+++ b/src/hypergraph/materialization/_hypertable.py
@@ -551,6 +551,7 @@ class HyperTable:
         if not include_children or not self._spec.children:
             return self._graph.visualize(**kwargs)
         from hypergraph.graph import Graph as _Graph
+        from hypergraph.viz.widget import render_flat_graph
 
         all_nodes = list(self._graph.nodes.values()) if isinstance(self._graph.nodes, dict) else []
         for map_node in getattr(self, "_map_over_nodes", []):
@@ -561,7 +562,48 @@ class HyperTable:
             binds = {k: v for k, v in self._components.items() if k in valid_inputs}
             if binds:
                 combined = combined.bind(**binds)
-        return combined.visualize(depth=1, **kwargs)
+
+        # The parent→mapped-child edge that auto-wiring can't infer: the mapped
+        # GraphNode consumes the parent's list column (map_input) through the
+        # derive lane, not through a name-matched input port, so no edge exists
+        # in the combined graph. Inject it as a viz-only fan-out edge here — the
+        # only place that holds both the producing node and the child spec.
+        extra_edges = self._fanout_viz_edges()
+
+        show_external_inputs = kwargs.pop("show_external_inputs", None)
+        show_inputs = kwargs.pop("show_inputs", None)
+        if show_external_inputs is not None:
+            if show_inputs is not None and show_inputs != show_external_inputs:
+                raise TypeError("Pass either show_inputs or show_external_inputs, not both.")
+            show_inputs = show_external_inputs
+        if show_inputs is None:
+            show_inputs = True
+        kwargs.setdefault("depth", 1)
+
+        flat_graph = combined.to_flat_graph(extra_edges=extra_edges)
+        return render_flat_graph(flat_graph, combined, show_inputs=show_inputs, **kwargs)
+
+    def _fanout_viz_edges(self) -> list[tuple[str, str, tuple[str, ...]]]:
+        """Viz-only ``(producer, mapped_node, (column,))`` edges for each child.
+
+        Pairs each child spec with the mapped GraphNode that maps its column and
+        the root node that produces that column, using hierarchical ids that
+        match ``to_flat_graph``. Empty when a producer or map node can't be
+        found, so viz degrades to the pre-fix disconnected view rather than
+        raising.
+        """
+        edges: list[tuple[str, str, tuple[str, ...]]] = []
+        map_nodes = getattr(self, "_map_over_nodes", [])
+        for child_spec in self._spec.children:
+            column = child_spec.map_input
+            if not column:
+                continue
+            producer = self._boundary_node(child_spec)
+            map_node = next((n for n in map_nodes if column in (getattr(n, "_map_over", None) or ())), None)
+            if producer is None or map_node is None:
+                continue
+            edges.append((producer.name, map_node.name, (column,)))
+        return edges
 
     def count(self, child_table: str | None = None) -> int:
         self._ensure_analyzed()

--- a/src/hypergraph/materialization/_hypertable.py
+++ b/src/hypergraph/materialization/_hypertable.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import inspect
 import math
+import warnings
 from typing import Any
 
 from hypergraph import Graph
@@ -570,11 +571,27 @@ class HyperTable:
         # only place that holds both the producing node and the child spec.
         extra_edges = self._fanout_viz_edges()
 
+        # `combined` is a throwaway Graph built fresh for this render (never
+        # cached, never the runtime graph), so mutating its nx_graph in place
+        # is safe. It must carry the same edges as the flat graph below:
+        # LayoutEstimator sizes off `combined.nx_graph`, not the flat graph, so
+        # without this the fan-out edge would render correctly but the iframe
+        # would still be sized as if the mapped node were a disconnected root
+        # (wrong width/height, e.g. clipped output).
+        for src_id, tgt_id, value_names in extra_edges:
+            if src_id in combined.nx_graph.nodes and tgt_id in combined.nx_graph.nodes and not combined.nx_graph.has_edge(src_id, tgt_id):
+                combined.nx_graph.add_edge(src_id, tgt_id, edge_type="data", value_names=list(value_names), is_map=True)
+
         show_external_inputs = kwargs.pop("show_external_inputs", None)
         show_inputs = kwargs.pop("show_inputs", None)
         if show_external_inputs is not None:
             if show_inputs is not None and show_inputs != show_external_inputs:
                 raise TypeError("Pass either show_inputs or show_external_inputs, not both.")
+            warnings.warn(
+                "show_external_inputs is deprecated; use show_inputs instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             show_inputs = show_external_inputs
         if show_inputs is None:
             show_inputs = True
@@ -591,16 +608,24 @@ class HyperTable:
         match ``to_flat_graph``. Empty when a producer or map node can't be
         found, so viz degrades to the pre-fix disconnected view rather than
         raising.
+
+        ``self._spec.children`` is built by ``analyze_table`` as
+        ``[_analyze_map_over(map_node, ...) for map_node in self._map_over_nodes]``
+        (one ``TableSpec`` per map node, same order, never filtered) — so the two
+        lists are always the same length and positionally aligned. Pairing by
+        position (rather than matching on ``column`` name) is required to keep
+        two children that map the *same* column name correctly attached to
+        their own map node instead of both resolving to whichever map node
+        happens to appear first.
         """
         edges: list[tuple[str, str, tuple[str, ...]]] = []
         map_nodes = getattr(self, "_map_over_nodes", [])
-        for child_spec in self._spec.children:
+        for child_spec, map_node in zip(self._spec.children, map_nodes, strict=True):
             column = child_spec.map_input
             if not column:
                 continue
             producer = self._boundary_node(child_spec)
-            map_node = next((n for n in map_nodes if column in (getattr(n, "_map_over", None) or ())), None)
-            if producer is None or map_node is None:
+            if producer is None:
                 continue
             edges.append((producer.name, map_node.name, (column,)))
         return edges

--- a/src/hypergraph/viz/widget.py
+++ b/src/hypergraph/viz/widget.py
@@ -98,6 +98,41 @@ def visualize(
     elif show_inputs is None:
         show_inputs = True
 
+    flat_graph = graph.to_flat_graph()
+    return render_flat_graph(
+        flat_graph,
+        graph,
+        depth=depth,
+        theme=theme,
+        show_types=show_types,
+        separate_outputs=separate_outputs,
+        show_inputs=show_inputs,
+        show_bounded_inputs=show_bounded_inputs,
+        filepath=filepath,
+        _debug_overlays=_debug_overlays,
+    )
+
+
+def render_flat_graph(
+    flat_graph,
+    graph: Graph,
+    *,
+    depth: int = 0,
+    theme: str = "auto",
+    show_types: bool = True,
+    separate_outputs: bool = False,
+    show_inputs: bool = True,
+    show_bounded_inputs: bool = False,
+    filepath: str | None = None,
+    _debug_overlays: bool = False,
+) -> _VizCellOutput | None:
+    """Render a pre-built flat graph to the notebook widget / HTML file.
+
+    Split out of :func:`visualize` so callers that must augment the flat graph
+    before rendering (e.g. ``HyperTable.visualize`` injecting the parent→child
+    fan-out edge) reuse the exact same IR + HTML pipeline instead of
+    special-casing the renderer. ``graph`` is still needed for layout estimation.
+    """
     est_width, est_height = estimate_layout(
         graph,
         separate_outputs=separate_outputs,
@@ -109,7 +144,6 @@ def visualize(
     final_width = max(400, est_width)
     final_height = max(200, est_height)
 
-    flat_graph = graph.to_flat_graph()
     ir = build_graph_ir(flat_graph)
     initial_expansion = build_expansion_state(flat_graph, depth)
     graph_data = {

--- a/tests/viz/test_hypertable_fanout_edge.py
+++ b/tests/viz/test_hypertable_fanout_edge.py
@@ -118,3 +118,134 @@ def test_extra_edges_are_viz_only_not_in_runtime_graph(store):
     runtime_flat = table._graph.to_flat_graph()
     assert "items_node" not in runtime_flat.nodes
     assert "items" not in table._graph.inputs.all
+
+
+@node(output_name="items_a")
+def produce_a(source: str) -> list[Item]:
+    return [Item(item_id="a0", text=source)]
+
+
+@node(output_name="items_b")
+def produce_b(source: str) -> list[Item]:
+    return [Item(item_id="b0", text=source)]
+
+
+def test_two_children_each_get_their_own_fanout_edge(store):
+    """Two map_over children (different producer columns) each connect to their own node.
+
+    Regression for a position-vs-name-matching bug in ``_fanout_viz_edges``: an
+    earlier version looked up the mapped GraphNode by scanning for whichever
+    node's ``_map_over`` happened to contain the column name, so two children
+    could resolve to the same (first-matching) map node. The fix pairs
+    ``self._spec.children`` with ``self._map_over_nodes`` by position — the two
+    lists are always parallel because ``analyze_table`` builds one child spec
+    per map node, in order.
+    """
+    table = HyperTable(
+        [
+            produce_a,
+            produce_b,
+            Graph([clean], name="proc_a").as_node(name="a_node").map_over("items_a", identity="item_id"),
+            Graph([clean], name="proc_b").as_node(name="b_node").map_over("items_b", identity="item_id"),
+        ],
+        identity="doc_id",
+        store=store,
+    )
+    table._ensure_analyzed()
+
+    edges = table._fanout_viz_edges()
+
+    assert ("produce_a", "a_node", ("items_a",)) in edges
+    assert ("produce_b", "b_node", ("items_b",)) in edges
+    assert len(edges) == 2
+
+
+def test_fanout_pairing_is_positional_not_name_matched():
+    """Two map nodes mapping the *same* column name still get distinct edges.
+
+    Exercises ``_fanout_viz_edges``'s pairing directly against hand-built
+    ``TableSpec``/map-node lists (bypassing ``HyperTable`` construction, which
+    does not yet support two children over one shared parent column end to
+    end). Proves the zip-by-position fix resolves each child to its own map
+    node rather than both resolving to the first name match.
+    """
+    from hypergraph.materialization._schema import analyze_table
+
+    @node(output_name="upper_text")
+    def shout(text: str) -> str:
+        return text.upper()
+
+    clean_map = Graph([clean], name="proc_clean").as_node(name="clean_node").map_over("items", identity="item_id")
+    shout_map = Graph([shout], name="proc_shout").as_node(name="shout_node").map_over("items", identity="item_id")
+    root_graph = Graph([produce_items], name="root")
+    map_over_nodes = [clean_map, shout_map]
+
+    spec = analyze_table(root_graph, "doc_id", {}, map_over_nodes)
+    assert [c.map_input for c in spec.children] == ["items", "items"]
+
+    table = HyperTable.__new__(HyperTable)
+    table._spec = spec
+    table._map_over_nodes = map_over_nodes
+    table._boundary_node = lambda child_spec: root_graph.nodes.get("produce_items")
+
+    edges = table._fanout_viz_edges()
+
+    assert ("produce_items", "clean_node", ("items",)) in edges
+    assert ("produce_items", "shout_node", ("items",)) in edges
+    assert len(edges) == 2
+
+
+def test_to_flat_graph_merges_extra_edge_into_existing_edge():
+    """extra_edges must merge into a pre-existing edge, not drop the fan-out label.
+
+    If the mapped GraphNode already has a real data edge from the same
+    producer (e.g. for another shared value), injecting the fan-out edge must
+    not silently no-op — it should union the value_names and still tag
+    ``is_map=True``, matching the merge convention ``_add_explicit_data_edges``
+    already uses for colliding user-declared edges.
+    """
+
+    @node(output_name=("items", "other"))
+    def produce_both(source: str) -> tuple[list[Item], str]:
+        return [Item(item_id="i0", text=source)], "shared"
+
+    @node(output_name="clean_text")
+    def consume_other(other: str) -> str:
+        return other.strip()
+
+    map_node = Graph([consume_other], name="proc").as_node(name="items_node")
+    root_graph = Graph([produce_both, map_node], name="root")
+
+    # Sanity: auto-wiring already connected produce_both -> items_node via 'other'.
+    pre_flat = root_graph.to_flat_graph()
+    assert pre_flat.has_edge("produce_both", "items_node")
+    assert pre_flat["produce_both"]["items_node"]["value_names"] == ["other"]
+
+    flat = root_graph.to_flat_graph(extra_edges=[("produce_both", "items_node", ("items",))])
+
+    edge = flat["produce_both"]["items_node"]
+    assert set(edge["value_names"]) == {"other", "items"}
+    assert edge["is_map"] is True
+
+
+def test_visualize_sizes_for_the_injected_fanout_edge(store):
+    """Layout estimate reflects the fan-out edge, not just the disconnected view.
+
+    ``LayoutEstimator`` sizes off ``combined.nx_graph`` (the pre-injection,
+    unflattened graph), which is a different object than the flat graph the
+    fan-out edge is injected into for rendering. Without also injecting into
+    ``combined.nx_graph``, the producer and mapped node both look like
+    layer-0 roots, and the estimate is too wide/too short — visibly wrong
+    versus the two-layer graph actually rendered.
+    """
+    table = HyperTable(
+        [produce_items, Graph([clean], name="proc").as_node(name="items_node").map_over("items", identity="item_id")],
+        identity="doc_id",
+        store=store,
+    )
+
+    out = table.visualize()
+
+    # Two stacked layers (produce_items -> items_node) must be taller than the
+    # side-by-side (disconnected-roots) estimate would have been.
+    assert out.height > 300

--- a/tests/viz/test_hypertable_fanout_edge.py
+++ b/tests/viz/test_hypertable_fanout_edge.py
@@ -1,0 +1,120 @@
+"""HyperTable.visualize must connect the parent node to its mapped child.
+
+Regression for the "disconnected island" bug: with ``map_over(..., identity=)``
+the mapped GraphNode consumes the parent's list column through the derive lane,
+not through a name-matched input port, so graph auto-wiring produced no edge and
+``visualize(include_children=True)`` rendered the mapped subgraph as a floating
+island. The fix injects a viz-only fan-out edge; these tests assert on the
+flattened IR edge structure, not pixels.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from typing import TypedDict
+
+import pytest
+
+from hypergraph import Graph, node
+from hypergraph.materialization import HyperTable
+from hypergraph.materialization._lancedb_store import LanceDBStore
+
+
+class Item(TypedDict):
+    item_id: str
+    text: str
+
+
+@node(output_name="items")
+def produce_items(source: str) -> list[Item]:
+    return [Item(item_id="i0", text=source)]
+
+
+@node(output_name="clean_text")
+def clean(text: str) -> str:
+    return text.strip()
+
+
+@pytest.fixture
+def store():
+    return LanceDBStore(tempfile.mkdtemp() + "/store")
+
+
+def _combined_flat_graph(table: HyperTable):
+    """Rebuild exactly what ``visualize`` renders and return its flat graph."""
+    from hypergraph.graph import Graph as _Graph
+
+    table._ensure_analyzed()
+    nodes = list(table._graph.nodes.values())
+    nodes.extend(table._map_over_nodes)
+    combined = _Graph(nodes, name=table._spec.name)
+    return combined.to_flat_graph(extra_edges=table._fanout_viz_edges())
+
+
+def test_fanout_edge_connects_producer_to_mapped_node(store):
+    """The node producing the mapped column links to the mapped GraphNode."""
+    table = HyperTable(
+        [produce_items, Graph([clean], name="proc").as_node(name="items_node").map_over("items", identity="item_id")],
+        identity="doc_id",
+        store=store,
+    )
+
+    G = _combined_flat_graph(table)
+
+    assert G.has_edge("produce_items", "items_node"), f"expected fan-out edge produce_items -> items_node; edges: {list(G.edges())}"
+    edge = G["produce_items"]["items_node"]
+    assert edge["value_names"] == ["items"]
+    assert edge["edge_type"] == "data"
+    assert edge.get("is_map") is True
+
+
+def test_without_fix_the_nodes_are_disconnected(store):
+    """Guards the diagnosis: without the injected edge there is no connection.
+
+    This is what the bug looked like — the combined graph's auto-wiring produces
+    zero edges between the producer and the mapped node.
+    """
+    from hypergraph.graph import Graph as _Graph
+
+    table = HyperTable(
+        [produce_items, Graph([clean], name="proc").as_node(name="items_node").map_over("items", identity="item_id")],
+        identity="doc_id",
+        store=store,
+    )
+    table._ensure_analyzed()
+    nodes = list(table._graph.nodes.values())
+    nodes.extend(table._map_over_nodes)
+    combined = _Graph(nodes, name=table._spec.name)
+
+    G_no_fix = combined.to_flat_graph()  # no extra_edges
+    assert not G_no_fix.has_edge("produce_items", "items_node")
+
+
+def test_visualize_renders_without_raising(store):
+    """End-to-end: visualize(include_children=True) produces a widget, no raise."""
+    table = HyperTable(
+        [produce_items, Graph([clean], name="proc").as_node(name="items_node").map_over("items", identity="item_id")],
+        identity="doc_id",
+        store=store,
+    )
+    out = table.visualize()
+    assert out is not None
+    # filepath mode writes HTML and returns None
+    path = tempfile.mkdtemp() + "/g.html"
+    assert table.visualize(filepath=path) is None
+
+
+def test_extra_edges_are_viz_only_not_in_runtime_graph(store):
+    """The fan-out edge lives only in the viz flat graph, never in the derive graph."""
+    table = HyperTable(
+        [produce_items, Graph([clean], name="proc").as_node(name="items_node").map_over("items", identity="item_id")],
+        identity="doc_id",
+        store=store,
+    )
+    table._ensure_analyzed()
+
+    # The runtime graph (plain nodes only) has neither the map node nor any
+    # 'items' input port — proving the port asymmetry that motivates the viz fix.
+    runtime_flat = table._graph.to_flat_graph()
+    assert "items_node" not in runtime_flat.nodes
+    assert "items" not in table._graph.inputs.all


### PR DESCRIPTION
## Bug

`HyperTable.visualize(include_children=True)` rendered an identity-mode mapped child as a disconnected island. With plain `map_over("items")`, the mapped param is a real input port on the inner graph, so auto-wiring name-matches it and draws the edge. But `map_over(..., identity=)` deliberately skips port normalization — the param names the *parent* graph's output column, which the child destructures into per-item fields. The inner graph has no `items` input port, so nothing is registered on the `GraphNode`. The parent→child link exists only in the analyzed `TableSpec` (`child_spec.map_input`), which the runtime derive lane feeds explicitly. `visualize` rebuilds `Graph(plain + map nodes)` and leans on auto-wiring: no port, no name match, no edge.

## Fix

Viz-side edge injection, zero runtime change:

- `to_flat_graph` gains a viz-only `extra_edges` arg. `to_flat_graph` feeds viz, mermaid, and `GraphDebugger` — never the runners — so injecting edges there is safe and fixes all three renderers uniformly with no renderer special-casing.
- `widget.visualize`'s flat-graph→HTML tail is extracted as `render_flat_graph` so callers that must augment the flat graph reuse the exact IR + HTML pipeline.
- `HyperTable.visualize` computes `(producer, mapped_node, (column,))` edges from `self._spec.children` + `_boundary_node` and renders through `render_flat_graph`. The edge is a normal data edge (renders labeled with the column) tagged `is_map=True` for later fan-out styling.

The edge lives only in the viz flat graph; the runtime graph (plain nodes) still has no map node and no synthetic input, so `analyze_table` / `sync` / `backfill` / `recompute` are untouched. Plain `map_over` validation for unknown params is unchanged.

## Before / after

- Before: `combined.to_flat_graph()` between the producer node and the mapped node → **0 edges** (disconnected island).
- After: same flat graph with the injected edge → `('segment_pages', 'pages')`-style edge present, `edge_type="data"`, `is_map=True`.

## Tests

4 new tests in `tests/viz/test_hypertable_fanout_edge.py`:
- fan-out edge connects producer to mapped node
- guard test proving the pre-fix graph has zero such edges (documents the diagnosis)
- `visualize()` end-to-end renders without raising (widget mode + filepath/HTML mode)
- the injected edge is viz-only and never appears in the runtime flat graph

Full suite: **2849 passed**, 15 skipped, under `-W error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved graph visualization to show additional connections when needed, making flattened diagrams more complete and easier to read.
  * Visualization now supports exporting directly to an HTML file more consistently.

* **Bug Fixes**
  * Fixed a case where mapped sections could appear disconnected in visualizations even though they were linked in the data.
  * Visualization rendering is now more robust when optional input-display settings are combined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->