### PR TITLE
viz: route the identity-mode fan-out edge through the mapped item's field pills (option A)

### DIFF
--- a/src/hypergraph/materialization/_hypertable.py
+++ b/src/hypergraph/materialization/_hypertable.py
@@ -21,6 +21,7 @@ from hypergraph.materialization._schema import (
     analyze_table,
     input_names,
     is_internal_column,
+    item_schema_fields,
     node_func,
     python_type_to_arrow,
     return_type,
@@ -598,6 +599,17 @@ class HyperTable:
         kwargs.setdefault("depth", 1)
 
         flat_graph = combined.to_flat_graph(extra_edges=extra_edges)
+
+        # Tag each injected fan-out edge with the mapped item's schema fields.
+        # The ir_builder reads ``map_fields`` to re-route the edge into the
+        # matching inner INPUT pill(s) when the container is expanded, and to
+        # mark those pills as map-fed (see ir_builder._build_ir_edge). Kept off
+        # ``extra_edges`` so ``to_flat_graph`` stays a generic viz affordance.
+        map_fields = self._fanout_map_fields()
+        for (src_id, tgt_id), field_names in map_fields.items():
+            if flat_graph.has_edge(src_id, tgt_id):
+                flat_graph[src_id][tgt_id]["map_fields"] = list(field_names)
+
         return render_flat_graph(flat_graph, combined, show_inputs=show_inputs, **kwargs)
 
     def _fanout_viz_edges(self) -> list[tuple[str, str, tuple[str, ...]]]:
@@ -629,6 +641,34 @@ class HyperTable:
                 continue
             edges.append((producer.name, map_node.name, (column,)))
         return edges
+
+    def _fanout_map_fields(self) -> dict[tuple[str, str], tuple[str, ...]]:
+        """``(producer, mapped_node) -> item-schema field names`` for each child.
+
+        The viz uses these to re-route the fan-out edge, when the container is
+        expanded, into the inner INPUT pill(s) fed by an item field — so the
+        unpack ``segment_pages ──pages──▶ [page_text] ──▶ embed_page`` is
+        visible instead of the edge landing on ``embed_page`` beside a
+        free-floating ``page_text`` input pill.
+
+        Field discovery priority (matches the fingerprinting/schema lanes):
+        the map node's ``_map_config["schema"]`` if set, else the producing
+        node's return annotation (``list[PageItem]`` where ``PageItem`` is a
+        TypedDict). A schema with no fields (``list[str]``) yields ``()`` — the
+        ir_builder then falls back to the container entrypoint (#169 behavior).
+        """
+        fields: dict[tuple[str, str], tuple[str, ...]] = {}
+        map_nodes = getattr(self, "_map_over_nodes", [])
+        for child_spec, map_node in zip(self._spec.children, map_nodes, strict=True):
+            if not child_spec.map_input:
+                continue
+            producer = self._boundary_node(child_spec)
+            if producer is None:
+                continue
+            config = getattr(map_node, "_map_config", None) or {}
+            schema = config.get("schema") or return_type(producer)
+            fields[(producer.name, map_node.name)] = item_schema_fields(schema)
+        return fields
 
     def count(self, child_table: str | None = None) -> int:
         self._ensure_analyzed()

--- a/src/hypergraph/materialization/_hypertable.py
+++ b/src/hypergraph/materialization/_hypertable.py
@@ -666,7 +666,16 @@ class HyperTable:
             if producer is None:
                 continue
             config = getattr(map_node, "_map_config", None) or {}
-            schema = config.get("schema") or return_type(producer)
+            schema = config.get("schema")
+            if schema is None:
+                # ``return_type`` resolves the producer's annotation, which can
+                # raise on an unresolved forward reference. Viz must degrade to
+                # entrypoint routing on a valid table, never crash — so treat an
+                # unresolvable annotation as "no discoverable fields".
+                try:
+                    schema = return_type(producer)
+                except Exception:
+                    schema = None
             fields[(producer.name, map_node.name)] = item_schema_fields(schema)
         return fields
 

--- a/src/hypergraph/materialization/_schema.py
+++ b/src/hypergraph/materialization/_schema.py
@@ -78,6 +78,36 @@ def return_type(node: Any) -> Any:
     return typing.get_type_hints(func).get("return", str)
 
 
+def item_schema_fields(schema: Any) -> tuple[str, ...]:
+    """Field names of a mapped-item schema, or ``()`` when it has none.
+
+    Used by the fan-out viz to tell an inner input that is fed by an item
+    field (``page_text`` off a ``list[PageItem]``) apart from a genuine
+    external input. Accepts either the item type directly (``PageItem``) or
+    the producer's ``list[PageItem]`` annotation. Only mapping-like schemas
+    (TypedDicts, dataclasses, Pydantic models) expose fields; a ``list[str]``
+    item has none, so the caller falls back to the entrypoint.
+    """
+    if schema is None:
+        return ()
+    origin = typing.get_origin(schema)
+    if origin in (list, tuple):
+        args = typing.get_args(schema)
+        if not args:
+            return ()
+        schema = args[0]
+    # Pydantic models expose their fields under ``model_fields``; TypedDicts and
+    # dataclasses expose them via annotations (get_type_hints resolves both).
+    model_fields = getattr(schema, "model_fields", None)
+    if isinstance(model_fields, dict) and model_fields:
+        return tuple(model_fields.keys())
+    try:
+        hints = typing.get_type_hints(schema)
+    except Exception:
+        hints = getattr(schema, "__annotations__", {}) or {}
+    return tuple(hints.keys())
+
+
 def _input_types(graph: Any) -> dict[str, Any]:
     input_types: dict[str, Any] = {}
     nodes_dict = graph.nodes if isinstance(graph.nodes, dict) else {}

--- a/src/hypergraph/viz/AGENTS.md
+++ b/src/hypergraph/viz/AGENTS.md
@@ -100,6 +100,12 @@ helper from ``tests/viz/conftest.py``. In the browser, App calls
 The IR carries all expansion-rewriting information eagerly:
 - ``IREdge.source_when_expanded`` / ``target_when_expanded`` re-route
   edges to the deepest internal producer/consumer when a container is expanded.
+  An identity-mode fan-out edge (``HyperTable.visualize``) re-routes instead to
+  the mapped item's field INPUT pill(s) — ``segment_pages ──pages──▶ [page_text]
+  ──▶ embed_page`` — so ``target_when_expanded`` may be a tuple of pill ids, and
+  each such pill is flagged ``IRExternalInput.map_fed`` (styled distinctly, not
+  as a free-floating external input). Falls back to the container entrypoint
+  when the mapped item has no matching field (e.g. ``list[str]``).
 - ``IREdge.is_back_edge`` marks DFS back-edges so feedback routing survives
   arbitrary expansion changes.
 - ``IRNode.outputs[i].internal_only`` flags outputs whose consumers all

--- a/src/hypergraph/viz/assets/scene_builder.js
+++ b/src/hypergraph/viz/assets/scene_builder.js
@@ -14,7 +14,8 @@
 
   // Pinned by Python via GraphIR.schema_version. Bump in lockstep with
   // ir_schema.py:CURRENT_SCHEMA_VERSION when the IR shape changes.
-  var SUPPORTED_SCHEMA_VERSION = '2';
+  // v3: tuple target_when_expanded (multi field-pill fan-out) + map_fed inputs.
+  var SUPPORTED_SCHEMA_VERSION = '3';
 
   function isSchemaSupported(ir) {
     if (!ir) return true;

--- a/src/hypergraph/viz/assets/scene_builder.js
+++ b/src/hypergraph/viz/assets/scene_builder.js
@@ -135,6 +135,7 @@
             params: params.slice(),
             paramTypes: typeHints.slice(),
             isBound: !!ext.is_bound,
+            mapFed: !!ext.map_fed,
             ownerContainer: ownerContainer,
             deepestOwnerContainer: ext.deepest_owner,
             actualTargets: (ext.consumers || []).slice(),
@@ -144,6 +145,7 @@
             label: params[0],
             typeHint: typeHints[0] || null,
             isBound: !!ext.is_bound,
+            mapFed: !!ext.map_fed,
             ownerContainer: ownerContainer,
             deepestOwnerContainer: ext.deepest_owner,
             actualTargets: (ext.consumers || []).slice(),
@@ -222,8 +224,15 @@
           ? irEdge.source_when_expanded.slice()
           : [irEdge.source_when_expanded];
       }
-      var tgt = irEdge.target;
-      if (expansionState[tgt] && irEdge.target_when_expanded) tgt = irEdge.target_when_expanded;
+      // A fan-out edge into an expanded container may re-route to several
+      // item-field INPUT pills, so target_when_expanded can be an array; emit
+      // one edge per target (mirrors the multi-source fan-out below).
+      var targets = [irEdge.target];
+      if (expansionState[irEdge.target] && irEdge.target_when_expanded) {
+        targets = Array.isArray(irEdge.target_when_expanded)
+          ? irEdge.target_when_expanded.slice()
+          : [irEdge.target_when_expanded];
+      }
 
       // A data edge can carry multiple value_names (one NetworkX edge per
       // (src,tgt) merges them). Merged-output mode should still render one
@@ -232,27 +241,30 @@
       var valueNames = irEdge.value_names || [];
       var valuesToEmit = (separateOutputs && irEdge.edge_type === 'data' && valueNames.length > 0) ? valueNames : [null];
 
-      for (var bs = 0; bs < baseSources.length; bs++) {
-        var baseSrc = baseSources[bs];
-        for (var v = 0; v < valuesToEmit.length; v++) {
-          var valueName = valuesToEmit[v];
-          var src = baseSrc;
-          if (separateOutputs && irEdge.edge_type === 'data' && valueName !== null) {
-            src = 'data_' + src + '_' + valueName;
+      for (var ti = 0; ti < targets.length; ti++) {
+        var tgt = targets[ti];
+        for (var bs = 0; bs < baseSources.length; bs++) {
+          var baseSrc = baseSources[bs];
+          for (var v = 0; v < valuesToEmit.length; v++) {
+            var valueName = valuesToEmit[v];
+            var src = baseSrc;
+            if (separateOutputs && irEdge.edge_type === 'data' && valueName !== null) {
+              src = 'data_' + src + '_' + valueName;
+            }
+            sceneEdges.push({
+              id: valueName === null ? src + '__' + tgt : src + '__' + tgt + '__' + valueName,
+              source: src,
+              target: tgt,
+              data: {
+                edgeType: irEdge.edge_type,
+                valueName: valueName,
+                label: (irEdge.label === undefined ? null : irEdge.label),
+                exclusive: !!irEdge.exclusive,
+                forceFeedback: !!irEdge.is_back_edge,
+              },
+              hidden: !visibleIds[src] || !visibleIds[tgt],
+            });
           }
-          sceneEdges.push({
-            id: valueName === null ? src + '__' + tgt : src + '__' + tgt + '__' + valueName,
-            source: src,
-            target: tgt,
-            data: {
-              edgeType: irEdge.edge_type,
-              valueName: valueName,
-              label: (irEdge.label === undefined ? null : irEdge.label),
-              exclusive: !!irEdge.exclusive,
-              forceFeedback: !!irEdge.is_back_edge,
-            },
-            hidden: !visibleIds[src] || !visibleIds[tgt],
-          });
         }
       }
     }

--- a/src/hypergraph/viz/assets/viz_nodes.js
+++ b/src/hypergraph/viz/assets/viz_nodes.js
@@ -116,13 +116,26 @@
     // ── INPUT node ──
     if (nodeType === 'INPUT') {
       var tc = isLight ? 'text-slate-400' : 'text-slate-500';
+      // A map-fed input (an item field of a fan-out's mapped item, e.g.
+      // ``page_text`` off ``list[PageItem]``) is supplied by the parent's list
+      // column through the map — NOT a free-floating external input. Style it
+      // distinctly (amber accent, ⤨ marker) and give it a target handle so the
+      // re-routed fan-out edge attaches to it instead of looking like an
+      // external supplier.
+      var mapFed = !!data.mapFed;
+      var mapFedCls = mapFed
+        ? (isLight ? ' border-amber-300 text-amber-700 shadow-amber-100 hover:border-amber-400'
+                   : ' border-amber-500/60 text-amber-300 shadow-black/50 hover:border-amber-400')
+        : (isLight ? ' bg-white border-slate-200 text-slate-700 shadow-slate-200 hover:border-slate-300'
+                   : ' bg-slate-900 border-slate-700 text-slate-300 shadow-black/50 hover:border-slate-600');
       return html`
         <div className="w-full h-full relative" style=${wrapStyle}>
-          <div className=${'px-3 py-1.5 w-full h-full relative rounded-full border shadow-sm flex items-center justify-center gap-2 transition-colors transition-shadow duration-200 hover:shadow-lg overflow-hidden' + (data.isBound ? ' border-dashed' : '') + (isLight ? ' bg-white border-slate-200 text-slate-700 shadow-slate-200 hover:border-slate-300' : ' bg-slate-900 border-slate-700 text-slate-300 shadow-black/50 hover:border-slate-600')}>
-            <span className=${'shrink-0 ' + (isLight ? 'text-slate-400' : 'text-slate-500')}><${Icons.Data} /></span>
+          <div className=${'px-3 py-1.5 w-full h-full relative rounded-full border shadow-sm flex items-center justify-center gap-2 transition-colors transition-shadow duration-200 hover:shadow-lg overflow-hidden' + (data.isBound ? ' border-dashed' : '') + (mapFed && isLight ? ' bg-amber-50' : '') + (mapFed && !isLight ? ' bg-slate-900' : '') + mapFedCls}>
+            <span className=${'shrink-0 ' + (mapFed ? (isLight ? 'text-amber-500' : 'text-amber-400') : (isLight ? 'text-slate-400' : 'text-slate-500'))}>${mapFed ? '⤨' : html`<${Icons.Data} />`}</span>
             <span className="text-xs font-mono font-medium shrink-0">${data.label}</span>
             ${data.showTypes && data.typeHint ? html`<span className=${'text-xs font-mono truncate min-w-0 ' + tc} title=${data.typeHint}>: ${truncateTypeHint(data.typeHint)}</span>` : null}
           </div>
+          ${mapFed ? html`<${Handle} type="target" position=${Position.Top} className="!w-2 !h-2 !opacity-0" style=${tgtStyle} />` : null}
           <${Handle} type="source" position=${Position.Bottom} className="!w-2 !h-2 !opacity-0" style=${srcStyle} />
         </div>`;
     }

--- a/src/hypergraph/viz/ir_schema.py
+++ b/src/hypergraph/viz/ir_schema.py
@@ -33,8 +33,11 @@ class IREdge:
     # branches can expose the same container output from multiple internal
     # producers, so scene_builder rewrites to all of them when expanded.
     source_when_expanded: str | tuple[str, ...] | None = None
-    # Symmetric: deepest internal consumer when the target container is expanded.
-    target_when_expanded: str | None = None
+    # Symmetric: deepest internal consumer when the target container is
+    # expanded. Usually one node; an identity-mode fan-out edge whose mapped
+    # item has multiple item-field inputs re-routes to all matching INPUT pills,
+    # so this may be a tuple (mirrors ``source_when_expanded``).
+    target_when_expanded: str | tuple[str, ...] | None = None
     # Output-value names this edge carries (for separate_outputs mode, where
     # the data flow goes producer -> data_node -> consumer instead of
     # producer -> consumer directly).
@@ -71,6 +74,12 @@ class IRExternalInput:
     type_hints: tuple[str | None, ...] = ()  # one per param
     is_bound: bool = False
     id_segments: tuple[str, ...] = ()  # one per param; falls back to params if empty
+    # True when this input is a field of a mapped item (e.g. ``page_text`` off
+    # a ``list[PageItem]`` fan-out): the parent's list column supplies it via
+    # the map, so it is NOT a genuine external supplier. The fan-out edge
+    # re-routes into this pill when the container is expanded; frontends style
+    # it distinctly instead of as a free-floating external input.
+    map_fed: bool = False
 
     @property
     def name(self) -> str:

--- a/src/hypergraph/viz/ir_schema.py
+++ b/src/hypergraph/viz/ir_schema.py
@@ -109,7 +109,10 @@ class IRExternalInput:
 # Bump when the IR shape changes in a way old scene_builders can't read.
 # Both Python and JS scene_builders pin to this value; mismatches trigger
 # the static-fallback banner instead of a runtime exception.
-CURRENT_SCHEMA_VERSION = "2"
+# v3: ``IREdge.target_when_expanded`` may be a tuple (multi field-pill fan-out
+# re-route) and ``IRExternalInput`` gained ``map_fed`` — an old v2 scene builder
+# would mis-render both, so it must hit the mismatch banner instead.
+CURRENT_SCHEMA_VERSION = "3"
 
 
 class IRSchemaError(ValueError):

--- a/src/hypergraph/viz/renderer/ir_builder.py
+++ b/src/hypergraph/viz/renderer/ir_builder.py
@@ -99,20 +99,23 @@ def _map_fed_fields(flat_graph: nx.DiGraph) -> dict[str, set[str]]:
 
     ``HyperTable.visualize`` stamps ``map_fields`` (the mapped item's schema
     field names) on each injected fan-out edge; the target is the mapped
-    container. Only fields an inner node actually consumes matter — a schema
-    field with no matching inner input (e.g. ``page_id``) is not a viz input,
-    so it is intersected out here.
+    container. Only fields the container actually consumes matter — a schema
+    field with no matching input (e.g. ``page_id``) is not a viz input, so it
+    is intersected out here.
+
+    Matching is against the mapped container's OWN input ports (parent-facing
+    names), not descendants' inner inputs. That is the name space the item
+    fields and the external-input pills share, so a container that renames an
+    inner input (``with_inputs(chunk="page_text")`` / ``rename_inputs``) still
+    matches on the parent-facing ``page_text`` rather than the renamed ``chunk``.
     """
     result: dict[str, set[str]] = {}
     for _src, tgt, attrs in flat_graph.edges(data=True):
         fields = attrs.get("map_fields")
         if not fields:
             continue
-        inner_inputs: set[str] = set()
-        for node_id, node_attrs in flat_graph.nodes(data=True):
-            if _is_descendant(node_id, tgt, flat_graph):
-                inner_inputs.update(node_attrs.get("inputs", ()))
-        matched = {f for f in fields if f in inner_inputs}
+        container_inputs = set(flat_graph.nodes.get(tgt, {}).get("inputs", ()))
+        matched = {f for f in fields if f in container_inputs}
         if matched:
             result.setdefault(tgt, set()).update(matched)
     return result

--- a/src/hypergraph/viz/renderer/ir_builder.py
+++ b/src/hypergraph/viz/renderer/ir_builder.py
@@ -78,7 +78,7 @@ def build_graph_ir(flat_graph: nx.DiGraph) -> GraphIR:
     # the container entrypoint (#169). Done here (not in _build_ir_edge) because
     # it needs the built ``external_inputs`` to resolve field -> pill id, which
     # keeps the edge target guaranteed to be a real scene node.
-    edges = _reroute_fanout_edges_to_field_pills(edges, flat_graph, external_inputs)
+    edges = _reroute_fanout_edges_to_field_pills(edges, flat_graph, external_inputs, map_fed_fields)
 
     configured_entrypoints = tuple(flat_graph.graph.get("configured_entrypoints") or ())
     visibility = build_graph_output_visibility(flat_graph)
@@ -118,27 +118,63 @@ def _map_fed_fields(flat_graph: nx.DiGraph) -> dict[str, set[str]]:
     return result
 
 
+def _owner_maps_field(
+    deepest_owner: str | None,
+    field: str | None,
+    map_fed_fields: dict[str, set[str]],
+    flat_graph: nx.DiGraph,
+) -> bool:
+    """True when ``field`` is an item field of a mapped container that owns the
+    input — the input's ``deepest_owner`` or any ancestor of it. Handles a field
+    consumer nested one or more graphs below the mapped container."""
+    if field is None:
+        return False
+    current = deepest_owner
+    while current is not None:
+        if field in map_fed_fields.get(current, set()):
+            return True
+        current = flat_graph.nodes.get(current, {}).get("parent")
+    return False
+
+
+def _mapped_container_for(owner: str | None, field: str, map_fed_fields: dict[str, set[str]], flat_graph: nx.DiGraph) -> str | None:
+    """The mapped container (``owner`` or an ancestor) whose map_fields hold ``field``."""
+    current = owner
+    while current is not None:
+        if field in map_fed_fields.get(current, set()):
+            return current
+        current = flat_graph.nodes.get(current, {}).get("parent")
+    return None
+
+
 def _reroute_fanout_edges_to_field_pills(
     edges: list[IREdge],
     flat_graph: nx.DiGraph,
     external_inputs: list[IRExternalInput],
+    map_fed_fields: dict[str, set[str]],
 ) -> list[IREdge]:
     """Point each map-fed fan-out edge at its item-field INPUT pill(s) on expand.
 
     For a fan-out edge into a container whose ``map_fields`` name inner inputs,
     the expanded target becomes the pill(s) for those fields (``input_page_text``)
     rather than the entrypoint — so the visible flow is
-    ``segment_pages ──pages──▶ [page_text] ──▶ embed_page``. Falls back to the
-    entrypoint target already computed by ``_build_ir_edge`` when no field pill
-    exists (broadcast-only inner inputs, or a fieldless ``list[str]`` item).
+    ``segment_pages ──pages──▶ [page_text] ──▶ embed_page``. A field consumer
+    nested a graph deeper than the mapped container still resolves: the pill is
+    keyed under the mapped container it belongs to, not its ``deepest_owner``.
+    Falls back to the entrypoint target already computed by ``_build_ir_edge``
+    when no field pill exists (broadcast-only inner inputs, or a fieldless
+    ``list[str]`` item).
     """
-    # container_id -> {field leaf name -> pill synthetic id}, from the map-fed
-    # pills already built into external_inputs.
+    # mapped-container_id -> {field leaf name -> pill synthetic id}. A map-fed
+    # pill is indexed under the mapped container that owns its field, which may
+    # be an ancestor of the pill's own deepest_owner (nested consumer).
     pill_by_field: dict[str, dict[str, str]] = {}
     for ext in external_inputs:
-        if ext.map_fed and ext.deepest_owner is not None and len(ext.params) == 1:
+        if ext.map_fed and len(ext.params) == 1:
             leaf = external_input_display_name(ext.params[0])
-            pill_by_field.setdefault(ext.deepest_owner, {})[leaf] = ext.synthetic_id
+            container = _mapped_container_for(ext.deepest_owner, leaf, map_fed_fields, flat_graph)
+            if container is not None:
+                pill_by_field.setdefault(container, {})[leaf] = ext.synthetic_id
 
     rerouted: list[IREdge] = []
     for edge in edges:
@@ -197,12 +233,14 @@ def _build_input_group(
     display_params = raw_params
     id_segments = tuple((id_for_param or {}).get(p, external_input_display_name(p)) for p in raw_params)
     # Map-fed when this single-param input's leaf name is an item field of the
-    # fan-out edge into its owning container. Multi-param INPUT_GROUPs never
-    # arise for a single mapped item's fields, so only single-param inputs are
-    # considered (a group would need every member field-fed to qualify, which
-    # the fan-out never produces).
-    fed_for_owner = (map_fed_fields or {}).get(deepest_owner or "", set())
-    map_fed = len(raw_params) == 1 and external_input_display_name(raw_params[0]) in fed_for_owner
+    # fan-out edge into a mapped container that owns this input. The owning
+    # container is ``deepest_owner`` OR any ancestor of it — a field consumer
+    # nested one graph deeper than the mapped container still counts (the pill's
+    # deepest_owner is then the inner container, but the map_fields live on the
+    # outer mapped container). Multi-param INPUT_GROUPs never arise for a single
+    # mapped item's fields, so only single-param inputs are considered.
+    leaf = external_input_display_name(raw_params[0]) if raw_params else None
+    map_fed = len(raw_params) == 1 and _owner_maps_field(deepest_owner, leaf, map_fed_fields or {}, flat_graph)
     return IRExternalInput(
         params=display_params,
         deepest_owner=deepest_owner,

--- a/src/hypergraph/viz/renderer/ir_builder.py
+++ b/src/hypergraph/viz/renderer/ir_builder.py
@@ -8,6 +8,8 @@ all 2^N states ahead of time.
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 import networkx as nx
 
 from hypergraph.viz._common import (
@@ -39,6 +41,11 @@ def build_graph_ir(flat_graph: nx.DiGraph) -> GraphIR:
     nodes = [
         _build_ir_node(node_id, attrs, bound_params, flat_graph) for node_id, attrs in flat_graph.nodes(data=True) if node_id not in hidden_nodes
     ]
+    # ``container -> {item-field names}`` fed by a fan-out edge's mapped item.
+    # An inner input whose name is in this set is supplied by the parent's list
+    # column through the map, not by a genuine external supplier — the fan-out
+    # edge re-routes into its pill on expansion, and the pill is marked map-fed.
+    map_fed_fields = _map_fed_fields(flat_graph)
     exclusive_edges = compute_exclusive_data_edges(flat_graph)
     mutex_groups = _compute_mutex_groups(flat_graph)
     back_edges = _find_back_edges(flat_graph)
@@ -64,7 +71,14 @@ def build_graph_ir(flat_graph: nx.DiGraph) -> GraphIR:
     # Pre-compute the synthetic-id mapping so colliding leaf names
     # (e.g. ``A.x`` and ``B.x``) get unique ``input_<id>`` ids.
     id_for_param = disambiguate_external_input_ids([list(group["params"]) for group in groups])
-    external_inputs = [_build_input_group(group, flat_graph, id_for_param) for group in groups]
+    external_inputs = [_build_input_group(group, flat_graph, id_for_param, map_fed_fields) for group in groups]
+
+    # Re-route each identity-mode fan-out edge, when its mapped container is
+    # expanded, into the inner INPUT pill(s) fed by an item field — instead of
+    # the container entrypoint (#169). Done here (not in _build_ir_edge) because
+    # it needs the built ``external_inputs`` to resolve field -> pill id, which
+    # keeps the edge target guaranteed to be a real scene node.
+    edges = _reroute_fanout_edges_to_field_pills(edges, flat_graph, external_inputs)
 
     configured_entrypoints = tuple(flat_graph.graph.get("configured_entrypoints") or ())
     visibility = build_graph_output_visibility(flat_graph)
@@ -80,10 +94,70 @@ def build_graph_ir(flat_graph: nx.DiGraph) -> GraphIR:
     )
 
 
+def _map_fed_fields(flat_graph: nx.DiGraph) -> dict[str, set[str]]:
+    """``container_id -> {item-field names}`` from fan-out edges' ``map_fields``.
+
+    ``HyperTable.visualize`` stamps ``map_fields`` (the mapped item's schema
+    field names) on each injected fan-out edge; the target is the mapped
+    container. Only fields an inner node actually consumes matter — a schema
+    field with no matching inner input (e.g. ``page_id``) is not a viz input,
+    so it is intersected out here.
+    """
+    result: dict[str, set[str]] = {}
+    for _src, tgt, attrs in flat_graph.edges(data=True):
+        fields = attrs.get("map_fields")
+        if not fields:
+            continue
+        inner_inputs: set[str] = set()
+        for node_id, node_attrs in flat_graph.nodes(data=True):
+            if _is_descendant(node_id, tgt, flat_graph):
+                inner_inputs.update(node_attrs.get("inputs", ()))
+        matched = {f for f in fields if f in inner_inputs}
+        if matched:
+            result.setdefault(tgt, set()).update(matched)
+    return result
+
+
+def _reroute_fanout_edges_to_field_pills(
+    edges: list[IREdge],
+    flat_graph: nx.DiGraph,
+    external_inputs: list[IRExternalInput],
+) -> list[IREdge]:
+    """Point each map-fed fan-out edge at its item-field INPUT pill(s) on expand.
+
+    For a fan-out edge into a container whose ``map_fields`` name inner inputs,
+    the expanded target becomes the pill(s) for those fields (``input_page_text``)
+    rather than the entrypoint — so the visible flow is
+    ``segment_pages ──pages──▶ [page_text] ──▶ embed_page``. Falls back to the
+    entrypoint target already computed by ``_build_ir_edge`` when no field pill
+    exists (broadcast-only inner inputs, or a fieldless ``list[str]`` item).
+    """
+    # container_id -> {field leaf name -> pill synthetic id}, from the map-fed
+    # pills already built into external_inputs.
+    pill_by_field: dict[str, dict[str, str]] = {}
+    for ext in external_inputs:
+        if ext.map_fed and ext.deepest_owner is not None and len(ext.params) == 1:
+            leaf = external_input_display_name(ext.params[0])
+            pill_by_field.setdefault(ext.deepest_owner, {})[leaf] = ext.synthetic_id
+
+    rerouted: list[IREdge] = []
+    for edge in edges:
+        fields = flat_graph.edges[edge.source, edge.target].get("map_fields") if flat_graph.has_edge(edge.source, edge.target) else None
+        pills_for_container = pill_by_field.get(edge.target, {}) if fields else {}
+        pill_ids = tuple(pills_for_container[f] for f in fields if f in pills_for_container) if fields else ()
+        if pill_ids:
+            new_target = pill_ids[0] if len(pill_ids) == 1 else pill_ids
+            rerouted.append(replace(edge, target_when_expanded=new_target))
+        else:
+            rerouted.append(edge)
+    return rerouted
+
+
 def _build_input_group(
     group: dict,
     flat_graph: nx.DiGraph,
     id_for_param: dict[str, str] | None = None,
+    map_fed_fields: dict[str, set[str]] | None = None,
 ) -> IRExternalInput:
     """Convert a build_input_groups dict into an IRExternalInput.
 
@@ -122,6 +196,13 @@ def _build_input_group(
     # still use the short leaf segment when it is unambiguous.
     display_params = raw_params
     id_segments = tuple((id_for_param or {}).get(p, external_input_display_name(p)) for p in raw_params)
+    # Map-fed when this single-param input's leaf name is an item field of the
+    # fan-out edge into its owning container. Multi-param INPUT_GROUPs never
+    # arise for a single mapped item's fields, so only single-param inputs are
+    # considered (a group would need every member field-fed to qualify, which
+    # the fan-out never produces).
+    fed_for_owner = (map_fed_fields or {}).get(deepest_owner or "", set())
+    map_fed = len(raw_params) == 1 and external_input_display_name(raw_params[0]) in fed_for_owner
     return IRExternalInput(
         params=display_params,
         deepest_owner=deepest_owner,
@@ -129,6 +210,7 @@ def _build_input_group(
         type_hints=tuple(type_hints),
         is_bound=bool(group.get("is_bound", False)),
         id_segments=id_segments,
+        map_fed=map_fed,
     )
 
 

--- a/src/hypergraph/viz/scene_builder.py
+++ b/src/hypergraph/viz/scene_builder.py
@@ -107,6 +107,7 @@ def build_initial_scene(
                         "params": list(ext.params),
                         "paramTypes": list(ext.type_hints),
                         "isBound": ext.is_bound,
+                        "mapFed": bool(ext.map_fed),
                         "ownerContainer": owner_container,
                         "deepestOwnerContainer": ext.deepest_owner,
                         "actualTargets": list(ext.consumers),
@@ -127,6 +128,7 @@ def build_initial_scene(
                         "label": ext.params[0],
                         "typeHint": ext.type_hints[0] if ext.type_hints else None,
                         "isBound": ext.is_bound,
+                        "mapFed": bool(ext.map_fed),
                         "ownerContainer": owner_container,
                         "deepestOwnerContainer": ext.deepest_owner,
                         "actualTargets": list(ext.consumers),
@@ -190,38 +192,43 @@ def build_initial_scene(
         if expansion_state.get(ir_edge.source) and ir_edge.source_when_expanded:
             expanded_sources = ir_edge.source_when_expanded
             base_sources = list(expanded_sources) if isinstance(expanded_sources, tuple) else [expanded_sources]
-        target = ir_edge.target
-        if expansion_state.get(target) and ir_edge.target_when_expanded:
-            target = ir_edge.target_when_expanded
+        # A fan-out edge into an expanded container may re-route to several item
+        # -field INPUT pills, so target_when_expanded can be a tuple; emit one
+        # edge per target (mirrors the multi-source fan-out below).
+        targets = [ir_edge.target]
+        if expansion_state.get(ir_edge.target) and ir_edge.target_when_expanded:
+            expanded_targets = ir_edge.target_when_expanded
+            targets = list(expanded_targets) if isinstance(expanded_targets, tuple) else [expanded_targets]
 
         # A data edge can carry multiple value_names (one NetworkX edge per
         # (src,tgt) merges them). Merged-output mode should still render one
         # visible edge per node pair; separate_outputs mode fans out through
         # one DATA node per value.
-        for base_source in base_sources:
-            if separate_outputs and ir_edge.edge_type == "data" and ir_edge.value_names:
-                edges_to_emit = [(value_name, base_source) for value_name in ir_edge.value_names]
-            else:
-                edges_to_emit = [(None, base_source)]
+        for target in targets:
+            for base_source in base_sources:
+                if separate_outputs and ir_edge.edge_type == "data" and ir_edge.value_names:
+                    edges_to_emit = [(value_name, base_source) for value_name in ir_edge.value_names]
+                else:
+                    edges_to_emit = [(None, base_source)]
 
-            for value_name, source in edges_to_emit:
-                if separate_outputs and ir_edge.edge_type == "data" and value_name is not None:
-                    source = f"data_{source}_{value_name}"
-                scene_edges.append(
-                    {
-                        "id": f"{source}__{target}" if value_name is None else f"{source}__{target}__{value_name}",
-                        "source": source,
-                        "target": target,
-                        "data": {
-                            "edgeType": ir_edge.edge_type,
-                            "valueName": value_name,
-                            "label": ir_edge.label,
-                            "exclusive": bool(ir_edge.exclusive),
-                            "forceFeedback": bool(ir_edge.is_back_edge),
-                        },
-                        "hidden": source not in visible_ids or target not in visible_ids,
-                    }
-                )
+                for value_name, source in edges_to_emit:
+                    if separate_outputs and ir_edge.edge_type == "data" and value_name is not None:
+                        source = f"data_{source}_{value_name}"
+                    scene_edges.append(
+                        {
+                            "id": f"{source}__{target}" if value_name is None else f"{source}__{target}__{value_name}",
+                            "source": source,
+                            "target": target,
+                            "data": {
+                                "edgeType": ir_edge.edge_type,
+                                "valueName": value_name,
+                                "label": ir_edge.label,
+                                "exclusive": bool(ir_edge.exclusive),
+                                "forceFeedback": bool(ir_edge.is_back_edge),
+                            },
+                            "hidden": source not in visible_ids or target not in visible_ids,
+                        }
+                    )
 
     if separate_outputs:
         # Add output edges from each producer to its DATA nodes. Mirrors

--- a/tests/viz/test_hypertable_fanout_edge.py
+++ b/tests/viz/test_hypertable_fanout_edge.py
@@ -41,14 +41,23 @@ def store():
 
 
 def _combined_flat_graph(table: HyperTable):
-    """Rebuild exactly what ``visualize`` renders and return its flat graph."""
+    """Rebuild exactly what ``visualize`` renders and return its flat graph.
+
+    Mirrors ``HyperTable.visualize``: injects the fan-out edges AND stamps each
+    with its mapped item's ``map_fields`` so the IR can re-route the edge into
+    the item-field INPUT pill(s) on expansion.
+    """
     from hypergraph.graph import Graph as _Graph
 
     table._ensure_analyzed()
     nodes = list(table._graph.nodes.values())
     nodes.extend(table._map_over_nodes)
     combined = _Graph(nodes, name=table._spec.name)
-    return combined.to_flat_graph(extra_edges=table._fanout_viz_edges())
+    flat = combined.to_flat_graph(extra_edges=table._fanout_viz_edges())
+    for (src, tgt), fields in table._fanout_map_fields().items():
+        if flat.has_edge(src, tgt):
+            flat[src][tgt]["map_fields"] = list(fields)
+    return flat
 
 
 def test_fanout_edge_connects_producer_to_mapped_node(store):
@@ -257,9 +266,10 @@ def test_fanout_edge_ir_reroutes_into_expanded_container(store):
     The mapped container starts EXPANDED at the default depth, and the JS scene
     builder ranks only visible nodes — an edge whose target is the (invisible,
     expanded) container crashes dagre with "Cannot set properties of undefined
-    (setting 'rank')". The consumer-by-name search can never resolve an
-    identity-mode fan-out edge (the value names a parent column no inner node
-    consumes), so it must fall back to the container's entrypoint.
+    (setting 'rank')". Option A: the mapped item ``Item`` has a ``text`` field
+    that the inner ``clean`` node consumes, so the fan-out edge re-routes to the
+    ``text`` INPUT pill — the visible unpack
+    ``produce_items ──items──▶ [text] ──▶ clean``.
     """
     from hypergraph.viz.renderer.ir_builder import build_graph_ir
 
@@ -272,6 +282,95 @@ def test_fanout_edge_ir_reroutes_into_expanded_container(store):
     ir = build_graph_ir(_combined_flat_graph(table))
 
     (fanout,) = [e for e in ir.edges if e.source == "produce_items" and e.target == "items_node"]
-    assert fanout.target_when_expanded == "items_node/clean", (
-        f"fan-out edge must re-route to the container entrypoint when expanded; got {fanout.target_when_expanded!r}"
+    assert fanout.target_when_expanded == "input_text", (
+        f"fan-out edge must re-route to the item-field INPUT pill when expanded; got {fanout.target_when_expanded!r}"
     )
+    # The re-routed target is a real INPUT pill marked map-fed — not a plain
+    # external input and not the entrypoint.
+    (text_pill,) = [e for e in ir.external_inputs if e.synthetic_id == "input_text"]
+    assert text_pill.map_fed is True
+    assert text_pill.deepest_owner == "items_node"
+
+
+def test_map_fed_field_pill_is_not_a_plain_external_input(store):
+    """The item-field input renders as map-fed, and a genuine external input does not.
+
+    ``Item`` = {item_id, text}; ``clean`` consumes ``text`` (a field) while
+    ``produce_items`` consumes ``source`` (a real external supplier). Only
+    ``text`` is flagged map-fed.
+    """
+    from hypergraph.viz.renderer.ir_builder import build_graph_ir
+
+    table = HyperTable(
+        [produce_items, Graph([clean], name="proc").as_node(name="items_node").map_over("items", identity="item_id")],
+        identity="doc_id",
+        store=store,
+    )
+    ir = build_graph_ir(_combined_flat_graph(table))
+
+    by_id = {e.synthetic_id: e for e in ir.external_inputs}
+    assert by_id["input_text"].map_fed is True, "item-field input must be map-fed"
+    assert by_id["input_source"].map_fed is False, "genuine external input must be untouched"
+
+
+@node(output_name="clean_text")
+def broadcast_consumer(config: str) -> str:
+    """Inner node consuming a broadcast input whose name is NOT an item field."""
+    return config.strip()
+
+
+def test_broadcast_input_is_untouched_and_edge_falls_back(store):
+    """A broadcast (non-field) inner input keeps its plain rendering.
+
+    ``Item`` = {item_id, text}; the inner node consumes ``config``, which is not
+    an item field, so it is a broadcast input: NOT map-fed, and the fan-out edge
+    has no field pill to land on — it falls back to the container entrypoint
+    (#169 behavior).
+    """
+    from hypergraph.viz.renderer.ir_builder import build_graph_ir
+
+    table = HyperTable(
+        [produce_items, Graph([broadcast_consumer], name="proc").as_node(name="items_node").map_over("items", identity="item_id")],
+        identity="doc_id",
+        store=store,
+    )
+    ir = build_graph_ir(_combined_flat_graph(table))
+
+    (config_pill,) = [e for e in ir.external_inputs if e.synthetic_id == "input_config"]
+    assert config_pill.map_fed is False, "broadcast input must not be map-fed"
+    (fanout,) = [e for e in ir.edges if e.source == "produce_items" and e.target == "items_node"]
+    assert fanout.target_when_expanded == "items_node/broadcast_consumer", (
+        f"with no matching field pill the fan-out edge falls back to the entrypoint; got {fanout.target_when_expanded!r}"
+    )
+
+
+@node(output_name="plain_items")
+def produce_plain_items(source: str) -> list[str]:
+    """Producer whose item type is ``str`` — a fieldless mapped item."""
+    return [source]
+
+
+@node(output_name="clean_text")
+def clean_plain(plain_items: str) -> str:
+    return plain_items.strip()
+
+
+def test_fieldless_item_falls_back_to_entrypoint(store):
+    """No schema and a fieldless annotation (``list[str]``) => entrypoint fallback.
+
+    ``_map_config`` carries only ``identity`` (no ``schema``), and the producer
+    returns ``list[str]``, which has no fields — so nothing is map-fed and the
+    fan-out edge routes to the entrypoint exactly as in #169.
+    """
+    from hypergraph.viz.renderer.ir_builder import build_graph_ir
+
+    table = HyperTable(
+        [produce_plain_items, Graph([clean_plain], name="proc").as_node(name="items_node").map_over("plain_items", identity="item_id")],
+        identity="doc_id",
+        store=store,
+    )
+    ir = build_graph_ir(_combined_flat_graph(table))
+
+    assert not any(e.map_fed for e in ir.external_inputs), "a fieldless list[str] item feeds no field pills"
+    (fanout,) = [e for e in ir.edges if e.source == "produce_plain_items" and e.target == "items_node"]
+    assert fanout.target_when_expanded == "items_node/clean_plain"

--- a/tests/viz/test_hypertable_fanout_edge.py
+++ b/tests/viz/test_hypertable_fanout_edge.py
@@ -374,3 +374,69 @@ def test_fieldless_item_falls_back_to_entrypoint(store):
     assert not any(e.map_fed for e in ir.external_inputs), "a fieldless list[str] item feeds no field pills"
     (fanout,) = [e for e in ir.edges if e.source == "produce_plain_items" and e.target == "items_node"]
     assert fanout.target_when_expanded == "items_node/clean_plain"
+
+
+def test_field_consumer_nested_a_graph_deeper_is_still_map_fed(store):
+    """A field consumer wrapped in ANOTHER nested graph is still map-fed.
+
+    Regression for the nested-owner gap: ``clean`` consumes the ``text`` field
+    but sits inside ``items_node/inner_node``, so the ``text`` pill's
+    ``deepest_owner`` is that inner container while ``map_fields`` live on the
+    mapped ``items_node``. Matching must walk ancestors, or the pill reads as a
+    plain external input and the edge falls back to the entrypoint.
+    """
+    from hypergraph.viz.renderer.ir_builder import build_graph_ir
+
+    inner = Graph([clean], name="inner").as_node(name="inner_node")
+    child = Graph([inner], name="proc").as_node(name="items_node").map_over("items", identity="item_id")
+    table = HyperTable([produce_items, child], identity="doc_id", store=store)
+    ir = build_graph_ir(_combined_flat_graph(table))
+
+    (text_pill,) = [e for e in ir.external_inputs if e.synthetic_id == "input_text"]
+    assert text_pill.map_fed is True, "nested field consumer must still be map-fed"
+    assert text_pill.deepest_owner == "items_node/inner_node"
+    (fanout,) = [e for e in ir.edges if e.source == "produce_items" and e.target == "items_node"]
+    assert fanout.target_when_expanded == "input_text", "edge must re-route to the nested field pill, not the entrypoint"
+
+
+def test_unresolvable_schema_yields_no_fields_not_a_raise():
+    """``_fanout_map_fields`` swallows a ``return_type`` failure (defensive).
+
+    A truly unresolved forward reference fails ``analyze_table`` (``_input_types``)
+    before viz is ever reached, so this can't be provoked through a constructed
+    table; the guard is exercised directly to prove field discovery degrades to
+    "no fields" rather than propagating, keeping ``visualize`` from raising if a
+    producer annotation ever resolves for analysis but not here.
+    """
+
+    class _RaisingProducer:
+        name = "producer"
+        data_outputs = ("items",)
+        func = None  # forces return_type -> str; we monkeypatch below
+
+    class _MapNode:
+        name = "items_node"
+        _map_config = {"identity": "item_id"}
+
+    class _ChildSpec:
+        map_input = "items"
+
+    table = HyperTable.__new__(HyperTable)
+
+    class _Spec:
+        children = [_ChildSpec()]
+
+    table._spec = _Spec()
+    table._map_over_nodes = [_MapNode()]
+    table._boundary_node = lambda child_spec: _RaisingProducer()
+
+    # Patch return_type to raise, simulating an annotation that resolves at
+    # analysis time but not here.
+    import hypergraph.materialization._hypertable as ht
+
+    original = ht.return_type
+    ht.return_type = lambda node: (_ for _ in ()).throw(NameError("Unresolved"))
+    try:
+        assert table._fanout_map_fields() == {("producer", "items_node"): ()}
+    finally:
+        ht.return_type = original

--- a/tests/viz/test_hypertable_fanout_edge.py
+++ b/tests/viz/test_hypertable_fanout_edge.py
@@ -399,6 +399,33 @@ def test_field_consumer_nested_a_graph_deeper_is_still_map_fed(store):
     assert fanout.target_when_expanded == "input_text", "edge must re-route to the nested field pill, not the entrypoint"
 
 
+@node(output_name="embedding")
+def embed_chunk(chunk: str) -> list[float]:
+    """Inner node whose input is renamed FROM the item field ``text``."""
+    return [0.0]
+
+
+def test_renamed_inner_input_is_still_map_fed(store):
+    """A container that renames the item field to a different inner input is map-fed.
+
+    Regression for the rename gap: ``with_inputs(chunk="text")`` makes the inner
+    node consume ``chunk`` while the parent-facing container input (and pill)
+    stays ``text``. Matching against the container's OWN inputs (parent-facing),
+    not the renamed inner input, keeps ``text`` map-fed and routes the edge to
+    its pill.
+    """
+    from hypergraph.viz.renderer.ir_builder import build_graph_ir
+
+    child = Graph([embed_chunk], name="proc").as_node(name="items_node").with_inputs(chunk="text").map_over("items", identity="item_id")
+    table = HyperTable([produce_items, child], identity="doc_id", store=store)
+    ir = build_graph_ir(_combined_flat_graph(table))
+
+    (text_pill,) = [e for e in ir.external_inputs if e.synthetic_id == "input_text"]
+    assert text_pill.map_fed is True, "renamed inner input must still be map-fed on the parent-facing name"
+    (fanout,) = [e for e in ir.edges if e.source == "produce_items" and e.target == "items_node"]
+    assert fanout.target_when_expanded == "input_text"
+
+
 def test_unresolvable_schema_yields_no_fields_not_a_raise():
     """``_fanout_map_fields`` swallows a ``return_type`` failure (defensive).
 

--- a/tests/viz/test_parity.py
+++ b/tests/viz/test_parity.py
@@ -14,10 +14,11 @@ import subprocess
 from dataclasses import asdict
 from itertools import product
 from pathlib import Path
-from typing import Any
+from typing import Any, TypedDict
 
 import pytest
 
+from hypergraph import node as _node
 from hypergraph.viz.renderer.ir_builder import build_graph_ir
 from hypergraph.viz.scene_builder import build_initial_scene
 from tests.viz.conftest import (
@@ -67,6 +68,7 @@ def _semantic_node_data(data: dict) -> tuple:
             data.get("label"),
             data.get("typeHint"),
             data.get("isBound"),
+            data.get("mapFed"),
             data.get("ownerContainer"),
             data.get("deepestOwnerContainer"),
             tuple(sorted(data.get("actualTargets") or ())),
@@ -76,6 +78,7 @@ def _semantic_node_data(data: dict) -> tuple:
             tuple(data.get("params") or ()),
             tuple(data.get("paramTypes") or ()),
             data.get("isBound"),
+            data.get("mapFed"),
             data.get("ownerContainer"),
             data.get("deepestOwnerContainer"),
             tuple(sorted(data.get("actualTargets") or ())),
@@ -223,3 +226,81 @@ def test_python_js_scenes_match(fixture_name: str, separate_outputs: bool, show_
         assert py_edges == js_edges, (
             f"Edge-set drift for {ctx}\nOnly in Python: {sorted(py_edges - js_edges)}\nOnly in JS:     {sorted(js_edges - py_edges)}"
         )
+
+
+class _FanoutItem(TypedDict):
+    """Mapped item whose fields ``page_text``/``page_number`` name inner
+    inputs the fan-out edge re-routes to; ``item_id`` is the identity."""
+
+    item_id: str
+    page_text: str
+    page_number: int
+
+
+@_node(output_name="items")
+def _produce_fanout_items(source: str) -> list[_FanoutItem]:
+    return [_FanoutItem(item_id="i0", page_text=source, page_number=1)]
+
+
+@_node(output_name="embedding")
+def _embed_one_field(page_text: str) -> list[float]:
+    return [0.0]
+
+
+@_node(output_name="embedding")
+def _embed_two_fields(page_text: str, page_number: int) -> list[float]:
+    return [float(page_number)]
+
+
+_FANOUT_EMBED = {("page_text",): _embed_one_field, ("page_text", "page_number"): _embed_two_fields}
+
+
+def _fanout_ir(inner_inputs: tuple[str, ...]):
+    """Build the fan-out IR (with ``map_fields`` stamped) for a mapped child
+    whose inner graph consumes ``inner_inputs`` (item fields of a TypedDict).
+
+    Two inner inputs exercise the tuple ``target_when_expanded`` path (the
+    fan-out edge re-routes to multiple item-field pills); one exercises the
+    scalar path.
+    """
+    import tempfile
+
+    from hypergraph import Graph
+    from hypergraph.graph import Graph as _Graph
+    from hypergraph.materialization import HyperTable
+    from hypergraph.materialization._lancedb_store import LanceDBStore
+
+    store = LanceDBStore(tempfile.mkdtemp() + "/store")
+    child = Graph([_FANOUT_EMBED[inner_inputs]], name="proc").as_node(name="items_node").map_over("items", identity="item_id")
+    table = HyperTable([_produce_fanout_items, child], identity="doc_id", store=store)
+    table._ensure_analyzed()
+    nodes = list(table._graph.nodes.values())
+    nodes.extend(table._map_over_nodes)
+    combined = _Graph(nodes, name=table._spec.name)
+    extra = table._fanout_viz_edges()
+    flat = combined.to_flat_graph(extra_edges=extra)
+    for (src, tgt), fields in table._fanout_map_fields().items():
+        if flat.has_edge(src, tgt):
+            flat[src][tgt]["map_fields"] = list(fields)
+    return build_graph_ir(flat)
+
+
+@pytest.mark.parametrize("inner_inputs", [("page_text",), ("page_text", "page_number")])
+@pytest.mark.parametrize("show_inputs", [False, True])
+def test_python_js_fanout_scenes_match(inner_inputs: tuple[str, ...], show_inputs: bool) -> None:
+    """Python and JS scene builders agree on the map-fed fan-out re-routing.
+
+    Covers both the scalar and tuple ``target_when_expanded`` paths and the
+    ``mapFed`` INPUT flag across every expansion state.
+    """
+    ir = _fanout_ir(inner_inputs)
+    ir_dict: dict[str, Any] = asdict(ir)
+
+    for expansion_state in _all_expansion_states(ir_dict):
+        py_scene = build_initial_scene(ir, expansion_state=expansion_state, show_inputs=show_inputs)
+        js_scene = _node_scene(ir_dict, {"expansionState": expansion_state, "showInputs": show_inputs})
+        py_nodes, py_edges = _project(py_scene)
+        js_nodes, js_edges = _project(js_scene)
+        ctx = f"fanout inner={inner_inputs} state={expansion_state} inputs={show_inputs}"
+        assert py_nodes == js_nodes, f"Node drift for {ctx}\nPy-only: {sorted(py_nodes - js_nodes)}\nJS-only: {sorted(js_nodes - py_nodes)}"
+        assert py_edges == js_edges, f"Edge drift for {ctx}\nPy-only: {sorted(py_edges - js_edges)}\nJS-only: {sorted(js_edges - py_edges)}"

--- a/tests/viz/test_schema_version.py
+++ b/tests/viz/test_schema_version.py
@@ -30,7 +30,7 @@ NODE = shutil.which("node")
 def test_current_schema_version_pinned() -> None:
     """A bump must be deliberate — pin both ends so the hard-coded JS
     constant in scene_builder.js stays in lockstep with Python."""
-    assert CURRENT_SCHEMA_VERSION == "2"
+    assert CURRENT_SCHEMA_VERSION == "3"
 
 
 def test_build_graph_ir_emits_current_schema_version() -> None:
@@ -69,7 +69,7 @@ def test_js_scene_builder_returns_mismatch_sentinel_for_future_version() -> None
     )
     assert proc.returncode == 0, proc.stderr
     scene = json.loads(proc.stdout)
-    assert scene.get("schemaVersionMismatch") == {"got": "999", "supported": "2"}
+    assert scene.get("schemaVersionMismatch") == {"got": "999", "supported": "3"}
     # The mismatch-sentinel must short-circuit derivation entirely so the
     # frontend can render the static fallback without dragging in any
     # potentially-stale interpretation of the IR.


### PR DESCRIPTION
## Bug

After #168/#169, expanding a mapped container (identity-mode `map_over`) landed the injected fan-out edge on the inner **entrypoint**, while a **floating input pill** for the item field also pointed at that same inner node — visually claiming an external supplier that doesn't exist.

Real Panda KB (`kb.pages`: `convert_document → segment_pages (outputs pages: list[PageItem]) → mapped Graph([embed_page])`, inner input `page_text`):

**Before** — `segment_pages ──pages──▶ embed_page`, and separately a free-floating `page_text: str` pill also `──▶ embed_page` (screenshot-verified by Gilad).

## Fix (option A, approved)

When the mapped container is **expanded**, the fan-out edge re-routes into the item-field **INPUT pill(s)**, so the unpack is visible:

**After** — `segment_pages ──pages──▶ [page_text] ──▶ embed_page`

The field pill is flagged **map-fed** and rendered distinctly (amber accent, `⤨` marker, target handle) rather than as a free-floating external input. **Collapsed** state is unchanged (edge to the container). Genuine external inputs (`sha256`, `filename`, `content_type`) are untouched.

Which inner inputs are item fields is discovered in priority order:
1. the map node's `_map_config["schema"]` if set,
2. else the producing node's return annotation (`list[PageItem]` where `PageItem` is a TypedDict — via `typing.get_type_hints`),
3. else fall back to the #169 entrypoint behavior (fieldless `list[str]`).

## Where

- `materialization/_schema.py` — `item_schema_fields()` (TypedDict / dataclass / Pydantic, or `list[...]` thereof).
- `materialization/_hypertable.py` — `_fanout_map_fields()` + `visualize()` stamps `map_fields` on the injected flat-graph edge (kept off `to_flat_graph`'s generic `extra_edges` affordance).
- `viz/renderer/ir_builder.py` — `_map_fed_fields()` intersects with real inner inputs; `_build_input_group` sets `IRExternalInput.map_fed`; a post-pass re-routes each map-fed fan-out edge's `target_when_expanded` to the resolved pill id(s) (always real scene nodes).
- `viz/ir_schema.py` — `target_when_expanded` may now be a tuple (multiple field pills, mirroring `source_when_expanded`); new `IRExternalInput.map_fed`.
- `scene_builder.py` + `assets/scene_builder.js` — emit one edge per expanded target (tuple support); pass `mapFed` into INPUT/INPUT_GROUP scene data.
- `assets/viz_nodes.js` — map-fed INPUT pills get a target handle + distinct style.

## Tests

- `test_hypertable_fanout_edge.py` — fan-out edge re-routes to the field pill when expanded; pill is map-fed; a **broadcast (non-field) input is untouched** and the edge falls back to the entrypoint; the **no-schema-no-annotation `list[str]` fallback**.
- `test_parity.py` — `mapFed` added to the INPUT/INPUT_GROUP parity signature; new HyperTable fan-out fixture covering the **scalar and tuple** `target_when_expanded` paths across every expansion state (Python == JS).

Full suite: **2861 passed, 15 skipped** (`-W error`).

Verified programmatically against the **real Panda KB** (`kb.pages.visualize()`, no HTML-body read): fan-out target = `input_page_text`, `page_text` map-fed, and the initial expansion state is fully dagre-rankable (every visible scene edge endpoint is a visible scene node).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded visualization support for mapped fan-out edges, with rerouting to the correct inner input fields when a container is expanded.
  * Inputs that are fed from mapped fields are now clearly marked and styled differently in the graph view.

* **Bug Fixes**
  * Improved edge rendering for expanded containers so multiple targets are shown correctly.
  * Added fallback behavior for mapped items without fields, preserving the expected container-level routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->