### PR TITLE
fix: four confirmed bugs from production-readiness audit

### DIFF
--- a/docs/06-api-reference/gates.md
+++ b/docs/06-api-reference/gates.md
@@ -111,7 +111,10 @@ Input parameter names from function signature.
 
 #### `outputs: tuple[str, ...]`
 
-Always empty tuple. Gates produce no data outputs.
+Derived from the current name: `("_<name>", *emit)`. The leading entry is an
+internal routing value (not user-facing data — gates produce no data outputs);
+`emit` names follow if declared. Renaming the node with `with_name()` renames
+the internal entry automatically.
 
 #### `targets: list[str]`
 
@@ -336,10 +339,13 @@ print(decide.inputs)  # ("x", "threshold")
 
 #### `outputs: tuple[str, ...]`
 
-Always empty tuple. Gates produce no data outputs.
+Derived from the current name: `("_<name>", *emit)`. The leading entry is an
+internal routing value (not user-facing data — gates produce no data outputs);
+`emit` names follow if declared. Renaming the node with `with_name()` renames
+the internal entry automatically.
 
 ```python
-print(decide.outputs)  # ()
+print(decide.outputs)  # ('_decide',)
 ```
 
 #### `targets: list[str]`

--- a/src/hypergraph/nodes/gate.py
+++ b/src/hypergraph/nodes/gate.py
@@ -19,7 +19,7 @@ from typing import Any, TypeVar
 from hypergraph._utils import ensure_tuple, hash_definition
 from hypergraph.nodes._callable import CallableMixin
 from hypergraph.nodes._input_extraction import extract_inputs
-from hypergraph.nodes._rename import _apply_renames
+from hypergraph.nodes._rename import RenameError, _apply_renames
 from hypergraph.nodes.base import HyperNode, _validate_emit_wait_for
 
 # =============================================================================
@@ -94,7 +94,6 @@ class GateNode(CallableMixin, HyperNode):
     Subclasses must set these attributes in __init__:
     - name: str
     - inputs: tuple[str, ...]
-    - outputs: tuple[str, ...] (empty or emit-only for gates)
     - targets: list[str]
     - descriptions: dict[...key..., str] (key type varies by subclass)
     - func: Callable (the routing function)
@@ -131,6 +130,33 @@ class GateNode(CallableMixin, HyperNode):
     def data_outputs(self) -> tuple[str, ...]:
         """Internal routing value output used for checkpoint/resume reconstruction."""
         return (f"_{self.name}",)
+
+    @property
+    def outputs(self) -> tuple[str, ...]:
+        """Internal routing output plus emit-only outputs.
+
+        Derived from the CURRENT name and emit tuple (single source of truth),
+        so rename operations like ``with_name()`` can never leave a stale
+        stored copy behind (a stale ``_<old_name>`` broke graph construction).
+        """
+        return (f"_{self.name}", *self._emit)
+
+    @outputs.setter
+    def outputs(self, value: tuple[str, ...]) -> None:
+        """Accept output renames from ``rename_outputs()``.
+
+        The first entry is the internal routing output ``_<name>``; it is
+        derived from the gate name and must not change here. The remaining
+        entries are the emit outputs, which may be renamed freely.
+        """
+        routing_output = f"_{self.name}"
+        if not value or value[0] != routing_output:
+            raise RenameError(
+                f"Gate '{self.name}': the internal routing output '{routing_output}' is "
+                f"derived from the gate name and cannot be renamed or removed. "
+                f"Use with_name() to rename the gate instead."
+            )
+        self._emit = tuple(value[1:])
 
     @property
     def is_gate(self) -> bool:
@@ -182,7 +208,7 @@ class RouteNode(GateNode):
     Attributes:
         name: Node name (default: func.__name__)
         inputs: Input parameter names from function signature
-        outputs: Always empty tuple (gates produce no data)
+        outputs: Derived ``("_<name>", *emit)`` — internal routing output plus emit
         targets: List of valid target names (or END)
         descriptions: Optional descriptions for visualization
         fallback: Default target if function returns None
@@ -289,9 +315,7 @@ class RouteNode(GateNode):
         self.default_open = default_open
         self._definition_hash = hash_definition(func)
 
-        # Core HyperNode attributes
-        self.outputs = (f"_{self.name}", *self._emit)
-
+        # `outputs` is a derived property on GateNode — no stored copy here.
         inputs, self._context_param = extract_inputs(func)
         self.inputs, self._rename_history = _apply_renames(inputs, rename_inputs, "inputs")
 
@@ -422,7 +446,7 @@ class IfElseNode(GateNode):
     Attributes:
         name: Node name (default: func.__name__)
         inputs: Input parameter names from function signature
-        outputs: Always empty tuple (gates produce no data)
+        outputs: Derived ``("_<name>", *emit)`` — internal routing output plus emit
         targets: [when_true, when_false] targets
         descriptions: Fixed {True: "True", False: "False"}
         when_true: Target when function returns True
@@ -502,9 +526,7 @@ class IfElseNode(GateNode):
         self.default_open = default_open
         self._definition_hash = hash_definition(func)
 
-        # Core HyperNode attributes
-        self.outputs = (f"_{self.name}", *self._emit)
-
+        # `outputs` is a derived property on GateNode — no stored copy here.
         inputs, self._context_param = extract_inputs(func)
         self.inputs, self._rename_history = _apply_renames(inputs, rename_inputs, "inputs")
 

--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -17,6 +17,7 @@ from hypergraph.exceptions import (
     InputOverrideRequiresForkError,
     MissingInputError,
     WorkflowAlreadyCompletedError,
+    WorkflowAlreadyRunningError,
     WorkflowForkError,
 )
 from hypergraph.runners._shared.event_metadata import (
@@ -530,7 +531,12 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                 error=error,
             )
 
-            if has_checkpointer:
+            # A bare WorkflowAlreadyRunningError is a pre-flight rejection of a
+            # DUPLICATE start: this call never owned the run row, and the
+            # original run is still executing — never touch its persisted
+            # status. (Wrapped in ExecutionError it came from a node, so the
+            # run genuinely failed and the write below is correct.)
+            if has_checkpointer and not isinstance(e, WorkflowAlreadyRunningError):
                 from hypergraph.checkpointers.types import WorkflowStatus as _WS
 
                 # Flush buffered steps so partial execution is preserved on failure

--- a/src/hypergraph/runners/_shared/template_sync.py
+++ b/src/hypergraph/runners/_shared/template_sync.py
@@ -16,6 +16,7 @@ from hypergraph.exceptions import (
     InputOverrideRequiresForkError,
     MissingInputError,
     WorkflowAlreadyCompletedError,
+    WorkflowAlreadyRunningError,
     WorkflowForkError,
 )
 from hypergraph.runners._shared.event_metadata import (
@@ -513,8 +514,13 @@ class SyncRunnerTemplate(BaseRunner, ABC):
                 error=error,
             )
 
-            # Flush buffered steps and mark run failed
-            if sync_cp is not None:
+            # Flush buffered steps and mark run failed.
+            # A bare WorkflowAlreadyRunningError is a pre-flight rejection of a
+            # DUPLICATE start: this call never owned the run row, and the
+            # original run is still executing — never touch its persisted
+            # status. (Wrapped in ExecutionError it came from a node, so the
+            # run genuinely failed and the write below is correct.)
+            if sync_cp is not None and not isinstance(e, WorkflowAlreadyRunningError):
                 from hypergraph.runners._shared.checkpoint_helpers import checkpoint_offsets as _cp_offsets
 
                 _, _step_off = _cp_offsets(resume_checkpoint)

--- a/src/hypergraph/runners/_shared/template_sync.py
+++ b/src/hypergraph/runners/_shared/template_sync.py
@@ -660,22 +660,28 @@ class SyncRunnerTemplate(BaseRunner, ABC):
                     )
                     continue
 
-                result = self.run(
-                    graph,
-                    variation_inputs,
-                    select=select,
-                    on_missing=on_missing,
-                    entrypoint=entrypoint,
-                    error_handling="continue",
-                    event_processors=event_processors,
-                    show_progress=False,
-                    workflow_id=child_workflow_id,
-                    _parent_span_id=map_span_id,
-                    _parent_run_id=workflow_id,
-                    _validation_ctx=ctx,
-                    _run_config={_MAP_SIGNATURE_CONFIG_KEY: item_signature},
-                    _item_index=idx,
-                )
+                try:
+                    result = self.run(
+                        graph,
+                        variation_inputs,
+                        select=select,
+                        on_missing=on_missing,
+                        entrypoint=entrypoint,
+                        error_handling="continue",
+                        event_processors=event_processors,
+                        show_progress=False,
+                        workflow_id=child_workflow_id,
+                        _parent_span_id=map_span_id,
+                        _parent_run_id=workflow_id,
+                        _validation_ctx=ctx,
+                        _run_config={_MAP_SIGNATURE_CONFIG_KEY: item_signature},
+                        _item_index=idx,
+                    )
+                except Exception as e:
+                    # Catch validation errors (e.g., MissingInputError) that raise
+                    # before run()'s execution try block — parity with async map
+                    # and both map_iter variants.
+                    result = RunResult(values={}, status=RunStatus.FAILED, run_id=_generate_run_id(), error=e)
                 results.append(result)
                 if error_handling == "raise" and result.status == RunStatus.FAILED:
                     raise result.error  # type: ignore[misc]

--- a/src/hypergraph/viz/debug.py
+++ b/src/hypergraph/viz/debug.py
@@ -40,6 +40,15 @@ if TYPE_CHECKING:
     from hypergraph.graph.core import Graph
 
 
+def _joined_value_names(edge_data: dict[str, Any]) -> str:
+    """Join a flat-graph edge's ``value_names`` (plural) into a display string.
+
+    Flat-graph edges carry ``value_names``; a singular ``value_name`` key never
+    exists on them (regression: reading it made every edge report no values).
+    """
+    return ", ".join(edge_data.get("value_names") or [])
+
+
 @dataclass
 class ValidationResult:
     """Result of graph validation."""
@@ -273,11 +282,11 @@ class VizDebugger:
         analysis: dict[str, Any] = {}
 
         if source in G.nodes:
-            from_source = [{"to": tgt, "value": G.edges[source, tgt].get("value_name")} for _, tgt in G.out_edges(source)]
+            from_source = [{"to": tgt, "value": _joined_value_names(G.edges[source, tgt])} for _, tgt in G.out_edges(source)]
             analysis["edges_from_source"] = from_source
 
         if target in G.nodes:
-            to_target = [{"from": src, "value": G.edges[src, target].get("value_name")} for src, _ in G.in_edges(target)]
+            to_target = [{"from": src, "value": _joined_value_names(G.edges[src, target])} for src, _ in G.in_edges(target)]
             analysis["edges_to_target"] = to_target
 
         if source in G.nodes and target in G.nodes:
@@ -366,7 +375,7 @@ class VizDebugger:
                     "source": src,
                     "target": tgt,
                     "edge_type": data.get("edge_type", "data"),
-                    "value_name": data.get("value_name", ""),
+                    "value_name": _joined_value_names(data),
                 }
             )
 

--- a/tests/test_checkpointer/test_duplicate_start_status.py
+++ b/tests/test_checkpointer/test_duplicate_start_status.py
@@ -1,0 +1,86 @@
+"""Regression tests: a duplicate start must NEVER corrupt the running row.
+
+Bug: starting a second run with a workflow_id that is still executing raises
+``WorkflowAlreadyRunningError`` at pre-flight (the rejected call never owns
+the run row), but the generic error handler in the run template caught it and
+called ``update_run_status(..., FAILED, ...)`` — marking the ORIGINAL,
+still-running workflow's persisted row FAILED (issue #127 evidence).
+"""
+
+import asyncio
+
+import pytest
+
+from hypergraph import AsyncRunner, Graph, RunStatus, SyncRunner, WorkflowAlreadyRunningError, node
+from hypergraph.checkpointers import MemoryCheckpointer, SqliteCheckpointer, WorkflowStatus
+
+
+class TestAsyncDuplicateStartStatus:
+    @pytest.mark.asyncio
+    async def test_duplicate_start_never_marks_running_row_failed(self):
+        """B4.1: run 1 held open; run 2 raises; run 1's row stays ACTIVE and
+        finishes COMPLETED — never FAILED."""
+        entered = asyncio.Event()
+        release = asyncio.Event()
+
+        @node(output_name="result")
+        async def hold() -> str:
+            entered.set()
+            await release.wait()
+            return "done"
+
+        graph = Graph([hold])
+        checkpointer = MemoryCheckpointer()
+        runner = AsyncRunner(checkpointer=checkpointer)
+
+        run1 = asyncio.create_task(runner.run(graph, workflow_id="wf-dup"))
+        await entered.wait()
+
+        # Duplicate start is rejected at pre-flight.
+        with pytest.raises(WorkflowAlreadyRunningError):
+            await runner.run(graph, workflow_id="wf-dup")
+
+        # The rejected call never owned the row — run 1 is still ACTIVE.
+        row = await checkpointer.get_run_async("wf-dup")
+        assert row is not None
+        assert row.status == WorkflowStatus.ACTIVE
+
+        release.set()
+        result = await run1
+        assert result.status == RunStatus.COMPLETED
+
+        row = await checkpointer.get_run_async("wf-dup")
+        assert row.status == WorkflowStatus.COMPLETED
+
+
+class TestSyncDuplicateStartStatus:
+    def test_duplicate_start_never_marks_running_row_failed(self, tmp_path):
+        """Parity: the sync template shares the handler bug. A same-thread
+        duplicate start (from inside a node) must not mark the row FAILED."""
+        checkpointer = SqliteCheckpointer(str(tmp_path / "dup.db"))
+        runner = SyncRunner(checkpointer=checkpointer)
+        graph_box: dict[str, Graph] = {}
+        observed_mid_flight: list[WorkflowStatus] = []
+
+        @node(output_name="result")
+        def duplicate_start() -> str:
+            # Same runner, same workflow_id, while this run is executing.
+            try:
+                runner.run(graph_box["g"], workflow_id="wf-dup")
+            except WorkflowAlreadyRunningError:
+                row = checkpointer.get_run("wf-dup")
+                assert row is not None
+                observed_mid_flight.append(row.status)
+            return "done"
+
+        graph_box["g"] = Graph([duplicate_start])
+
+        result = runner.run(graph_box["g"], workflow_id="wf-dup")
+        assert result.status == RunStatus.COMPLETED
+
+        # The rejected inner call must not have touched the row's status.
+        assert observed_mid_flight == [WorkflowStatus.ACTIVE]
+
+        row = checkpointer.get_run("wf-dup")
+        assert row.status == WorkflowStatus.COMPLETED
+        checkpointer._sync_db().close()

--- a/tests/test_nodes_gate.py
+++ b/tests/test_nodes_gate.py
@@ -603,3 +603,129 @@ class TestGateNodeTypeAnnotations:
         # This should NOT raise GraphConfigError
         graph = Graph([make_decision, gate, done], strict_types=True)
         assert graph.strict_types is True
+
+
+# =============================================================================
+# Gate Rename Consistency Tests (regression: with_name corrupted outputs)
+# =============================================================================
+
+
+class TestGateRenameOutputConsistency:
+    """A gate's outputs must always derive from its CURRENT name and emit.
+
+    Regression: RouteNode/IfElseNode stored `outputs` at construction time
+    while `data_outputs` re-derived from the current name. `.with_name()`
+    left the stored tuple stale, so graphs rejected the renamed gate with
+    "Invalid output name '_<old_name>'".
+    """
+
+    def test_route_with_name_updates_outputs(self):
+        """B1.1: renaming a RouteNode keeps outputs in sync with the name."""
+
+        @route(targets=["a"])
+        def decide(x):
+            return "a"
+
+        renamed = decide.with_name("chooser")
+        assert renamed.outputs == ("_chooser",)
+        assert renamed.data_outputs == ("_chooser",)
+        # Original unchanged
+        assert decide.outputs == ("_decide",)
+
+    def test_route_with_name_graph_builds_and_routes(self):
+        """B1.1: a renamed @route gate builds into a Graph and routes at runtime."""
+        from hypergraph import Graph, RunStatus, SyncRunner, node
+
+        @node(output_name="a")
+        def start(x):
+            return x
+
+        @node(output_name="result")
+        def positive_path(a):
+            return a * 2
+
+        @node(output_name="result")
+        def negative_path(a):
+            return a * -1
+
+        @route(targets=["positive_path", "negative_path"])
+        def decide(a):
+            return "positive_path" if a > 0 else "negative_path"
+
+        renamed = decide.with_name("chooser")
+        graph = Graph([start, renamed, positive_path, negative_path])
+
+        result = SyncRunner().run(graph, {"x": 5})
+        assert result.status == RunStatus.COMPLETED
+        assert result["result"] == 10
+
+        result = SyncRunner().run(graph, {"x": -5})
+        assert result.status == RunStatus.COMPLETED
+        assert result["result"] == 5
+
+    def test_ifelse_with_name_updates_outputs_and_routes(self):
+        """B1.2: IfElseNode shares the fix — renamed gate builds and routes."""
+        from hypergraph import Graph, RunStatus, SyncRunner, node
+        from hypergraph.nodes.gate import ifelse
+
+        @node(output_name="a")
+        def start(x):
+            return x
+
+        @node(output_name="result")
+        def process(a):
+            return a * 2
+
+        @node(output_name="result")
+        def skip(a):
+            return a
+
+        @ifelse(when_true="process", when_false="skip")
+        def is_positive(a):
+            return a > 0
+
+        renamed = is_positive.with_name("checker")
+        assert renamed.outputs == ("_checker",)
+        assert renamed.data_outputs == ("_checker",)
+
+        graph = Graph([start, renamed, process, skip])
+        result = SyncRunner().run(graph, {"x": 3})
+        assert result.status == RunStatus.COMPLETED
+        assert result["result"] == 6
+
+    def test_route_with_name_preserves_emit(self):
+        """B1.4: rename keeps emit outputs; outputs stays a tuple[str, ...]."""
+
+        @route(targets=["a"], emit="sig")
+        def decide(x):
+            return "a"
+
+        renamed = decide.with_name("chooser")
+        assert renamed.outputs == ("_chooser", "sig")
+        assert isinstance(renamed.outputs, tuple)
+        assert all(isinstance(o, str) for o in renamed.outputs)
+
+    def test_route_rename_emit_output_still_works(self):
+        """B1.3: renaming an emit output on a gate keeps working."""
+
+        @route(targets=["a"], emit="sig")
+        def decide(x):
+            return "a"
+
+        renamed = decide.rename_outputs(sig="signal")
+        assert renamed.outputs == ("_decide", "signal")
+        assert renamed.data_outputs == ("_decide",)
+        # Original unchanged
+        assert decide.outputs == ("_decide", "sig")
+
+    def test_route_rename_internal_output_fails_loudly(self):
+        """B1.3: the internal routing output derives from the gate name and
+        cannot be renamed independently — fail loudly, never diverge silently."""
+        from hypergraph.nodes._rename import RenameError
+
+        @route(targets=["a"])
+        def decide(x):
+            return "a"
+
+        with pytest.raises(RenameError, match="derived from the gate name"):
+            decide.rename_outputs({"_decide": "decision"})

--- a/tests/test_runners/test_graphnode_map_over.py
+++ b/tests/test_runners/test_graphnode_map_over.py
@@ -852,13 +852,28 @@ class TestMaxConcurrency:
         assert result["value"] == [2, 4, 6]
 
     async def test_map_over_with_product_mode_and_concurrency(self):
-        """Product mode map_over respects concurrency limits."""
+        """Product mode map_over runs all mapped items concurrently.
+
+        Structural parallelism proof (no wall-clock asserts — they flake
+        under CPU contention with xdist): every mapped call must be in
+        flight simultaneously before ANY may complete. If execution were
+        serialized, the first item would wait on the barrier forever and
+        the wait_for timeout would fail the test.
+        """
         import asyncio
-        import time
+
+        total_items = 4  # product of [1,2] x [10,20]
+        arrived = 0
+        all_arrived = asyncio.Event()
 
         @node(output_name="sum")
         async def slow_add(a: int, b: int) -> int:
-            await asyncio.sleep(0.02)
+            nonlocal arrived
+            arrived += 1
+            if arrived == total_items:
+                all_arrived.set()
+            # Deadlocks (→ TimeoutError) unless all items overlap in flight.
+            await asyncio.wait_for(all_arrived.wait(), timeout=15)
             return a + b
 
         inner = Graph([slow_add], name="inner")
@@ -866,17 +881,13 @@ class TestMaxConcurrency:
 
         runner = AsyncRunner()
 
-        # Product of [1,2] x [10,20] = 4 combinations
         # a, b are owned by inner GraphNode → addressed by its parent-facing key
-        start = time.time()
         result = await runner.run(outer, {"a": [1, 2], "b": [10, 20]})
-        elapsed = time.time() - start
 
         assert result.status == RunStatus.COMPLETED
         assert len(result["sum"]) == 4
         assert sorted(result["sum"]) == [11, 12, 21, 22]
-        # All 4 run in parallel: ~0.02s
-        assert elapsed < 0.1, f"Expected parallel, got {elapsed:.3f}s"
+        assert arrived == total_items
 
     async def test_error_in_nested_map_with_concurrency(self):
         """Errors propagate correctly from nested maps with concurrency."""

--- a/tests/test_runners/test_map_pre_run_item_errors.py
+++ b/tests/test_runners/test_map_pre_run_item_errors.py
@@ -1,0 +1,131 @@
+"""Regression tests: map(error_handling="continue") must survive PRE-RUN item errors.
+
+Bug: sync ``map()`` called ``self.run(...)`` bare, so an exception raised
+before run()'s internal try block (e.g. per-item input validation) escaped
+and aborted the whole batch — even with ``error_handling="continue"``.
+Async ``map()`` and both ``map_iter`` variants already converted such
+exceptions into FAILED item results. Sync ``map()`` was the sole outlier.
+
+Sync/async parity: both runners must produce the same per-item statuses.
+"""
+
+import pytest
+
+from hypergraph import AsyncRunner, Graph, MissingInputError, RunStatus, SyncRunner, node
+
+
+@node(output_name="total")
+def add(x: int, y: int) -> int:
+    return x + y
+
+
+@node(output_name="doubled")
+def double(x: int) -> int:
+    return x * 2
+
+
+def _flaky_run_wrapper(real_run, failing_index):
+    """Wrap a runner's ``run`` so exactly one item raises BEFORE execution.
+
+    Simulates a pre-run validation error (the kind run() raises before its
+    internal try block) for a single item, so the batch has mixed outcomes.
+    """
+
+    def wrapper(*args, **kwargs):
+        if kwargs.get("_item_index") == failing_index:
+            raise MissingInputError(missing=["y"], provided=["x"])
+        return real_run(*args, **kwargs)
+
+    return wrapper
+
+
+def _flaky_async_run_wrapper(real_run, failing_index):
+    async def wrapper(*args, **kwargs):
+        if kwargs.get("_item_index") == failing_index:
+            raise MissingInputError(missing=["y"], provided=["x"])
+        return await real_run(*args, **kwargs)
+
+    return wrapper
+
+
+class TestSyncMapContinuePreRunErrors:
+    def test_missing_required_input_continue_returns_failed_items(self):
+        """B2.1: pre-run validation error (missing input) with continue —
+        the batch completes and every item carries FAILED + the error."""
+        graph = Graph([add])
+        runner = SyncRunner()
+
+        # "y" is required but never provided → each item's run() raises
+        # MissingInputError before its execution try block.
+        result = runner.map(graph, {"x": [1, 2, 3]}, map_over="x", error_handling="continue")
+
+        assert len(result.results) == 3
+        for item in result.results:
+            assert item.status == RunStatus.FAILED
+            assert isinstance(item.error, MissingInputError)
+
+    def test_single_item_pre_run_error_continue_mixed_statuses(self):
+        """B2.1: item 2 raises pre-run; items 1/3 complete; batch survives."""
+        graph = Graph([double])
+        runner = SyncRunner()
+        runner.run = _flaky_run_wrapper(runner.run, failing_index=1)
+
+        result = runner.map(graph, {"x": [1, 2, 3]}, map_over="x", error_handling="continue")
+
+        statuses = [r.status for r in result.results]
+        assert statuses == [RunStatus.COMPLETED, RunStatus.FAILED, RunStatus.COMPLETED]
+        assert isinstance(result.results[1].error, MissingInputError)
+        assert result.results[0]["doubled"] == 2
+        assert result.results[2]["doubled"] == 6
+
+    def test_pre_run_error_raise_mode_still_raises(self):
+        """B2.3: error_handling="raise" behavior is unchanged — still raises."""
+        graph = Graph([add])
+        runner = SyncRunner()
+
+        with pytest.raises(MissingInputError):
+            runner.map(graph, {"x": [1, 2, 3]}, map_over="x", error_handling="raise")
+
+
+class TestAsyncMapContinuePreRunErrorsParity:
+    @pytest.mark.asyncio
+    async def test_missing_required_input_continue_parity(self):
+        """B2.2: async map produces the same per-item statuses as sync map."""
+        graph = Graph([add])
+
+        sync_result = SyncRunner().map(graph, {"x": [1, 2, 3]}, map_over="x", error_handling="continue")
+        async_result = await AsyncRunner().map(graph, {"x": [1, 2, 3]}, map_over="x", error_handling="continue")
+
+        sync_statuses = [r.status for r in sync_result.results]
+        async_statuses = [r.status for r in async_result.results]
+        assert sync_statuses == async_statuses == [RunStatus.FAILED] * 3
+        for item in async_result.results:
+            assert isinstance(item.error, MissingInputError)
+
+    @pytest.mark.asyncio
+    async def test_single_item_pre_run_error_continue_parity(self):
+        """B2.2: mixed-status scenario matches across sync and async."""
+        graph = Graph([double])
+
+        sync_runner = SyncRunner()
+        sync_runner.run = _flaky_run_wrapper(sync_runner.run, failing_index=1)
+        sync_result = sync_runner.map(graph, {"x": [1, 2, 3]}, map_over="x", error_handling="continue")
+
+        async_runner = AsyncRunner()
+        async_runner.run = _flaky_async_run_wrapper(async_runner.run, failing_index=1)
+        async_result = await async_runner.map(graph, {"x": [1, 2, 3]}, map_over="x", error_handling="continue")
+
+        sync_statuses = [r.status for r in sync_result.results]
+        async_statuses = [r.status for r in async_result.results]
+        assert sync_statuses == async_statuses == [RunStatus.COMPLETED, RunStatus.FAILED, RunStatus.COMPLETED]
+
+    @pytest.mark.asyncio
+    async def test_pre_run_error_raise_mode_parity(self):
+        """B2.3 parity: raise mode raises on both runners."""
+        graph = Graph([add])
+
+        with pytest.raises(MissingInputError):
+            SyncRunner().map(graph, {"x": [1, 2, 3]}, map_over="x", error_handling="raise")
+
+        with pytest.raises(MissingInputError):
+            await AsyncRunner().map(graph, {"x": [1, 2, 3]}, map_over="x", error_handling="raise")

--- a/tests/viz/test_debug.py
+++ b/tests/viz/test_debug.py
@@ -410,3 +410,38 @@ class TestExtractDebugData:
         captured = capsys.readouterr()
         assert "Edge Validation Report" in captured.out
         assert "Nodes:" in captured.out
+
+
+class TestEdgeValueNames:
+    """Regression: debug read `value_name` (singular) but flat-graph edges
+    carry `value_names` (plural) — every edge reported an empty value."""
+
+    def test_debug_dump_edge_carries_value_name(self):
+        """B3.1: debug_dump edge entries contain the actual value name(s)."""
+        graph = Graph(nodes=[double, add_one])
+        debugger = VizDebugger(graph)
+
+        dump = debugger.debug_dump()
+
+        edge = next(e for e in dump["edges"] if e["source"] == "double" and e["target"] == "add_one")
+        assert edge["value_name"] == "doubled"
+
+    def test_analyze_missing_edge_carries_value_names(self):
+        """B3.2: _analyze_missing_edge reports real value names on the
+        neighbouring edges, not None."""
+        graph = Graph(nodes=[double, add_one, triple])
+        debugger = VizDebugger(graph)
+
+        # double -> triple does not exist; the analysis lists double's real
+        # out-edges (double -> add_one, carrying "doubled").
+        edge = debugger.trace_edge("double", "triple")
+        assert edge.edge_found is False
+        from_source = edge.analysis["edges_from_source"]
+        assert {"to": "add_one", "value": "doubled"} in from_source
+
+        # triple -> add_one does not exist; the analysis lists add_one's real
+        # in-edges (from double, carrying "doubled").
+        edge = debugger.trace_edge("triple", "add_one")
+        assert edge.edge_found is False
+        to_target = edge.analysis["edges_to_target"]
+        assert {"from": "double", "value": "doubled"} in to_target


### PR DESCRIPTION
## Problem / Bug / Challenge

Whole-library audit (thermo-nuclear review + issue triage) confirmed four user-facing bugs. Each fixed red-green: regression test shown failing on base, then fixed. Closes #104. Partially addresses #127 (fixes the status-corruption sub-bug only; cross-process locking remains open).

## Before / After

**1. Renamed gates couldn't join any graph** (`gate.py` stored `outputs` at init, `data_outputs` re-derived from current name):
```python
renamed = decide.with_name("chooser")
# Before: Graph([...renamed...]) → GraphConfigError: Invalid output name '_decide'
# After: builds and routes; outputs derived from current name. IfElseNode shared the bug — also fixed.
# Bonus: rename_outputs() on the internal channel now raises RenameError (was silent corruption).
```

**2. Sync `map(error_handling="continue")` aborted the whole batch** on pre-run item errors while async yielded a FAILED item — parity break:
```python
# Before: item 2 invalid → MissingInputError aborts items 1 and 3
# After: item 2 → status=FAILED with error attached; 1/3 COMPLETED. Parity test asserts sync == async.
```

**3. `debug_dump()` showed empty values on every edge** (read `value_name`, edges carry `value_names`).

**4. Duplicate-start marked the still-running workflow's row FAILED** (generic handler caught the pre-flight `WorkflowAlreadyRunningError`). Now a bare pre-flight rejection never touches the row; a node-raised WARE (wrapped) still fails its own run — both directions pinned by tests.

Plus: de-flaked the map-over concurrency test (barrier proves overlap structurally; the old `elapsed < 0.1` failed under CPU load).

## Test Plan

- [x] RED runs pasted for all four bugs on base, GREEN after
- [x] CI-equivalent suite: 2942 passed, 15 skipped
- [x] Counter-case falsifier: node-raised `WorkflowAlreadyRunningError` still marks its row FAILED
- [x] Cross-model review: APPROVE (all hunts clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)