### PR TITLE
fix(hypertable): consult schema for metadata evolve; make evolve_schema idempotent

### DIFF
--- a/docs/08-hypertable/implementing-a-store.md
+++ b/docs/08-hypertable/implementing-a-store.md
@@ -28,8 +28,17 @@ class MyStore(TableStore):
     def evolve_schema(self, table_name, new_columns): ...  # new_columns: {name: pa.DataType}
 ```
 
-`search`, `save_manifest`, and `load_manifest` are optional (they default to
-"not supported" / no-op) — implement them only if your backend offers them.
+`search`, `save_manifest`, `load_manifest`, and `column_names` are optional (they
+default to "not supported" / no-op / `[]`) — implement them only if your backend
+offers them.
+
+**`column_names` lets HyperTable consult your schema.** It returns a table's
+physical column names (`[]` when the table doesn't exist yet). HyperTable's
+metadata evolution uses it to learn which columns already exist rather than
+inferring the set by sampling a row — a sample is empty exactly when a table has
+been emptied, which is when inference goes wrong. Override it if your store tracks
+a schema; leave the `[]` default if it doesn't, and `evolve_schema` idempotence
+(below) still protects you.
 
 **Named indexes need both manifest hooks.** `save_manifest` / `load_manifest`
 persist a table's index specs. They stay optional for any store that never uses
@@ -92,6 +101,15 @@ fields = [pa.field(name, arrow_type) for name, arrow_type in new_columns.items()
 self._schema[table_name] += list(new_columns.keys())
 ```
 
+**`evolve_schema` is idempotent.** Adding a column the schema already holds is a
+no-op for that column, never an error — skip it and return the current column
+names. HyperTable can ask to add an existing column: it re-infers the "new"
+metadata set from an emptied table (every row deleted) and doesn't always know
+the physical schema, so it may re-offer a column added earlier. An Arrow-native
+store that blindly appends builds a schema with a duplicate field and the backend
+rejects the next write; filter `new_columns` against your existing columns first.
+The conformance harness asserts this on the emptied-table shape.
+
 ## What is *not* your job
 
 The store is a dumb persistence layer. HyperTable owns everything semantic:
@@ -105,8 +123,8 @@ invariants above.
 `validate_store(store)` is a quick shape check (subclass + `open()`). For the real
 thing, run the **conformance harness** in your test suite — it drives a fresh store
 through the observable contract (newest-gen reads, every operator, delete counts,
-schema evolution, parent/child filtering) and fails with a precise message naming
-any invariant you missed:
+schema evolution and its idempotence, parent/child filtering) and fails with a
+precise message naming any invariant you missed:
 
 ```python
 from hypergraph.materialization import check_store_conformance

--- a/src/hypergraph/materialization/_conformance.py
+++ b/src/hypergraph/materialization/_conformance.py
@@ -186,6 +186,45 @@ def _check_evolve_schema(store: TableStore) -> None:
     assert got is not None and got.get("extra") == "hello", f"a row written after evolve_schema must round-trip the new column; got {got!r}"
 
 
+def _check_evolve_schema_is_idempotent(store: TableStore) -> None:
+    """Re-evolving a column the schema already holds is a no-op, never an error.
+
+    HyperTable can ask to add a metadata column that already exists — it re-infers
+    the "new" set from an emptied table and cannot always know the physical schema.
+    A store must skip the existing column rather than append a duplicate field
+    (which breaks the next write). Exercised on the emptied-table shape that first
+    surfaced the bug: add a column, delete every row, then re-evolve + re-insert.
+    """
+    store.open(_spec("c_evolve_idem"), [])
+    store.write_rows("c_evolve_idem", [_row("a", 1, 1)])
+    store.evolve_schema("c_evolve_idem", {"extra": pa.utf8()})
+    # Empty the table — the state in which HyperTable re-infers columns wrongly.
+    store.delete_rows("c_evolve_idem", [("cid", "eq", "a")])
+
+    cols = store.evolve_schema("c_evolve_idem", {"extra": pa.utf8()})
+    assert "extra" in cols, f"re-evolving an existing column must still report it in the column names; got {cols!r}"
+    # Duplicate field only surfaces on the next write; this must not raise.
+    store.write_rows("c_evolve_idem", [_row("b", 2, 1, extra="world")])
+    got = store.read_one("c_evolve_idem", "cid", "b")
+    assert got is not None and got.get("extra") == "world", f"after an idempotent re-evolve, a row must still round-trip the column; got {got!r}"
+
+
+def _check_column_names(store: TableStore) -> None:
+    """``column_names`` reports the physical schema, growing as it evolves.
+
+    The default is ``[]`` (a store that cannot introspect its schema), so this
+    only asserts the shape when a store returns anything: an opened table lists at
+    least its identity column, and an evolved column shows up afterwards.
+    """
+    store.open(_spec("c_cols"), [])
+    names = store.column_names("c_cols")
+    if not names:
+        return  # store opts out of schema introspection; evolve idempotence guards it
+    assert "cid" in names, f"column_names must include the identity column of an opened table; got {names!r}"
+    store.evolve_schema("c_cols", {"tag": pa.utf8()})
+    assert "tag" in store.column_names("c_cols"), "column_names must reflect a column added by evolve_schema"
+
+
 def _check_parent_child_filter(store: TableStore) -> None:
     store.open(_spec("c_parent"), [_spec("c_child", identity="kid", parent_link=True)])
     store.write_rows(
@@ -278,6 +317,8 @@ _CHECKS: list[Callable[[TableStore], None]] = [
     _check_string_quotes,
     _check_max_write_gen,
     _check_evolve_schema,
+    _check_evolve_schema_is_idempotent,
+    _check_column_names,
     _check_parent_child_filter,
     _check_binary_source_roundtrip,
     _check_binary_in_updates,

--- a/src/hypergraph/materialization/_hypertable.py
+++ b/src/hypergraph/materialization/_hypertable.py
@@ -293,8 +293,17 @@ class HyperTable:
         store = self._store
         target = table_name or self._spec.name
         id_col = identity or self._identity
-        sample = store.read_rows(target, limit=1)
-        known_cols = set(sample[0].keys()) if sample else {c.name for c in self._spec.columns}
+        # Consult the physical schema, not a sampled row. Sampling returns nothing
+        # exactly when the table has been emptied (every row deleted), and the
+        # spec-only fallback omits metadata columns added earlier via update — so a
+        # re-inserted row would re-evolve a column the schema already holds. The
+        # store reports its real columns; only when it cannot introspect (default
+        # ``[]``) do we fall back to sampling, and evolve_schema idempotence guards
+        # that case.
+        known_cols = set(store.column_names(target))
+        if not known_cols:
+            sample = store.read_rows(target, limit=1)
+            known_cols = set(sample[0].keys()) if sample else {c.name for c in self._spec.columns}
         new_meta = {k: python_type_to_arrow(type(v) if v is not None else str) for k, v in item.items() if k not in known_cols and k != id_col}
         if new_meta:
             store.evolve_schema(target, new_meta)

--- a/src/hypergraph/materialization/_lancedb_store.py
+++ b/src/hypergraph/materialization/_lancedb_store.py
@@ -262,8 +262,24 @@ class LanceDBStore(TableStore):
             return None
         return json.loads(path.read_text())
 
+    def column_names(self, table_name: str) -> list[str]:
+        # Advance to the latest committed version so a schema evolved by another
+        # connection on the same folder is visible (mirrors the read path).
+        tbl = self._readable(table_name)
+        if tbl is None:
+            return []
+        return [f.name for f in tbl.schema]
+
     def evolve_schema(self, table_name: str, new_columns: dict[str, pa.DataType]) -> list[str]:
         tbl = self._tables[table_name]
+        # Idempotent: skip any column the physical schema already holds. HyperTable
+        # can ask to add a column that exists (it re-infers the "new" set from an
+        # emptied table); appending it would build a schema with a duplicate field
+        # and LanceDB rejects that on the next write.
+        existing = {f.name for f in tbl.schema}
+        new_columns = {name: arrow_type for name, arrow_type in new_columns.items() if name not in existing}
+        if not new_columns:
+            return [f.name for f in tbl.schema]
         existing_data = tbl.to_arrow()
         new_fields = list(tbl.schema) + [pa.field(name, arrow_type) for name, arrow_type in new_columns.items()]
         new_schema = pa.schema(new_fields)

--- a/src/hypergraph/materialization/_lancedb_store.py
+++ b/src/hypergraph/materialization/_lancedb_store.py
@@ -271,7 +271,14 @@ class LanceDBStore(TableStore):
         return [f.name for f in tbl.schema]
 
     def evolve_schema(self, table_name: str, new_columns: dict[str, pa.DataType]) -> list[str]:
-        tbl = self._tables[table_name]
+        # Advance to the latest committed version first: another connection on the
+        # same folder may have added a column since this handle was opened. Reading
+        # the stale cached schema would keep that column in ``new_columns`` and the
+        # rewrite would build a duplicate field — the exact case the idempotence
+        # guarantee exists to prevent (mirrors ``column_names`` / the read path).
+        tbl = self._readable(table_name)
+        if tbl is None:
+            raise KeyError(f"table {table_name!r} is not open; call open() before evolve_schema()")
         # Idempotent: skip any column the physical schema already holds. HyperTable
         # can ask to add a column that exists (it re-infers the "new" set from an
         # emptied table); appending it would build a schema with a duplicate field

--- a/src/hypergraph/materialization/_table_store.py
+++ b/src/hypergraph/materialization/_table_store.py
@@ -83,7 +83,28 @@ class TableStore(ABC):
         intermediate type system: stores map Arrow to their native format (or
         ignore types when schemaless). No store performs Python-to-Arrow
         conversion — the HyperTable layer does it once before calling here.
+
+        Evolving a column the physical schema ALREADY holds must be a no-op for
+        that column, not an error. HyperTable decides a metadata column is "new"
+        without always knowing the physical schema (e.g. it re-derives that set
+        from an empty table after every row is deleted), so it can ask to add a
+        column that already exists. A conforming store skips such columns and
+        returns the current column names; it never appends a duplicate field.
+        The conformance harness asserts this idempotence.
         """
+
+    def column_names(self, table_name: str) -> list[str]:
+        """The physical column names of a table, ``[]`` when it does not exist yet.
+
+        This is the schema-consultation seam: HyperTable's metadata evolution asks
+        the store what columns physically exist rather than inferring the set by
+        sampling a row — a sample is empty exactly when the table has been emptied,
+        which is when inference goes wrong. A store that cannot introspect its
+        schema may leave this default (``[]``); it is then protected by
+        ``evolve_schema`` idempotence instead. Stores that track a schema override
+        this to return it.
+        """
+        return []
 
     def search(
         self,

--- a/tests/test_hypertable_mutations.py
+++ b/tests/test_hypertable_mutations.py
@@ -217,6 +217,50 @@ class TestUpdate:
 
 
 # ---------------------------------------------------------------------------
+# Metadata evolution on an emptied table (archive -> restore regression)
+# ---------------------------------------------------------------------------
+
+
+class TestMetadataEvolveOnEmptyTable:
+    """A metadata column added earlier must not be re-evolved once the table empties.
+
+    ``_evolve_for_metadata`` decides which columns are "new" by sampling one
+    stored row. When the table is EMPTY (every row deleted — the archive step in
+    Superposition's KB), the sample is empty and it falls back to the spec-only
+    column set, which excludes any metadata column previously added via update.
+    Re-inserting a row carrying that column then re-evolves a column the physical
+    schema already holds, and LanceDB rejects the duplicate field.
+    """
+
+    def test_reinsert_metadata_column_after_emptying_table(self, store):
+        """Add a metadata column, delete every row, re-insert with it — must not crash."""
+        from hypergraph.materialization import HyperTable
+
+        def build_table():
+            return HyperTable([clean, count_words], identity="doc_id", store=store).with_runner(SyncRunner())
+
+        # 1. Insert a row and add a brand-new metadata column via update.
+        #    This evolves the physical schema to carry ``station``.
+        table = build_table()
+        table.insert(doc_id="d1", text="hello")
+        table.update("d1", station="north")
+        assert table.get("d1")["station"] == "north"
+
+        # 2. Empty the table (the archive step deletes the last corpus row).
+        table.delete("d1")
+        assert table.count() == 0
+
+        # 3. Re-insert a row that itself CARRIES ``station`` into the now-empty
+        #    table (the restore step). ``_evolve_for_metadata`` runs against zero
+        #    stored rows, falls back to spec-only columns, and re-adds ``station``
+        #    to a physical schema that already holds it → LanceDB duplicate-field
+        #    crash on the next write.
+        table = build_table()
+        table.insert(doc_id="d2", text="world", station="south")
+        assert table.get("d2")["station"] == "south"
+
+
+# ---------------------------------------------------------------------------
 # Delete
 # ---------------------------------------------------------------------------
 

--- a/tests/test_store_conformance.py
+++ b/tests/test_store_conformance.py
@@ -96,8 +96,12 @@ class DictTableStore(TableStore):
         rows = self._tables.get(table_name, [])
         return max((r.get("_write_gen", 0) for r in rows), default=0)
 
+    def column_names(self, table_name: str) -> list[str]:
+        return list(self._schemas.get(table_name, []))
+
     def evolve_schema(self, table_name: str, new_columns: dict[str, pa.DataType]) -> list[str]:
         known = self._schemas.setdefault(table_name, [])
+        # Idempotent: only append columns the tracked schema does not already have.
         for name in new_columns:
             if name not in known:
                 known.append(name)

--- a/tests/test_store_conformance.py
+++ b/tests/test_store_conformance.py
@@ -191,6 +191,54 @@ def test_lancedb_projection_unknown_column_fails_loudly(tmp_path) -> None:
         raise AssertionError("read_rows must fail loudly on an unknown projected column, not silently drop it")
 
 
+def test_lancedb_evolve_schema_idempotent_across_connections(tmp_path) -> None:
+    """Re-evolving a column another connection already added must be a no-op.
+
+    Two ``LanceDBStore`` handles over one folder model the KB gate flow. If one
+    connection evolves in a column and a second (whose cached handle predates that
+    commit) is asked to evolve the same column, reading its stale cached schema
+    would keep the column in ``new_columns`` and rebuild a schema with a duplicate
+    field — crashing the next write. ``evolve_schema`` must advance to the latest
+    committed version first, see the column, and treat the call as a no-op.
+    """
+    from hypergraph.materialization._schema import ColumnSpec, TableSpec
+
+    path = str(tmp_path / "evolve_cross_conn")
+    spec = TableSpec(
+        name="t",
+        identity="cid",
+        columns=[
+            ColumnSpec("cid", role="identity", arrow_type=pa.utf8()),
+            ColumnSpec("n", role="source", arrow_type=pa.int64()),
+            ColumnSpec("_write_gen", role="internal", arrow_type=pa.int64()),
+            ColumnSpec("_status", role="internal", arrow_type=pa.utf8()),
+            ColumnSpec("_row_fingerprint", role="internal", arrow_type=pa.utf8()),
+            ColumnSpec("_error", role="internal", arrow_type=pa.utf8()),
+        ],
+    )
+    base = {"_status": "complete", "_row_fingerprint": "fp", "_error": None}
+
+    writer = LanceDBStore(path)
+    writer.open(spec, [])
+    writer.write_rows("t", [{"cid": "a", "n": 1, "_write_gen": 1, **base}])
+
+    # A second handle opens BEFORE the column is added, pinning its cached schema.
+    other = LanceDBStore(path)
+    other.open(spec, [])
+
+    # The writer evolves in `tag` and commits it.
+    writer.evolve_schema("t", {"tag": pa.utf8()})
+    writer.write_rows("t", [{"cid": "a", "n": 1, "_write_gen": 2, "tag": "x", **base}])
+
+    # The stale handle re-evolves the same column: must be an idempotent no-op,
+    # then a subsequent write must not hit a duplicate field.
+    cols = other.evolve_schema("t", {"tag": pa.utf8()})
+    assert "tag" in cols, f"evolve_schema must report `tag` after advancing to the committed schema; got {cols!r}"
+    other.write_rows("t", [{"cid": "b", "n": 2, "_write_gen": 1, "tag": "y", **base}])
+    got = other.read_one("t", "cid", "b")
+    assert got is not None and got.get("tag") == "y", f"row must round-trip after a cross-connection idempotent evolve; got {got!r}"
+
+
 def test_minimal_store_conforms_via_base_projection() -> None:
     """A store with no native projection conforms through TableStore._project_rows."""
     store = DictTableStore()


### PR DESCRIPTION
## The bug

`HyperTable._evolve_for_metadata` decides which metadata columns are "new" by **sampling one stored row**:

```python
sample = store.read_rows(target, limit=1)
known_cols = set(sample[0].keys()) if sample else {c.name for c in self._spec.columns}
```

When the table is **empty** (every row deleted), the sample is empty and it falls back to the spec-only column set. That set omits metadata columns added earlier via `update` (e.g. a curated `station` tag). Re-inserting a row that carries such a column then re-evolves a column the physical schema **already holds**, and LanceDB rejects the duplicate field on the next write:

```
RuntimeError: lance error: LanceError(Schema): Duplicate field name "station" in schema
```

This surfaced in the Superposition KB **archive → restore** flow (PRD 0024): archive deletes the last corpus row (emptying the table); restore re-inserts a document carrying its curated metadata → crash.

## Root cause: sampling vs. schema

The decision input is wrong. Whether a metadata column is new should be answered from the store's **actual schema**, not inferred from a row that happens to be absent exactly when the table has been emptied.

## The fix — two layers, each independently justified

**1. Decision input — `TableStore.column_names(table_name)`** (the schema-consultation seam). `_evolve_for_metadata` now asks the store which columns physically exist instead of sampling; it only falls back to sampling when a store cannot introspect its schema (default `[]`). `LanceDBStore` implements it against the live, version-advanced schema (so a schema evolved by another connection on the same folder is visible, consistent with the read path).

**2. Robustness — `evolve_schema` is now contractually idempotent.** Adding a column the schema already holds is a no-op for that column, never a duplicate field. This is added to the **conformance harness** (`_conformance.py`) — an idempotence check on the emptied-table shape plus a `column_names` shape check — so **every** `TableStore` implementation inherits the guarantee. The reference `DictTableStore` and `LanceDBStore` both pass.

Both layers compose: schema-consultation is the correct decision, and evolve idempotence protects even a store that can't introspect (`column_names` → `[]`).

## Superposition context

Superposition already worked around this in its own store layer (`LazyLanceDBStore.evolve_schema`, made idempotent against the physical schema; its archive→restore test covers the guard). That workaround is harmless and stays — **this PR is the root-cause fix in hypergraph**. The Superposition workaround was not modified.

## Before / after

```python
def build_table():
    return HyperTable([clean, count_words], identity="doc_id", store=store).with_runner(SyncRunner())

table = build_table()
table.insert(doc_id="d1", text="hello")
table.update("d1", station="north")   # evolves physical schema to carry `station`
table.delete("d1")                     # empty table; `.lance` schema still has `station`

table = build_table()
table.insert(doc_id="d2", text="world", station="south")   # re-insert carrying it
```

- **Before:** `RuntimeError: Duplicate field name "station" in schema`
- **After:** row round-trips; `table.get("d2")["station"] == "south"`

## Tests (TDD, red → green)

- New failing test first: `TestMetadataEvolveOnEmptyTable::test_reinsert_metadata_column_after_emptying_table` — reproduced the duplicate-field crash on `master`; green after the fix.
- Conformance harness extended: `_check_evolve_schema_is_idempotent`, `_check_column_names`.
- Full suite: **2872 passed / 15 skipped** under CI flags (`-W error`).
- Consumer cross-check (unmodified): `PYTHONPATH=<worktree>/src` running Superposition's `tests.test_kb_substrate tests.test_studio_run_records` (the archive→restore test) — **28 tests OK** against this branch.

Docs: `docs/08-hypertable/implementing-a-store.md` (canon store-author guide) updated with the `column_names` seam and the `evolve_schema` idempotence invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stronger schema-awareness for table-backed data, helping column updates behave consistently even after a table has been emptied.
  * Improved support for stores that can report existing columns directly.

* **Bug Fixes**
  * Fixed a case where re-adding an existing metadata column could cause duplicate-field issues.
  * Preserved metadata values correctly when rows are deleted and later reinserted.
  * Improved validation feedback so conformance failures now identify the missing invariant more clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->