### PR TITLE
feat(repr): plain display mode for agent-run notebooks

### DIFF
--- a/docs/05-how-to/visualize-graphs.md
+++ b/docs/05-how-to/visualize-graphs.md
@@ -164,3 +164,26 @@ print(trace.outgoing_edges)  # [{'to': 'add_one', 'value': 'doubled', 'type': 'd
 
 edge_trace = debugger.trace_edge("double", "add_one")
 ```
+
+## Agent-Friendly Display Mode
+
+Every hypergraph object shown at the end of a notebook cell — a `Graph`, a `RunResult`, a checkpointer — stores its rich HTML widget in the `.ipynb` file. A single displayed `Graph` adds ~800 KB. When an agent runs the notebook and reads it back, that HTML is wasted context.
+
+Plain display mode makes implicit display fall back to the compact text reprs instead:
+
+```python
+import hypergraph
+
+hypergraph.set_display_mode("plain")
+
+graph    # Graph: pipeline | 2 nodes | 1 edge | no cycles   (~100 bytes, not ~800 KB)
+result   # RunResult(status=completed, values={'doubled': 4}, ...)
+```
+
+Or set it from the environment — it is read at display time, so setting it after import works too:
+
+```bash
+export HYPERGRAPH_DISPLAY=plain
+```
+
+A `set_display_mode()` call overrides the environment variable. Explicit visualization stays rich in plain mode: `graph.visualize()` and `graph.to_mermaid()` still render the full output — an agent that asks for the widget gets the widget. Switch back anytime with `hypergraph.set_display_mode("rich")`.

--- a/src/hypergraph/__init__.py
+++ b/src/hypergraph/__init__.py
@@ -1,5 +1,6 @@
 """Hypergraph - A hierarchical and modular graph workflow framework."""
 
+from hypergraph._repr import get_display_mode, set_display_mode
 from hypergraph.cache import CacheBackend, DiskCache, InMemoryCache
 from hypergraph.checkpointers import (
     Checkpointer,
@@ -149,4 +150,7 @@ __all__ = [
     "Checkpointer",
     "CheckpointPolicy",
     "SqliteCheckpointer",
+    # Display
+    "set_display_mode",
+    "get_display_mode",
 ]

--- a/src/hypergraph/_repr.py
+++ b/src/hypergraph/_repr.py
@@ -10,9 +10,87 @@ from __future__ import annotations
 import hashlib
 import html as _html
 import itertools
+import os
 from typing import Any
 
 from hypergraph._utils import format_datetime, format_duration_ms, plural
+
+# ---------------------------------------------------------------------------
+# Display mode — rich HTML widgets (default) vs plain text reprs
+# ---------------------------------------------------------------------------
+
+_DISPLAY_MODES = ("rich", "plain")
+_DISPLAY_ENV_VAR = "HYPERGRAPH_DISPLAY"
+
+# Explicit mode set via set_display_mode(); None means "follow the env var".
+_display_mode: str | None = None
+
+
+def set_display_mode(mode: str) -> None:
+    """Set how hypergraph objects display in notebooks.
+
+    In ``"plain"`` mode every implicit ``_repr_html_`` in the package returns
+    None, so notebook display falls back to the compact text ``__repr__``.
+    Explicit calls such as ``graph.visualize()`` stay rich. Calling this
+    function overrides the ``HYPERGRAPH_DISPLAY`` environment variable.
+
+    Args:
+        mode: ``"rich"`` for full HTML widgets (the default) or ``"plain"``
+            for compact text reprs.
+
+    Raises:
+        ValueError: If ``mode`` is not one of the valid modes.
+    """
+    global _display_mode
+    if mode not in _DISPLAY_MODES:
+        raise ValueError(
+            f"Invalid display mode {mode!r}.\n\n"
+            f"Valid modes: {list(_DISPLAY_MODES)}\n\n"
+            f'How to fix: Call set_display_mode("rich") or set_display_mode("plain").'
+        )
+    _display_mode = mode
+
+
+def get_display_mode() -> str:
+    """Return the effective display mode.
+
+    Precedence: the value passed to :func:`set_display_mode` if it was called,
+    else the ``HYPERGRAPH_DISPLAY`` environment variable (read at call time,
+    so setting it after import works), else ``"rich"``.
+
+    Returns:
+        Either ``"rich"`` or ``"plain"``.
+
+    Raises:
+        ValueError: If the ``HYPERGRAPH_DISPLAY`` environment variable is set
+            to a value other than ``"rich"`` or ``"plain"``.
+    """
+    if _display_mode is not None:
+        return _display_mode
+    env = os.environ.get(_DISPLAY_ENV_VAR)
+    if env is None:
+        return "rich"
+    if env not in _DISPLAY_MODES:
+        raise ValueError(
+            f"Invalid {_DISPLAY_ENV_VAR} value {env!r}.\n\n"
+            f"Valid values: {list(_DISPLAY_MODES)}\n\n"
+            f"How to fix: Set {_DISPLAY_ENV_VAR}=plain (or =rich), or unset it."
+        )
+    return env
+
+
+def plain_reprs() -> bool:
+    """Whether implicit ``_repr_html_`` methods should return None.
+
+    Used as the first-line guard of every implicit ``_repr_html_`` in the
+    package: returning None makes IPython fall back to the ``text/plain``
+    repr, keeping notebook files compact for agent-run workflows.
+
+    Returns:
+        True when the effective display mode is ``"plain"``.
+    """
+    return get_display_mode() == "plain"
+
 
 # ---------------------------------------------------------------------------
 # Theme — light-dark() for automatic dark/light adaptation

--- a/src/hypergraph/checkpointers/sqlite.py
+++ b/src/hypergraph/checkpointers/sqlite.py
@@ -190,8 +190,11 @@ class SqliteCheckpointer(Checkpointer):
         """Database path."""
         return self._path
 
-    def _repr_html_(self) -> str:
-        from hypergraph._repr import _code, theme_wrap, widget_state_key
+    def _repr_html_(self) -> str | None:
+        from hypergraph._repr import _code, plain_reprs, theme_wrap, widget_state_key
+
+        if plain_reprs():
+            return None
 
         state_key = widget_state_key("checkpointer", self._path)
         try:

--- a/src/hypergraph/checkpointers/types.py
+++ b/src/hypergraph/checkpointers/types.py
@@ -70,9 +70,12 @@ class StepRecord:
             parts.append(f"error: {self.error[:60]}")
         return " | ".join(parts)
 
-    def _repr_html_(self) -> str:
+    def _repr_html_(self) -> str | None:
+        from hypergraph._repr import plain_reprs
         from hypergraph.checkpointers.presenters import render_step_record_html
 
+        if plain_reprs():
+            return None
         return render_step_record_html(self)
 
     def to_dict(self) -> dict[str, Any]:
@@ -138,9 +141,12 @@ class Run:
             parts.append(", ".join(items))
         return " | ".join(parts)
 
-    def _repr_html_(self) -> str:
+    def _repr_html_(self) -> str | None:
+        from hypergraph._repr import plain_reprs
         from hypergraph.checkpointers.presenters import render_run_html
 
+        if plain_reprs():
+            return None
         return render_run_html(self)
 
     def to_dict(self) -> dict[str, Any]:
@@ -184,9 +190,12 @@ class Checkpoint:
             origin = f" from {self.source_run_id}{at}"
         return f"Checkpoint{origin}: {plural(len(self.values), 'value')}, {plural(len(self.steps), 'step')}"
 
-    def _repr_html_(self) -> str:
+    def _repr_html_(self) -> str | None:
+        from hypergraph._repr import plain_reprs
         from hypergraph.checkpointers.presenters import render_checkpoint_html
 
+        if plain_reprs():
+            return None
         return render_checkpoint_html(self)
 
 
@@ -214,9 +223,12 @@ class RunTable(list):
             lines.append(f"  {run!r}")
         return "\n".join(lines)
 
-    def _repr_html_(self) -> str:
+    def _repr_html_(self) -> str | None:
+        from hypergraph._repr import plain_reprs
         from hypergraph.checkpointers.presenters import render_run_table_html
 
+        if plain_reprs():
+            return None
         return render_run_table_html(self)
 
 
@@ -234,9 +246,12 @@ class StepTable(list):
             lines.append(f"  {step!r}")
         return "\n".join(lines)
 
-    def _repr_html_(self) -> str:
+    def _repr_html_(self) -> str | None:
+        from hypergraph._repr import plain_reprs
         from hypergraph.checkpointers.presenters import render_step_table_html
 
+        if plain_reprs():
+            return None
         return render_step_table_html(self)
 
 
@@ -293,7 +308,10 @@ class LineageView(list):
             lines.append(summary + marker)
         return "\n".join(lines)
 
-    def _repr_html_(self) -> str:
+    def _repr_html_(self) -> str | None:
+        from hypergraph._repr import plain_reprs
         from hypergraph.checkpointers.presenters import render_lineage_view_html
 
+        if plain_reprs():
+            return None
         return render_lineage_view_html(self)

--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -1481,9 +1481,12 @@ class Graph:
         name = self.name or "unnamed"
         return f"Graph: {name} | {plural(n_nodes, 'node')} | {plural(n_edges, 'edge')}{prop_str}"
 
-    def _repr_html_(self) -> str:
-        from hypergraph._repr import _code, html_detail, html_panel, html_table, status_badge, theme_wrap, widget_state_key
+    def _repr_html_(self) -> str | None:
+        from hypergraph._repr import _code, html_detail, html_panel, html_table, plain_reprs, status_badge, theme_wrap, widget_state_key
         from hypergraph._utils import plural
+
+        if plain_reprs():
+            return None
 
         n_nodes = len(self._nodes)
         n_edges = self._nx_graph.number_of_edges()

--- a/src/hypergraph/runners/_shared/types.py
+++ b/src/hypergraph/runners/_shared/types.py
@@ -269,7 +269,7 @@ class RunResult:
             return
         pretty_printer.text(repr(self))
 
-    def _repr_html_(self) -> str:
+    def _repr_html_(self) -> str | None:
         from hypergraph._repr import (
             ERROR_COLOR,
             duration_html,
@@ -277,11 +277,15 @@ class RunResult:
             html_detail,
             html_kv,
             html_panel,
+            plain_reprs,
             status_badge,
             theme_wrap,
             values_html,
             widget_state_key,
         )
+
+        if plain_reprs():
+            return None
 
         kvs = [html_kv("Status", status_badge(self.status.value))]
         if self.log:
@@ -489,17 +493,21 @@ class MapResult:
             return
         pretty_printer.text(repr(self))
 
-    def _repr_html_(self) -> str:
+    def _repr_html_(self) -> str | None:
         from hypergraph._repr import (
             ERROR_COLOR,
             duration_html,
             html_detail,
             html_kv,
             html_panel,
+            plain_reprs,
             status_badge,
             theme_wrap,
             widget_state_key,
         )
+
+        if plain_reprs():
+            return None
 
         n = len(self.results)
         n_completed = sum(1 for r in self.results if r.status == RunStatus.COMPLETED)
@@ -1088,16 +1096,20 @@ class RunLog:
             return
         pretty_printer.text(str(self))
 
-    def _repr_html_(self) -> str:
+    def _repr_html_(self) -> str | None:
         from hypergraph._repr import (
             _code,
             duration_html,
             html_panel,
             html_table,
+            plain_reprs,
             status_badge,
             theme_wrap,
             widget_state_key,
         )
+
+        if plain_reprs():
+            return None
 
         headers = ["Step", "Node", "Status", "Duration"]
         has_decisions = any(s.decision is not None for s in self.steps)
@@ -1263,7 +1275,7 @@ class MapLog:
             return
         pretty_printer.text(str(self))
 
-    def _repr_html_(self) -> str:
+    def _repr_html_(self) -> str | None:
         from hypergraph._repr import (
             BORDER_COLOR,
             MUTED_COLOR,
@@ -1274,11 +1286,15 @@ class MapLog:
             html_filter_paginate_script,
             html_panel,
             html_table_with_row_attrs,
+            plain_reprs,
             status_badge,
             theme_wrap,
             unique_dom_id,
             widget_state_key,
         )
+
+        if plain_reprs():
+            return None
 
         headers = ["Item", "Duration", "Status", "Nodes"]
         rows = []

--- a/tests/test_display_mode.py
+++ b/tests/test_display_mode.py
@@ -1,0 +1,243 @@
+"""Tests for the plain display mode (set_display_mode / HYPERGRAPH_DISPLAY).
+
+Plain mode makes every implicit ``_repr_html_`` return None so notebook
+display falls back to compact text reprs. Explicit calls such as
+``graph.visualize()`` stay rich.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+
+import pytest
+
+import hypergraph
+import hypergraph._repr as repr_module
+from hypergraph import Graph, SyncRunner, get_display_mode, node, set_display_mode
+
+
+@pytest.fixture(autouse=True)
+def _isolated_display_mode(monkeypatch):
+    """Reset the module-level mode and env var around every test."""
+    monkeypatch.setattr(repr_module, "_display_mode", None)
+    monkeypatch.delenv("HYPERGRAPH_DISPLAY", raising=False)
+
+
+def make_graph() -> Graph:
+    @node(output_name="doubled")
+    def double(x: int) -> int:
+        return x * 2
+
+    return Graph([double], name="pipeline")
+
+
+# ---------------------------------------------------------------------------
+# API surface
+# ---------------------------------------------------------------------------
+
+
+class TestApi:
+    def test_exported_from_root(self):
+        assert "set_display_mode" in hypergraph.__all__
+        assert "get_display_mode" in hypergraph.__all__
+        assert callable(hypergraph.set_display_mode)
+        assert callable(hypergraph.get_display_mode)
+
+    def test_default_mode_is_rich(self):
+        assert get_display_mode() == "rich"
+
+    def test_setter_roundtrip(self):
+        set_display_mode("plain")
+        assert get_display_mode() == "plain"
+        set_display_mode("rich")
+        assert get_display_mode() == "rich"
+
+    def test_invalid_setter_value_raises(self):
+        with pytest.raises(ValueError, match="'rich'.*'plain'"):
+            set_display_mode("fancy")
+
+    def test_invalid_env_value_raises_at_display_time(self, monkeypatch):
+        monkeypatch.setenv("HYPERGRAPH_DISPLAY", "compact")
+        with pytest.raises(ValueError, match="HYPERGRAPH_DISPLAY"):
+            make_graph()._repr_html_()
+
+
+# ---------------------------------------------------------------------------
+# Implicit display: rich by default, plain on demand, reversible
+# ---------------------------------------------------------------------------
+
+
+class TestImplicitDisplay:
+    def test_default_rich_graph_html(self):
+        html = make_graph()._repr_html_()
+        assert isinstance(html, str)
+        assert len(html) > 0
+
+    def test_plain_mode_falls_back_to_text_reprs(self):
+        """Plain mode: HTML is None, text repr still carries the payload."""
+        graph = make_graph()
+        result = SyncRunner().run(graph, {"x": 2})
+
+        set_display_mode("plain")
+        assert graph._repr_html_() is None
+        assert result._repr_html_() is None
+        # The fallback the agent actually reads: status + values.
+        text = repr(result)
+        assert "completed" in text
+        assert "doubled" in text
+
+        # Not one-way: flipping back restores the HTML path.
+        set_display_mode("rich")
+        assert isinstance(graph._repr_html_(), str)
+        assert isinstance(result._repr_html_(), str)
+
+    def test_env_var_read_dynamically_after_import(self, monkeypatch):
+        graph = make_graph()
+        assert isinstance(graph._repr_html_(), str)
+
+        monkeypatch.setenv("HYPERGRAPH_DISPLAY", "plain")
+        assert graph._repr_html_() is None
+
+        monkeypatch.delenv("HYPERGRAPH_DISPLAY")
+        assert isinstance(graph._repr_html_(), str)
+
+    def test_setter_overrides_env(self, monkeypatch):
+        monkeypatch.setenv("HYPERGRAPH_DISPLAY", "plain")
+        set_display_mode("rich")
+        assert get_display_mode() == "rich"
+        assert isinstance(make_graph()._repr_html_(), str)
+
+
+# ---------------------------------------------------------------------------
+# Explicit display stays rich
+# ---------------------------------------------------------------------------
+
+
+class TestExplicitDisplayStaysRich:
+    def test_visualize_output_stays_rich_in_plain_mode(self):
+        set_display_mode("plain")
+        widget = make_graph().visualize()
+        html = widget._repr_html_()
+        assert isinstance(html, str)
+        assert len(html) > 0
+
+
+# ---------------------------------------------------------------------------
+# Sweep: every _repr_html_ in the package obeys the mode
+# ---------------------------------------------------------------------------
+
+# Classes whose _repr_html_ is only reachable via an explicit user call
+# (`graph.visualize()`); the contract keeps these rich even in plain mode.
+EXPLICIT_DISPLAY_EXCEPTIONS = {
+    "hypergraph.viz.widget._VizCellOutput",
+}
+
+
+def _iter_repr_html_classes():
+    """Yield every class in the package that defines its own _repr_html_."""
+    seen: set[str] = set()
+    for modinfo in pkgutil.walk_packages(hypergraph.__path__, prefix="hypergraph.", onerror=lambda name: None):
+        try:
+            module = importlib.import_module(modinfo.name)
+        except Exception:
+            continue  # optional dependency missing (e.g. daft, aiosqlite)
+        for cls in vars(module).values():
+            if not isinstance(cls, type) or cls.__module__ != module.__name__:
+                continue
+            if "_repr_html_" not in cls.__dict__:
+                continue
+            qualname = f"{cls.__module__}.{cls.__qualname__}"
+            if qualname not in seen:
+                seen.add(qualname)
+                yield qualname, cls
+
+
+def _instance_factories() -> dict[str, object]:
+    """One constructed instance per known _repr_html_-defining class."""
+    from hypergraph.checkpointers.types import (
+        Checkpoint,
+        LineageRow,
+        LineageView,
+        Run,
+        RunTable,
+        StepRecord,
+        StepStatus,
+        StepTable,
+        WorkflowStatus,
+    )
+    from hypergraph.runners._shared.types import MapLog, MapResult, NodeRecord, RunLog, RunResult, RunStatus
+
+    step = StepRecord(run_id="r", superstep=0, node_name="a", index=0, status=StepStatus.COMPLETED, input_versions={})
+    run = Run(id="r-1", status=WorkflowStatus.COMPLETED)
+    run_log = RunLog(
+        graph_name="g",
+        run_id="r-1",
+        total_duration_ms=1.0,
+        steps=(NodeRecord(node_name="a", superstep=0, duration_ms=1.0, status="completed", span_id="s"),),
+    )
+    run_result = RunResult(values={"x": 1}, status=RunStatus.COMPLETED, log=run_log)
+
+    factories: dict[str, object] = {
+        "hypergraph.graph.core.Graph": lambda: make_graph(),
+        "hypergraph.runners._shared.types.RunResult": lambda: run_result,
+        "hypergraph.runners._shared.types.MapResult": lambda: MapResult(
+            results=(run_result,),
+            run_id="r-1",
+            total_duration_ms=1.0,
+            map_over=("x",),
+            map_mode="zip",
+            graph_name="g",
+        ),
+        "hypergraph.runners._shared.types.RunLog": lambda: run_log,
+        "hypergraph.runners._shared.types.MapLog": lambda: MapLog(graph_name="g", total_duration_ms=1.0, items=(run_log,)),
+        "hypergraph.checkpointers.types.StepRecord": lambda: step,
+        "hypergraph.checkpointers.types.Run": lambda: run,
+        "hypergraph.checkpointers.types.Checkpoint": lambda: Checkpoint(values={"x": 1}, steps=[step]),
+        "hypergraph.checkpointers.types.RunTable": lambda: RunTable([run]),
+        "hypergraph.checkpointers.types.StepTable": lambda: StepTable([step]),
+        "hypergraph.checkpointers.types.LineageView": lambda: LineageView(
+            [LineageRow(lane="", run=run, depth=0, is_selected=True)],
+            selected_run_id="r-1",
+            root_run_id="r-1",
+        ),
+    }
+
+    try:
+        from hypergraph.checkpointers.sqlite import SqliteCheckpointer
+    except ImportError:
+        pass  # aiosqlite not installed; the walk will not discover the class either
+    else:
+        factories["hypergraph.checkpointers.sqlite.SqliteCheckpointer"] = lambda: SqliteCheckpointer(":memory:")
+
+    return factories
+
+
+class TestPlainModeSweep:
+    def test_every_implicit_repr_html_returns_none_in_plain_mode(self):
+        """Pins future _repr_html_ additions to the display-mode contract."""
+        classes = dict(_iter_repr_html_classes())
+        # Sanity: the walk actually discovered the core surface.
+        assert "hypergraph.graph.core.Graph" in classes
+        assert "hypergraph.runners._shared.types.RunResult" in classes
+
+        factories = _instance_factories()
+        set_display_mode("plain")
+        for qualname in sorted(classes):
+            if qualname in EXPLICIT_DISPLAY_EXCEPTIONS:
+                continue
+            factory = factories.get(qualname)
+            assert factory is not None, (
+                f"{qualname} defines _repr_html_ but this sweep has no instance factory for it.\n\n"
+                "How to fix: gate the new _repr_html_ with plain_reprs() from hypergraph._repr "
+                "and register a factory in _instance_factories(); or, if it is only reachable "
+                "via an explicit user call, add it to EXPLICIT_DISPLAY_EXCEPTIONS."
+            )
+            instance = factory()
+            assert instance._repr_html_() is None, f"{qualname}._repr_html_ must return None in plain display mode"
+
+    def test_same_instances_render_html_in_rich_mode(self):
+        set_display_mode("rich")
+        for qualname, factory in _instance_factories().items():
+            html = factory()._repr_html_()
+            assert isinstance(html, str) and len(html) > 0, f"{qualname}._repr_html_ must return HTML in rich mode"


### PR DESCRIPTION
## Problem / Bug / Challenge

Agents running hypergraph in notebooks (via hypernote) pay a huge token/storage cost for rich HTML reprs: a bare `Graph` evaluated at the end of a cell stores **826 KB** of widget HTML in the `.ipynb`; a `RunResult` stores 10 KB where the text repr is 131 bytes.

## Before / After

**Before:**
```python
g          # → 828,916 bytes of HTML into the notebook
result     # → 10,333 bytes
```

**After:**
```python
import hypergraph
hypergraph.set_display_mode("plain")   # or HYPERGRAPH_DISPLAY=plain in the kernel env

g          # → 'Graph: pipeline | 2 nodes | 1 edge | no cycles'  (46 bytes)
result     # → "RunResult(status=completed, values={...}, ...)"   (132 bytes)
g.visualize()  # explicit call still returns the full rich widget
```

Mechanism: every implicit `_repr_html_` (12 sites) returns `None` in plain mode, so Jupyter falls back to `text/plain`. Env var is read dynamically (setting it after import works); setter overrides env; invalid values fail loudly. An import-walk sweep test pins every current and future `_repr_html_` to the contract.

## Test Plan

- [x] 12 new tests incl. sweep test over all `_repr_html_` classes; CI-equivalent suite: 2938 passed
- [x] Independent foreman falsifiers: mode reversible, env-after-import works, invalid env raises naming the variable, `visualize()` stays rich
- [x] Cross-model review: APPROVE (None-into-HTML composition hunt clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)