### PR TITLE
feat(graph)!: enforce build-time graph strictness

### DIFF
--- a/dev/ARCHITECTURE.md
+++ b/dev/ARCHITECTURE.md
@@ -37,7 +37,7 @@ Graph construction and build-time validation.
 | File | Purpose |
 |------|---------|
 | `core.py` | `Graph` class — the build pipeline, `bind`/`select`/`unbind`/`with_entrypoint` |
-| `input_spec.py` | `InputSpec` — classifies inputs as required/optional/entrypoint. Also computes active subgraph scope from entrypoints and selection. |
+| `input_spec.py` | `InputSpec` — classifies active inputs as required or optional and records bound values. Entrypoints and selection narrow the active subgraph; cycle bootstrap parameters remain required or optional inputs. |
 | `validation.py` | All build-time checks (names, edges, gates, types, conflicts) |
 | `_conflict.py` | Name conflict detection and resolution |
 | `_helpers.py` | Graph construction helpers |

--- a/docs/03-patterns/03-agentic-loops.md
+++ b/docs/03-patterns/03-agentic-loops.md
@@ -269,15 +269,15 @@ def should_continue(messages: list) -> str:
 
 **Validation**: emit names must not overlap with `output_name`, and wait_for names must not overlap with function parameters. Referencing a nonexistent emit/output address in `wait_for` raises `GraphConfigError` at build time.
 
-## Entry Points
+## Cycle Bootstrap Inputs
 
-When a parameter is both an input and output of a cycle (like `history` or `iteration`), it becomes an **entrypoint parameter** — an initial value needed to start the first iteration. Provide these in the `values` dict when calling `runner.run()`:
+When a parameter is both an input and output of a cycle (like `history` or `iteration`), it is a **cycle bootstrap parameter** — an initial value needed to start the first iteration. Provide these in the `values` dict when calling `runner.run()`:
 
 ```python
 result = runner.run(graph, {
     "prompt": "...",
-    "history": [],       # Entry point: initial value before first iteration
-    "iteration": 0,      # Entry point: starting counter
+    "history": [],       # Bootstrap value before the first iteration
+    "iteration": 0,      # Bootstrap value for the starting counter
 })
 ```
 

--- a/docs/03-patterns/03-agentic-loops.md
+++ b/docs/03-patterns/03-agentic-loops.md
@@ -281,14 +281,14 @@ result = runner.run(graph, {
 })
 ```
 
-You can check what entrypoints a graph has via `graph.inputs.entrypoints`. This returns a dict mapping node names to the cycle parameters they need:
+Cycle bootstrap parameters appear directly in `graph.inputs.required` (or `optional` when bound or defaulted), alongside the graph's other inputs:
 
 ```python
-print(graph.inputs.entrypoints)
-# {'accumulate_history': ('history',), 'increment': ('iteration',)}
+print(graph.inputs.required)
+# ('prompt', 'history', 'iteration')
 ```
 
-Pick ONE entrypoint per cycle and provide its parameters. For full details, see [InputSpec](../06-api-reference/inputspec.md).
+Provide each cycle's bootstrap parameters in the `values` dict. For full details, see [InputSpec](../06-api-reference/inputspec.md).
 
 ## Tracking State Across Iterations
 

--- a/docs/06-api-reference/graph.md
+++ b/docs/06-api-reference/graph.md
@@ -451,6 +451,27 @@ print(partial.inputs.bound)  # {'y': 10}
 
 **Returns:** New Graph with specified bindings removed
 
+### `add_nodes(*nodes) -> Graph`
+
+Add nodes to the graph. Returns a new Graph (immutable pattern).
+
+Equivalent to rebuilding the graph with the combined node list, then replaying the existing configuration: entrypoints, bindings, and selection are all preserved.
+
+```python
+g = Graph([upstream, downstream]).with_entrypoint("downstream")
+g2 = g.add_nodes(extra)
+print(g2.entrypoints_config)  # ('downstream',) — entrypoints preserved
+```
+
+**Args:**
+- `*nodes`: Nodes to add.
+
+**Returns:** New Graph containing the combined nodes with entrypoints, bindings, and selection replayed
+
+**Raises:**
+- `GraphConfigError` - If the graph was constructed with explicit edges, or if the rebuilt graph is structurally invalid (e.g., the added nodes create conflicting producers)
+- `ValueError` - If an existing binding is no longer a valid graph input after adding nodes (call `unbind()` first)
+
 ### `select(*names) -> Graph`
 
 Set a default output selection. Returns a new Graph (immutable pattern).

--- a/docs/06-api-reference/graph.md
+++ b/docs/06-api-reference/graph.md
@@ -499,6 +499,7 @@ Runtime `select=` overrides are not supported. Use `graph.select(...)` to config
 
 **Raises:**
 - `ValueError` - If any name is not in `graph.outputs`
+- `GraphConfigError` - If entrypoints are configured and every producer of a selected output is upstream of them (the output could never be produced)
 
 #### Nested graph behavior
 
@@ -558,6 +559,7 @@ print(g2.inputs.required)  # ('embedding', 'query') - embedding is now a user in
 **Raises:**
 - `GraphConfigError` - If any name is not a node in the graph
 - `GraphConfigError` - If any name is a gate node (gates control routing, they cannot be entry points)
+- `GraphConfigError` - If a previously selected output becomes unreachable from the configured entry points
 
 #### Chainable
 
@@ -593,6 +595,13 @@ configured = (
 )
 print(configured.inputs.required)  # ('embedding', 'query')
 print(configured.inputs.optional)  # ('top_k',)
+```
+
+The combination must be able to produce the selection. If every producer of a selected output is upstream of the configured entrypoints, the graph raises `GraphConfigError` at configuration time (in whichever call completes the combination — the order of `select()` and `with_entrypoint()` does not matter):
+
+```python
+g.with_entrypoint("retrieve").select("embedding")
+# GraphConfigError: Selected output(s) 'embedding' cannot be produced from entrypoint(s) 'retrieve'.
 ```
 
 #### Active-set enforcement

--- a/docs/06-api-reference/inputspec.md
+++ b/docs/06-api-reference/inputspec.md
@@ -52,14 +52,13 @@ print(configured.inputs.optional)  # ('top_k',)
 
 ## The InputSpec Dataclass
 
-InputSpec is a frozen dataclass with four fields:
+InputSpec is a frozen dataclass with three fields:
 
 ```python
 @dataclass(frozen=True)
 class InputSpec:
     required: tuple[str, ...]
     optional: tuple[str, ...]
-    entrypoints: dict[str, tuple[str, ...]]
     bound: dict[str, Any]
 ```
 
@@ -89,12 +88,6 @@ g = Graph([process])
 print(g.inputs.required)  # ('x',)
 print(g.inputs.optional)  # ('scale',)
 ```
-
-### `entrypoints: dict[str, tuple[str, ...]]`
-
-Reserved for compatibility. For configured graphs, this field is `{}`.
-
-Cyclic graphs must be constructed with graph-level `entrypoint` configuration (`Graph(..., entrypoint=...)`). Cycle bootstrap parameters are represented directly in canonical `required`/`optional`.
 
 ### `bound: dict[str, Any]`
 
@@ -155,8 +148,9 @@ def update(state: dict, input: int) -> dict:
 
 g = Graph([update], entrypoint="update")
 print(g.inputs.required)    # ('state', 'input')
-print(g.inputs.entrypoints) # {}
 ```
+
+Cycle bootstrap parameters are represented directly in `required`/`optional` — there is no separate entrypoints category on InputSpec.
 
 ### GraphNode Boundary Inputs
 
@@ -240,7 +234,7 @@ For namespaced GraphNodes, `.expose("x")` replaces `inner.x` with the flat paren
 
 ### Scope Narrowing (Entrypoint and Select)
 
-`with_entrypoint()` and `select()` narrow which nodes are considered when computing InputSpec. Parameters from excluded nodes do not appear in `required`, `optional`, or `entrypoints`.
+`with_entrypoint()` and `select()` narrow which nodes are considered when computing InputSpec. Parameters from excluded nodes do not appear in `required` or `optional`.
 
 ```python
 from hypergraph import node, Graph
@@ -283,7 +277,6 @@ spec = g.inputs  # Returns InputSpec
 
 print(spec.required)      # tuple of required param names
 print(spec.optional)      # tuple of optional param names
-print(spec.entrypoints)  # {} (reserved for compatibility)
 print(spec.bound)         # dict of bound values
 ```
 
@@ -349,7 +342,6 @@ g = Graph([embed, retrieve])
 
 print(g.inputs.required)      # ('text',)
 print(g.inputs.optional)      # ('top_k',)
-print(g.inputs.entrypoints)  # {}
 print(g.inputs.bound)         # {}
 ```
 
@@ -382,7 +374,6 @@ def chat(messages: list[str], user_input: str) -> list[str]:
 
 g = Graph([chat], entrypoint="chat")
 print(g.inputs.required)      # ('messages', 'user_input')
-print(g.inputs.entrypoints)   # {}
 ```
 
 ### Multiple Nodes Sharing a Parameter
@@ -461,7 +452,6 @@ g = Graph([embed, search, update_history], entrypoint="update_history")
 # Inspect InputSpec
 print("Required:", g.inputs.required)        # ('text', 'history')
 print("Optional:", g.inputs.optional)        # ('top_k', 'threshold')
-print("Entry points:", g.inputs.entrypoints)  # {}
 print("Bound:", g.inputs.bound)              # {}
 print("All:", g.inputs.all)                  # ('text', 'history', 'top_k', 'threshold')
 
@@ -470,6 +460,5 @@ configured = g.bind(top_k=10, threshold=0.9)
 print("\nAfter bind:")
 print("Required:", configured.inputs.required)        # ('text', 'history')
 print("Optional:", configured.inputs.optional)        # ('top_k', 'threshold') - still have fallback
-print("Entry points:", configured.inputs.entrypoints)  # {}
 print("Bound:", configured.inputs.bound)              # {'top_k': 10, 'threshold': 0.9}
 ```

--- a/docs/06-api-reference/nodes.md
+++ b/docs/06-api-reference/nodes.md
@@ -182,7 +182,30 @@ def __init__(
 
 **Raises:**
 - `ValueError` - If function source cannot be retrieved (for definition_hash)
+- `TypeError` - If the signature contains a positional-only, `*args`, or `**kwargs` parameter (see [Supported Parameter Kinds](#supported-parameter-kinds))
 - `UserWarning` - If function has return annotation but no output_name provided
+
+### Supported Parameter Kinds
+
+Hypergraph invokes node functions with keyword arguments, so every parameter must be addressable by keyword. This applies to all function-backed node types: `@node`, `@route`, `@ifelse`, and `@interrupt`.
+
+| Parameter kind | Example | Supported |
+|----------------|---------|-----------|
+| Regular | `def f(a)` | Yes |
+| Keyword-only | `def f(*, kw)` | Yes |
+| Positional-only | `def f(a, /)` | No — rejected at construction |
+| Variadic positional | `def f(*args)` | No — rejected at construction |
+| Variadic keyword | `def f(**kwargs)` | No — rejected at construction |
+
+Unsupported kinds raise `TypeError` at construction time, naming the offending parameter:
+
+```python
+@node(output_name="result")
+def bad(*args):
+    ...
+# TypeError: Function 'bad' has parameter(s) that cannot be called by keyword:
+#   -> parameter 'args' is variadic positional (*args)
+```
 
 ### Creating from a function
 

--- a/docs/06-api-reference/nodes.md
+++ b/docs/06-api-reference/nodes.md
@@ -993,6 +993,9 @@ def map_over(
     *params: str,
     mode: Literal["zip", "product"] = "zip",
     error_handling: Literal["raise", "continue"] = "raise",
+    clone: bool | list[str] = False,
+    identity: str | None = None,
+    schema: type | None = None,
 ) -> GraphNode: ...
 ```
 

--- a/docs/06-api-reference/nodes.md
+++ b/docs/06-api-reference/nodes.md
@@ -890,6 +890,31 @@ def consumer(value: int) -> int:
 outer = Graph([gn, consumer], strict_types=True)  # Works!
 ```
 
+#### Heterogeneous boundary types
+
+When multiple inner nodes share one boundary name with different annotations, the reported type is deterministic: the first *annotated* inner node in sorted inner-node-name order wins.
+
+```python
+@node(output_name="out1")
+def node_int(x: int) -> int: ...
+
+@node(output_name="out2")
+def node_str(x: str) -> str: ...
+
+gn = Graph([node_str, node_int], name="inner").as_node()
+print(gn.get_input_type("x"))  # <class 'int'> — 'node_int' sorts first
+```
+
+Under `strict_types=True`, a wired boundary port with conflicting inner annotations is rejected at construction time instead, naming both inner nodes and both types:
+
+```text
+GraphConfigError: Conflicting type annotations for input 'x' on GraphNode 'inner' in strict_types mode
+  -> inner node 'node_int' declares: <class 'int'>
+  -> inner node 'node_str' declares: <class 'str'>
+```
+
+The permissive default (`strict_types=False`) is unchanged.
+
 ### Nested Composition Example
 
 ```python

--- a/docs/06-api-reference/runners.md
+++ b/docs/06-api-reference/runners.md
@@ -1042,6 +1042,22 @@ except InfiniteLoopError as e:
     # Graph execution exceeded 100 iterations
 ```
 
+### ExecutionError
+
+Wraps an exception raised inside a node during graph execution and carries the partial `GraphState` accumulated before the failure (`partial_state` attribute).
+
+`runner.run()` with the default `error_handling="raise"` unwraps it and re-raises the original node exception, so application code normally catches the node's own exception type. `ExecutionError` is exported for advanced integrations (custom runners, executors, or superstep-level code) that need access to the partial state alongside the failure.
+
+```python
+from hypergraph import ExecutionError
+
+try:
+    advanced_execution_surface(...)
+except ExecutionError as e:
+    print(e.partial_state)   # state accumulated before the failure
+    print(e.__cause__)       # the original node exception
+```
+
 ---
 
 ## Execution Model

--- a/docs/07-design/guiding-principles.md
+++ b/docs/07-design/guiding-principles.md
@@ -190,17 +190,18 @@ def should_continue(score: float) -> str:
 
 ## 7. Cycles Require Entry Points
 
-When a value participates in a cycle, the first iteration needs an initial value. Entry points group these by the node where execution starts.
+When a value participates in a cycle, the first iteration needs an initial value. The graph-level entrypoint identifies where execution starts and narrows the active subgraph.
 
 ### Explicit signals
 
-- InputSpec docs define `entrypoints` for cyclic inputs, grouped by node name.
+- `Graph(..., entrypoint=...)` configures where a cyclic graph starts.
+- `InputSpec` exposes cycle bootstrap inputs through `required` or `optional`; it has no separate `entrypoints` field.
 
 ### Implicit invariants
 
-- Cycle parameters are classified as entrypoint parameters.
-- Missing entrypoint values fail input validation.
-- Entry point values can be bound with `bind()` or provided at `runner.run()` time.
+- Cycle bootstrap parameters are required unless a binding or default makes them optional.
+- Missing required cycle bootstrap values fail input validation.
+- Cycle bootstrap values can be bound with `bind()` or provided at `runner.run()` time.
 
 ### Good example
 

--- a/docs/07-design/roadmap.md
+++ b/docs/07-design/roadmap.md
@@ -11,7 +11,7 @@ Core features are working and stable. API may still change before 1.0.
 ### Core
 - `@node` decorator for wrapping functions (sync, async, generators)
 - `Graph` construction with automatic edge inference
-- `InputSpec` categorization (required, optional, bound, internal)
+- `InputSpec` categorization (required, optional, and bound values)
 - Rename API (`.rename_inputs()`, `.rename_outputs()`, `.with_name()`)
 - Build-time validation with helpful error messages
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -142,7 +142,7 @@
 
 ### Changed
 
-- **InputSpec is now scope-aware** — `graph.inputs` considers both `with_entrypoint()` (forward-reachable) and `select()` (backward-reachable) when determining required, optional, and entrypoint parameters. Parameters from excluded nodes no longer appear in InputSpec.
+- **InputSpec is now scope-aware** — `graph.inputs` considers both `with_entrypoint()` (forward-reachable) and `select()` (backward-reachable) when determining required or optional parameters, including cycle bootstrap inputs. Parameters from excluded nodes no longer appear in InputSpec; there is no separate `entrypoints` field.
 
 ## January 2026
 

--- a/scripts/test_api_docs.py
+++ b/scripts/test_api_docs.py
@@ -93,7 +93,6 @@ def retrieve(embedding: list[float], top_k: int = 5) -> list[str]:
 g4 = Graph([embed, retrieve])
 print(f"required: {g4.inputs.required}")
 print(f"optional: {g4.inputs.optional}")
-print(f"entry_points: {g4.inputs.entry_points}")
 print(f"bound: {g4.inputs.bound}")
 print(f"all: {g4.inputs.all}")
 

--- a/scripts/test_graph_examples.py
+++ b/scripts/test_graph_examples.py
@@ -32,7 +32,7 @@ print(f"g.has_async_nodes = {g.has_async_nodes}")  # False
 print("\n=== Binding Values ===")
 bound = g.bind(a=10)
 print(f"bound.inputs.required = {bound.inputs.required}")  # ('b',)
-print(f"bound.inputs.bound = {bound.inputs.bound}")  # ('a',)
+print(f"bound.inputs.bound = {bound.inputs.bound}")  # {'a': 10}
 
 print("\n=== strict_types Compatible ===")
 

--- a/src/hypergraph/__init__.py
+++ b/src/hypergraph/__init__.py
@@ -29,6 +29,7 @@ from hypergraph.events import (
 )
 from hypergraph.events.rich_progress import RichProgressProcessor
 from hypergraph.exceptions import (
+    ExecutionError,
     GraphChangedError,
     IncompatibleRunnerError,
     InfiniteLoopError,
@@ -107,6 +108,7 @@ __all__ = [
     "MissingInputError",
     "InfiniteLoopError",
     "IncompatibleRunnerError",
+    "ExecutionError",
     "WorkflowAlreadyCompletedError",
     "GraphChangedError",
     "WorkflowForkError",

--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -118,7 +118,7 @@ class Graph:
         nodes: Map of node name → HyperNode
         outputs: All output names produced by nodes
         leaf_outputs: Outputs from terminal nodes (no downstream destinations)
-        inputs: InputSpec describing required/optional/entrypoint parameters
+        inputs: InputSpec describing required and optional parameters plus bound values
         has_cycles: True if graph contains cycles
         has_async_nodes: True if any FunctionNode is async
         strict_types: If True, type validation between nodes is enabled

--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -1043,6 +1043,8 @@ class Graph:
 
         Raises:
             ValueError: If any name is not a graph output.
+            GraphConfigError: If entrypoints are configured and a selected
+                output's producer is not reachable from them.
 
         Example:
             >>> graph = Graph([embed, retrieve, generate]).select("answer")
@@ -1061,7 +1063,43 @@ class Graph:
 
         new_graph = self._shallow_copy()
         new_graph._selected = names
+        new_graph._validate_selection_reachable()
         return new_graph
+
+    def _validate_selection_reachable(self) -> None:
+        """Reject entrypoint+select combinations that cannot produce the selection.
+
+        Only meaningful when BOTH dimensions are configured: entrypoints narrow
+        the active scope to forward-reachable nodes, and a selected output whose
+        producers all fall outside that scope could never be produced. Uses the
+        canonical active-scope computation (never a second reachability walk).
+        """
+        if self._selected is None or self._entrypoints is None:
+            return
+
+        active_nodes, _ = _compute_active_scope(
+            self._nodes,
+            self._nx_graph,
+            entrypoints=self._entrypoints,
+            selected=None,
+        )
+        producible = {output for node in active_nodes.values() for output in node.outputs}
+        unreachable = [name for name in self._selected if name not in producible]
+        if not unreachable:
+            return
+
+        unreachable_str = ", ".join(f"'{name}'" for name in unreachable)
+        entrypoints_str = ", ".join(f"'{name}'" for name in self._entrypoints)
+        raise GraphConfigError(
+            f"Selected output(s) {unreachable_str} cannot be produced from entrypoint(s) {entrypoints_str}.\n\n"
+            f"  -> Every producer of {unreachable_str} is upstream of the configured entrypoints,\n"
+            f"     so it would never execute.\n"
+            f"  -> Outputs producible from these entrypoints: {sorted(producible)}\n\n"
+            f"How to fix:\n"
+            f"  - Select one of the producible outputs, OR\n"
+            f"  - Move the entrypoint upstream so the producer is included, OR\n"
+            f"  - Drop the entrypoint/select that excludes the producer."
+        )
 
     def add_nodes(self, *nodes: HyperNode) -> Graph:
         """Add nodes to graph. Returns new Graph (immutable).
@@ -1129,7 +1167,9 @@ class Graph:
             New Graph with entry points configured.
 
         Raises:
-            GraphConfigError: If node doesn't exist or is a gate.
+            GraphConfigError: If node doesn't exist or is a gate, or if a
+                previously selected output becomes unreachable from the
+                configured entrypoints.
 
         Example:
             >>> # Skip upstream, provide intermediate values directly
@@ -1146,6 +1186,7 @@ class Graph:
         new_graph = self._shallow_copy()
         existing = self._entrypoints or ()
         new_graph._entrypoints = tuple(dict.fromkeys(existing + normalized_names))
+        new_graph._validate_selection_reachable()
         return new_graph
 
     @property

--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -1425,9 +1425,6 @@ class Graph:
             lines.append(f"    optional: {formatted}")
         if bound_in_scope:
             lines.append(f"    bound: {', '.join(bound_in_scope)}")
-        for node_name, params in self.inputs.entrypoints.items():
-            formatted = ", ".join(self._describe_input(param, active_nodes, show_types=show_types) for param in params)
-            lines.append(f"    entrypoint[{node_name}]: {formatted}")
         if len(lines) == 2:
             lines.append("    none")
 
@@ -1739,7 +1736,6 @@ class Graph:
             "required": input_spec.required,
             "optional": input_spec.optional,
             "bound": dict(input_spec.bound),
-            "entrypoints": {k: list(v) for k, v in input_spec.entrypoints.items()},
         }
         G.graph["output_to_sources"] = output_to_sources
         G.graph["configured_entrypoints"] = list(self._entrypoints or ())

--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -1105,9 +1105,13 @@ class Graph:
         """Add nodes to graph. Returns new Graph (immutable).
 
         Equivalent to rebuilding the graph with the combined node list,
-        then replaying bind/select.
+        then replaying entrypoints/bind/select. Configured entrypoints are
+        preserved, so the execution scope stays narrowed after adding nodes.
 
-        Raises GraphConfigError if graph was constructed with explicit edges.
+        Raises GraphConfigError if graph was constructed with explicit edges,
+        or if the rebuilt graph is structurally invalid (e.g., conflicting
+        producers, or a replayed selection that the preserved entrypoints
+        cannot produce).
         Raises ValueError if existing bindings become invalid after
         adding nodes (e.g., a bound key becomes emit-only).
         Fix: call unbind() before add_nodes().
@@ -1124,6 +1128,7 @@ class Graph:
         new_graph = Graph(
             all_nodes,
             name=self.name,
+            entrypoint=list(self._entrypoints) if self._entrypoints else None,
             strict_types=self._strict_types,
             shared=sorted(self._shared) if self._shared else None,
         )

--- a/src/hypergraph/graph/input_spec.py
+++ b/src/hypergraph/graph/input_spec.py
@@ -25,25 +25,16 @@ class InputSpec:
     Categories follow the "edge cancels default" rule:
     - required: No edge, no default, not bound -> must always provide
     - optional: No edge, has default OR bound -> can omit (fallback exists)
-    - entrypoints: Reserved for compatibility; empty for configured graphs.
     """
 
     required: tuple[str, ...]
     optional: tuple[str, ...]
-    entrypoints: dict[str, tuple[str, ...]]
     bound: dict[str, Any]
 
     @property
     def all(self) -> tuple[str, ...]:
         """All input names (required + optional)."""
-        seen = set(self.required + self.optional)
-        entry_params: list[str] = []
-        for params in self.entrypoints.values():
-            for p in params:
-                if p not in seen:
-                    seen.add(p)
-                    entry_params.append(p)
-        return self.required + self.optional + tuple(entry_params)
+        return self.required + self.optional
 
 
 def compute_input_spec(
@@ -113,7 +104,6 @@ def compute_input_spec(
     return InputSpec(
         required=tuple(required),
         optional=tuple(optional),
-        entrypoints={},
         bound=all_bound,
     )
 

--- a/src/hypergraph/graph/validation.py
+++ b/src/hypergraph/graph/validation.py
@@ -214,8 +214,9 @@ def _validate_types(nodes: dict[str, HyperNode], nx_graph: nx.DiGraph) -> None:
     """Validate type compatibility between connected nodes.
 
     Checks each edge (source_node -> target_node) for:
-    1. Missing type annotations (raises error if either side is missing)
-    2. Type mismatches (raises error if types are incompatible)
+    1. Conflicting annotations behind a GraphNode boundary port
+    2. Missing type annotations (raises error if either side is missing)
+    3. Type mismatches (raises error if types are incompatible)
 
     Only called when strict_types=True.
     """
@@ -228,6 +229,8 @@ def _validate_types(nodes: dict[str, HyperNode], nx_graph: nx.DiGraph) -> None:
         target_node = nodes[target_name]
 
         for value_name in value_names:
+            _validate_no_boundary_type_conflict(source_node, target_node, value_name)
+
             # Get types using universal capability methods
             output_type = source_node.get_output_type(value_name)
             input_type = target_node.get_input_type(value_name)
@@ -259,6 +262,47 @@ def _validate_types(nodes: dict[str, HyperNode], nx_graph: nx.DiGraph) -> None:
                     f"  Either change the type annotation on one of the nodes, or add a\n"
                     f"  conversion node between them."
                 )
+
+
+def _validate_no_boundary_type_conflict(
+    source_node: HyperNode,
+    target_node: HyperNode,
+    value_name: str,
+) -> None:
+    """Reject GraphNode boundary ports whose inner annotations disagree.
+
+    Without strict mode, a heterogeneous boundary port deterministically
+    reports the first annotated inner node in sorted inner-node-name order.
+    In strict mode that ambiguity is an error: name both inner nodes and
+    both types so the user can align them.
+    """
+    from hypergraph.nodes.graph_node import GraphNode
+
+    if isinstance(source_node, GraphNode):
+        conflicts = source_node.boundary_output_type_conflicts(value_name)
+        if conflicts:
+            _raise_boundary_type_conflict(source_node.name, "output", value_name, conflicts)
+
+    if isinstance(target_node, GraphNode):
+        conflicts = target_node.boundary_input_type_conflicts(value_name)
+        if conflicts:
+            _raise_boundary_type_conflict(target_node.name, "input", value_name, conflicts)
+
+
+def _raise_boundary_type_conflict(
+    graph_node_name: str,
+    port_role: str,
+    value_name: str,
+    conflicts: tuple[tuple[str, Any], ...],
+) -> None:
+    lines = "\n".join(f"  -> inner node '{inner_name}' declares: {annotation}" for inner_name, annotation in conflicts)
+    raise GraphConfigError(
+        f"Conflicting type annotations for {port_role} '{value_name}' on GraphNode '{graph_node_name}' in strict_types mode\n\n"
+        f"{lines}\n\n"
+        f"How to fix:\n"
+        f"  Align the annotations on the inner nodes, or rename the ports so\n"
+        f"  each {port_role} has a single type."
+    )
 
 
 # =============================================================================

--- a/src/hypergraph/nodes/_input_extraction.py
+++ b/src/hypergraph/nodes/_input_extraction.py
@@ -15,6 +15,14 @@ from typing import get_type_hints
 # Currently only NodeContext; kept as a set for future extensibility.
 _INJECTABLE_TYPES: set[type] = set()
 
+# Node functions are invoked with keyword arguments (func(**inputs)), so
+# parameters that cannot be addressed by keyword can never receive a value.
+_UNSUPPORTED_PARAM_KINDS: dict[inspect._ParameterKind, str] = {
+    inspect.Parameter.POSITIONAL_ONLY: "positional-only",
+    inspect.Parameter.VAR_POSITIONAL: "variadic positional (*args)",
+    inspect.Parameter.VAR_KEYWORD: "variadic keyword (**kwargs)",
+}
+
 
 def register_injectable(cls: type) -> None:
     """Register a type as framework-injectable (excluded from node.inputs)."""
@@ -36,8 +44,12 @@ def extract_inputs(func: Callable) -> tuple[tuple[str, ...], str | None]:
 
     Raises:
         TypeError: If more than one injectable parameter is declared.
+        TypeError: If the signature contains a positional-only, ``*args``,
+            or ``**kwargs`` parameter. Nodes are invoked with keyword
+            arguments, so such parameters could never receive a value.
     """
     sig = inspect.signature(func)
+    _reject_non_keyword_callable_params(func, sig)
     hints = _safe_get_type_hints(func)
 
     inputs: list[str] = []
@@ -55,6 +67,24 @@ def extract_inputs(func: Callable) -> tuple[tuple[str, ...], str | None]:
             inputs.append(name)
 
     return tuple(inputs), context_param
+
+
+def _reject_non_keyword_callable_params(func: Callable, sig: inspect.Signature) -> None:
+    """Reject signatures the framework could never invoke with keyword args."""
+    offending = [(name, _UNSUPPORTED_PARAM_KINDS[param.kind]) for name, param in sig.parameters.items() if param.kind in _UNSUPPORTED_PARAM_KINDS]
+    if not offending:
+        return
+
+    offending_str = "\n".join(f"  -> parameter '{name}' is {kind}" for name, kind in offending)
+    raise TypeError(
+        f"Function '{func.__name__}' has parameter(s) that cannot be called by keyword:\n\n"
+        f"{offending_str}\n\n"
+        f"Hypergraph calls node functions with keyword arguments, so every parameter\n"
+        f"must be a regular or keyword-only parameter.\n\n"
+        f"How to fix:\n"
+        f"  Declare each input as a named parameter, e.g. def {func.__name__}(a, b) or\n"
+        f"  def {func.__name__}(a, *, b). Remove '/', '*args', and '**kwargs' from the signature."
+    )
 
 
 def _safe_get_type_hints(func: Callable) -> dict:

--- a/src/hypergraph/nodes/graph_node.py
+++ b/src/hypergraph/nodes/graph_node.py
@@ -344,9 +344,14 @@ class GraphNode(HyperNode):
 
         Returns:
             dict mapping output names to their type annotations.
-            For each output, finds the node in the inner graph that produces it
-            and gets that node's type annotation for that specific output.
-            Returns empty dict entries for outputs without type annotations.
+            For each output, finds the inner node that produces it and gets
+            that node's type annotation for that specific output.
+            Returns None entries for outputs without type annotations.
+
+            When multiple inner nodes produce the same boundary output (mutex
+            branches), the annotation from the first *annotated* producer in
+            sorted inner-node-name order wins. This makes heterogeneous
+            boundary types deterministic instead of iteration-order dependent.
 
             When map_over is configured, output types are wrapped in list[T]
             since mapped execution produces lists of results.
@@ -362,26 +367,10 @@ class GraphNode(HyperNode):
             {'x': list[str]}
         """
         result: dict[str, Any] = {}
-
-        # Build mapping: output_name -> source_node
-        output_to_node: dict[str, HyperNode] = {}
-        for node in self._graph.iter_nodes():
-            for output in node.outputs:
-                output_to_node[output] = node
-
-        # For each output of this GraphNode, get type from source node
         for output_name in self.outputs:
-            local_output = self._local_output_for_address(output_name)
-            original_output = self.resolve_original_output_name(local_output)
-            source_node = output_to_node.get(original_output)
-            if source_node is None:
-                result[output_name] = self._wrap_type_for_map_over(None)
-                continue
-
-            # Use universal get_output_type method
-            output_type = source_node.get_output_type(original_output)
+            candidates = self._boundary_output_type_candidates(output_name)
+            output_type = next((annotation for _, annotation in candidates if annotation is not None), None)
             result[output_name] = self._wrap_type_for_map_over(output_type)
-
         return result
 
     def _wrap_type_for_map_over(self, inner_type: type | None) -> type | None:
@@ -414,22 +403,69 @@ class GraphNode(HyperNode):
     def get_input_type(self, param: str) -> type | None:
         """Get expected type for an input parameter from the inner graph.
 
-        Derives the type from whichever node in the inner graph declares
-        this parameter as an input.
+        Derives the type from the inner nodes that declare this parameter as
+        an input. When multiple inner consumers share the boundary name with
+        different annotations, the annotation from the first *annotated*
+        consumer in sorted inner-node-name order wins — deterministic
+        regardless of node insertion order. (Under ``strict_types=True`` the
+        parent graph rejects conflicting annotations at validation time.)
 
         Args:
             param: Input parameter name (may be a renamed external name)
 
         Returns:
-            The type annotation, or None if not annotated.
+            The type annotation, or None if no inner consumer is annotated.
         """
+        for _, annotation in self._boundary_input_type_candidates(param):
+            if annotation is not None:
+                return annotation
+        return None
+
+    def _boundary_input_type_candidates(self, param: str) -> list[tuple[str, Any]]:
+        """(inner node name, annotation) pairs for consumers of a boundary input.
+
+        Sorted by inner node name so boundary type selection is deterministic.
+        """
+        candidates: list[tuple[str, Any]] = []
         for local_param in self._local_inputs_for_address(param):
             original_param = self._resolve_original_input_name(local_param)
-            # Find which node in inner graph has this as an input
             for inner_node in self._graph.iter_nodes():
                 if original_param in inner_node.inputs:
-                    return inner_node.get_input_type(original_param)
-        return None
+                    candidates.append((inner_node.name, inner_node.get_input_type(original_param)))
+        candidates.sort(key=lambda pair: pair[0])
+        return candidates
+
+    def _boundary_output_type_candidates(self, output: str) -> list[tuple[str, Any]]:
+        """(inner node name, annotation) pairs for producers of a boundary output.
+
+        Sorted by inner node name so boundary type selection is deterministic.
+        """
+        local_output = self._local_output_for_address(output)
+        original_output = self.resolve_original_output_name(local_output)
+        candidates: list[tuple[str, Any]] = []
+        for inner_node in self._graph.iter_nodes():
+            if original_output in inner_node.outputs:
+                candidates.append((inner_node.name, inner_node.get_output_type(original_output)))
+        candidates.sort(key=lambda pair: pair[0])
+        return candidates
+
+    def boundary_input_type_conflicts(self, param: str) -> tuple[tuple[str, Any], ...]:
+        """Annotated inner consumers of a boundary input with conflicting types.
+
+        Returns () when zero or one distinct annotation exists. Otherwise
+        returns every annotated (inner node name, annotation) pair, so
+        strict-mode validation can name all sides of the conflict.
+        """
+        return _conflicting_candidates(self._boundary_input_type_candidates(param))
+
+    def boundary_output_type_conflicts(self, output: str) -> tuple[tuple[str, Any], ...]:
+        """Annotated inner producers of a boundary output with conflicting types.
+
+        Returns () when zero or one distinct annotation exists. Otherwise
+        returns every annotated (inner node name, annotation) pair, so
+        strict-mode validation can name all sides of the conflict.
+        """
+        return _conflicting_candidates(self._boundary_output_type_candidates(output))
 
     def _resolve_original_input_name(self, param: str) -> str:
         """Resolve a possibly-renamed input name back to the original.
@@ -1046,6 +1082,18 @@ class GraphNode(HyperNode):
                     leaf_outputs.append(mapped_output)
 
         return tuple(leaf_outputs)
+
+
+def _conflicting_candidates(candidates: list[tuple[str, Any]]) -> tuple[tuple[str, Any], ...]:
+    """Return annotated candidates when they disagree, else ()."""
+    annotated = [(name, annotation) for name, annotation in candidates if annotation is not None]
+    distinct: list[Any] = []
+    for _, annotation in annotated:
+        if not any(annotation == seen for seen in distinct):
+            distinct.append(annotation)
+    if len(distinct) <= 1:
+        return ()
+    return tuple(annotated)
 
 
 def _validate_clone(

--- a/src/hypergraph/nodes/graph_node.py
+++ b/src/hypergraph/nodes/graph_node.py
@@ -403,11 +403,12 @@ class GraphNode(HyperNode):
     def get_input_type(self, param: str) -> type | None:
         """Get expected type for an input parameter from the inner graph.
 
-        Derives the type from the inner nodes that declare this parameter as
-        an input. When multiple inner consumers share the boundary name with
-        different annotations, the annotation from the first *annotated*
-        consumer in sorted inner-node-name order wins — deterministic
-        regardless of node insertion order. (Under ``strict_types=True`` the
+        Derives the type from the active inner nodes that declare this
+        parameter as an input. When multiple active inner consumers share the
+        boundary name with different annotations, the annotation from the
+        first *annotated* consumer in sorted inner-node-name order wins —
+        deterministic regardless of node insertion order. (Under
+        ``strict_types=True`` the
         parent graph rejects conflicting annotations at validation time.)
 
         Args:
@@ -422,28 +423,28 @@ class GraphNode(HyperNode):
         return None
 
     def _boundary_input_type_candidates(self, param: str) -> list[tuple[str, Any]]:
-        """(inner node name, annotation) pairs for consumers of a boundary input.
+        """(inner node name, annotation) pairs for active boundary-input consumers.
 
         Sorted by inner node name so boundary type selection is deterministic.
         """
         candidates: list[tuple[str, Any]] = []
         for local_param in self._local_inputs_for_address(param):
             original_param = self._resolve_original_input_name(local_param)
-            for inner_node in self._graph.iter_nodes():
+            for inner_node in self.iter_active_inner_nodes():
                 if original_param in inner_node.inputs:
                     candidates.append((inner_node.name, inner_node.get_input_type(original_param)))
         candidates.sort(key=lambda pair: pair[0])
         return candidates
 
     def _boundary_output_type_candidates(self, output: str) -> list[tuple[str, Any]]:
-        """(inner node name, annotation) pairs for producers of a boundary output.
+        """(inner node name, annotation) pairs for active boundary-output producers.
 
         Sorted by inner node name so boundary type selection is deterministic.
         """
         local_output = self._local_output_for_address(output)
         original_output = self.resolve_original_output_name(local_output)
         candidates: list[tuple[str, Any]] = []
-        for inner_node in self._graph.iter_nodes():
+        for inner_node in self.iter_active_inner_nodes():
             if original_output in inner_node.outputs:
                 candidates.append((inner_node.name, inner_node.get_output_type(original_output)))
         candidates.sort(key=lambda pair: pair[0])

--- a/src/hypergraph/runners/_shared/validation.py
+++ b/src/hypergraph/runners/_shared/validation.py
@@ -30,7 +30,6 @@ class _InputValidationContext:
     input_spec: InputSpec
     edge_produced: set[str]
     interrupt_outputs: set[str]
-    cycle_ep_params: set[str]
 
 
 def precompute_input_validation(
@@ -53,7 +52,6 @@ def precompute_input_validation(
         raise ValueError("Runtime select overrides are no longer supported. Configure output scope on the graph via graph.select(...).")
     active_nodes, active_subgraph = _resolve_active_scope(graph, graph.selected)
     input_spec = graph.inputs
-    cycle_ep_params = {p for params in input_spec.entrypoints.values() for p in params}
     edge_produced = get_edge_produced_values(active_subgraph)
     interrupt_outputs = _get_interrupt_outputs(active_nodes)
 
@@ -64,7 +62,6 @@ def precompute_input_validation(
         input_spec=input_spec,
         edge_produced=edge_produced,
         interrupt_outputs=interrupt_outputs,
-        cycle_ep_params=cycle_ep_params,
     )
 
 
@@ -100,7 +97,6 @@ def validate_item_inputs(
             active_nodes=ctx.active_nodes,
             provided=provided,
             internal_edge=internal_edge,
-            cycle_ep_params=ctx.cycle_ep_params,
         )
         if conflict_errors:
             raise ValueError("Cannot determine whether to run or skip node(s):\n" + "\n".join(conflict_errors))
@@ -139,7 +135,6 @@ def validate_item_inputs(
         missing=sorted(missing_required),
         provided=list(provided),
         suggestions=suggestions,
-        entrypoints=inputs_spec.entrypoints,
     )
 
     raise MissingInputError(
@@ -198,7 +193,6 @@ def _build_missing_input_message(
     missing: list[str],
     provided: list[str],
     suggestions: dict[str, list[str]],
-    entrypoints: dict[str, tuple[str, ...]] | None = None,
 ) -> str:
     """Build a helpful error message for missing inputs."""
     from hypergraph.graph._helpers import describe_addressed_input
@@ -216,12 +210,6 @@ def _build_missing_input_message(
 
     if provided:
         msg += f"\n\nProvided: {', '.join(f'{p!r}' for p in sorted(provided))}"
-
-    if entrypoints:
-        msg += "\n\nCycle entry points:"
-        for name, params in sorted(entrypoints.items()):
-            params_str = ", ".join(params) if params else "(no params needed)"
-            msg += f"\n  {name} → {params_str}"
 
     if suggestions:
         msg += "\n\nDid you mean:"
@@ -338,7 +326,6 @@ def _find_internal_override_conflicts(
     active_nodes: dict[str, HyperNode],
     provided: set[str],
     internal_edge: set[str],
-    cycle_ep_params: set[str],
 ) -> list[str]:
     """Find hard conflicts where compute and inject modes are mixed."""
     if not internal_edge:
@@ -348,7 +335,7 @@ def _find_internal_override_conflicts(
     conflicts: list[str] = []
 
     for node in active_nodes.values():
-        node_outputs = set(node.outputs) - cycle_ep_params
+        node_outputs = set(node.outputs)
         injected_outputs = sorted(node_outputs & internal_edge)
         if not injected_outputs:
             continue
@@ -365,7 +352,7 @@ def _find_internal_override_conflicts(
                 )
             else:
                 defaults = sorted([p for p in node.inputs if node.has_default_for(p)])
-                consumed_for_node = (node_outputs & downstream_consumed) - cycle_ep_params
+                consumed_for_node = node_outputs & downstream_consumed
                 all_needed = sorted(consumed_for_node)
                 conflicts.append(
                     f"- '{node.name}' conflict — you provided its outputs "
@@ -376,7 +363,7 @@ def _find_internal_override_conflicts(
             continue
 
         # Partial inject: some outputs provided but downstream needs others
-        consumed_for_node = (node_outputs & downstream_consumed) - cycle_ep_params
+        consumed_for_node = node_outputs & downstream_consumed
         missing_consumed = sorted(consumed_for_node - provided)
         if missing_consumed:
             all_needed = sorted(consumed_for_node)
@@ -499,15 +486,11 @@ def _find_bypassed_inputs(graph: Graph, provided: set[str], inputs_spec: InputSp
     for node in graph._nodes.values():
         consumed_outputs.update(node.inputs)
 
-    # Cycle entry point params bootstrap a cycle and do not imply that an
-    # active producer has been replaced.
-    cycle_ep_params = {p for params in inputs_spec.entrypoints.values() for p in params}
-
-    # A node is considered fully replaced only if ALL its non-cycle consumed
+    # A node is considered fully replaced only if ALL its consumed
     # outputs are provided by the user.
     bypassed_nodes: set[str] = set()
     for node in graph._nodes.values():
-        node_consumed_outputs = (set(node.outputs) & consumed_outputs) - cycle_ep_params
+        node_consumed_outputs = set(node.outputs) & consumed_outputs
         if node_consumed_outputs and node_consumed_outputs <= provided:
             # All consumed outputs are provided — treat the node as replaced for
             # conflict analysis.
@@ -516,13 +499,13 @@ def _find_bypassed_inputs(graph: Graph, provided: set[str], inputs_spec: InputSp
     if not bypassed_nodes:
         return set()
 
-    # Also mark nodes as replaced if ALL their non-cycle outputs are provided.
+    # Also mark nodes as replaced if ALL their outputs are provided.
     # Unlike the first pass (consumed only), this catches nodes whose outputs
     # are not consumed downstream but are still being fully supplied by the
     # user in a contradictory request.
     for node in graph._nodes.values():
-        non_cycle_outputs = set(node.outputs) - cycle_ep_params
-        if non_cycle_outputs and non_cycle_outputs <= provided:
+        node_outputs = set(node.outputs)
+        if node_outputs and node_outputs <= provided:
             bypassed_nodes.add(node.name)
 
     # Collect inputs exclusively needed by bypassed nodes

--- a/tests/capabilities/builders.py
+++ b/tests/capabilities/builders.py
@@ -28,49 +28,45 @@ def _make_sync_func(name: str, input_name: str, output_name: str) -> FunctionNod
     """Create a sync function node."""
 
     @node(output_name=output_name)
-    def sync_node(**kwargs: Any) -> int:
-        val = kwargs.get(input_name, 0)
-        return val * 2 if isinstance(val, int) else 0
+    def sync_node(value: Any) -> int:
+        return value * 2 if isinstance(value, int) else 0
 
     # Rename to match expected interface
-    return sync_node.with_name(name).rename_inputs(**{list(sync_node.inputs)[0]: input_name})
+    return sync_node.with_name(name).rename_inputs(value=input_name)
 
 
 def _make_async_func(name: str, input_name: str, output_name: str) -> FunctionNode:
     """Create an async function node."""
 
     @node(output_name=output_name)
-    async def async_node(**kwargs: Any) -> int:
-        val = kwargs.get(input_name, 0)
-        return val * 2 if isinstance(val, int) else 0
+    async def async_node(value: Any) -> int:
+        return value * 2 if isinstance(value, int) else 0
 
-    return async_node.with_name(name).rename_inputs(**{list(async_node.inputs)[0]: input_name})
+    return async_node.with_name(name).rename_inputs(value=input_name)
 
 
 def _make_sync_generator(name: str, input_name: str, output_name: str) -> FunctionNode:
     """Create a sync generator node."""
 
     @node(output_name=output_name)
-    def sync_gen(**kwargs: Any):
-        val = kwargs.get(input_name, 0)
-        if isinstance(val, int):
-            yield val
-            yield val * 2
+    def sync_gen(value: Any):
+        if isinstance(value, int):
+            yield value
+            yield value * 2
 
-    return sync_gen.with_name(name).rename_inputs(**{list(sync_gen.inputs)[0]: input_name})
+    return sync_gen.with_name(name).rename_inputs(value=input_name)
 
 
 def _make_async_generator(name: str, input_name: str, output_name: str) -> FunctionNode:
     """Create an async generator node."""
 
     @node(output_name=output_name)
-    async def async_gen(**kwargs: Any):
-        val = kwargs.get(input_name, 0)
-        if isinstance(val, int):
-            yield val
-            yield val * 2
+    async def async_gen(value: Any):
+        if isinstance(value, int):
+            yield value
+            yield value * 2
 
-    return async_gen.with_name(name).rename_inputs(**{list(async_gen.inputs)[0]: input_name})
+    return async_gen.with_name(name).rename_inputs(value=input_name)
 
 
 def _make_node(node_type: NodeType, name: str, input_name: str, output_name: str) -> FunctionNode:

--- a/tests/test_code_review_fixes.py
+++ b/tests/test_code_review_fixes.py
@@ -252,17 +252,18 @@ class TestValueComparisonSafety:
         assert v1 == v2  # Version should not change for same object
 
 
-class TestGraphNodeInputTypeConsistency:
-    """Edge 1: GraphNode input type returns arbitrary match.
+class TestGraphNodeBoundaryTypeDeterminism:
+    """Edge 1 (#118): heterogeneous boundary types are deterministic, not iteration-order roulette.
 
-    If multiple inner nodes share an input with different types,
-    get_input_type returns first found (dict ordering dependent).
+    When multiple inner nodes share one parent-facing boundary name with
+    different annotations, the reported type comes from the first annotated
+    inner node in sorted inner-node-name order. Under strict_types=True the
+    conflict is rejected at validation time instead.
     """
 
-    def test_input_type_consistency_warning(self):
-        """Graph should warn/error if shared inputs have inconsistent types."""
+    def test_input_type_deterministic_sorted_node_order(self):
+        """get_input_type picks the alphabetically-first annotated inner consumer."""
 
-        # This tests the design choice: we should validate at graph construction
         @node(output_name="out1")
         def node_int(x: int) -> int:
             return x
@@ -271,16 +272,121 @@ class TestGraphNodeInputTypeConsistency:
         def node_str(x: str) -> str:
             return x
 
-        # Both consume 'x' but with different types
-        # This should either raise or warn during validation
-        # For now, test the current behavior
-        inner = Graph([node_int, node_str], name="inner")
+        # Insertion order reversed vs sorted order: node_str first.
+        inner = Graph([node_str, node_int], name="inner")
         gn = inner.as_node()
 
-        # get_input_type should return a consistent result
-        # (currently returns first match - test documents behavior)
-        t = gn.get_input_type("x")
-        assert t in (int, str)  # Documents current behavior
+        # 'node_int' < 'node_str' in sorted order -> int wins, regardless of insertion order.
+        assert gn.get_input_type("x") is int
+        assert Graph([node_int, node_str], name="inner").as_node().get_input_type("x") is int
+
+    def test_input_type_skips_unannotated_consumers(self):
+        """An unannotated consumer earlier in sort order does not hide a real annotation."""
+
+        @node(output_name="out1")
+        def a_unannotated(x) -> int:
+            return x
+
+        @node(output_name="out2")
+        def b_typed(x: str) -> str:
+            return x
+
+        gn = Graph([a_unannotated, b_typed], name="inner").as_node()
+        assert gn.get_input_type("x") is str
+
+    def test_output_type_deterministic_sorted_node_order(self):
+        """get_output_type picks the alphabetically-first annotated inner producer."""
+
+        @route(targets=["as_int", "as_str"])
+        def pick(x: int) -> str:
+            return "as_int" if x > 0 else "as_str"
+
+        @node(output_name="result")
+        def as_int(x: int) -> int:
+            return x
+
+        @node(output_name="result")
+        def as_str(x: int) -> str:
+            return str(x)
+
+        # Under the old last-write-wins behavior, as_str (inserted last) won.
+        # Sorted inner-node-name order must win regardless of insertion order.
+        inner = Graph([pick, as_int, as_str], name="inner")
+        gn = inner.as_node()
+        assert gn.get_output_type("result") is int
+        flipped = Graph([pick, as_str, as_int], name="inner")
+        assert flipped.as_node().get_output_type("result") is int
+
+    def test_permissive_default_builds_fine(self):
+        """Without strict_types, conflicting boundary annotations stay permissive."""
+
+        @node(output_name="out1")
+        def node_int(x: int) -> int:
+            return x
+
+        @node(output_name="out2")
+        def node_str(x: str) -> str:
+            return x
+
+        @node(output_name="x")
+        def produce_x() -> int:
+            return 1
+
+        inner = Graph([node_str, node_int], name="inner")
+        outer = Graph([produce_x, inner.as_node()])  # no strict_types
+        assert "produce_x" in outer.nodes
+
+    def test_strict_mode_rejects_conflicting_input_annotations(self):
+        """strict_types=True raises with both node names and both types."""
+        from hypergraph import GraphConfigError
+
+        @node(output_name="out1")
+        def node_int(x: int) -> int:
+            return x
+
+        @node(output_name="out2")
+        def node_str(x: str) -> str:
+            return x
+
+        @node(output_name="x")
+        def produce_x() -> int:
+            return 1
+
+        inner = Graph([node_str, node_int], name="inner")
+        with pytest.raises(GraphConfigError) as exc_info:
+            Graph([produce_x, inner.as_node()], strict_types=True)
+        message = str(exc_info.value)
+        assert "node_int" in message
+        assert "node_str" in message
+        assert "int" in message
+        assert "str" in message
+
+    def test_strict_mode_rejects_conflicting_output_annotations(self):
+        """Mutex producers with different annotations for one exposed output are rejected."""
+        from hypergraph import GraphConfigError
+
+        @route(targets=["as_int", "as_str"])
+        def pick(x: int) -> str:
+            return "as_int" if x > 0 else "as_str"
+
+        @node(output_name="result")
+        def as_int(x: int) -> int:
+            return x
+
+        @node(output_name="result")
+        def as_str(x: int) -> str:
+            return str(x)
+
+        @node(output_name="final")
+        def consume(result: int) -> int:
+            return result
+
+        inner = Graph([pick, as_str, as_int], name="inner")
+        with pytest.raises(GraphConfigError) as exc_info:
+            Graph([inner.as_node(), consume], strict_types=True)
+        message = str(exc_info.value)
+        assert "as_int" in message
+        assert "as_str" in message
 
 
 class TestSelectParameterValidation:

--- a/tests/test_code_review_fixes.py
+++ b/tests/test_code_review_fixes.py
@@ -261,6 +261,82 @@ class TestGraphNodeBoundaryTypeDeterminism:
     conflict is rejected at validation time instead.
     """
 
+    @staticmethod
+    def _scoped_input_graph(scope: str) -> Graph:
+        @node(output_name="excluded_result")
+        def a_excluded(x: str) -> str:
+            return x
+
+        @node(output_name="active_result")
+        def z_active(x: int) -> int:
+            return x
+
+        graph = Graph([a_excluded, z_active], name=f"{scope}_input")
+        if scope == "select":
+            return graph.select("active_result")
+        return graph.with_entrypoint("z_active")
+
+    @staticmethod
+    def _scoped_output_graph(scope: str) -> Graph:
+        @route(targets=["a_excluded", "z_active"])
+        def choose(seed: int) -> str:
+            return "z_active" if seed > 0 else "a_excluded"
+
+        @node(output_name="result")
+        def a_excluded(seed: int) -> str:
+            return str(seed)
+
+        @node(output_name="result")
+        def z_active(seed: int) -> int:
+            return seed
+
+        graph = Graph([choose, a_excluded, z_active], name=f"{scope}_output")
+        if scope == "select_and_entrypoint":
+            # select() exposes every producer of its output, so excluding one
+            # duplicate producer requires intersecting it with entrypoint scope.
+            return graph.select("result").with_entrypoint("z_active")
+        return graph.with_entrypoint("z_active")
+
+    @pytest.mark.parametrize("scope", ["select", "entrypoint"])
+    def test_scoped_out_input_consumer_cannot_affect_boundary_type(self, scope):
+        """Select and entrypoint scope ignore excluded input annotations."""
+        from hypergraph import GraphConfigError
+
+        graph_node = self._scoped_input_graph(scope).as_node()
+
+        @node(output_name="x")
+        def produce_x() -> int:
+            return 1
+
+        try:
+            Graph([produce_x, graph_node], strict_types=True)
+        except GraphConfigError as error:
+            strict_error = str(error)
+        else:
+            strict_error = None
+
+        assert (graph_node.get_input_type("x"), strict_error) == (int, None)
+
+    @pytest.mark.parametrize("scope", ["entrypoint", "select_and_entrypoint"])
+    def test_scoped_out_output_producer_cannot_affect_boundary_type(self, scope):
+        """Entrypoint scope ignores excluded output annotations, including under select."""
+        from hypergraph import GraphConfigError
+
+        graph_node = self._scoped_output_graph(scope).as_node()
+
+        @node(output_name="final")
+        def consume(result: int) -> int:
+            return result
+
+        try:
+            Graph([graph_node, consume], strict_types=True)
+        except GraphConfigError as error:
+            strict_error = str(error)
+        else:
+            strict_error = None
+
+        assert (graph_node.get_output_type("result"), strict_error) == (int, None)
+
     def test_input_type_deterministic_sorted_node_order(self):
         """get_input_type picks the alphabetically-first annotated inner consumer."""
 

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -111,3 +111,31 @@ def test_cyclic_docs_examples_configure_entrypoints() -> None:
     assert 'entrypoint="generate_prompt_variants"' in hierarchical
     assert "optimization_loop = Graph(" in hierarchical
     assert 'entrypoint="variant_tester"' in hierarchical
+
+
+def test_inputspec_mirrors_distinguish_scope_from_input_categories() -> None:
+    current_surfaces = (
+        "src/hypergraph/graph/core.py",
+        "dev/ARCHITECTURE.md",
+        "docs/03-patterns/03-agentic-loops.md",
+        "docs/07-design/guiding-principles.md",
+        "docs/changelog.md",
+    )
+    stale_category_claims = (
+        "required/optional/entrypoint",
+        "required, optional, and entrypoint parameters",
+        "InputSpec docs define `entrypoints`",
+        "classified as entrypoint parameters",
+        "**entrypoint parameter**",
+    )
+
+    for path in current_surfaces:
+        text = _read(path)
+        for stale_claim in stale_category_claims:
+            assert stale_claim not in text, f"{path} still contains {stale_claim!r}"
+
+    inputspec = _read("docs/06-api-reference/inputspec.md")
+    assert "there is no separate entrypoints category on InputSpec" in inputspec
+    scope_narrowing = _section(inputspec, "### Scope Narrowing (Entrypoint and Select)")
+    assert "`with_entrypoint()` and `select()` narrow" in scope_narrowing
+    assert "`required` or `optional`" in scope_narrowing

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -111,31 +111,3 @@ def test_cyclic_docs_examples_configure_entrypoints() -> None:
     assert 'entrypoint="generate_prompt_variants"' in hierarchical
     assert "optimization_loop = Graph(" in hierarchical
     assert 'entrypoint="variant_tester"' in hierarchical
-
-
-def test_inputspec_mirrors_distinguish_scope_from_input_categories() -> None:
-    current_surfaces = (
-        "src/hypergraph/graph/core.py",
-        "dev/ARCHITECTURE.md",
-        "docs/03-patterns/03-agentic-loops.md",
-        "docs/07-design/guiding-principles.md",
-        "docs/changelog.md",
-    )
-    stale_category_claims = (
-        "required/optional/entrypoint",
-        "required, optional, and entrypoint parameters",
-        "InputSpec docs define `entrypoints`",
-        "classified as entrypoint parameters",
-        "**entrypoint parameter**",
-    )
-
-    for path in current_surfaces:
-        text = _read(path)
-        for stale_claim in stale_category_claims:
-            assert stale_claim not in text, f"{path} still contains {stale_claim!r}"
-
-    inputspec = _read("docs/06-api-reference/inputspec.md")
-    assert "there is no separate entrypoints category on InputSpec" in inputspec
-    scope_narrowing = _section(inputspec, "### Scope Narrowing (Entrypoint and Select)")
-    assert "`with_entrypoint()` and `select()` narrow" in scope_narrowing
-    assert "`required` or `optional`" in scope_narrowing

--- a/tests/test_explicit_edges.py
+++ b/tests/test_explicit_edges.py
@@ -193,7 +193,6 @@ class TestExplicitEdgesInputSpec:
             entrypoint="ask_user",
         )
         assert g.inputs.required == ()
-        assert g.inputs.entrypoints == {}
 
 
 # ── Execution tests ──────────────────────────────────────────────────────────

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -15,38 +15,38 @@ class TestInputSpec:
         spec = InputSpec(
             required=("param1", "param2"),
             optional=("param3",),
-            entrypoints={"node_a": ("param4",)},
             bound={"param5": 42},
         )
 
         assert spec.required == ("param1", "param2")
         assert spec.optional == ("param3",)
-        assert spec.entrypoints == {"node_a": ("param4",)}
         assert spec.bound == {"param5": 42}
+
+    def test_input_spec_has_no_entrypoints_field(self):
+        """The always-empty entrypoints field was removed (D11a)."""
+        spec = InputSpec(required=(), optional=(), bound={})
+        assert not hasattr(spec, "entrypoints")
 
     def test_input_spec_all_property(self):
         """Test .all property returns combined tuple of all inputs."""
         spec = InputSpec(
             required=("a", "b"),
             optional=("c",),
-            entrypoints={"node_a": ("d",)},
             bound={},
         )
 
-        assert spec.all == ("a", "b", "c", "d")
+        assert spec.all == ("a", "b", "c")
 
     def test_input_spec_empty_fields(self):
         """Test InputSpec works with empty tuples/dicts."""
         spec = InputSpec(
             required=(),
             optional=(),
-            entrypoints={},
             bound={},
         )
 
         assert spec.required == ()
         assert spec.optional == ()
-        assert spec.entrypoints == {}
         assert spec.bound == {}
         assert spec.all == ()
 
@@ -55,7 +55,6 @@ class TestInputSpec:
         spec = InputSpec(
             required=("param1",),
             optional=(),
-            entrypoints={},
             bound={},
         )
 
@@ -63,15 +62,14 @@ class TestInputSpec:
             spec.required = ("param2",)
 
     def test_input_spec_all_preserves_order(self):
-        """Test .all property preserves order: required + optional + entrypoint params."""
+        """Test .all property preserves order: required + optional."""
         spec = InputSpec(
             required=("r1", "r2"),
             optional=("o1", "o2"),
-            entrypoints={"node_a": ("s1",), "node_b": ("s2",)},
             bound={},
         )
 
-        assert spec.all == ("r1", "r2", "o1", "o2", "s1", "s2")
+        assert spec.all == ("r1", "r2", "o1", "o2")
 
 
 class TestGraphDescribe:
@@ -477,7 +475,6 @@ class TestGraphInputs:
 
         assert g.inputs.required == ("a", "b", "c")
         assert g.inputs.optional == ()
-        assert g.inputs.entrypoints == {}
         assert g.inputs.bound == {}
 
     def test_with_defaults_become_optional(self):
@@ -491,7 +488,6 @@ class TestGraphInputs:
 
         assert g.inputs.required == ("a",)
         assert g.inputs.optional == ("b", "c")
-        assert g.inputs.entrypoints == {}
         assert g.inputs.bound == {}
 
     def test_edge_connected_not_in_inputs(self):
@@ -523,7 +519,6 @@ class TestGraphInputs:
             Graph([counter])
 
         g = Graph([counter], entrypoint="counter")
-        assert g.inputs.entrypoints == {}
         assert g.inputs.required == ("count",)
         assert g.inputs.optional == ()
 

--- a/tests/test_graph_topologies.py
+++ b/tests/test_graph_topologies.py
@@ -173,7 +173,6 @@ class TestMultiNodeCycle:
             return b - 1
 
         g = Graph([node_a, node_b, node_c], entrypoint="node_a")
-        assert g.inputs.entrypoints == {}
         assert g.inputs.required == ("c",)
 
     def test_three_node_cycle_no_required_inputs(self):
@@ -211,7 +210,6 @@ class TestMultiNodeCycle:
 
         g = Graph([node_a, node_b, node_c], entrypoint="node_a")
         assert set(g.inputs.required) == {"c", "x"}
-        assert g.inputs.entrypoints == {}
 
 
 class TestMultipleCycles:
@@ -275,7 +273,6 @@ class TestMultipleCycles:
             return q - 5
 
         g = Graph([x_node, y_node, p_node, q_node, r_node], entrypoint=["x_node", "p_node"])
-        assert g.inputs.entrypoints == {}
         assert set(g.inputs.required) == {"y", "r"}
 
     def test_cycles_with_shared_external_input(self):
@@ -305,7 +302,6 @@ class TestMultipleCycles:
         assert "config" in g.inputs.required
         assert "y" in g.inputs.required
         assert "r" in g.inputs.required
-        assert g.inputs.entrypoints == {}
 
 
 class TestIsolatedSubgraphs:

--- a/tests/test_inputspec_docs_contract.py
+++ b/tests/test_inputspec_docs_contract.py
@@ -1,0 +1,69 @@
+"""Static mirror checks for the public ``InputSpec`` contract."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+CURRENT_SURFACES = (
+    "src/hypergraph/graph/core.py",
+    "dev/ARCHITECTURE.md",
+    "docs/03-patterns/03-agentic-loops.md",
+    "docs/07-design/guiding-principles.md",
+    "docs/07-design/roadmap.md",
+    "docs/changelog.md",
+    "scripts/test_api_docs.py",
+    "scripts/test_graph_examples.py",
+)
+
+
+def _read(path: str) -> str:
+    return (ROOT / path).read_text()
+
+
+def _section(text: str, heading: str) -> str:
+    start = text.index(heading)
+    next_heading = text.find("\n##", start + len(heading))
+    if next_heading == -1:
+        return text[start:]
+    return text[start:next_heading]
+
+
+def test_inputspec_mirrors_distinguish_scope_from_input_categories() -> None:
+    stale_category_claims = (
+        "required/optional/entrypoint",
+        "required, optional, and entrypoint parameters",
+        "InputSpec docs define `entrypoints`",
+        "classified as entrypoint parameters",
+        "**entrypoint parameter**",
+    )
+    stale_attribute_access = re.compile(r"\.inputs\.(?:entry_points|entrypoints)\b")
+    invalid_inputspec_category = re.compile(
+        r"InputSpec[^\n]*\bcategor(?:y|ies|ization)\b[^\n]*"
+        r"\b(?:internal|entry_?points?)\b",
+        re.IGNORECASE,
+    )
+    tuple_bound_comment = re.compile(r"inputs\.bound[^\n]*#\s*\([^\n]*\)")
+    violations: list[str] = []
+
+    for path in CURRENT_SURFACES:
+        text = _read(path)
+        for stale_claim in stale_category_claims:
+            if stale_claim in text:
+                violations.append(f"{path} still contains {stale_claim!r}")
+        if stale_attribute_access.search(text):
+            violations.append(f"{path} accesses an entrypoint category that InputSpec does not expose")
+        if invalid_inputspec_category.search(text):
+            violations.append(f"{path} advertises a nonexistent InputSpec category")
+        if tuple_bound_comment.search(text):
+            violations.append(f"{path} describes InputSpec.bound as a tuple instead of a dict")
+
+    assert not violations, "\n" + "\n".join(violations)
+
+    inputspec = _read("docs/06-api-reference/inputspec.md")
+    assert "there is no separate entrypoints category on InputSpec" in inputspec
+    scope_narrowing = _section(inputspec, "### Scope Narrowing (Entrypoint and Select)")
+    assert "`with_entrypoint()` and `select()` narrow" in scope_narrowing
+    assert "`required` or `optional`" in scope_narrowing

--- a/tests/test_nodes_function.py
+++ b/tests/test_nodes_function.py
@@ -647,73 +647,74 @@ class TestFunctionNodeOutputAnnotation:
 
 
 class TestFunctionSignatures:
-    """Tests for FunctionNode handling of all Python parameter types (FUNC-01 through FUNC-05).
+    """Construction-time contract for Python parameter kinds (FUNC-01 through FUNC-05, #116).
 
-    Python has 5 parameter kinds (from inspect.Parameter.kind):
-    - POSITIONAL_ONLY: def f(a, /)
-    - POSITIONAL_OR_KEYWORD: def f(a) (standard, already tested elsewhere)
-    - VAR_POSITIONAL: def f(*args)
-    - KEYWORD_ONLY: def f(*, kw)
-    - VAR_KEYWORD: def f(**kwargs)
+    Hypergraph invokes node functions with keyword arguments, so only
+    keyword-addressable parameters are supported:
+    - POSITIONAL_OR_KEYWORD: def f(a) — supported
+    - KEYWORD_ONLY: def f(*, kw) — supported
+    - POSITIONAL_ONLY: def f(a, /) — rejected at construction
+    - VAR_POSITIONAL: def f(*args) — rejected at construction
+    - VAR_KEYWORD: def f(**kwargs) — rejected at construction
     """
 
-    # FUNC-01: *args tests
+    # FUNC-01: *args is rejected at construction
 
-    def test_var_positional_in_inputs(self):
-        """*args parameter appears in inputs (FUNC-01)."""
-
-        def foo(*args):
-            pass
-
-        fn = FunctionNode(foo)
-        assert "args" in fn.inputs
-        assert fn.inputs == ("args",)
-
-    def test_var_positional_no_default(self):
-        """*args has no default (FUNC-01)."""
+    def test_var_positional_rejected(self):
+        """*args cannot be a node parameter (FUNC-01)."""
 
         def foo(*args):
             pass
 
-        fn = FunctionNode(foo)
-        assert fn.defaults == {}
-        assert not fn.has_default_for("args")
+        with pytest.raises(TypeError, match="args"):
+            FunctionNode(foo)
 
-    def test_var_positional_with_annotation(self):
-        """*args can have type annotation (FUNC-01)."""
+    def test_var_positional_error_names_param_and_kind(self):
+        """Rejection names the offending parameter and its kind (FUNC-01)."""
+
+        def foo(*args):
+            pass
+
+        with pytest.raises(TypeError) as exc_info:
+            FunctionNode(foo)
+        message = str(exc_info.value)
+        assert "'args'" in message
+        assert "variadic positional" in message
+        assert "How to fix" in message
+
+    def test_var_positional_with_annotation_rejected(self):
+        """Annotated *args is still rejected (FUNC-01)."""
 
         def foo(*args: int):
             pass
 
-        fn = FunctionNode(foo)
-        # The annotation for *args may or may not appear in parameter_annotations
-        # depending on how get_type_hints handles variadic parameters
-        # Just verify no exception is raised
-        assert "args" in fn.inputs
+        with pytest.raises(TypeError, match="args"):
+            FunctionNode(foo)
 
-    # FUNC-02: **kwargs tests
+    # FUNC-02: **kwargs is rejected at construction
 
-    def test_var_keyword_in_inputs(self):
-        """**kwargs parameter appears in inputs (FUNC-02)."""
+    def test_var_keyword_rejected(self):
+        """**kwargs cannot be a node parameter (FUNC-02)."""
 
         def foo(**kwargs):
             pass
 
-        fn = FunctionNode(foo)
-        assert "kwargs" in fn.inputs
-        assert fn.inputs == ("kwargs",)
+        with pytest.raises(TypeError, match="kwargs"):
+            FunctionNode(foo)
 
-    def test_var_keyword_no_default(self):
-        """**kwargs has no default (FUNC-02)."""
+    def test_var_keyword_error_names_param_and_kind(self):
+        """Rejection names the offending parameter and its kind (FUNC-02)."""
 
         def foo(**kwargs):
             pass
 
-        fn = FunctionNode(foo)
-        assert fn.defaults == {}
-        assert not fn.has_default_for("kwargs")
+        with pytest.raises(TypeError) as exc_info:
+            FunctionNode(foo)
+        message = str(exc_info.value)
+        assert "'kwargs'" in message
+        assert "variadic keyword" in message
 
-    # FUNC-03: keyword-only tests
+    # FUNC-03: keyword-only params remain fully supported
 
     def test_keyword_only_in_inputs(self):
         """Keyword-only params appear in inputs (FUNC-03)."""
@@ -754,101 +755,8 @@ class TestFunctionSignatures:
         fn = FunctionNode(foo)
         assert fn.parameter_annotations.get("kw") is str
 
-    # FUNC-04: positional-only tests
-
-    def test_positional_only_in_inputs(self):
-        """Positional-only params appear in inputs (FUNC-04)."""
-
-        def foo(a, /, b):
-            pass
-
-        fn = FunctionNode(foo)
-        assert fn.inputs == ("a", "b")
-
-    def test_positional_only_with_default(self):
-        """Positional-only can have defaults (FUNC-04)."""
-
-        def foo(a=5, /, b=10):
-            pass
-
-        fn = FunctionNode(foo)
-        assert fn.defaults == {"a": 5, "b": 10}
-
-    def test_positional_only_with_annotation(self):
-        """Positional-only with type annotation (FUNC-04)."""
-
-        def foo(a: int, /) -> str:
-            return ""
-
-        fn = FunctionNode(foo, output_name="result")
-        assert fn.parameter_annotations.get("a") is int
-
-    # FUNC-05: mixed argument types tests
-
-    def test_mixed_all_param_kinds(self):
-        """Function with all parameter kinds (FUNC-05)."""
-
-        def foo(pos_only, /, regular, *args, kw_only, **kwargs):
-            pass
-
-        fn = FunctionNode(foo)
-        assert fn.inputs == ("pos_only", "regular", "args", "kw_only", "kwargs")
-
-    def test_mixed_with_defaults(self):
-        """Mixed params with various defaults (FUNC-05)."""
-
-        def foo(pos=1, /, reg=2, *args, kw=3, **kwargs):
-            pass
-
-        fn = FunctionNode(foo)
-        assert fn.defaults == {"pos": 1, "reg": 2, "kw": 3}
-        # *args and **kwargs never have defaults
-        assert "args" not in fn.defaults
-        assert "kwargs" not in fn.defaults
-
-    def test_mixed_with_annotations(self):
-        """Mixed params with type annotations (FUNC-05)."""
-
-        def foo(pos: int, /, reg: str, *args: float, kw: bool, **kwargs: dict) -> list:
-            pass
-
-        fn = FunctionNode(foo, output_name="result")
-        # Verify standard params are annotated
-        assert fn.parameter_annotations.get("pos") is int
-        assert fn.parameter_annotations.get("reg") is str
-        assert fn.parameter_annotations.get("kw") is bool
-
-    def test_mixed_rename_works(self):
-        """rename_inputs works with mixed param kinds (FUNC-05)."""
-
-        def foo(a, /, b, *, c):
-            pass
-
-        fn = FunctionNode(foo, rename_inputs={"a": "x", "b": "y", "c": "z"})
-        assert fn.inputs == ("x", "y", "z")
-
-    def test_mixed_callable(self):
-        """Mixed-signature function is still callable (FUNC-05)."""
-
-        def foo(a, /, b, *args, c, **kwargs):
-            return (a, b, args, c, kwargs)
-
-        fn = FunctionNode(foo, output_name="result")
-        result = fn(1, 2, 3, 4, c=5, extra=6)
-        assert result == (1, 2, (3, 4), 5, {"extra": 6})
-
-    def test_only_var_args_and_kwargs(self):
-        """Function with just *args and **kwargs (FUNC-05)."""
-
-        def foo(*args, **kwargs):
-            pass
-
-        fn = FunctionNode(foo)
-        assert fn.inputs == ("args", "kwargs")
-        assert fn.defaults == {}
-
     def test_keyword_only_multiple(self):
-        """Multiple keyword-only params (FUNC-05)."""
+        """Multiple keyword-only params (FUNC-03)."""
 
         def foo(*, a, b=1, c):
             pass
@@ -857,14 +765,99 @@ class TestFunctionSignatures:
         assert fn.inputs == ("a", "b", "c")
         assert fn.defaults == {"b": 1}
 
-    def test_positional_only_multiple(self):
-        """Multiple positional-only params (FUNC-05)."""
+    # FUNC-04: positional-only params are rejected at construction
+
+    def test_positional_only_rejected(self):
+        """Positional-only params cannot be node parameters (FUNC-04)."""
+
+        def foo(a, /, b):
+            pass
+
+        with pytest.raises(TypeError, match="'a'"):
+            FunctionNode(foo)
+
+    def test_positional_only_error_names_param_and_kind(self):
+        """Rejection names the offending parameter and its kind (FUNC-04)."""
+
+        def foo(a: int, /) -> str:
+            return ""
+
+        with pytest.raises(TypeError) as exc_info:
+            FunctionNode(foo, output_name="result")
+        message = str(exc_info.value)
+        assert "'a'" in message
+        assert "positional-only" in message
+
+    def test_positional_only_with_default_rejected(self):
+        """Defaults do not make positional-only params callable by keyword (FUNC-04)."""
+
+        def foo(a=5, /, b=10):
+            pass
+
+        with pytest.raises(TypeError, match="'a'"):
+            FunctionNode(foo)
+
+    def test_positional_only_multiple_rejected(self):
+        """Multiple positional-only params are all reported (FUNC-04)."""
 
         def foo(a, b, c, /):
             pass
 
-        fn = FunctionNode(foo)
-        assert fn.inputs == ("a", "b", "c")
+        with pytest.raises(TypeError) as exc_info:
+            FunctionNode(foo)
+        message = str(exc_info.value)
+        assert "'a'" in message
+        assert "'b'" in message
+        assert "'c'" in message
+
+    # FUNC-05: mixed signatures are rejected when any unsupported kind is present
+
+    def test_mixed_all_param_kinds_rejected(self):
+        """Function mixing supported and unsupported kinds is rejected (FUNC-05)."""
+
+        def foo(pos_only, /, regular, *args, kw_only, **kwargs):
+            pass
+
+        with pytest.raises(TypeError) as exc_info:
+            FunctionNode(foo)
+        message = str(exc_info.value)
+        assert "'pos_only'" in message
+        assert "'args'" in message
+        assert "'kwargs'" in message
+        # Supported params are not blamed
+        assert "'regular'" not in message
+        assert "'kw_only'" not in message
+
+    def test_only_var_args_and_kwargs_rejected(self):
+        """Function with just *args and **kwargs is rejected (FUNC-05)."""
+
+        def foo(*args, **kwargs):
+            pass
+
+        with pytest.raises(TypeError):
+            FunctionNode(foo)
+
+    def test_rejection_applies_to_all_node_kinds(self):
+        """Gates and interrupts reject unsupported kinds too — one choke point (FUNC-05)."""
+        from hypergraph import END, ifelse, interrupt, route
+
+        with pytest.raises(TypeError, match="args"):
+
+            @route(targets=["a", END])
+            def gate(*args):
+                return END
+
+        with pytest.raises(TypeError, match="'flag'"):
+
+            @ifelse(when_true="a", when_false="b")
+            def branch(flag, /):
+                return bool(flag)
+
+        with pytest.raises(TypeError, match="kwargs"):
+
+            @interrupt(output_name="decision")
+            def approval(**kwargs):
+                return None
 
 
 class TestGeneratorEdgeCases:

--- a/tests/test_partial_inputs.py
+++ b/tests/test_partial_inputs.py
@@ -454,18 +454,52 @@ class TestImmutability:
         g2 = graph.with_entrypoint("process_node")
         assert g2.entrypoints_config == ("process_node",)
 
-    def test_add_nodes_resets_entrypoints(self):
-        """add_nodes creates fresh graph without entrypoints."""
+    def test_add_nodes_preserves_entrypoints(self):
+        """add_nodes keeps configured entrypoints instead of silently dropping them (#115)."""
         graph = Graph([root1, process_node])
         g2 = graph.with_entrypoint("process_node")
-        assert g2.entrypoints_config is not None
+        assert g2.entrypoints_config == ("process_node",)
 
         @node(output_name="extra")
         def extra_node(a):
             return a
 
         g3 = g2.add_nodes(extra_node)
-        assert g3.entrypoints_config is None
+        assert g3.entrypoints_config == ("process_node",)
+        # Scope stays narrowed: root1 is still excluded, 'a' remains a user input.
+        assert "a" in g3.inputs.required
+
+    def test_add_nodes_cycle_with_preserved_entrypoint_builds(self):
+        """Preserved entrypoint satisfies the cyclic-graph requirement after add_nodes."""
+
+        @node(output_name="draft")
+        def write(topic, feedback="none"):
+            return f"{topic}:{feedback}"
+
+        @node(output_name="feedback")
+        def review(draft):
+            return f"review of {draft}"
+
+        graph = Graph([write]).with_entrypoint("write")
+        # Adding review forms the cycle write -> review -> write. With the old
+        # reset behavior this raised "Cyclic graphs require an explicit
+        # entrypoint"; the preserved entrypoint now satisfies that check.
+        g2 = graph.add_nodes(review)
+        assert g2.has_cycles
+        assert g2.entrypoints_config == ("write",)
+
+    def test_add_nodes_invalid_combination_fails_loud(self):
+        """Rebuild validation still fires with preserved entrypoints (loud failure)."""
+        graph = Graph([root1, process_node]).with_entrypoint("process_node")
+
+        @node(output_name="r1")
+        def rival_producer(q):
+            return q
+
+        # Two unordered producers of 'r1' (root1 + rival_producer) is a
+        # rebuild-time conflict. Entrypoint preservation must not mask it.
+        with pytest.raises(GraphConfigError):
+            graph.add_nodes(rival_producer)
 
 
 # === Runtime select rejected ===

--- a/tests/test_partial_inputs.py
+++ b/tests/test_partial_inputs.py
@@ -185,6 +185,60 @@ class TestEntrypointNarrowsActiveSet:
 # === Entrypoint + select composition ===
 
 
+@node(output_name="mid_val")
+def chain_upstream(x):
+    return x
+
+
+@node(output_name="out_val")
+def chain_downstream(mid_val):
+    return mid_val
+
+
+class TestUnreachableSelectRejected:
+    """entrypoint+select combos that cannot produce the selection fail at build time (#119)."""
+
+    def test_select_after_entrypoint_raises(self):
+        """Selecting an output whose producer is upstream of the entrypoint raises."""
+        graph = Graph([chain_upstream, chain_downstream])
+        with pytest.raises(GraphConfigError, match="mid_val"):
+            graph.with_entrypoint("chain_downstream").select("mid_val")
+
+    def test_entrypoint_after_select_raises(self):
+        """Order-independent: .select(...).with_entrypoint(...) raises too."""
+        graph = Graph([chain_upstream, chain_downstream])
+        with pytest.raises(GraphConfigError, match="mid_val"):
+            graph.select("mid_val").with_entrypoint("chain_downstream")
+
+    def test_partially_unreachable_selection_raises(self):
+        """A mix of reachable and unreachable selected outputs still raises."""
+        graph = Graph([chain_upstream, chain_downstream])
+        with pytest.raises(GraphConfigError, match="mid_val"):
+            graph.with_entrypoint("chain_downstream").select("out_val", "mid_val")
+
+    def test_error_lists_producible_outputs_and_fix(self):
+        """House message style: what / valid options / how to fix."""
+        graph = Graph([chain_upstream, chain_downstream])
+        with pytest.raises(GraphConfigError) as exc_info:
+            graph.with_entrypoint("chain_downstream").select("mid_val")
+        message = str(exc_info.value)
+        assert "chain_downstream" in message  # entrypoint context
+        assert "out_val" in message  # what IS producible
+        assert "How to fix" in message
+
+    def test_reachable_selection_still_allowed(self):
+        """Selecting an output the entrypoint can reach stays valid."""
+        graph = Graph([chain_upstream, chain_downstream])
+        g2 = graph.with_entrypoint("chain_downstream").select("out_val")
+        assert g2.selected == ("out_val",)
+
+    def test_constructor_entrypoint_then_select_raises(self):
+        """Graph(entrypoint=...) followed by select() validates the combination."""
+        graph = Graph([chain_upstream, chain_downstream], entrypoint="chain_downstream")
+        with pytest.raises(GraphConfigError, match="mid_val"):
+            graph.select("mid_val")
+
+
 class TestEntrypointAndSelectCompose:
     """Both with_entrypoint and select narrow together."""
 

--- a/tests/test_public_exports.py
+++ b/tests/test_public_exports.py
@@ -1,0 +1,19 @@
+"""Public export surface checks for the hypergraph root package."""
+
+import hypergraph
+
+
+class TestExceptionExports:
+    """All runtime exceptions are importable from the hypergraph root."""
+
+    def test_execution_error_exported(self):
+        """ExecutionError is importable from the root and listed in __all__ (D10)."""
+        from hypergraph import ExecutionError
+
+        assert ExecutionError is hypergraph.exceptions.ExecutionError
+        assert "ExecutionError" in hypergraph.__all__
+
+    def test_all_names_resolve(self):
+        """Every name in __all__ is an attribute of the package."""
+        for name in hypergraph.__all__:
+            assert hasattr(hypergraph, name), f"__all__ lists missing attribute: {name}"

--- a/tests/test_red_team_fixes.py
+++ b/tests/test_red_team_fixes.py
@@ -324,7 +324,6 @@ class TestControlOnlyCycles:
 
         # "data" feeds process but is NOT part of any data cycle
         assert "data" in graph.inputs.required, f"'data' should be required, got: {graph.inputs.required}"
-        assert graph.inputs.entrypoints == {}
 
 
 # === Fix #11: Output rename propagation in GraphNode ===

--- a/tests/viz/conftest.py
+++ b/tests/viz/conftest.py
@@ -196,7 +196,6 @@ def _viz_cache_key(
         graph.name,
         input_spec.required,
         input_spec.optional,
-        tuple(sorted(input_spec.entrypoints.keys())),
         bound_items,
         depth,
         theme,


### PR DESCRIPTION
## Problem / Bug / Challenge

Wave 2 found several graph-shape errors that were accepted at construction time and only failed—or silently changed behavior—later: incompatible entrypoint/selection combinations, dropped entrypoints after `add_nodes()`, unsupported Python signatures, and insertion-order-dependent nested boundary types.

Part of #182.

## Before / After

**Before:**

```python
graph = Graph([fetch]).with_entrypoint("fetch").select("answer")
graph = graph.add_nodes(format_answer)  # configured entrypoint could be lost

@node
def collect(*items: str) -> str:         # accepted; failed at execution time
    return "".join(items)
```

**After:**

```python
graph = Graph([fetch]).with_entrypoint("fetch").select("answer")
graph = graph.add_nodes(format_answer)  # entrypoint is preserved

# Invalid entrypoint/selection combinations now raise GraphConfigError
# at build time with a "How to fix" explanation, regardless of call order.

@node
def collect(*items: str) -> str:
    ...
# TypeError at node construction: variadic parameters are unsupported
```

The branch also makes GraphNode boundary typing deterministic, raises strict-mode type conflicts, exports `ExecutionError` from `hypergraph`, removes the always-empty `InputSpec.entrypoints` field, updates every current mirror to distinguish graph entrypoint scope from bootstrap inputs, and completes the documented `map_over()` signature.

## Test Plan

- [x] `uv run pytest -W error -W 'ignore::pytest.PytestUnraisableExceptionWarning'` — 2,951 passed on this branch
- [x] Own-hands graph strictness falsifier: both entrypoint/select orders, active-scope boundary types, `add_nodes()` preservation, variadic/positional-only rejection, keyword-only support, boundary-type conflicts, InputSpec shape, root export
- [x] Combined Wave-2 integration tree — 3,025 passed
- [x] `uv run pre-commit run --all-files` on the combined tree
