### PR TITLE
viz: fix dagre crash on the fan-out edge into an expanded mapped container

### DIFF
--- a/src/hypergraph/viz/renderer/ir_builder.py
+++ b/src/hypergraph/viz/renderer/ir_builder.py
@@ -165,10 +165,13 @@ def _build_ir_edge(
             if internal is not None:
                 target_when_expanded = internal
                 break
-        # Control edges to a container should re-route to the container's
-        # entrypoint when the container is expanded — value_names is empty
-        # for control edges, so the producer/consumer search above is a no-op.
-        if target_when_expanded is None and edge_type == "control":
+        # Any edge into a container still unresolved here must re-route to the
+        # container's entrypoint when the container is expanded, or the scene
+        # holds an edge into a node the layouter never ranked. Two ways to land
+        # here: control edges (value_names is empty, so the consumer search is
+        # a no-op) and identity-mode fan-out edges (the value names a parent
+        # column — e.g. "pages" — that no inner node consumes by name).
+        if target_when_expanded is None:
             target_when_expanded = _first_container_entrypoint(tgt, flat_graph)
 
     label = _branch_label_for_edge(src_attrs, tgt) if edge_type == "control" else None

--- a/tests/viz/test_hypertable_fanout_edge.py
+++ b/tests/viz/test_hypertable_fanout_edge.py
@@ -249,3 +249,29 @@ def test_visualize_sizes_for_the_injected_fanout_edge(store):
     # Two stacked layers (produce_items -> items_node) must be taller than the
     # side-by-side (disconnected-roots) estimate would have been.
     assert out.height > 300
+
+
+def test_fanout_edge_ir_reroutes_into_expanded_container(store):
+    """The IR edge into the mapped GRAPH container must carry target_when_expanded.
+
+    The mapped container starts EXPANDED at the default depth, and the JS scene
+    builder ranks only visible nodes — an edge whose target is the (invisible,
+    expanded) container crashes dagre with "Cannot set properties of undefined
+    (setting 'rank')". The consumer-by-name search can never resolve an
+    identity-mode fan-out edge (the value names a parent column no inner node
+    consumes), so it must fall back to the container's entrypoint.
+    """
+    from hypergraph.viz.renderer.ir_builder import build_graph_ir
+
+    table = HyperTable(
+        [produce_items, Graph([clean], name="proc").as_node(name="items_node").map_over("items", identity="item_id")],
+        identity="doc_id",
+        store=store,
+    )
+
+    ir = build_graph_ir(_combined_flat_graph(table))
+
+    (fanout,) = [e for e in ir.edges if e.source == "produce_items" and e.target == "items_node"]
+    assert fanout.target_when_expanded == "items_node/clean", (
+        f"fan-out edge must re-route to the container entrypoint when expanded; got {fanout.target_when_expanded!r}"
+    )


### PR DESCRIPTION
## Bug

Follow-up to #168. Rendering `HyperTable.visualize()` for an identity-mode mapped child crashed the widget at layout time: **"Cannot set properties of undefined (setting 'rank')"** (dagre), reported from the real Panda KB.

## Root cause

The injected fan-out edge targets the mapped GRAPH container, and its value name is the parent column (`pages`) — which no inner node consumes by name (the inner input is the item field `page_text`). So `_find_deepest_internal_consumer` never resolves, `target_when_expanded` stayed `None`, and since the mapped container starts EXPANDED at the default depth, the JS scene builder emitted an edge into a node dagre never ranked.

## Fix

`_build_ir_edge` already had the correct fallback for control edges (same no-op-search shape: empty `value_names`): re-route to the container's entrypoint. Widen that fallback to any edge into a container left unresolved by the consumer search. Resolved edges are untouched.

## Before / after (real Panda KB)

- Before: `target_when_expanded=None` → widget crashes with the dagre rank error.
- After: `target_when_expanded='pages/embed_page'` → renders; `convert_document → segment_pages → PAGES` one connected component.

## Tests

- New: `test_fanout_edge_ir_reroutes_into_expanded_container` (asserts the IR redirect, the python proxy for the JS crash).
- Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)