### PR TITLE
docs: checkpointers page, HITL cycle mechanics, hypertable provenance, nav fixes

### DIFF
--- a/docs/03-patterns/07-human-in-the-loop.md
+++ b/docs/03-patterns/07-human-in-the-loop.md
@@ -91,6 +91,10 @@ When paused, the `RunResult` has:
 
 Combine `@interrupt` with agentic loops for a multi-turn conversation where the user provides input each turn.
 
+{% hint style="warning" %}
+Cyclic graphs (this one loops `should_continue` → `ask_user`) require an explicit `entrypoint=`. Hypergraph raises `GraphConfigError: Cyclic graphs require an explicit entrypoint` at construction if you omit it — there is no default starting node for a cycle.
+{% endhint %}
+
 ```python
 from hypergraph import Graph, node, route, END, AsyncRunner, interrupt
 
@@ -117,7 +121,17 @@ def should_continue(messages: list) -> str:
         return END
     return "ask_user"
 
-graph = Graph([ask_user, add_user_message, generate, accumulate, should_continue])
+graph = Graph(
+    [ask_user, add_user_message, generate, accumulate, should_continue],
+    edges=[
+        (ask_user, add_user_message),
+        (add_user_message, generate),
+        (generate, accumulate),
+        (accumulate, should_continue),
+    ],
+    shared=["messages"],
+    entrypoint=["ask_user", "add_user_message"],
+)
 
 # Pre-fill messages so the first step (ask_user) can run immediately
 chat = graph.bind(messages=[])
@@ -142,7 +156,32 @@ Key patterns:
 - **`.bind(messages=[])`** pre-fills the seed input so `.run({})` works with no values
 - **Interrupt as first step**: the graph pauses immediately, asking the user for input
 - **`emit="turn_done"` + `wait_for="turn_done"`**: ensures `should_continue` sees the fully updated messages
+- **Explicit `edges=[...]`**: `messages` has two producers (`add_user_message` and `accumulate`) feeding downstream nodes across the cycle, so auto-wiring can't pick one on its own — declare the edges directly
 - Each resume replays the graph, providing all previous responses
+
+### The Entrypoint Must Include the Interrupt
+
+`entrypoint=["ask_user", "add_user_message"]` lists **two** entrypoints, not one. This matters because of how a resumed cyclic run picks its starting node: on each call, the runner starts from whichever entrypoint's inputs are satisfied by the values you passed.
+
+If you only set `entrypoint="add_user_message"` (skipping `ask_user`), the first turn still "works" in the sense that it doesn't raise — but it silently never reaches the interrupt:
+
+```python
+# entrypoint="add_user_message" only (WRONG for a graph that should pause at ask_user)
+graph = Graph(
+    [ask_user, add_user_message, generate, accumulate, should_continue],
+    edges=[...],
+    shared=["messages"],
+    entrypoint="add_user_message",
+)
+chat = graph.bind(messages=[])
+
+result = await runner.run(chat, {"user_input": "hello"})
+# result.status == RunStatus.COMPLETED, result.paused == False
+# add_user_message ran; generate/accumulate/should_continue never ran;
+# ask_user never ran either. No error, no warning.
+```
+
+Because `add_user_message` was the only entrypoint and its required input (`user_input`) was already supplied, the run starts and finishes there — the rest of the cycle, including `ask_user`, is simply never scheduled. Nothing here is invalid input or a missing value, so there is no exception to catch. The fix is always the same: **every node the graph should be able to pause at must be listed in `entrypoint=`**, so a call with only the seed values (an empty `{}` or just `messages=[]`) can still reach it.
 
 ### Alternative: Explicit Edges
 

--- a/docs/05-how-to/batch-processing.md
+++ b/docs/05-how-to/batch-processing.md
@@ -347,6 +347,8 @@ Without `workflow_id`, `runner.map()` still works but results exist only in-proc
 
 ### Run Lineage: Resume vs Fork
 
+See [Checkpointers](../06-api-reference/checkpointers.md) for the `Checkpointer` ABC, `CheckpointPolicy`, and the `lineage()` view used to audit fork/retry trees. This section covers the `run()`-level resume/fork input rules.
+
 `run()` now uses strict, git-like lineage semantics when a checkpointer is configured:
 
 - Same `workflow_id` means "same lineage"

--- a/docs/05-how-to/debug-workflows.md
+++ b/docs/05-how-to/debug-workflows.md
@@ -25,7 +25,7 @@ def double(x: int) -> int:
 def triple(doubled: int) -> int:
     return doubled * 3
 
-graph = Graph([double, triple])
+graph = Graph([double, triple], name="graph")
 runner = SyncRunner()
 result = runner.run(graph, {"x": 5})
 
@@ -36,25 +36,28 @@ print(result.log)
 Output:
 
 ```
-RunLog: graph | 0.3ms | 2 nodes | 0 errors
+RunLog: graph | 4ms | 2 nodes | 0 errors
 
-  Step  Node    Duration  Status
-  ────  ──────  ────────  ─────────
-     0  double     0.1ms  completed
-     1  triple     0.1ms  completed
+  Step            Node              Duration          Status
+────────────────  ────────────────  ────────────────  ────────────────
+     0            double            3ms               completed
+     1            triple            0ms               completed
 ```
 
 ### Finding Slow Nodes
 
 ```python
+# result.log.steps is a tuple[NodeRecord, ...] in execution order
 # Sort by duration (slowest first)
-for record in result.log.slowest():
+for record in sorted(result.log.steps, key=lambda r: r.duration_ms, reverse=True):
     print(f"{record.node_name}: {record.duration_ms:.1f}ms")
 
 # Per-node aggregates (useful for map operations)
 for name, stats in result.log.node_stats.items():
     print(f"{name}: avg={stats.avg_ms:.1f}ms, count={stats.count}")
 ```
+
+`result.log.steps` yields `NodeRecord` — one per node execution, with `node_name`, `superstep`, `duration_ms`, `status`, `decision`, `error`. `result.log.node_stats` maps node name to `NodeStats` — aggregate `avg_ms`/`count` across all executions of that node in the run. `result.log.errors` is the subset of `.steps` where `status == "failed"`.
 
 ### Finding Errors
 
@@ -67,14 +70,14 @@ for record in result.log.errors:
 
 # Summary
 print(result.log.summary())
-# "2 nodes, 1 error, 0 cached | total: 42.5ms"
+# "2 nodes | 21ms | 0 errors | slowest: double (16ms)"
 ```
 
 ### Routing Decisions
 
 ```python
 # Which path did each gate take?
-for record in result.log.records:
+for record in result.log.steps:
     if record.decision:
         print(f"{record.node_name} → {record.decision}")
 ```
@@ -84,7 +87,8 @@ for record in result.log.records:
 ```python
 # Export for logging, dashboards, etc.
 log_dict = result.log.to_dict()
-# {"records": [...], "node_stats": {...}, "total_ms": 42.5, ...}
+# {"graph_name": "...", "run_id": "...", "total_duration_ms": 42.5,
+#  "steps": [...], "node_stats": {...}}
 ```
 
 ### RunLog with map()
@@ -106,6 +110,8 @@ if results.failed:
     for f in results.failures:
         print(f"Failed: {f.error}")
 ```
+
+`results.log` also returns a single batch-level `MapLog` (`graph_name`, `total_duration_ms`, `items` — a tuple of the per-item `RunLog`s, plus an aggregate `.errors`), for when you want one object instead of iterating `results` yourself.
 
 ### runner.map() vs map_over for debugging
 
@@ -708,7 +714,7 @@ hypergraph runs ls --db /path/to/runs.db
 | "I want to run a graph from the terminal" | CLI (`hypergraph run`) |
 | "I want to batch-run with different inputs" | CLI (`hypergraph map`) |
 | "What happened in the run I just finished?" | RunLog (`result.log`) |
-| "Which node was slowest?" | RunLog (`result.log.slowest()`) or CLI (`runs stats`) |
+| "Which node was slowest?" | RunLog (`sorted(result.log.steps, key=...)`) or CLI (`runs stats`) |
 | "What happened in yesterday's run?" | Checkpointer + CLI |
 | "What values were produced at step 3?" | CLI (`runs values --superstep 3`) |
 | "What failed runs exist?" | CLI (`runs ls --status failed`) |

--- a/docs/05-how-to/integrate-with-llms.md
+++ b/docs/05-how-to/integrate-with-llms.md
@@ -2,6 +2,10 @@
 
 Patterns for using OpenAI, Anthropic, and other LLM providers with hypergraph.
 
+{% hint style="info" %}
+This page is about calling LLM provider SDKs from inside `@node` functions — it has no relationship to the `hypergraph.integrations` package (currently just the Daft integration; see [Use Hypergraph with Daft](daft-workflows.md)). LLM clients are plain dependencies you `.bind()` to a graph like any other component, not a `hypergraph.integrations` entry.
+{% endhint %}
+
 ## Anthropic Claude
 
 ### Setup

--- a/docs/05-how-to/observe-execution.md
+++ b/docs/05-how-to/observe-execution.md
@@ -102,6 +102,24 @@ graph outer
         └── node double
 ```
 
+To correlate your own logging with the current node span from inside a node body, call `current_node_span()`:
+
+```python
+from hypergraph import Graph, node, SyncRunner, current_node_span
+
+@node(output_name="result")
+def do_work(x: int) -> int:
+    ref = current_node_span()
+    # NodeSpanRef(run_id="...", span_id="...", node_name="do_work", graph_name=...)
+    my_logger.info("processing", extra={"span_id": ref.span_id if ref else None})
+    return x * 2
+
+runner = SyncRunner()
+runner.run(Graph([do_work]), {"x": 5})
+```
+
+`current_node_span()` returns `None` outside of node execution (for example, if called at module import time).
+
 Mapped work uses a parent `map` span plus child graph spans per item:
 
 ```text

--- a/docs/05-how-to/visualize-graphs.md
+++ b/docs/05-how-to/visualize-graphs.md
@@ -125,3 +125,42 @@ When nested graphs are expanded, cross-boundary edges remap to the visible inter
 ## Works Offline
 
 All JavaScript dependencies (React, React Flow, Dagre layout) are bundled with hypergraph. No CDN calls, no internet required.
+
+## Mermaid Text Diagrams
+
+`graph.to_mermaid()` returns a `MermaidDiagram` — a text-based Mermaid flowchart instead of the interactive widget. Useful anywhere Markdown renders Mermaid (GitHub, GitBook) or in plain terminals with no notebook:
+
+```python
+diagram = graph.to_mermaid()   # accepts the same depth/show_types/separate_outputs as .visualize()
+diagram                        # renders inline in Jupyter/VS Code via a text/vnd.mermaid MIME type
+print(diagram)                 # raw Mermaid source, works anywhere
+diagram.source                 # the raw string directly
+```
+
+## Debugging Graph Structure
+
+`hypergraph.viz` also has non-interactive tools for spotting structural issues before you render anything — useful in scripts, tests, or headless environments.
+
+```python
+from hypergraph.viz import validate_graph, find_issues
+
+result = validate_graph(graph)
+if not result.valid:
+    print(result.errors)
+
+issues = find_issues(graph)
+# IssueReport(validation_errors=[], orphan_edges=[], disconnected_nodes=[],
+#             missing_parents=[], self_loops=[])
+```
+
+`VizDebugger` (also reachable as `graph.debug_viz()`) adds interactive tracing for a specific node or edge:
+
+```python
+debugger = graph.debug_viz()  # same as VizDebugger(graph)
+
+trace = debugger.trace_node("double")
+print(trace.status)          # "FOUND" or "NOT_FOUND"
+print(trace.outgoing_edges)  # [{'to': 'add_one', 'value': 'doubled', 'type': 'data'}]
+
+edge_trace = debugger.trace_edge("double", "add_one")
+```

--- a/docs/06-api-reference/checkpointers.md
+++ b/docs/06-api-reference/checkpointers.md
@@ -1,0 +1,265 @@
+# Checkpointers
+
+A checkpointer persists every step of a run so it can be resumed, forked, retried, or inspected after the process exits. It is opt-in: a graph runs exactly the same with or without one, and existing `run()`/`map()` behavior is unchanged when `checkpointer=None`.
+
+{% hint style="info" %}
+This page covers the checkpointer subsystem itself — the `Checkpointer` ABC, `CheckpointPolicy`, and lineage (fork/retry) mechanics. For `run()`/`map()` parameter semantics (`workflow_id`, `fork_from`, `retry_from`, `override_workflow`), see [Runners](runners.md#run). For the `map()` batch-checkpointing walkthrough, see [Batch Processing](../05-how-to/batch-processing.md#checkpointing-with-map).
+{% endhint %}
+
+## Turning It On
+
+Pass a checkpointer to the runner, then pass a `workflow_id` to `run()`:
+
+```python
+from hypergraph import AsyncRunner, Graph, node
+from hypergraph.checkpointers import SqliteCheckpointer
+
+@node(output_name="doubled")
+def double(x: int) -> int:
+    return x * 2
+
+@node(output_name="tripled")
+def triple(doubled: int) -> int:
+    return doubled * 3
+
+checkpointer = SqliteCheckpointer("./runs.db")
+runner = AsyncRunner(checkpointer=checkpointer)
+graph = Graph([double, triple])
+
+result = await runner.run(graph, {"x": 5}, workflow_id="wf-1")
+print(result.values)  # {'doubled': 10, 'tripled': 30}
+
+run = checkpointer.get_run("wf-1")
+print(run)  # Run: wf-1 | completed | 6ms | 2 steps
+
+for step in checkpointer.steps("wf-1"):
+    print(step)  # Step [0] double | completed | ...
+```
+
+`SqliteCheckpointer` exposes both async methods (`get_run_async`, `get_steps`, used by `AsyncRunner`) and sync convenience methods (`get_run`, `steps`, `state`, `values`, `runs`, `lineage`) for reading results back after a run. `SyncRunner` also accepts a `checkpointer=` — it uses the sync write path (`create_run_sync`, `save_step_sync`) instead of the async one.
+
+Both durability requires an on-disk or shared-memory SQLite database:
+
+```python
+# On disk — survives process restarts
+SqliteCheckpointer("./runs.db")
+
+# Shared in-memory — same process only, useful for tests
+SqliteCheckpointer(":memory:")
+```
+
+`MemoryCheckpointer` is a simpler async-only, in-process alternative with no SQLite dependency — good for unit tests that don't need durability across restarts.
+
+## Checkpointer ABC
+
+Every checkpointer implements the same contract, so runners don't need to know which backend is behind `checkpointer=`:
+
+| Method | Purpose |
+|---|---|
+| `save_step(record)` | Persist one node's execution atomically. Upserts on `(run_id, superstep, node_name)`. |
+| `create_run(run_id, ...)` | Create or reset a run record at run start. |
+| `update_run_status(run_id, status, ...)` | Update lifecycle status with duration/counts. |
+| `get_state(run_id, superstep=None)` | Fold step values into accumulated state. `None` means latest. |
+| `get_steps(run_id, superstep=None)` | Raw step records through a superstep. |
+| `get_checkpoint(run_id, superstep=None)` | `Checkpoint` (values + steps) for forking — has a default implementation built from `get_state`/`get_steps`. |
+| `list_runs(status=None, parent_run_id=None, limit=100)` | List runs, optionally filtered. |
+| `count_runs(status=None, parent_run_id=None, retry_of=None)` | Count without materializing full run objects. |
+| `search_async(query, field=None, limit=20)` | FTS search over step values. Returns `[]` if unsupported. |
+
+Steps are the source of truth — state is always computed by folding steps, never stored as a separate mutable blob. This is what makes time-travel (`get_state(run_id, superstep=3)`) and forking from an arbitrary point possible.
+
+## CheckpointPolicy
+
+`CheckpointPolicy` controls *when* checkpoints are written and *how much history* is kept:
+
+```python
+from hypergraph.checkpointers import CheckpointPolicy
+
+CheckpointPolicy()
+# CheckpointPolicy(durability='async', retention='full', window=None, ttl=None)
+```
+
+| Field | Values | Meaning |
+|---|---|---|
+| `durability` | `"sync"` \| `"async"` (default) \| `"exit"` | `sync` blocks until each step is written (safest). `async` writes in the background. `exit` only writes at run completion — fastest, no mid-run recovery. |
+| `retention` | `"full"` (default) \| `"latest"` \| `"windowed"` | `full` keeps every step (time travel). `latest` keeps only materialized latest state. `windowed` keeps the last `window` supersteps. |
+| `window` | `int \| None` | Required when `retention="windowed"`. |
+| `ttl` | `timedelta \| None` | Auto-expire completed runs after this duration. |
+
+Invalid combinations raise at construction, not at run time:
+
+```python
+CheckpointPolicy(durability="exit", retention="full")
+# ValueError: durability="exit" requires retention="latest", got retention="full".
+# With exit mode, steps are not persisted mid-run.
+
+CheckpointPolicy(retention="windowed")
+# ValueError: retention="windowed" requires window parameter
+```
+
+Pass a policy directly, or use the `durability=`/`retention=` shortcut kwargs on `SqliteCheckpointer` (the two are mutually exclusive):
+
+```python
+SqliteCheckpointer("./runs.db", durability="sync", retention="latest")
+
+# Equivalent:
+SqliteCheckpointer("./runs.db", policy=CheckpointPolicy(durability="sync", retention="latest"))
+
+# Raises — pick one:
+SqliteCheckpointer("./runs.db", policy=CheckpointPolicy(), durability="sync")
+# ValueError: Cannot pass both 'policy' and 'durability'/'retention'. Use one or the other.
+```
+
+## Fork and Retry
+
+Both operations start a **new** `workflow_id` from an existing run's checkpoint. They differ in intent and in the lineage metadata recorded on the new run:
+
+```python
+await runner.run(graph, {"x": 5}, workflow_id="job-1")
+
+# Fork: branch history, optionally override inputs
+forked = await runner.run(graph, {"x": 100}, fork_from="job-1")
+checkpointer.get_run(forked.workflow_id).forked_from  # "job-1"
+
+# Retry: same intent as fork, but records retry lineage
+retried = await runner.run(graph, retry_from="job-1")
+checkpointer.get_run(retried.workflow_id).retry_of  # "job-1"
+```
+
+{% hint style="warning" %}
+`fork_workflow_async`/`retry_workflow_async` (called internally by `run(fork_from=...)`) fall back to a `{source}-fork-{hex}` / `{source}-retry-{n}` name **only when `workflow_id` is `None`**. In practice, `run()` always auto-generates a `workflow_id` (`run-YYYYMMDD-hex`) before the fork/retry branch runs, so calling `runner.run(graph, fork_from="job-1")` without an explicit `workflow_id=` produces an auto-generated id, not a `job-1-fork-...` name. Pass `workflow_id=` explicitly if you want a specific, readable name for the new run.
+{% endhint %}
+
+Call the checkpointer's own `fork_workflow`/`retry_workflow` (sync) or `fork_workflow_async`/`retry_workflow_async` directly to get the `{source}-fork-{hex}` naming convention:
+
+```python
+fork_id, fork_checkpoint = checkpointer.fork_workflow("job-1")
+fork_id  # "job-1-fork-a1b2c3"
+
+retry_id, retry_checkpoint = checkpointer.retry_workflow("job-1")
+retry_id  # "job-1-retry-1" (increments per retry of the same source)
+```
+
+## Lineage
+
+`checkpointer.lineage(root_workflow_id)` renders a git-log-style view of a run and all its fork/retry descendants:
+
+```python
+checkpointer.lineage("root-1")
+```
+```
+LineageView: root-1 (root=root-1)
+
+● root-1 [completed] (root) | steps=2 cached=0 failed=0 <selected>
+└─ root-1-fork-a [completed] (fork) <- root-1 | steps=2 cached=0 failed=0
+```
+
+Use this to audit which forks/retries came from which source run, and their status, without re-deriving anything.
+
+## Lineage and Concurrency Errors
+
+| Error | Raised when |
+|---|---|
+| `WorkflowAlreadyRunningError` | A second `run()` starts for a `workflow_id` that already has an active run. At most one active `run()` per `workflow_id` — use different `workflow_id`s for concurrent runs. |
+| `WorkflowForkError` | An explicit `checkpoint=` is passed to fork into a `workflow_id` that already exists. Use a new `workflow_id` for the fork. |
+
+```python
+from hypergraph.exceptions import WorkflowForkError
+
+await runner.run(graph, {"x": 5}, workflow_id="job-1")
+checkpoint = checkpointer.checkpoint("job-1")
+
+try:
+    await runner.run(graph, {"x": 100}, checkpoint=checkpoint, workflow_id="job-1")
+except WorkflowForkError as e:
+    print(e)  # Cannot fork into existing workflow 'job-1'. Use a new workflow_id.
+```
+
+See also `GraphChangedError`, `WorkflowAlreadyCompletedError`, and `InputOverrideRequiresForkError`, covered in [Batch Processing — Run Lineage](../05-how-to/batch-processing.md#run-lineage-resume-vs-fork).
+
+## Types
+
+`checkpointer.steps(run_id)` and `checkpointer.get_run(run_id)` (used throughout this page) return these dataclasses:
+
+| Type | Fields | Notes |
+|---|---|---|
+| `StepRecord` | `run_id`, `superstep`, `node_name`, `index`, `status`, `input_versions`, `values`, `duration_ms`, `cached`, `decision`, `error`, `created_at`, `completed_at` | One per node execution. `status` is a `StepStatus`. |
+| `StepStatus` | `COMPLETED`, `FAILED`, `PAUSED` | Enum. |
+| `Run` | `id`, `status`, `graph_name`, `duration_ms`, `node_count`, `error_count`, `parent_run_id`, `forked_from`, `fork_superstep`, `retry_of`, `retry_index`, `created_at`, `completed_at` | `status` is a `WorkflowStatus`. |
+| `WorkflowStatus` | `ACTIVE`, `PAUSED`, `STOPPED`, `PARTIAL`, `COMPLETED`, `FAILED` | Enum. Kept distinct from the runner-level `RunStatus` to avoid a naming collision. |
+| `Checkpoint` | `values`, `steps`, `source_run_id`, `source_superstep`, `retry_of`, `retry_index` | What `get_checkpoint()`/`fork_workflow()`/`retry_workflow()` return — folded state plus the steps it was built from. |
+
+```python
+step = checkpointer.steps("wf-1")[0]
+step.status == StepStatus.COMPLETED  # True
+
+run = checkpointer.get_run("wf-1")
+run.status == WorkflowStatus.COMPLETED  # True
+```
+
+## Backend Comparison
+
+| | `SqliteCheckpointer` | `MemoryCheckpointer` |
+|---|---|---|
+| Durability | On disk (or shared `:memory:`) | In-process only, lost on exit |
+| Works with | `AsyncRunner` and `SyncRunner` | `AsyncRunner` only |
+| Sync convenience methods (`get_run`, `steps`, `lineage`, ...) | Yes | No — async only |
+| Best for | Production durability, multi-process resume, CLI inspection | Unit tests, short-lived scripts |
+
+## Checkpointing vs the No-Checkpointer Re-Drive Pattern
+
+You do not need a checkpointer to pause and resume a graph. Without one, each `run()` call replays the graph from the start, and you re-supply previously-collected interrupt responses by seeding them back into the input values:
+
+```python
+from hypergraph import Graph, node, AsyncRunner, interrupt
+
+@node(output_name="draft")
+def generate(prompt: str) -> str:
+    return f"Draft: {prompt}"
+
+@interrupt(output_name="feedback")
+def review(draft: str) -> str | None:
+    return None
+
+@interrupt(output_name="final_draft")
+def edit(feedback: str) -> str | None:
+    return None
+
+@node(output_name="result")
+def publish(final_draft: str) -> str:
+    return f"Published: {final_draft}"
+
+graph = Graph([generate, review, edit, publish])
+runner = AsyncRunner()  # no checkpointer
+
+values = {"prompt": "hello"}
+r1 = await runner.run(graph, values)
+# r1.pause.node_name == "review", r1.pause.response_key == "feedback"
+
+values[r1.pause.response_key] = "Needs more detail"
+r2 = await runner.run(graph, values)
+# r2.pause.node_name == "edit", r2.pause.response_key == "final_draft"
+
+values[r2.pause.response_key] = "Detailed draft about hello"
+r3 = await runner.run(graph, values)
+# r3.status == RunStatus.COMPLETED, r3.values["result"] == "Published: Detailed draft about hello"
+```
+
+This works with zero setup and no persistence dependency, but the caller owns replay: it must resend the whole `values` dict every call, and there is no durability across process restarts.
+
+| | No checkpointer (re-drive) | With checkpointer |
+|---|---|---|
+| Setup | None | `SqliteCheckpointer` + `workflow_id` |
+| Resume across process restart | No — state lives only in the caller's `values` dict | Yes — state is read back from disk |
+| What you resend each call | The full accumulated `values` dict | Only the new interrupt response |
+| Time travel / inspect past steps | Not available | `get_state(run_id, superstep=N)`, `steps(run_id)` |
+| Fork / retry a past run | Not available | `fork_from=`, `retry_from=` |
+| Best for | Prototyping, stateless request/response apps that already keep their own conversation state | Durable multi-turn workflows, production HITL, long-running batches |
+
+See [Human-in-the-Loop](../03-patterns/07-human-in-the-loop.md) for the interrupt side of this pattern, including nested-graph interrupts and multi-turn chat.
+
+## What's Next
+
+- [Human-in-the-Loop](../03-patterns/07-human-in-the-loop.md) — pause/resume mechanics, cyclic-graph entrypoints
+- [Runners](runners.md#run) — `workflow_id`, `fork_from`, `retry_from` parameter reference
+- [Batch Processing — Checkpointing with map()](../05-how-to/batch-processing.md#checkpointing-with-map) — parent/child batch runs

--- a/docs/06-api-reference/checkpointers.md
+++ b/docs/06-api-reference/checkpointers.md
@@ -263,3 +263,18 @@ See [Human-in-the-Loop](../03-patterns/07-human-in-the-loop.md) for the interrup
 - [Human-in-the-Loop](../03-patterns/07-human-in-the-loop.md) — pause/resume mechanics, cyclic-graph entrypoints
 - [Runners](runners.md#run) — `workflow_id`, `fork_from`, `retry_from` parameter reference
 - [Batch Processing — Checkpointing with map()](../05-how-to/batch-processing.md#checkpointing-with-map) — parent/child batch runs
+
+## Cleanup
+
+A checkpointer owns a live database connection, and the runner does not manage its lifecycle. Call `await checkpointer.close()` when you are done — a process that skips this can hang on exit waiting for the open connection:
+
+{% code overflow="wrap" %}
+```python
+checkpointer = SqliteCheckpointer("./runs.db")
+try:
+    runner = AsyncRunner(checkpointer=checkpointer)
+    result = await runner.run(graph, {"x": 1}, workflow_id="run-1")
+finally:
+    await checkpointer.close()
+```
+{% endcode %}

--- a/docs/06-api-reference/runners.md
+++ b/docs/06-api-reference/runners.md
@@ -1134,7 +1134,7 @@ Checkpoint lineage has two different input rules:
 - **Strict resume**: using an existing `workflow_id` resumes persisted state and rejects fresh runtime inputs, because new inputs would silently rewrite history. Interrupt response payloads are the exception; pass the paused response key/value to resolve the pending interrupt.
 - **Fork/retry**: `fork_from` and `retry_from` create a new lineage from a checkpoint, so runtime inputs may override restored values for the new run.
 
-See [Run Lineage](../05-how-to/batch-processing.md#run-lineage-resume-vs-fork).
+See [Run Lineage](../05-how-to/batch-processing.md#run-lineage-resume-vs-fork). For the `Checkpointer` ABC, `CheckpointPolicy`, backend comparison, and the no-checkpointer re-drive alternative, see [Checkpointers](checkpointers.md).
 
 ### Cyclic Graphs
 

--- a/docs/08-hypertable/api-reference.md
+++ b/docs/08-hypertable/api-reference.md
@@ -30,7 +30,7 @@ table = HyperTable(
 
 table.insert(doc_id="d1", text="Hello World")
 print(table.get("d1"))
-# {'doc_id': 'd1', 'text': 'hello world', 'clean_text': 'hello world', 'word_count': 2}
+# {'doc_id': 'd1', 'text': 'Hello World', 'clean_text': 'hello world', 'word_count': 2}
 ```
 
 The graph's required inputs (`text`) become source columns. The node outputs (`clean_text`, `word_count`) become derived columns. The identity column (`doc_id`) is the primary key.
@@ -708,6 +708,46 @@ table.filter(where={"doc_id": "d1"})
 ```
 
 Supported operators: `"eq"`, `"ne"`, `"lt"`, `"lte"`, `"gt"`, `"gte"`, `"in"`.
+
+### Fingerprints and Provenance
+
+Every row carries a `_row_fingerprint` and one `_provenance_<column>` per derived column -- both SHA-256 hashes, and both hidden from read results unless you inspect the store directly. [What Triggers Re-Derivation](overview.md#what-triggers-re-derivation) covers the black-box behavior (what changes cause a re-derive); this section covers the three hashes underneath it.
+
+**Row fingerprint** -- `hash(source column values + node definition hashes + component config hashes)`. This is the fast-path check: on `insert()`/`update()`, the new fingerprint is compared to the stored one. A match skips the row entirely, with no per-column work.
+
+```python
+table.insert(doc_id="d1", text="Hello World")
+raw = table._store.read_rows("doc", None)  # inspecting the physical store directly
+print(raw[0]["_row_fingerprint"])
+# 'be70cedf32588ba9b1a095dfaa1aea738aea3f79f71001bd741e9e9911132645' (64 hex chars = SHA-256)
+```
+
+**Recipe fingerprint** -- `hash(node code + consumed component configs)`, used by named indexes (`create_index`/`list_indexes`) to detect when the recipe behind an indexed column has changed. Unlike the row fingerprint, it excludes input values entirely -- it names *how* a column is derived, not *what* it was derived from.
+
+**Per-column provenance** -- `hash(producing node's code + its direct input values + consumed component configs)`, stored as `_provenance_<column>` and computed once per node, after that node runs. Because a node's direct inputs are themselves stored columns, provenance comparison is value-based, which gives you a **cascade stop**: if an upstream column's value comes out the same after re-derivation, the provenance hash for anything reading that column doesn't change, and the cascade halts there.
+
+```python
+@node(output_name="clean_text")
+def clean(text: str) -> str:
+    return text.strip().lower()
+
+@node(output_name="word_count")
+def count_words(clean_text: str) -> int:
+    return len(clean_text.split())
+
+table = HyperTable([clean, count_words], identity="doc_id", store=store).with_runner(SyncRunner())
+table.insert(doc_id="d1", text="Hello World")
+
+# "Hello World" and "  Hello World  " both normalize to "hello world"
+table.update("d1", text="  Hello World  ")
+
+raw = table._store.read_rows("doc", None)[0]
+# _provenance_clean_text changed (its direct input, "text", changed)
+# _provenance_word_count did NOT change (its direct input, "clean_text", came out
+# the same value -- "hello world" both times -- so the cascade stops here)
+```
+
+`word_count` is not recomputed on this update, even though `text` changed upstream, because the value it actually depends on (`clean_text`) didn't change.
 
 ### Identity Column
 

--- a/docs/08-hypertable/examples/document-processing.md
+++ b/docs/08-hypertable/examples/document-processing.md
@@ -24,7 +24,7 @@ from typing import TypedDict
 
 from hypergraph import Graph, node
 from hypergraph.materialization import HyperTable
-from hypergraph.materialization.stores import LanceDBStore
+from hypergraph.materialization._lancedb_store import LanceDBStore
 from hypergraph.runners import SyncRunner
 
 

--- a/docs/08-hypertable/getting-started.md
+++ b/docs/08-hypertable/getting-started.md
@@ -7,7 +7,7 @@ Use `HyperTable` to persist graph outputs as table columns and only re-derive wh
 ```python
 from hypergraph import node, Graph
 from hypergraph.materialization import HyperTable
-from hypergraph.materialization.stores import LanceDBStore
+from hypergraph.materialization._lancedb_store import LanceDBStore
 from hypergraph.runners import SyncRunner
 
 # 1. Write logic for ONE item
@@ -49,7 +49,7 @@ That same shape works for:
 ```python
 from hypergraph import node
 from hypergraph.materialization import HyperTable
-from hypergraph.materialization.stores import LanceDBStore
+from hypergraph.materialization._lancedb_store import LanceDBStore
 from hypergraph.runners import SyncRunner
 
 @node(output_name="clean_text")
@@ -154,7 +154,7 @@ When each row contains a collection (a document has pages, a video has utterance
 from typing import TypedDict
 from hypergraph import Graph, node
 from hypergraph.materialization import HyperTable
-from hypergraph.materialization.stores import LanceDBStore
+from hypergraph.materialization._lancedb_store import LanceDBStore
 from hypergraph.runners import SyncRunner
 
 # --- Parent graph nodes ---

--- a/docs/08-hypertable/overview.md
+++ b/docs/08-hypertable/overview.md
@@ -68,6 +68,8 @@ The row fingerprint is `hash(source values + node definition hashes + component 
 | Component config | Swap `Embedder("v1")` for `Embedder("v2")` | All rows re-derive on next insert/sync |
 | Nothing | Same source, same code, same components | Row skipped |
 
+The row fingerprint is a fast skip/re-derive check. Underneath it, each derived column also carries its own per-column provenance hash, which stops a re-derivation cascade as soon as an upstream value comes out unchanged — see [Fingerprints and Provenance](api-reference.md#fingerprints-and-provenance) for the three hashes and a live example.
+
 ## Child Tables
 
 When a single item expands into many sub-items (a document into pages, a video into utterances), use `map_over` to create a child table:
@@ -148,6 +150,7 @@ docs.insert(doc_id="d1", text="...")
 - **Runner** executes the graph (`SyncRunner` or `AsyncRunner`)
 - **Identity** is the stable key for each row — explicit, not convention-based
 - **Fingerprint** decides skip vs re-derive — automatic, no manual cache invalidation
+- **A named index (`create_index`) is a query spec, not a materialized table** — it records which table, which vector column, and which row slice to search; the store searches that column directly, so there is no separate index artifact to keep in sync
 
 ## Next Steps
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -40,6 +40,7 @@
 * [Nodes from Component Methods](05-how-to/nodes-from-component-methods.md)
 * [Rename and Adapt](05-how-to/rename-and-adapt.md)
 * [Integrate with LLMs](05-how-to/integrate-with-llms.md)
+* [Use Hypergraph with Daft](05-how-to/daft-workflows.md)
 * [Test Without Framework](05-how-to/test-without-framework.md)
 * [Observe Execution](05-how-to/observe-execution.md)
 * [Visualize Graphs](05-how-to/visualize-graphs.md)
@@ -52,6 +53,7 @@
 * [Runners](06-api-reference/runners.md)
 * [Events](06-api-reference/events.md)
 * [InputSpec](06-api-reference/inputspec.md)
+* [Checkpointers](06-api-reference/checkpointers.md)
 
 ## HyperTable (Incremental Tables)
 


### PR DESCRIPTION
## Summary

Docs-only round covering the seeded gaps from a 2026-07-06 source audit, plus completeness sweep against real exports. **Docs only — `git diff --stat` against master touches only `docs/**`.**

- New page: `docs/06-api-reference/checkpointers.md` — `Checkpointer` ABC, `CheckpointPolicy`, fork/retry, `lineage()`, backend comparison, and the no-checkpointer re-drive pattern as an explicit alternative.
- Human-in-the-loop cycle mechanics added to `docs/03-patterns/07-human-in-the-loop.md`, including a fix for a pre-existing broken example (see Bugs found).
- Fingerprint/provenance deep-dive added to `docs/08-hypertable/api-reference.md` + `overview.md` (three SHA-256 hashes, live-verified cascade-stop example, "index is a projection not a table" one-liner).
- `hypergraph.integrations` / `integrate-with-llms.md` naming collision called out.
- Orphaned `daft-workflows.md` linked into `SUMMARY.md` nav (verified current, not stale).
- New "Mermaid Text Diagrams" + "Debugging Graph Structure" sections in `visualize-graphs.md` (previously-undocumented `hypergraph.viz` debug surface).
- Several pre-existing broken doc snippets fixed (see Bugs found) since I was already editing the surrounding content and could not in good conscience leave a proven-`AttributeError` snippet in place.

## Gap list and dispositions

1. **Checkpointers have no dedicated page** — DONE. New `docs/06-api-reference/checkpointers.md`: opt-in mechanics, `CheckpointPolicy` knobs, fork/retry, `lineage()`, backend comparison table, and a side-by-side comparison with the no-checkpointer re-drive pattern (seeding interrupts via `RunResult.pause.response_key`).
2. **HITL page needs live-verified cycle mechanics** — DONE. Added: cyclic graphs require explicit `entrypoint=` (verified: `GraphConfigError: Cyclic graphs require an explicit entrypoint`); an interrupt not listed in `entrypoint=` silently never runs even though it's reachable via an edge (verified with a minimal repro); the ask→validate→cycle-back pattern, verified with `entrypoint=["ask_user", "add_user_message"]`.
3. **Provenance/fingerprints have no dedicated treatment** — DONE. New "Fingerprints and Provenance" subsection in `08-hypertable/api-reference.md`: row fingerprint, recipe fingerprint, per-column provenance, live-verified value-transitive cascade stop. Cross-linked from `overview.md`.
4. **"An index is a query spec, not a materialized table"** — DONE. One-liner added to `overview.md`'s architecture bullets, matching the source comment in `_hypertable.py:835`.
5. **`daft-workflows.md` orphaned from nav** — DONE (linked, not removed). Verified current: all 10 referenced example scripts exist, and the quickstart snippet runs correctly against `daft==0.7.14`. Linked into `SUMMARY.md` under How-To Guides.
6. **`hypergraph.integrations` / `integrate-with-llms.md` naming collision** — DONE. One-sentence `{% hint %}` added at the top of `integrate-with-llms.md` clarifying the two are unrelated.
7. **`HyperTable(nodes=[])`** — NOT documented as supported, per instruction. Live-verified it works (construction, insert, get, count all succeed with a table that has only an identity column). Filed under Bugs & issues found below with a repro; needs a pinning decision from the foreman before it becomes a documented feature.

## Snippet ledger

Every snippet below was written to a scratch file outside the repo and run with `uv run python <file>` (checkpointer/SQLite snippets required `dangerouslyDisableSandbox` — see Deviations). All scratch files lived in `/tmp/hg-docs-scratch/`, never committed.

| # | What it verifies | Command | Real output (abridged) |
|---|---|---|---|
| 1 | Basic checkpointer run/get_run/steps | `uv run python s1_checkpointer_basic.py` | `result: {'doubled': 10, 'tripled': 30} RunStatus.COMPLETED` / `run: Run: wf-1 \| completed \| 6ms \| 2 steps` |
| 2 | `CheckpointPolicy` validation rules | `uv run python s2_checkpointer_policy.py` | `exit+full error: durability="exit" requires retention="latest"...` / `windowed no window error: retention="windowed" requires window parameter` |
| 3 | `fork_from` via `runner.run()` | `uv run python s3_checkpointer_fork_retry.py` | `forked workflow_id: run-20260706-386a58` (NOT `fork-src-fork-...`) |
| 4 | Cyclic graph requires `entrypoint=` | `uv run python s4_cyclic_entrypoint_required.py` | `construction error: GraphConfigError Cyclic graphs require an explicit entrypoint.` |
| 5 | Interrupt-in-cycle silent skip (first repro) | `uv run python s5_interrupt_in_cycle_entrypoint.py` | `status: RunStatus.COMPLETED paused: False` (should have paused) |
| 6/7 | Silent-skip confirmation, multiple entrypoint configs | `uv run python s7_multi_entrypoint_debug.py` | Case A/B (entrypoint w/o `ask_user`): `add_user_message` runs, nothing else, `paused: False`. Case C (`entrypoint="ask_user"`): `paused: True node: ask_user` |
| 9 | `getting-started.md` corrected import + incrementality | `uv run python s9_hypertable_getting_started.py` | `row: {...'clean_text': 'hello world'...}` / `re-insert same -> count unchanged: 2` |
| 10 | Fingerprint/provenance columns exist, SHA-256 | `uv run python s10_provenance.py` | `_row_fingerprint: be70cedf...` (64 hex chars) |
| 11 | Cascade stop (value-transitive) | `uv run python s11_cascade_stop.py` | `_provenance_clean_text changed? True` / `_provenance_word_count changed? False` |
| 12 | `HyperTable(nodes=[])` | `uv run python s12_empty_nodes.py` | `construction ok` / `insert ok: {'doc_id': 'd1', 'text': 'hello'}` / `count: 1` |
| 13 | `checkpointer.lineage()` | `uv run python s13_lineage.py` | `LineageView: root-1 (root=root-1)` with fork row |
| 14 | No-checkpointer re-drive, multiple interrupts | `uv run python s14_redrive_pattern.py` | `r3 status: RunStatus.COMPLETED result: Published: Detailed draft about hello` |
| 15 | `SyncRunner` + `SqliteCheckpointer` | `uv run python s15_sync_runner_checkpoint.py` | `run: Run: sync-wf-1 \| completed \| 5ms \| 1 step` |
| 16 | `durability=`/`retention=` shortcut kwargs | `uv run python s16_policy_shortcuts.py` | `conflict error: Cannot pass both 'policy' and 'durability'/'retention'...` |
| 19/21 | Fixed multi-turn HITL example (final, doc-matching) | `uv run python s21_correct_ask_cycle_pattern.py` | Turn 1 pauses at `ask_user`; turn 2 runs full cycle and pauses again with accumulated messages |
| 22 | Exact HITL doc code block, with its own asserts | `uv run python s22_verify_doc_block_exact.py` | `ALL ASSERTS PASSED` |
| 23 | `create_index`/`list_indexes` | `uv run python s23_index_is_projection.py` | `index spec: {'name': 'main_search', 'on': 'doc', ... 'recipe_fingerprint': '...'}` |
| 24 | Full `api-reference.md` cumulative context + new provenance blocks | `uv run python s24_full_apiref_cumulative.py` | Confirms `text` stored verbatim (not lowercased) — see Bugs found |
| 25 | `daft-workflows.md` quickstart snippet | `uv run python s25_daft_quickstart_snippet.py` | `['Shandra Shamas', 'Zaya Zaphora']` / `['senior', 'mid-career']` |
| 26/27 | `current_node_span()` inside/outside a node | `uv run python s27_verify_observe_snippet.py` | `processing {'span_id': '2d904fca5cb74f5d'}` |
| 28/29/30 | `RunLog` real API (`.steps`, no `.slowest()`/`.records`) | `uv run python s30_debug_workflows_cumulative.py` | `AttributeError: 'RunLog' object has no attribute 'slowest'` (first run) → all blocks pass after fix |
| 31/32 | `MapResult`/`MapLog` | `uv run python s32_maplog_type.py` | `MapLog` / `items count: 3` |
| 33/34/35 | `WorkflowAlreadyRunningError`, `WorkflowForkError` | `uv run python s35_verify_checkpointers_doc_block.py` | `Cannot fork into existing workflow 'job-1'. Use a new workflow_id.` |
| 36/37 | `hypergraph.viz` debug tools (`validate_graph`, `find_issues`, `VizDebugger`) | `uv run python s37_verify_viz_doc_block.py` | `FOUND` / `[{'to': 'add_one', 'value': 'doubled', 'type': 'data'}]` / `ALL OK` |
| 38/39 | `graph.to_mermaid()` (simpler than the module function) | `uv run python s39_final_viz_section.py` | Mermaid flowchart source printed correctly |
| 40/41 | `StepRecord`/`StepStatus`/`Run`/`WorkflowStatus` types | `uv run python s41_final_types_snippet.py` | `True` / `True` |

(Numbering skips snippets that were superseded by a corrected version in the same investigation, e.g. s5→s7, s17/18/20→s21.)

## Bugs & issues found

None of these were fixed as new features — either pre-existing doc/import bugs (fixed as trivial, in-scope corrections since I was already editing the surrounding text) or explicitly-scoped-out items per the brief.

1. **`HyperTable(nodes=[])` works but is unspecified.** Repro: `HyperTable([], identity="doc_id", store=LanceDBStore(path)).with_runner(SyncRunner())` then `.insert(doc_id="d1", text="hello")` succeeds, returns `{'doc_id': 'd1', 'text': 'hello'}`, `count() == 1`. No tests cover this. **Not documented as supported**, per instruction — needs a pinning decision (is an all-metadata table a real use case, or should the constructor reject empty `nodes`?).
2. **`fork_from` via `runner.run()` never produces the `{source}-fork-{hex}` name.** `Checkpointer.fork_workflow_async(source_run_id, workflow_id=None)` has a fallback name `f"{source_run_id}-fork-{uuid4().hex[:6]}"`, but `template_async.py`'s `run()` always auto-generates a `workflow_id` (`run-YYYYMMDD-hex`) *before* the fork/retry branch executes (`if workflow_id is None: workflow_id = generate_workflow_id()` runs unconditionally, ahead of the `fork_from` check). So that fallback naming is effectively dead code on the `runner.run(fork_from=...)` call path — it only fires if you call `checkpointer.fork_workflow_async(...)` directly. Documented the *observed* behavior only (auto-generated id unless you pass `workflow_id=` explicitly); did not change the code.
3. **Pre-existing broken import in shipped docs**: `docs/08-hypertable/getting-started.md` (3 occurrences) and `docs/08-hypertable/examples/document-processing.md` (1 occurrence) imported `from hypergraph.materialization.stores import LanceDBStore` — that module does not exist (`ModuleNotFoundError`). Fixed to the real path, `hypergraph.materialization._lancedb_store`, matching `api-reference.md` and `media-knowledge-base.md`.
4. **Pre-existing wrong output comment**: `api-reference.md`'s first example claimed `table.get("d1")` returns `'text': 'hello world'` (lowercased) — verified live, `text` is stored verbatim as `'Hello World'`; only `clean_text` is lowercased. Fixed the comment.
5. **Pre-existing broken example in `07-human-in-the-loop.md`**: the "Multi-Turn Chat with Human Input" example raised `GraphConfigError: Input 'messages' on node 'generate' has 2 competing producers` at construction — it never had explicit edges or a `shared=`/`entrypoint=` to disambiguate `messages`, unlike the (working) checkpointed example lower in the same file. Fixed using that file's own established working pattern (explicit `edges=`, `shared=["messages"]`, `entrypoint=[...]`).
6. **Pre-existing broken API references in `debug-workflows.md`**: `result.log.slowest()` and `result.log.records` do not exist on `RunLog` (`AttributeError`) — repro: `uv run python -c "from hypergraph import Graph, SyncRunner, node; ..."` then call `.slowest()`. The real attribute is `.steps` (a `tuple[NodeRecord, ...]`); "slowest" requires manual sorting. Also fixed: `result.log.to_dict()`'s claimed output keys (`"records"`, `"total_ms"`) don't match the real keys (`"steps"`, `"total_duration_ms"`, plus `"graph_name"`/`"run_id"`); `result.log.summary()`'s claimed format string didn't match the real one; the `Graph([...])` in that example had no `name=`, so the shown `RunLog: graph | ...` header would actually print `RunLog: None | ...`. All fixed to match verified live output.

## Deviations & inventions

New pages/sections not explicitly named in the brief, added to satisfy the "every export has a doc home or is named undocumented" completion criterion:

- `docs/06-api-reference/checkpointers.md` — the seeded gap asked for this, but I additionally added a "Types" section (`StepRecord`, `StepStatus`, `Run`, `WorkflowStatus`, `Checkpoint` — already used pervasively via `.steps()`/`.get_run()` but never named) and a "Lineage and Concurrency Errors" section (`WorkflowAlreadyRunningError`, `WorkflowForkError`).
- `docs/05-how-to/visualize-graphs.md` — added "Mermaid Text Diagrams" (`graph.to_mermaid()`, `MermaidDiagram`) and "Debugging Graph Structure" (`validate_graph`, `find_issues`, `VizDebugger`/`graph.debug_viz()`) — the entire `hypergraph.viz` debug-tooling surface had zero prior doc mentions and wasn't in the seeded gap list, but the completion criterion required a disposition.
- `docs/05-how-to/debug-workflows.md` — added one sentence naming `NodeRecord`/`NodeStats` as the types behind `result.log.steps`/`result.log.node_stats`, and one sentence naming `MapLog` as the type behind `results.log` on a `MapResult`. Not asked for, closes export coverage.
- `docs/05-how-to/observe-execution.md` — added a `current_node_span()`/`NodeSpanRef` section. Not asked for, closes export coverage.
- Fixed 6 pre-existing bugs in already-shipped docs (listed above) rather than working around them, since I was directly editing the surrounding text in every case and the brief's snippet discipline made them impossible to miss.

**Deliberately undocumented** (top-level exports and subpackage members with no doc home in this PR — a full guide for these is out of scope for a docs round and would need product/API judgment, not just docs work):

- `BaseRunner` — the abstract base class for authoring a custom runner. Advanced extensibility surface; writing a custom-runner guide is a separate, larger effort.
- `hypergraph.checkpointers`: `JsonSerializer`, `PickleSerializer`, `Serializer` (pluggable step-value serialization), `RunInspector`, `SqliteRunInspector` (the sync inspection Protocol), `RunTable`, `StepTable`, `LineageRow` (display/table wrapper types; `LineageView`, which wraps them, is documented).
- `hypergraph.viz`: `extract_debug_data`, `RenderedDebugData`, `RenderedEdge` — lower-level primitives for extracting debug data from an already-rendered visualization (looks like internal tooling for testing the JS viz widget itself, not an end-user API).

## Test plan

- [x] Every code snippet in touched/new docs was written to a scratch file and run with `uv run python` before being pasted (see ledger above — SQLite/checkpointer runs needed sandbox disabled locally, a tooling quirk, not a library issue).
- [x] `git diff --stat` against `master` touches only `docs/**`.
- [x] `git diff --check` (whitespace) — clean.
- [x] Pre-push `ruff check`/`ruff format` hooks passed (confirms no accidental `src/`/`tests/` changes slipped in).
- [ ] Not run: the full `uv run python -m unittest discover` suite — out of scope for a docs-only change and I did not modify anything under `src/` or `tests/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)