### PR TITLE
fix(runners): harden typed execution and durability signals

### DIFF
--- a/docs/06-api-reference/checkpointers.md
+++ b/docs/06-api-reference/checkpointers.md
@@ -86,6 +86,16 @@ CheckpointPolicy()
 | `window` | `int \| None` | Required when `retention="windowed"`. |
 | `ttl` | `timedelta \| None` | Auto-expire completed runs after this duration. |
 
+**Async durability is best-effort.** With `durability="async"` (the default), step writes happen in background tasks: a failed write does not fail the run — the run still returns `COMPLETED`, and the failure is reported on the result instead. Check `result.checkpoint_ok` (and `result.checkpoint_errors`, a tuple of error strings) to detect gaps in the persisted history:
+
+```python
+result = await runner.run(graph, {"x": 5}, workflow_id="wf-1")
+if not result.checkpoint_ok:
+    log.warning("run completed but steps were not persisted: %s", result.checkpoint_errors)
+```
+
+With `durability="sync"`, the same write failure propagates and fails the run. `SyncRunner` always writes steps synchronously (there is no event loop to defer to), so a write failure fails the run regardless of the configured durability.
+
 Invalid combinations raise at construction, not at run time:
 
 ```python

--- a/docs/06-api-reference/events.md
+++ b/docs/06-api-reference/events.md
@@ -174,6 +174,24 @@ class StopRequestedEvent(BaseEvent):
     info: object                 # Optional stop metadata
 ```
 
+### StreamingChunkEvent
+
+Emitted when a node calls `ctx.stream(chunk)` to publish a live-preview chunk
+without changing the node's return value.
+
+```python
+@dataclass(frozen=True)
+class StreamingChunkEvent(BaseEvent):
+    chunk: object                # Streamed token, fragment, or payload
+    node_name: str               # Node that emitted the chunk
+    graph_name: str              # Graph containing the node
+```
+
+Inherited `run_id`, `workflow_id`, and `item_index` fields correlate the chunk
+with its run, persisted workflow, and mapped item. Inherited `parent_span_id`
+is the span of the emitting node, so consumers can attach chunks to the exact
+node execution even when siblings run concurrently.
+
 ### CacheHitEvent
 
 Emitted when a node result is served from cache instead of being executed.

--- a/docs/06-api-reference/runners.md
+++ b/docs/06-api-reference/runners.md
@@ -249,7 +249,7 @@ caps = runner.capabilities
 
 caps.supports_cycles       # True
 caps.supports_async_nodes  # False
-caps.supports_streaming    # False
+caps.supports_streaming    # True (map_iter + ctx.stream chunks)
 caps.returns_coroutine     # False
 caps.supports_interrupts   # False
 ```
@@ -800,7 +800,7 @@ caps = runner.capabilities
 
 caps.supports_cycles       # True
 caps.supports_async_nodes  # True
-caps.supports_streaming    # False (Phase 2)
+caps.supports_streaming    # True (map_iter + ctx.stream chunks)
 caps.returns_coroutine     # True
 caps.supports_interrupts   # True
 ```

--- a/docs/06-api-reference/runners.md
+++ b/docs/06-api-reference/runners.md
@@ -839,7 +839,14 @@ class RunResult:
     workflow_id: str | None     # Optional workflow tracking
     error: BaseException | None # Exception if FAILED
     pause: PauseInfo | None     # Pause info if PAUSED (InterruptNode)
+    log: RunLog | None          # Execution trace, if collected
+    checkpoint_ok: bool         # False when a best-effort async step save failed
+    checkpoint_errors: tuple[str, ...]  # String-only checkpoint save errors
 ```
+
+With async checkpoint durability, step saves are best-effort: a persistence gap
+does not change the execution status. Check `checkpoint_ok` and
+`checkpoint_errors` when durable history is required.
 
 ### Convenience Properties
 
@@ -886,7 +893,7 @@ This is useful for debugging — you can inspect which nodes completed successfu
 result.summary()   # "3 nodes | 12ms | 0 errors | slowest: generate (8ms)"
 
 # JSON-serializable metadata (no raw values or exception objects)
-result.to_dict()   # {"status": "completed", "run_id": "run-abc", "log": {...}}
+result.to_dict()   # {"status": "completed", "run_id": "run-abc", "checkpoint_ok": True, "checkpoint_errors": [], "log": {...}}
 ```
 
 ---
@@ -918,6 +925,10 @@ results.failed       # True if any failed
 results.partial      # True if some items completed and some failed
 results.stopped      # True if any item stopped and none failed/paused
 results.failures     # List of failed RunResult items
+
+# Derived durability aggregation (properties, not dataclass fields)
+results.checkpoint_ok      # True only when every item persisted successfully
+results.checkpoint_errors  # Tuple of save errors in stable item order
 
 # Progressive disclosure
 results.summary()    # "3 items | 3 completed | 12ms"

--- a/src/hypergraph/events/types.py
+++ b/src/hypergraph/events/types.py
@@ -260,10 +260,15 @@ class StreamingChunkEvent(BaseEvent):
     Attributes:
         chunk: The streamed payload (token, JSON fragment, etc.).
         node_name: Name of the node that emitted the chunk.
+        graph_name: Name of the graph containing the node.
+        parent_span_id: Inherited from BaseEvent — span of the emitting node.
+        workflow_id: Inherited from BaseEvent — workflow identifier, if any.
+        item_index: Inherited from BaseEvent — mapped item index, if any.
     """
 
     chunk: object = None
     node_name: str = ""
+    graph_name: str = ""
 
 
 @dataclass(frozen=True)

--- a/src/hypergraph/exceptions.py
+++ b/src/hypergraph/exceptions.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from hypergraph.runners._shared.types import GraphState
 
 
@@ -96,15 +98,27 @@ class IncompatibleRunnerError(Exception):
 class ExecutionError(Exception):
     """Wraps an exception that occurred during graph execution.
 
-    Carries the partial GraphState accumulated before the error,
-    replacing the monkey-patched ``_partial_state`` attribute pattern.
+    Carries the partial GraphState accumulated before the error, plus
+    per-superstep failure attribution as real constructor parameters.
 
     Attributes:
         partial_state: GraphState snapshot from before the failure
+        attempted_node_names: Names of nodes attempted in the failing
+            superstep. Empty when the failure cannot be attributed to
+            specific nodes (e.g. a scheduler-level error).
+        node_errors: Mapping of node name to the exception that node raised.
     """
 
-    def __init__(self, cause: BaseException, partial_state: GraphState) -> None:
+    def __init__(
+        self,
+        cause: BaseException,
+        partial_state: GraphState,
+        attempted_node_names: tuple[str, ...] = (),
+        node_errors: Mapping[str, BaseException] | None = None,
+    ) -> None:
         self.partial_state = partial_state
+        self.attempted_node_names = tuple(attempted_node_names)
+        self.node_errors: dict[str, BaseException] = dict(node_errors) if node_errors else {}
         super().__init__(str(cause))
         self.__cause__ = cause
 

--- a/src/hypergraph/runners/_shared/helpers.py
+++ b/src/hypergraph/runners/_shared/helpers.py
@@ -524,6 +524,24 @@ def get_ready_nodes_in_component(
     )
 
 
+def plan_interrupt_batch(ready_nodes: list[HyperNode]) -> list[HyperNode]:
+    """Isolate interrupt nodes so a pause cannot cancel sibling work.
+
+    ``PauseExecution`` extends ``BaseException``; raised inside
+    ``asyncio.gather`` it would cancel all sibling tasks mid-flight. When any
+    interrupt node is ready, run exactly one interrupt alone this superstep —
+    the other ready nodes are deferred to the next superstep, where they
+    remain ready. Batches without interrupts pass through unchanged.
+
+    Must be applied once, before the runner captures the batch's node names
+    for checkpoint metadata, so recorded batch == executed batch.
+    """
+    interrupts = [node for node in ready_nodes if node.is_interrupt]
+    if interrupts:
+        return [interrupts[0]]
+    return ready_nodes
+
+
 def find_missing_resume_seed_inputs(
     graph: Graph,
     state: GraphState,

--- a/src/hypergraph/runners/_shared/node_context.py
+++ b/src/hypergraph/runners/_shared/node_context.py
@@ -43,7 +43,16 @@ class NodeContext:
         result = llm(messages=["hi"], ctx=ctx)
     """
 
-    __slots__ = ("_stop_signal", "_emit_fn", "_node_name", "_run_id")
+    __slots__ = (
+        "_stop_signal",
+        "_emit_fn",
+        "_node_name",
+        "_run_id",
+        "_graph_name",
+        "_workflow_id",
+        "_item_index",
+        "_parent_span_id",
+    )
 
     def __init__(
         self,
@@ -51,11 +60,20 @@ class NodeContext:
         emit_fn: Callable[[Any], None],
         node_name: str,
         run_id: str = "",
+        *,
+        graph_name: str = "",
+        workflow_id: str | None = None,
+        item_index: int | None = None,
+        parent_span_id: str | None = None,
     ) -> None:
         self._stop_signal = stop_signal
         self._emit_fn = emit_fn
         self._node_name = node_name
         self._run_id = run_id
+        self._graph_name = graph_name
+        self._workflow_id = workflow_id
+        self._item_index = item_index
+        self._parent_span_id = parent_span_id
 
     @property
     def stop_requested(self) -> bool:
@@ -74,8 +92,12 @@ class NodeContext:
             self._emit_fn(
                 StreamingChunkEvent(
                     run_id=self._run_id,
+                    parent_span_id=self._parent_span_id,
+                    workflow_id=self._workflow_id,
+                    item_index=self._item_index,
                     chunk=chunk,
                     node_name=self._node_name,
+                    graph_name=self._graph_name,
                 )
             )
 
@@ -94,13 +116,29 @@ def build_node_context(
     node_name: str,
     emit_fn: Callable[[Any], None] | None,
     run_id: str = "",
+    *,
+    graph_name: str = "",
+    workflow_id: str | None = None,
+    item_index: int | None = None,
+    parent_span_id: str | None = None,
 ) -> NodeContext:
     """Build a NodeContext for executor injection.
 
     Reads the StopSignal from the contextvar (set by the runner).
-    Falls back to an unset signal if none is active.
+    Falls back to an unset signal if none is active. The correlation
+    fields (graph_name, workflow_id, item_index, parent_span_id) are
+    stamped onto every ``StreamingChunkEvent`` the node emits.
     """
     from hypergraph.runners._shared.stop import StopSignal, get_stop_signal
 
     signal = get_stop_signal() or StopSignal()
-    return NodeContext(signal, emit_fn or _noop_emit, node_name, run_id=run_id)
+    return NodeContext(
+        signal,
+        emit_fn or _noop_emit,
+        node_name,
+        run_id=run_id,
+        graph_name=graph_name,
+        workflow_id=workflow_id,
+        item_index=item_index,
+        parent_span_id=parent_span_id,
+    )

--- a/src/hypergraph/runners/_shared/protocols.py
+++ b/src/hypergraph/runners/_shared/protocols.py
@@ -2,13 +2,24 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Protocol, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, Protocol, TypeVar, runtime_checkable
 
 if TYPE_CHECKING:
     from hypergraph.nodes.base import HyperNode
     from hypergraph.runners._shared.types import ExecutionContext, GraphState
 
 N = TypeVar("N", bound="HyperNode", contravariant=True)
+
+
+@runtime_checkable
+class CheckpointErrorSinkRunner(Protocol):
+    """Runner that explicitly accepts private checkpoint-error sink kwargs.
+
+    Declaring this marker promises that ``run()`` and ``map()`` both accept
+    ``_checkpoint_error_sink`` and forward every durability gap exactly once.
+    """
+
+    _accepts_checkpoint_error_sink: ClassVar[Literal[True]]
 
 
 class NodeExecutor(Protocol[N]):

--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -48,6 +48,7 @@ from hypergraph.runners._shared.input_normalization import (
 )
 from hypergraph.runners._shared.run_log import RunLogCollector
 from hypergraph.runners._shared.types import (
+    CheckpointErrorSink,
     ErrorHandling,
     GraphState,
     MapResult,
@@ -217,6 +218,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
         _run_config: dict[str, Any] | None = None,
         _complete_on_stop: bool = False,
         _item_index: int | None = None,
+        _checkpoint_error_sink: CheckpointErrorSink | None = None,
         **input_values: Any,
     ) -> RunResult:
         """Execute a graph once."""
@@ -585,6 +587,9 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                 checkpoint_errors=tuple(checkpoint_save_errors),
             )
         finally:
+            if _checkpoint_error_sink is not None:
+                for checkpoint_error in checkpoint_save_errors:
+                    _checkpoint_error_sink(checkpoint_error)
             if _parent_span_id is None and dispatcher.active:
                 await self._shutdown_dispatcher_async(dispatcher)
 
@@ -607,6 +612,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
         _parent_span_id: str | None = None,
         _parent_run_id: str | None = None,
         _item_index: int | None = None,
+        _checkpoint_error_sink: CheckpointErrorSink | None = None,
         **input_values: Any,
     ) -> MapResult:
         """Execute a graph multiple times with different inputs."""
@@ -734,6 +740,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                     _validation_ctx=ctx,
                     _run_config={_MAP_SIGNATURE_CONFIG_KEY: item_signature},
                     _item_index=idx,
+                    _checkpoint_error_sink=_checkpoint_error_sink,
                 )
             except Exception as e:
                 # Catch validation errors (e.g., MissingInputError) that raise

--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -9,7 +9,7 @@ import time
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import AsyncIterator
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 from hypergraph.exceptions import (
     ExecutionError,
@@ -85,6 +85,8 @@ _MAP_SIGNATURE_CONFIG_KEY = "map_item_signature"
 
 class AsyncRunnerTemplate(BaseRunner, ABC):
     """Template implementation for async run/map lifecycle."""
+
+    _accepts_checkpoint_error_sink: ClassVar[Literal[True]] = True
 
     @property
     @abstractmethod
@@ -666,6 +668,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                 f"Too many map tasks without a concurrency limit: {len(input_variations)}. "
                 f"Set max_concurrency or keep inputs at <= {MAX_UNBOUNDED_MAP_TASKS}."
             )
+        item_checkpoint_errors: list[list[str]] = [[] for _ in input_variations]
 
         dispatcher = self._create_dispatcher(event_processors)
         map_run_id, map_span_id = await self._emit_run_start_async(
@@ -740,7 +743,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                     _validation_ctx=ctx,
                     _run_config={_MAP_SIGNATURE_CONFIG_KEY: item_signature},
                     _item_index=idx,
-                    _checkpoint_error_sink=_checkpoint_error_sink,
+                    _checkpoint_error_sink=(item_checkpoint_errors[idx].append if _checkpoint_error_sink is not None else None),
                 )
             except Exception as e:
                 # Catch validation errors (e.g., MissingInputError) that raise
@@ -862,6 +865,10 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                 )
             raise
         finally:
+            if _checkpoint_error_sink is not None:
+                for checkpoint_errors in item_checkpoint_errors:
+                    for checkpoint_error in checkpoint_errors:
+                        _checkpoint_error_sink(checkpoint_error)
             if token is not None:
                 self._reset_concurrency_limiter(token)
             if _parent_span_id is None and dispatcher.active:

--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -402,14 +402,14 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
             )
             output_values = filter_outputs(state, graph, select, on_missing)
             total_duration_ms = (time.time() - start_time) * 1000
-            was_stopped = getattr(state, "_stopped", False)
+            was_stopped = state.stopped
             status = RunStatus.STOPPED if was_stopped else RunStatus.COMPLETED
 
             # Emit StopRequestedEvent if stopped
             if was_stopped and dispatcher.active:
                 from hypergraph.events.types import StopRequestedEvent
 
-                stop_info = getattr(state, "_stop_info", None)
+                stop_info = state.stop_info
                 await dispatcher.emit_async(
                     StopRequestedEvent(
                         run_id=run_id,

--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -459,8 +459,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                 )
             return result
         except PauseExecution as pause:
-            partial_state = getattr(pause, "_partial_state", None)
-            was_stopped = getattr(pause, "_stopped", False)
+            partial_state = pause.partial_state
             partial_values = filter_outputs(partial_state, graph, select) if partial_state is not None else {}
             total_duration_ms = (time.time() - start_time) * 1000
             if dispatcher.active:
@@ -515,7 +514,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
             )
         except Exception as e:
             error = e
-            partial_state = getattr(e, "_partial_state", None)
+            partial_state = None
             if isinstance(e, ExecutionError):
                 error = e.__cause__ or e
                 partial_state = e.partial_state

--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -117,10 +117,16 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
         workflow_id: str | None = None,
         checkpoint: Any | None = None,
         step_buffer: list[Any] | None = None,
+        checkpoint_save_errors: list[str] | None = None,
         _complete_on_stop: bool = False,
         item_index: int | None = None,
     ) -> GraphState:
-        """Execute graph and return final state."""
+        """Execute graph and return final state.
+
+        ``checkpoint_save_errors`` is a caller-owned sink: implementations
+        append string reprs of background step-save failures (durability
+        "async") so the template can surface them on the RunResult.
+        """
         ...
 
     @abstractmethod
@@ -383,6 +389,9 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
 
         # Step buffer for "exit" durability — records are flushed after run completes
         step_buffer: list[Any] = []
+        # Sink for background step-save failures ("async" durability) —
+        # surfaced as result.checkpoint_ok / result.checkpoint_errors.
+        checkpoint_save_errors: list[str] = []
 
         try:
             state = await self._execute_graph_impl_async(
@@ -397,6 +406,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                 workflow_id=workflow_id,
                 checkpoint=resume_checkpoint,
                 step_buffer=step_buffer,
+                checkpoint_save_errors=checkpoint_save_errors,
                 _complete_on_stop=_complete_on_stop,
                 item_index=_item_index,
             )
@@ -428,6 +438,8 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                 run_id=run_id,
                 workflow_id=workflow_id,
                 log=collector.build(graph.name, run_id, total_duration_ms),
+                checkpoint_ok=not checkpoint_save_errors,
+                checkpoint_errors=tuple(checkpoint_save_errors),
             )
             await self._emit_run_end_async(
                 dispatcher,
@@ -511,6 +523,8 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                 workflow_id=workflow_id,
                 pause=pause.pause_info,
                 log=collector.build(graph.name, run_id, total_duration_ms),
+                checkpoint_ok=not checkpoint_save_errors,
+                checkpoint_errors=tuple(checkpoint_save_errors),
             )
         except Exception as e:
             error = e
@@ -567,6 +581,8 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                 workflow_id=workflow_id,
                 error=error,
                 log=collector.build(graph.name, run_id, total_duration_ms),
+                checkpoint_ok=not checkpoint_save_errors,
+                checkpoint_errors=tuple(checkpoint_save_errors),
             )
         finally:
             if _parent_span_id is None and dispatcher.active:

--- a/src/hypergraph/runners/_shared/template_sync.py
+++ b/src/hypergraph/runners/_shared/template_sync.py
@@ -389,14 +389,14 @@ class SyncRunnerTemplate(BaseRunner, ABC):
             )
             output_values = filter_outputs(state, graph, select, on_missing)
             total_duration_ms = (time.time() - start_time) * 1000
-            was_stopped = getattr(state, "_stopped", False)
+            was_stopped = state.stopped
             status = RunStatus.STOPPED if was_stopped else RunStatus.COMPLETED
 
             # Emit StopRequestedEvent if stopped
             if was_stopped and dispatcher.active:
                 from hypergraph.events.types import StopRequestedEvent
 
-                stop_info = getattr(state, "_stop_info", None)
+                stop_info = state.stop_info
                 dispatcher.emit(
                     StopRequestedEvent(
                         run_id=run_id,

--- a/src/hypergraph/runners/_shared/template_sync.py
+++ b/src/hypergraph/runners/_shared/template_sync.py
@@ -443,7 +443,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
                 )
             return result
         except PauseExecution as pause:
-            partial_state = getattr(pause, "_partial_state", None)
+            partial_state = pause.partial_state
             partial_values = filter_outputs(partial_state, graph, select) if partial_state is not None else {}
             total_duration_ms = (time.time() - start_time) * 1000
             if dispatcher.active:
@@ -498,7 +498,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
             )
         except Exception as e:
             error = e
-            partial_state = getattr(e, "_partial_state", None)
+            partial_state = None
             if isinstance(e, ExecutionError):
                 error = e.__cause__ or e
                 partial_state = e.partial_state

--- a/src/hypergraph/runners/_shared/types.py
+++ b/src/hypergraph/runners/_shared/types.py
@@ -666,10 +666,25 @@ class PauseExecution(BaseException):
     catches it and re-raises with a prefixed node_name (e.g.
     ``"outer/inner/interrupt_node"``), propagating the pause up
     through arbitrarily deep nesting.
+
+    Attributes:
+        pause_info: Details about the interrupt that paused the run.
+        partial_state: GraphState accumulated before the pause. Attached by
+            the runner as the pause propagates; None until then.
+        stopped: Whether a cooperative stop was also requested when the
+            pause propagated.
+        span_id: Span of the interrupt node, set by the superstep.
     """
 
-    def __init__(self, pause_info: PauseInfo):
+    def __init__(
+        self,
+        pause_info: PauseInfo,
+        partial_state: GraphState | None = None,
+        stopped: bool = False,
+    ):
         self.pause_info = pause_info
+        self.partial_state = partial_state
+        self.stopped = stopped
         self.span_id: str | None = None
         super().__init__(f"Paused at {pause_info.node_name}")
 

--- a/src/hypergraph/runners/_shared/types.py
+++ b/src/hypergraph/runners/_shared/types.py
@@ -706,7 +706,10 @@ class RunnerCapabilities:
         supports_cycles: Can execute graphs with cycles (default: True)
         supports_gates: Can execute graphs with gate nodes (default: True)
         supports_async_nodes: Can execute async nodes (default: False)
-        supports_streaming: Supports .iter() streaming (default: False)
+        supports_streaming: Streams results incrementally — per-item
+            yielding via map_iter() and StreamingChunkEvent emission from
+            ctx.stream() (default: False). SyncRunner and AsyncRunner set
+            this to True.
         supports_events: Supports event processors (default: True)
         supports_distributed: Can distribute across workers (default: False)
         returns_coroutine: run() returns a coroutine (default: False)

--- a/src/hypergraph/runners/_shared/types.py
+++ b/src/hypergraph/runners/_shared/types.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from hypergraph.events.processor import EventProcessor
 
 ErrorHandling = Literal["raise", "continue"]
+CheckpointErrorSink = Callable[[str], None]
 
 _MAX_STRING_PREVIEW = 120
 _MAX_SEQUENCE_PREVIEW = 6
@@ -221,10 +222,16 @@ class RunResult:
     def summary(self) -> str:
         """One-line overview: 'completed | 3 nodes | 12ms' or 'failed: ValueError'."""
         if self.log:
-            return self.log.summary()
-        if self.error:
-            return f"{self.status.value}: {type(self.error).__name__}: {self.error}"
-        return self.status.value
+            summary = self.log.summary()
+        elif self.error:
+            summary = f"{self.status.value}: {type(self.error).__name__}: {self.error}"
+        else:
+            summary = self.status.value
+        if not self.checkpoint_ok:
+            error_count = len(self.checkpoint_errors)
+            detail = f" ({plural(error_count, 'save error')})" if error_count else ""
+            summary += f" | checkpoint gap{detail}"
+        return summary
 
     def to_dict(self) -> dict[str, Any]:
         """JSON-serializable dict with status, run_id, and log.
@@ -236,6 +243,8 @@ class RunResult:
             "status": self.status.value,
             "run_id": self.run_id,
             "workflow_id": self.workflow_id,
+            "checkpoint_ok": self.checkpoint_ok,
+            "checkpoint_errors": list(self.checkpoint_errors),
         }
         if self.log:
             d["log"] = self.log.to_dict()
@@ -257,6 +266,9 @@ class RunResult:
 
     def __repr__(self) -> str:
         """Compact repr to avoid extremely large notebook output."""
+        checkpoint = ""
+        if not self.checkpoint_ok:
+            checkpoint = f", checkpoint_ok=False, checkpoint_errors={_compact_value(self.checkpoint_errors)}"
         text = (
             "RunResult("
             f"status={self.status.value}, "
@@ -265,6 +277,7 @@ class RunResult:
             f"workflow_id={self.workflow_id!r}, "
             f"error={_compact_value(self.error)}, "
             f"pause={_compact_value(self.pause)}"
+            f"{checkpoint}"
             ")"
         )
         return _truncate_text(text, _MAX_RUN_RESULT_REPR)
@@ -301,6 +314,10 @@ class RunResult:
             n_errors = len(self.log.errors)
             if n_errors:
                 kvs.append(html_kv("Errors", f'<span style="color:{ERROR_COLOR}">{n_errors}</span>'))
+        if not self.checkpoint_ok:
+            error_count = len(self.checkpoint_errors)
+            detail = f" ({plural(error_count, 'save error')})" if error_count else ""
+            kvs.append(html_kv("Checkpoint", f'<span style="color:{ERROR_COLOR}">gap{detail}</span>'))
         kvs.append(html_kv("Values", plural(len(self.values), "key")))
         body = " &nbsp;|&nbsp; ".join(kvs)
         if self.error:
@@ -310,6 +327,12 @@ class RunResult:
                 f"Values ({plural(len(self.values), 'key')})",
                 values_html(self.values),
                 state_key="values",
+            )
+        if self.checkpoint_errors:
+            body += html_detail(
+                f"Checkpoint errors ({plural(len(self.checkpoint_errors), 'save error')})",
+                values_html({str(index): error for index, error in enumerate(self.checkpoint_errors)}),
+                state_key="checkpoint-errors",
             )
         if self.log:
             body += html_detail("Run Log", self.log._repr_html_(), state_key="run-log")
@@ -413,6 +436,21 @@ class MapResult:
         return [r for r in self.results if r.status == RunStatus.FAILED]
 
     @property
+    def checkpoint_ok(self) -> bool:
+        """Whether every item persisted all best-effort async checkpoints."""
+        return all(result.checkpoint_ok for result in self.results)
+
+    @property
+    def checkpoint_errors(self) -> tuple[str, ...]:
+        """Checkpoint-save errors flattened in stable item order."""
+        return tuple(error for result in self.results for error in result.checkpoint_errors)
+
+    @property
+    def _checkpoint_gap_count(self) -> int:
+        """Number of items with incomplete best-effort checkpoint persistence."""
+        return sum(1 for result in self.results if not result.checkpoint_ok)
+
+    @property
     def log(self) -> MapLog:
         """Batch-level execution trace."""
         return MapLog(
@@ -447,6 +485,9 @@ class MapResult:
             status_parts.append(f"{n_stopped} stopped")
         if status_parts:
             parts.append(", ".join(status_parts))
+        checkpoint_gap_count = self._checkpoint_gap_count
+        if checkpoint_gap_count:
+            parts.append(f"{plural(checkpoint_gap_count, 'item')} with checkpoint gaps")
         if n_completed > 0:
             completed_items = [r for r in self.results if r.status == RunStatus.COMPLETED]
             completed_ms = sum(r.log.total_duration_ms for r in completed_items if r.log)
@@ -464,6 +505,8 @@ class MapResult:
             "map_over": list(self.map_over),
             "map_mode": self.map_mode,
             "graph_name": self.graph_name,
+            "checkpoint_ok": self.checkpoint_ok,
+            "checkpoint_errors": list(self.checkpoint_errors),
             "item_count": len(self.results),
             "completed_count": n_completed,
             "failed_count": n_failed,
@@ -486,13 +529,15 @@ class MapResult:
         if n_stopped:
             parts.append(f"{n_stopped} stopped")
         status = ", ".join(parts) if parts else "empty"
+        checkpoint_gap_count = self._checkpoint_gap_count
+        checkpoint_part = f", {plural(checkpoint_gap_count, 'item')} with checkpoint gaps" if checkpoint_gap_count else ""
         avg_part = ""
         if n_completed > 0:
             completed_items = [r for r in self.results if r.status == RunStatus.COMPLETED]
             completed_ms = sum(r.log.total_duration_ms for r in completed_items if r.log)
             avg = completed_ms / n_completed
             avg_part = f", avg {_format_duration(avg)}/item"
-        return f"MapResult({plural(n, 'item')}: {status}{avg_part}, map_over={self.map_over!r})"
+        return f"MapResult({plural(n, 'item')}: {status}{checkpoint_part}{avg_part}, map_over={self.map_over!r})"
 
     def _repr_pretty_(self, pretty_printer: Any, cycle: bool) -> None:
         if cycle:
@@ -527,6 +572,14 @@ class MapResult:
             kvs.append(html_kv("Completed", str(n_completed)))
         if n_failed:
             kvs.append(html_kv("Failed", f'<span style="color:{ERROR_COLOR}">{n_failed}</span>'))
+        checkpoint_gap_count = self._checkpoint_gap_count
+        if checkpoint_gap_count:
+            kvs.append(
+                html_kv(
+                    "Checkpoint gaps",
+                    f'<span style="color:{ERROR_COLOR}">{plural(checkpoint_gap_count, "item")}</span>',
+                )
+            )
         if n_completed > 0:
             completed_items = [r for r in self.results if r.status == RunStatus.COMPLETED]
             completed_ms = sum(r.log.total_duration_ms for r in completed_items if r.log)
@@ -748,6 +801,7 @@ class ExecutionContext:
     provided_values: dict[str, Any] = field(default_factory=dict)
     is_resuming: bool = False
     on_inner_log: Callable[[RunLog], None] | None = None
+    checkpoint_error_sink: CheckpointErrorSink | None = None
     emit_fn: Callable[[Any], None] | None = None
 
 

--- a/src/hypergraph/runners/_shared/types.py
+++ b/src/hypergraph/runners/_shared/types.py
@@ -762,6 +762,10 @@ class GraphState:
         versions: Version number for each value (incremented on update)
         node_executions: History of node executions (for staleness detection)
         routing_decisions: Routing decisions made by gate nodes
+        stopped: Whether a cooperative stop was requested during this run.
+            Runtime-only: checkpoint restores start fresh (False).
+        stop_info: Optional metadata passed to ``runner.stop(info=...)``.
+            Runtime-only: checkpoint restores start fresh (None).
     """
 
     values: dict[str, Any] = field(default_factory=dict)
@@ -769,6 +773,8 @@ class GraphState:
     node_executions: dict[str, NodeExecution] = field(default_factory=dict)
     routing_decisions: dict[str, Any] = field(default_factory=dict)
     resume_values: frozenset[str] = frozenset()
+    stopped: bool = False
+    stop_info: Any = None
 
     def update_value(self, name: str, value: Any) -> None:
         """Update a value and increment its version if value changed.
@@ -831,6 +837,8 @@ class GraphState:
             },
             routing_decisions=dict(self.routing_decisions),
             resume_values=frozenset(self.resume_values),
+            stopped=self.stopped,
+            stop_info=self.stop_info,
         )
 
 

--- a/src/hypergraph/runners/_shared/types.py
+++ b/src/hypergraph/runners/_shared/types.py
@@ -181,6 +181,11 @@ class RunResult:
         error: Exception if status is FAILED, else None
         pause: PauseInfo if status is PAUSED, else None
         log: RunLog with execution trace (timing, status, routing), or None
+        checkpoint_ok: False when background checkpoint step-saves failed
+            under ``durability="async"`` (best-effort persistence). The run
+            itself still completes; check this flag to detect gaps in the
+            persisted history.
+        checkpoint_errors: String reprs of failed background step-saves.
     """
 
     values: dict[str, Any]
@@ -190,6 +195,8 @@ class RunResult:
     error: BaseException | None = None
     pause: PauseInfo | None = None
     log: RunLog | None = None
+    checkpoint_ok: bool = True
+    checkpoint_errors: tuple[str, ...] = ()
 
     @property
     def stopped(self) -> bool:

--- a/src/hypergraph/runners/async_/executors/function_node.py
+++ b/src/hypergraph/runners/async_/executors/function_node.py
@@ -73,7 +73,15 @@ class AsyncFunctionNodeExecutor:
         if getattr(node, "_context_param", None) is not None:
             from hypergraph.runners._shared.node_context import build_node_context
 
-            func_inputs[node._context_param] = build_node_context(node.name, ctx.emit_fn, run_id=ctx.run_id)
+            func_inputs[node._context_param] = build_node_context(
+                node.name,
+                ctx.emit_fn,
+                run_id=ctx.run_id,
+                graph_name=ctx.graph_name,
+                workflow_id=ctx.workflow_id,
+                item_index=ctx.item_index,
+                parent_span_id=ctx.parent_span_id,
+            )
 
         # Call the function (with cache observer installed for hypercache telemetry)
         emit_fn = ctx.emit_fn if ctx.emit_fn is not None else lambda _: None

--- a/src/hypergraph/runners/async_/executors/graph_node.py
+++ b/src/hypergraph/runners/async_/executors/graph_node.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import inspect
 from typing import TYPE_CHECKING, Any
 
+from hypergraph.exceptions import IncompatibleRunnerError
 from hypergraph.runners._shared.helpers import collect_as_lists, graphnode_child_workflow_id, map_inputs_to_func_params
-from hypergraph.runners._shared.template_async import AsyncRunnerTemplate
+from hypergraph.runners._shared.protocols import CheckpointErrorSinkRunner
 from hypergraph.runners._shared.types import PauseExecution, PauseInfo, RunResult, RunStatus
 
 if TYPE_CHECKING:
@@ -118,6 +119,23 @@ class AsyncGraphNodeExecutor:
 
         # Use delegated runner if configured, otherwise inherit parent
         runner = node.runner_override or self.runner
+        accepts_checkpoint_error_sink = isinstance(runner, CheckpointErrorSinkRunner) and runner._accepts_checkpoint_error_sink is True
+        if (
+            ctx.checkpoint_error_sink is not None
+            and runner.capabilities.returns_coroutine
+            and runner.capabilities.supports_checkpointing
+            and not accepts_checkpoint_error_sink
+        ):
+            raise IncompatibleRunnerError(
+                f"GraphNode {node.name!r} uses checkpoint-capable async runner "
+                f"{type(runner).__name__}, but that runner does not declare "
+                f"checkpoint error forwarding. Nested durability failures could be lost.\n\n"
+                f"How to fix: use AsyncRunner, or declare "
+                f"_accepts_checkpoint_error_sink = True and accept "
+                f"_checkpoint_error_sink in both run() and map().",
+                node_name=node.name,
+                capability="checkpoint_error_sink",
+            )
 
         if map_config:
             _, mode, error_handling = map_config
@@ -137,7 +155,7 @@ class AsyncGraphNodeExecutor:
             }
             if getattr(node, "_complete_on_stop", False):
                 map_kwargs["_complete_on_stop"] = True
-            if ctx.checkpoint_error_sink is not None and isinstance(runner, AsyncRunnerTemplate):
+            if ctx.checkpoint_error_sink is not None and accepts_checkpoint_error_sink:
                 map_kwargs["_checkpoint_error_sink"] = ctx.checkpoint_error_sink
             map_call = runner.map(node.graph, inner_inputs, **map_kwargs)
             # Delegated runner may be sync (e.g. DaftRunner) — await only if needed
@@ -162,7 +180,7 @@ class AsyncGraphNodeExecutor:
             run_kwargs["retry_from"] = child_retry_from
         if getattr(node, "_complete_on_stop", False):
             run_kwargs["_complete_on_stop"] = True
-        if ctx.checkpoint_error_sink is not None and isinstance(runner, AsyncRunnerTemplate):
+        if ctx.checkpoint_error_sink is not None and accepts_checkpoint_error_sink:
             run_kwargs["_checkpoint_error_sink"] = ctx.checkpoint_error_sink
 
         run_call = runner.run(node.graph, inner_inputs, **run_kwargs)

--- a/src/hypergraph/runners/async_/executors/graph_node.py
+++ b/src/hypergraph/runners/async_/executors/graph_node.py
@@ -6,6 +6,7 @@ import inspect
 from typing import TYPE_CHECKING, Any
 
 from hypergraph.runners._shared.helpers import collect_as_lists, graphnode_child_workflow_id, map_inputs_to_func_params
+from hypergraph.runners._shared.template_async import AsyncRunnerTemplate
 from hypergraph.runners._shared.types import PauseExecution, PauseInfo, RunResult, RunStatus
 
 if TYPE_CHECKING:
@@ -136,6 +137,8 @@ class AsyncGraphNodeExecutor:
             }
             if getattr(node, "_complete_on_stop", False):
                 map_kwargs["_complete_on_stop"] = True
+            if ctx.checkpoint_error_sink is not None and isinstance(runner, AsyncRunnerTemplate):
+                map_kwargs["_checkpoint_error_sink"] = ctx.checkpoint_error_sink
             map_call = runner.map(node.graph, inner_inputs, **map_kwargs)
             # Delegated runner may be sync (e.g. DaftRunner) — await only if needed
             results = await map_call if inspect.isawaitable(map_call) else map_call
@@ -159,6 +162,8 @@ class AsyncGraphNodeExecutor:
             run_kwargs["retry_from"] = child_retry_from
         if getattr(node, "_complete_on_stop", False):
             run_kwargs["_complete_on_stop"] = True
+        if ctx.checkpoint_error_sink is not None and isinstance(runner, AsyncRunnerTemplate):
+            run_kwargs["_checkpoint_error_sink"] = ctx.checkpoint_error_sink
 
         run_call = runner.run(node.graph, inner_inputs, **run_kwargs)
         # Delegated runner may be sync (e.g. DaftRunner) — await only if needed

--- a/src/hypergraph/runners/async_/runner.py
+++ b/src/hypergraph/runners/async_/runner.py
@@ -380,8 +380,8 @@ class AsyncRunner(AsyncRunnerTemplate):
                 reset_concurrency_limiter(token)
 
         # Propagate stopped flag to the template layer
-        state._stopped = signal.is_set  # type: ignore[attr-defined]
-        state._stop_info = signal.info  # type: ignore[attr-defined]
+        state.stopped = signal.is_set
+        state.stop_info = signal.info
         return state
 
     async def _save_superstep_records(

--- a/src/hypergraph/runners/async_/runner.py
+++ b/src/hypergraph/runners/async_/runner.py
@@ -300,7 +300,9 @@ class AsyncRunner(AsyncRunnerTemplate):
                         run_span_id=run_span_id,
                         superstep_idx=superstep_idx,
                     )
-                except PauseExecution:
+                except PauseExecution as pause:
+                    if pause.partial_state is not None:
+                        state = pause.partial_state
                     # Save step records before propagating the pause.
                     # The interrupt node gets a "paused" status record.
                     if has_checkpointer:

--- a/src/hypergraph/runners/async_/runner.py
+++ b/src/hypergraph/runners/async_/runner.py
@@ -349,8 +349,8 @@ class AsyncRunner(AsyncRunnerTemplate):
                 superstep_idx += 1
 
         except PauseExecution as pause:
-            pause._partial_state = state  # type: ignore[attr-defined]
-            pause._stopped = signal.is_set  # type: ignore[attr-defined]
+            pause.partial_state = state
+            pause.stopped = signal.is_set
             raise
         finally:
             # Clean up signal registry

--- a/src/hypergraph/runners/async_/runner.py
+++ b/src/hypergraph/runners/async_/runner.py
@@ -226,6 +226,7 @@ class AsyncRunner(AsyncRunnerTemplate):
                 item_index=item_index,
                 provided_values=values,
                 is_resuming=(checkpoint is not None if self._checkpointer_instance is not None else True),
+                checkpoint_error_sink=checkpoint_save_errors.append if checkpoint_save_errors is not None else None,
                 emit_fn=dispatcher.emit if dispatcher.active else None,
             )
 

--- a/src/hypergraph/runners/async_/runner.py
+++ b/src/hypergraph/runners/async_/runner.py
@@ -171,12 +171,15 @@ class AsyncRunner(AsyncRunnerTemplate):
         workflow_id: str | None = None,
         checkpoint: Any | None = None,
         step_buffer: list[Any] | None = None,
+        checkpoint_save_errors: list[str] | None = None,
         _complete_on_stop: bool = False,
         item_index: int | None = None,
     ) -> GraphState:
         """Execute graph until no more ready nodes or max_iterations reached.
 
         On failure, raises ExecutionError wrapping the cause and partial state.
+        Background step-save failures (durability "async") are appended to
+        ``checkpoint_save_errors`` as string reprs for the template to surface.
         """
         state = initialize_state(graph, values, checkpoint=checkpoint)
         scope = compute_execution_scope(graph)
@@ -368,6 +371,8 @@ class AsyncRunner(AsyncRunnerTemplate):
                 results = await asyncio.gather(*save_tasks, return_exceptions=True)
                 failures = [r for r in results if isinstance(r, BaseException)]
                 if failures:
+                    if checkpoint_save_errors is not None:
+                        checkpoint_save_errors.extend(repr(f) for f in failures)
                     import logging
 
                     logger = logging.getLogger("hypergraph.checkpointers")

--- a/src/hypergraph/runners/async_/runner.py
+++ b/src/hypergraph/runners/async_/runner.py
@@ -18,7 +18,13 @@ from hypergraph.runners._shared.event_metadata import (
     RunContext,
     RunLineage,
 )
-from hypergraph.runners._shared.helpers import ExecutionFrontier, compute_execution_scope, graphnode_child_workflow_id, initialize_state
+from hypergraph.runners._shared.helpers import (
+    ExecutionFrontier,
+    compute_execution_scope,
+    graphnode_child_workflow_id,
+    initialize_state,
+    plan_interrupt_batch,
+)
 from hypergraph.runners._shared.protocols import AsyncNodeExecutor
 from hypergraph.runners._shared.stop import StopSignal, get_stop_signal, reset_stop_signal, set_stop_signal
 from hypergraph.runners._shared.template_async import AsyncRunnerTemplate
@@ -239,9 +245,9 @@ class AsyncRunner(AsyncRunnerTemplate):
                 if not ready_nodes:
                     continue
 
-                interrupts = [node for node in ready_nodes if node.is_interrupt]
-                if interrupts:
-                    ready_nodes = [interrupts[0]]
+                # Isolate interrupts BEFORE ready_node_names is captured below,
+                # so checkpoint metadata records exactly the executed batch.
+                ready_nodes = plan_interrupt_batch(ready_nodes)
 
                 if dispatcher.active:
                     from hypergraph.events.types import SuperstepStartEvent, _generate_span_id

--- a/src/hypergraph/runners/async_/runner.py
+++ b/src/hypergraph/runners/async_/runner.py
@@ -314,9 +314,9 @@ class AsyncRunner(AsyncRunnerTemplate):
                     raise
                 except ExecutionError as e:
                     superstep_error = e
-                    state = e.partial_state  # type: ignore[assignment]
-                    attempted_node_names = getattr(e, "_attempted_node_names", None)
-                    node_errors = getattr(e, "_node_errors", None)
+                    state = e.partial_state
+                    attempted_node_names = e.attempted_node_names
+                    node_errors = e.node_errors
                 except Exception as e:
                     superstep_error = ExecutionError(e, state)
                     attempted_node_names = ()

--- a/src/hypergraph/runners/async_/superstep.py
+++ b/src/hypergraph/runners/async_/superstep.py
@@ -269,11 +269,14 @@ async def run_superstep_async(
 
     # Separate successes from failures, applying successful outputs first
     first_error: BaseException | None = None
+    control_flow_error: BaseException | None = None
     node_errors: dict[str, BaseException] = {}
     for node, result in zip(ready_nodes, results, strict=True):
         if isinstance(result, BaseException):
             if first_error is None:
                 first_error = result
+            if control_flow_error is None and not isinstance(result, Exception):
+                control_flow_error = result
             node_errors[node.name] = result
             continue
         node, outputs, input_versions, wait_for_versions, duration_ms, cached = result
@@ -288,17 +291,13 @@ async def run_superstep_async(
             cached=cached,
         )
 
+    if control_flow_error is not None:
+        # Pause/cancellation/system-exit control flow must not be hidden by an
+        # ordinary Exception that happened to appear earlier in graph order.
+        raise control_flow_error
+
     if first_error is not None:
-        # PauseExecution (BaseException) must propagate unwrapped for the
-        # runner's except PauseExecution handler to work
-        if not isinstance(first_error, Exception):
-            raise first_error
         attempted = tuple(node.name for node in ready_nodes)
-        if isinstance(first_error, ExecutionError):
-            # Re-attribute an inner ExecutionError to this superstep's batch.
-            first_error.attempted_node_names = attempted
-            first_error.node_errors = node_errors
-            raise first_error
         error = ExecutionError(
             first_error,
             new_state,

--- a/src/hypergraph/runners/async_/superstep.py
+++ b/src/hypergraph/runners/async_/superstep.py
@@ -294,6 +294,8 @@ async def run_superstep_async(
     if control_flow_error is not None:
         # Pause/cancellation/system-exit control flow must not be hidden by an
         # ordinary Exception that happened to appear earlier in graph order.
+        if isinstance(control_flow_error, PauseExecution):
+            control_flow_error.partial_state = new_state
         raise control_flow_error
 
     if first_error is not None:

--- a/src/hypergraph/runners/async_/superstep.py
+++ b/src/hypergraph/runners/async_/superstep.py
@@ -297,11 +297,18 @@ async def run_superstep_async(
         # runner's except PauseExecution handler to work
         if not isinstance(first_error, Exception):
             raise first_error
-        error = first_error if isinstance(first_error, ExecutionError) else ExecutionError(first_error, new_state)
-        error._attempted_node_names = tuple(node.name for node in ready_nodes)  # type: ignore[attr-defined]
-        error._node_errors = node_errors  # type: ignore[attr-defined]
-        if error is first_error:
-            raise error
+        attempted = tuple(node.name for node in ready_nodes)
+        if isinstance(first_error, ExecutionError):
+            # Re-attribute an inner ExecutionError to this superstep's batch.
+            first_error.attempted_node_names = attempted
+            first_error.node_errors = node_errors
+            raise first_error
+        error = ExecutionError(
+            first_error,
+            new_state,
+            attempted_node_names=attempted,
+            node_errors=node_errors,
+        )
         raise error from first_error
 
     return new_state

--- a/src/hypergraph/runners/async_/superstep.py
+++ b/src/hypergraph/runners/async_/superstep.py
@@ -94,13 +94,9 @@ async def run_superstep_async(
     new_state = state.copy()
     active = dispatcher is not None and dispatcher.active
 
-    # Execute interrupt nodes alone (not concurrently with other nodes).
-    # PauseExecution extends BaseException, so if raised inside asyncio.gather
-    # it cancels all sibling tasks. By isolating interrupt nodes, other ready
-    # nodes are deferred to the next superstep where they'll still be ready.
-    interrupts = [n for n in ready_nodes if n.is_interrupt]
-    if interrupts:
-        ready_nodes = [interrupts[0]]
+    # Interrupt isolation happens in the runner (plan_interrupt_batch in
+    # _shared/helpers.py) BEFORE checkpoint metadata captures the batch —
+    # ready_nodes arrives here already planned.
 
     async def execute_one(
         node: HyperNode,

--- a/src/hypergraph/runners/sync/executors/function_node.py
+++ b/src/hypergraph/runners/sync/executors/function_node.py
@@ -48,7 +48,15 @@ class SyncFunctionNodeExecutor:
         if getattr(node, "_context_param", None) is not None:
             from hypergraph.runners._shared.node_context import build_node_context
 
-            func_inputs[node._context_param] = build_node_context(node.name, ctx.emit_fn, run_id=ctx.run_id)
+            func_inputs[node._context_param] = build_node_context(
+                node.name,
+                ctx.emit_fn,
+                run_id=ctx.run_id,
+                graph_name=ctx.graph_name,
+                workflow_id=ctx.workflow_id,
+                item_index=ctx.item_index,
+                parent_span_id=ctx.parent_span_id,
+            )
 
         # Call the function (with cache observer installed for hypercache telemetry)
         emit_fn = ctx.emit_fn if ctx.emit_fn is not None else lambda _: None

--- a/src/hypergraph/runners/sync/runner.py
+++ b/src/hypergraph/runners/sync/runner.py
@@ -293,8 +293,8 @@ class SyncRunner(SyncRunnerTemplate):
                 self._active_signals.pop(workflow_id, None)
 
         # Propagate stopped flag to the template layer
-        state._stopped = signal.is_set  # type: ignore[attr-defined]
-        state._stop_info = signal.info  # type: ignore[attr-defined]
+        state.stopped = signal.is_set
+        state.stop_info = signal.info
         return state
 
     # Template hook implementations

--- a/src/hypergraph/runners/sync/runner.py
+++ b/src/hypergraph/runners/sync/runner.py
@@ -254,9 +254,9 @@ class SyncRunner(SyncRunnerTemplate):
                     )
                 except ExecutionError as e:
                     superstep_error = e
-                    state = e.partial_state  # type: ignore[assignment]
-                    attempted_node_names = getattr(e, "_attempted_node_names", None)
-                    node_errors = getattr(e, "_node_errors", None)
+                    state = e.partial_state
+                    attempted_node_names = e.attempted_node_names
+                    node_errors = e.node_errors
                 except Exception as e:
                     superstep_error = ExecutionError(e, state)
                     attempted_node_names = ()

--- a/src/hypergraph/runners/sync/superstep.py
+++ b/src/hypergraph/runners/sync/superstep.py
@@ -78,9 +78,12 @@ def run_superstep_sync(
         try:
             inputs = collect_inputs_for_node(node, graph, state, provided_values)
         except Exception as e:
-            error = ExecutionError(e, new_state)
-            error._attempted_node_names = tuple(attempted_node_names)  # type: ignore[attr-defined]
-            error._node_errors = {node.name: e}  # type: ignore[attr-defined]
+            error = ExecutionError(
+                e,
+                new_state,
+                attempted_node_names=tuple(attempted_node_names),
+                node_errors={node.name: e},
+            )
             raise error from e
 
         # Record input versions under the same parent-facing key the staleness
@@ -241,9 +244,12 @@ def run_superstep_sync(
                     raise
                 # Wrap only Exception subclasses
                 if isinstance(e, Exception):
-                    error = ExecutionError(e, new_state)
-                    error._attempted_node_names = tuple(attempted_node_names)  # type: ignore[attr-defined]
-                    error._node_errors = {node.name: e}  # type: ignore[attr-defined]
+                    error = ExecutionError(
+                        e,
+                        new_state,
+                        attempted_node_names=tuple(attempted_node_names),
+                        node_errors={node.name: e},
+                    )
                     raise error from e
                 # Re-raise other BaseExceptions (KeyboardInterrupt, SystemExit, etc.)
                 raise

--- a/tests/test_checkpointer/test_async_durability_visibility.py
+++ b/tests/test_checkpointer/test_async_durability_visibility.py
@@ -8,12 +8,15 @@ fails the run (pinned existing behavior, sync AND async runner flavors).
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
-from hypergraph import AsyncRunner, Graph, SyncRunner, node
+from hypergraph import AsyncRunner, Graph, RunStatus, SyncRunner, interrupt, node
 from hypergraph.checkpointers import MemoryCheckpointer, SqliteCheckpointer
 from hypergraph.checkpointers.base import CheckpointPolicy
 from hypergraph.checkpointers.types import StepRecord
+from hypergraph.runners._shared.node_context import NodeContext
 
 
 @node(output_name="doubled")
@@ -31,6 +34,23 @@ class FailingSaveCheckpointer(MemoryCheckpointer):
     async def save_step(self, record: StepRecord) -> None:
         self.save_attempts += 1
         raise RuntimeError("disk full")
+
+
+class ChildOnlyFailingSaveCheckpointer(MemoryCheckpointer):
+    """Fail step writes below the parent workflow, but persist parent steps."""
+
+    async def save_step(self, record: StepRecord) -> None:
+        if "/" in record.run_id:
+            raise RuntimeError(f"disk full for {record.run_id}")
+        await super().save_step(record)
+
+
+def _assert_nested_checkpoint_failures(result, *run_ids: str) -> None:
+    expected = {f"RuntimeError('disk full for {run_id}')" for run_id in run_ids}
+    assert result.checkpoint_ok is False
+    assert set(result.checkpoint_errors) == expected
+    assert len(result.checkpoint_errors) == len(expected)
+    assert all(isinstance(error, str) for error in result.checkpoint_errors)
 
 
 class TestAsyncDurabilityBestEffort:
@@ -62,6 +82,114 @@ class TestAsyncDurabilityBestEffort:
 
     async def test_no_checkpointer_defaults_checkpoint_ok(self):
         result = await AsyncRunner().run(Graph([double]), {"x": 5})
+        assert result.checkpoint_ok is True
+        assert result.checkpoint_errors == ()
+
+
+class TestNestedAsyncDurabilityBestEffort:
+    async def test_deeply_nested_graph_completion_surfaces_each_child_failure_once(self):
+        checkpointer = ChildOnlyFailingSaveCheckpointer()
+        runner = AsyncRunner(checkpointer=checkpointer)
+        leaf = Graph([double], name="leaf")
+        middle = Graph([leaf.as_node()], name="middle")
+        outer = Graph([middle.as_node()], name="outer")
+
+        result = await runner.run(outer, {"x": 5}, workflow_id="wf-nested")
+
+        assert result.completed
+        assert result["doubled"] == 10
+        _assert_nested_checkpoint_failures(
+            result,
+            "wf-nested/middle",
+            "wf-nested/middle/leaf",
+        )
+
+    async def test_mapped_graph_completion_surfaces_child_failures(self):
+        checkpointer = ChildOnlyFailingSaveCheckpointer()
+        runner = AsyncRunner(checkpointer=checkpointer)
+        inner = Graph([double], name="inner")
+        outer = Graph([inner.as_node().map_over("x")], name="outer")
+
+        result = await runner.run(outer, {"x": [2, 3]}, workflow_id="wf-mapped")
+
+        assert result.completed
+        assert result["doubled"] == [4, 6]
+        _assert_nested_checkpoint_failures(
+            result,
+            "wf-mapped/inner/0",
+            "wf-mapped/inner/1",
+        )
+
+    async def test_nested_pause_surfaces_child_failure(self):
+        @interrupt(output_name="decision")
+        def approval(draft: str) -> str: ...
+
+        checkpointer = ChildOnlyFailingSaveCheckpointer()
+        runner = AsyncRunner(checkpointer=checkpointer)
+        inner = Graph([approval], name="inner")
+        outer = Graph([inner.as_node()], name="outer")
+
+        result = await runner.run(outer, {"draft": "review me"}, workflow_id="wf-paused")
+
+        assert result.status == RunStatus.PAUSED
+        _assert_nested_checkpoint_failures(result, "wf-paused/inner")
+
+    async def test_nested_cooperative_stop_surfaces_child_failure(self):
+        started = asyncio.Event()
+
+        @node(output_name="partial")
+        async def stream(ctx: NodeContext) -> str:
+            started.set()
+            while not ctx.stop_requested:
+                await asyncio.sleep(0)
+            return "saved partial"
+
+        checkpointer = ChildOnlyFailingSaveCheckpointer()
+        runner = AsyncRunner(checkpointer=checkpointer)
+        inner = Graph([stream], name="inner")
+        outer = Graph([inner.as_node()], name="outer")
+
+        async def stop_child() -> None:
+            await started.wait()
+            runner.stop("wf-stopped")
+
+        stop_task = asyncio.create_task(stop_child())
+        result = await runner.run(outer, workflow_id="wf-stopped")
+        await stop_task
+
+        assert result.status == RunStatus.STOPPED
+        assert result["partial"] == "saved partial"
+        _assert_nested_checkpoint_failures(result, "wf-stopped/inner")
+
+    async def test_outer_continue_failure_surfaces_child_checkpoint_failure(self):
+        @node(output_name="never")
+        def fail_inside_child(x: int) -> int:
+            raise ValueError(f"bad child input: {x}")
+
+        checkpointer = ChildOnlyFailingSaveCheckpointer()
+        runner = AsyncRunner(checkpointer=checkpointer)
+        inner = Graph([fail_inside_child], name="inner")
+        outer = Graph([inner.as_node()], name="outer")
+
+        result = await runner.run(
+            outer,
+            {"x": 5},
+            workflow_id="wf-failed",
+            error_handling="continue",
+        )
+
+        assert result.status == RunStatus.FAILED
+        assert isinstance(result.error, ValueError)
+        _assert_nested_checkpoint_failures(result, "wf-failed/inner")
+
+    async def test_healthy_nested_run_keeps_checkpoint_evidence_clean(self):
+        runner = AsyncRunner(checkpointer=MemoryCheckpointer())
+        inner = Graph([double], name="inner")
+        outer = Graph([inner.as_node()], name="outer")
+
+        result = await runner.run(outer, {"x": 5}, workflow_id="wf-healthy-nested")
+
+        assert result.completed
         assert result.checkpoint_ok is True
         assert result.checkpoint_errors == ()
 

--- a/tests/test_checkpointer/test_async_durability_visibility.py
+++ b/tests/test_checkpointer/test_async_durability_visibility.py
@@ -1,0 +1,91 @@
+"""Async checkpoint durability is best-effort but visible (decision D1, issue #126).
+
+With the default ``durability="async"``, background step-save failures must not
+fail the run — but they must surface on ``result.checkpoint_ok`` /
+``result.checkpoint_errors``. With ``durability="sync"``, the same failure
+fails the run (pinned existing behavior, sync AND async runner flavors).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hypergraph import AsyncRunner, Graph, SyncRunner, node
+from hypergraph.checkpointers import MemoryCheckpointer, SqliteCheckpointer
+from hypergraph.checkpointers.base import CheckpointPolicy
+from hypergraph.checkpointers.types import StepRecord
+
+
+@node(output_name="doubled")
+def double(x: int) -> int:
+    return x * 2
+
+
+class FailingSaveCheckpointer(MemoryCheckpointer):
+    """MemoryCheckpointer whose step writes always fail."""
+
+    def __init__(self):
+        super().__init__()
+        self.save_attempts = 0
+
+    async def save_step(self, record: StepRecord) -> None:
+        self.save_attempts += 1
+        raise RuntimeError("disk full")
+
+
+class TestAsyncDurabilityBestEffort:
+    async def test_async_durability_failure_completes_but_flags_checkpoint(self):
+        checkpointer = FailingSaveCheckpointer()
+        checkpointer.policy = CheckpointPolicy(durability="async")
+        runner = AsyncRunner(checkpointer=checkpointer)
+
+        result = await runner.run(Graph([double]), {"x": 5}, workflow_id="wf-best-effort")
+
+        assert result.completed
+        assert result["doubled"] == 10
+        assert checkpointer.save_attempts > 0
+        assert result.checkpoint_ok is False
+        assert result.checkpoint_errors
+        assert any("disk full" in err for err in result.checkpoint_errors)
+        # String reprs only — no live exception objects across the boundary.
+        assert all(isinstance(err, str) for err in result.checkpoint_errors)
+
+    async def test_healthy_checkpointer_reports_checkpoint_ok(self):
+        checkpointer = MemoryCheckpointer()
+        runner = AsyncRunner(checkpointer=checkpointer)
+
+        result = await runner.run(Graph([double]), {"x": 5}, workflow_id="wf-healthy")
+
+        assert result.completed
+        assert result.checkpoint_ok is True
+        assert result.checkpoint_errors == ()
+
+    async def test_no_checkpointer_defaults_checkpoint_ok(self):
+        result = await AsyncRunner().run(Graph([double]), {"x": 5})
+        assert result.checkpoint_ok is True
+        assert result.checkpoint_errors == ()
+
+
+class TestSyncDurabilityFailsTheRun:
+    async def test_async_runner_sync_durability_failure_fails_run(self):
+        """Pinned: durability='sync' step-save failures propagate and fail the run."""
+        checkpointer = FailingSaveCheckpointer()
+        checkpointer.policy = CheckpointPolicy(durability="sync", retention="full")
+        runner = AsyncRunner(checkpointer=checkpointer)
+
+        with pytest.raises(RuntimeError, match="disk full"):
+            await runner.run(Graph([double]), {"x": 5}, workflow_id="wf-sync-durability")
+
+    def test_sync_runner_save_failure_fails_run(self, tmp_path):
+        """Pinned parity: SyncRunner writes steps synchronously, so a save
+        failure always fails the run — there is no best-effort mode."""
+
+        class FailingSyncCheckpointer(SqliteCheckpointer):
+            def save_step_sync(self, record: StepRecord) -> None:
+                raise RuntimeError("disk full")
+
+        checkpointer = FailingSyncCheckpointer(str(tmp_path / "cp.db"))
+        runner = SyncRunner(checkpointer=checkpointer)
+
+        with pytest.raises(RuntimeError, match="disk full"):
+            runner.run(Graph([double]), {"x": 5}, workflow_id="wf-sync-runner")

--- a/tests/test_checkpointer/test_async_durability_visibility.py
+++ b/tests/test_checkpointer/test_async_durability_visibility.py
@@ -16,6 +16,7 @@ from hypergraph import AsyncRunner, Graph, RunStatus, SyncRunner, interrupt, nod
 from hypergraph.checkpointers import MemoryCheckpointer, SqliteCheckpointer
 from hypergraph.checkpointers.base import CheckpointPolicy
 from hypergraph.checkpointers.types import StepRecord
+from hypergraph.exceptions import IncompatibleRunnerError
 from hypergraph.runners._shared.node_context import NodeContext
 
 
@@ -43,6 +44,81 @@ class ChildOnlyFailingSaveCheckpointer(MemoryCheckpointer):
         if "/" in record.run_id:
             raise RuntimeError(f"disk full for {record.run_id}")
         await super().save_step(record)
+
+
+class CheckpointForwardingAsyncRunner:
+    """Non-template runner wrapper that explicitly accepts the private sink."""
+
+    _accepts_checkpoint_error_sink = True
+
+    def __init__(self, checkpointer: MemoryCheckpointer):
+        self._runner = AsyncRunner(checkpointer=checkpointer)
+
+    @property
+    def capabilities(self):
+        return self._runner.capabilities
+
+    @property
+    def supported_node_types(self):
+        return self._runner.supported_node_types
+
+    async def run(self, *args, _checkpoint_error_sink=None, **kwargs):
+        return await self._runner.run(
+            *args,
+            _checkpoint_error_sink=_checkpoint_error_sink,
+            **kwargs,
+        )
+
+    async def map(self, *args, _checkpoint_error_sink=None, **kwargs):
+        return await self._runner.map(
+            *args,
+            _checkpoint_error_sink=_checkpoint_error_sink,
+            **kwargs,
+        )
+
+
+class NonParticipatingCheckpointAsyncRunner:
+    """Checkpoint-capable async wrapper that does not accept sink forwarding."""
+
+    def __init__(self, checkpointer: MemoryCheckpointer):
+        self._runner = AsyncRunner(checkpointer=checkpointer)
+        self.run_calls = 0
+
+    @property
+    def capabilities(self):
+        return self._runner.capabilities
+
+    @property
+    def supported_node_types(self):
+        return self._runner.supported_node_types
+
+    async def run(self, *args, **kwargs):
+        self.run_calls += 1
+        return await self._runner.run(*args, **kwargs)
+
+    async def map(self, *args, **kwargs):
+        return await self._runner.map(*args, **kwargs)
+
+
+class NonCheckpointingAsyncRunner:
+    """Non-template async wrapper with no durability evidence to forward."""
+
+    def __init__(self):
+        self._runner = AsyncRunner()
+
+    @property
+    def capabilities(self):
+        return self._runner.capabilities
+
+    @property
+    def supported_node_types(self):
+        return self._runner.supported_node_types
+
+    async def run(self, *args, **kwargs):
+        return await self._runner.run(*args, **kwargs)
+
+    async def map(self, *args, **kwargs):
+        return await self._runner.map(*args, **kwargs)
 
 
 def _assert_nested_checkpoint_failures(result, *run_ids: str) -> None:
@@ -192,6 +268,94 @@ class TestNestedAsyncDurabilityBestEffort:
         assert result.completed
         assert result.checkpoint_ok is True
         assert result.checkpoint_errors == ()
+
+
+class TestDelegatedRunnerDurabilityForwarding:
+    async def test_noncheckpointing_async_wrapper_does_not_need_sink_capability(self):
+        inner = Graph([double], name="inner")
+        outer = Graph([inner.as_node(runner=NonCheckpointingAsyncRunner())])
+        parent = AsyncRunner(checkpointer=MemoryCheckpointer())
+
+        result = await parent.run(
+            outer,
+            {"x": 5},
+            workflow_id="wf-wrapper-no-checkpointer",
+        )
+
+        assert result.completed
+        assert result["doubled"] == 10
+        assert result.checkpoint_ok is True
+
+    async def test_non_template_wrapper_forwards_run_checkpoint_failure(self):
+        child_checkpointer = ChildOnlyFailingSaveCheckpointer()
+        child_runner = CheckpointForwardingAsyncRunner(child_checkpointer)
+        inner = Graph([double], name="inner")
+        outer = Graph([inner.as_node(runner=child_runner)], name="outer")
+        parent = AsyncRunner(checkpointer=MemoryCheckpointer())
+
+        result = await parent.run(outer, {"x": 5}, workflow_id="wf-wrapper-run")
+
+        assert result.completed
+        assert result["doubled"] == 10
+        assert result.checkpoint_errors == ("RuntimeError('disk full for wf-wrapper-run/inner')",)
+
+    async def test_non_template_wrapper_forwards_mapped_failures_in_item_order(self):
+        @node(output_name="doubled")
+        async def delayed_double(x: int) -> int:
+            await asyncio.sleep((4 - x) * 0.01)
+            return x * 2
+
+        child_checkpointer = ChildOnlyFailingSaveCheckpointer()
+        child_runner = CheckpointForwardingAsyncRunner(child_checkpointer)
+        inner = Graph([delayed_double], name="inner")
+        outer = Graph([inner.as_node(runner=child_runner).map_over("x")], name="outer")
+        parent = AsyncRunner(checkpointer=MemoryCheckpointer())
+
+        result = await parent.run(
+            outer,
+            {"x": [1, 2, 3]},
+            workflow_id="wf-wrapper-map",
+        )
+
+        assert result.completed
+        assert result["doubled"] == [2, 4, 6]
+        assert result.checkpoint_errors == tuple(f"RuntimeError('disk full for wf-wrapper-map/inner/{index}')" for index in range(3))
+
+    async def test_non_template_wrapper_forwards_checkpoint_failure_when_child_raises(self):
+        @node(output_name="never")
+        async def fail_child(x: int) -> int:
+            await asyncio.sleep(0)
+            raise ValueError(f"bad child input: {x}")
+
+        child_checkpointer = ChildOnlyFailingSaveCheckpointer()
+        child_runner = CheckpointForwardingAsyncRunner(child_checkpointer)
+        inner = Graph([fail_child], name="inner")
+        outer = Graph([inner.as_node(runner=child_runner)], name="outer")
+        parent = AsyncRunner(checkpointer=MemoryCheckpointer())
+
+        result = await parent.run(
+            outer,
+            {"x": 5},
+            workflow_id="wf-wrapper-raised",
+            error_handling="continue",
+        )
+
+        assert result.status == RunStatus.FAILED
+        assert isinstance(result.error, ValueError)
+        assert result.checkpoint_errors == ("RuntimeError('disk full for wf-wrapper-raised/inner')",)
+
+    async def test_nonparticipating_checkpoint_async_wrapper_is_rejected_before_run(self):
+        child_runner = NonParticipatingCheckpointAsyncRunner(ChildOnlyFailingSaveCheckpointer())
+        inner = Graph([double], name="inner")
+        outer = Graph([inner.as_node(runner=child_runner)], name="outer")
+        parent = AsyncRunner(checkpointer=MemoryCheckpointer())
+
+        with pytest.raises(IncompatibleRunnerError) as exc_info:
+            await parent.run(outer, {"x": 5}, workflow_id="wf-wrapper-rejected")
+
+        assert child_runner.run_calls == 0
+        assert "checkpoint error" in str(exc_info.value).lower()
+        assert "How to fix:" in str(exc_info.value)
 
 
 class TestSyncDurabilityFailsTheRun:

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -6,7 +6,7 @@ import ast
 import inspect
 from pathlib import Path
 
-from hypergraph import Graph, RunResult
+from hypergraph import Graph, MapResult, RunResult
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -18,6 +18,16 @@ def _read(path: str) -> str:
 def _section(text: str, heading: str) -> str:
     start = text.index(heading)
     next_heading = text.find("\n##", start + len(heading))
+    if next_heading == -1:
+        return text[start:]
+    return text[start:next_heading]
+
+
+def _scoped_section(text: str, heading: str) -> str:
+    """Return one Markdown heading through the next heading at the same level."""
+    start = text.index(heading)
+    level = heading.split(maxsplit=1)[0]
+    next_heading = text.find(f"\n{level} ", start + len(heading))
     if next_heading == -1:
         return text[start:]
     return text[start:next_heading]
@@ -111,3 +121,43 @@ def test_cyclic_docs_examples_configure_entrypoints() -> None:
     assert 'entrypoint="generate_prompt_variants"' in hierarchical
     assert "optimization_loop = Graph(" in hierarchical
     assert 'entrypoint="variant_tester"' in hierarchical
+
+
+def test_result_docs_mirror_checkpoint_evidence() -> None:
+    runners = _read("docs/06-api-reference/runners.md")
+
+    run_result = _scoped_section(runners, "## RunResult")
+    run_attributes = _scoped_section(run_result, "### Attributes")
+    assert "log: RunLog | None" in run_attributes
+    assert "checkpoint_ok: bool" in run_attributes
+    assert "checkpoint_errors: tuple[str, ...]" in run_attributes
+    assert "best-effort" in run_result
+    run_progressive_disclosure = _scoped_section(run_result, "### Progressive Disclosure")
+    assert '"checkpoint_ok": True' in run_progressive_disclosure
+    assert '"checkpoint_errors": []' in run_progressive_disclosure
+
+    map_result = _scoped_section(runners, "## MapResult")
+    assert "results.checkpoint_ok" in map_result
+    assert "results.checkpoint_errors" in map_result
+    assert "derived" in map_result.lower()
+    map_attributes = _scoped_section(map_result, "### Attributes")
+    assert "checkpoint_ok" not in map_attributes
+    assert "checkpoint_errors" not in map_attributes
+    assert "checkpoint_ok" not in MapResult.__dataclass_fields__
+    assert "checkpoint_errors" not in MapResult.__dataclass_fields__
+    assert isinstance(inspect.getattr_static(MapResult, "checkpoint_ok"), property)
+    assert isinstance(inspect.getattr_static(MapResult, "checkpoint_errors"), property)
+
+
+def test_streaming_chunk_event_docs_mirror_correlation_fields() -> None:
+    events = _read("docs/06-api-reference/events.md")
+
+    streaming = _scoped_section(events, "### StreamingChunkEvent")
+    assert "chunk: object" in streaming
+    assert "node_name: str" in streaming
+    assert "graph_name: str" in streaming
+    assert "`run_id`" in streaming
+    assert "`workflow_id`" in streaming
+    assert "`item_index`" in streaming
+    assert "`parent_span_id`" in streaming
+    assert "span of the emitting node" in streaming

--- a/tests/test_map_result.py
+++ b/tests/test_map_result.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Sequence
 
 import pytest
@@ -30,12 +31,16 @@ def _make_result(
     values: dict | None = None,
     error: Exception | None = None,
     log: RunLog | None = None,
+    checkpoint_ok: bool = True,
+    checkpoint_errors: tuple[str, ...] = (),
 ) -> RunResult:
     return RunResult(
         values=values or {},
         status=status,
         error=error,
         log=log,
+        checkpoint_ok=checkpoint_ok,
+        checkpoint_errors=checkpoint_errors,
     )
 
 
@@ -136,6 +141,64 @@ class TestRunResultToDict:
         r = _make_result()
         d = r.to_dict()
         assert "error" not in d
+
+    def test_healthy_checkpoint_evidence_is_always_serialized(self):
+        d = _make_result().to_dict()
+
+        assert d["checkpoint_ok"] is True
+        assert d["checkpoint_errors"] == []
+        json.dumps(d)
+
+    def test_failed_checkpoint_evidence_is_serialized_as_strings(self):
+        d = _make_result(
+            checkpoint_ok=False,
+            checkpoint_errors=("RuntimeError: disk full",),
+        ).to_dict()
+
+        assert d["checkpoint_ok"] is False
+        assert d["checkpoint_errors"] == ["RuntimeError: disk full"]
+        assert all(isinstance(error, str) for error in d["checkpoint_errors"])
+        json.dumps(d)
+
+
+class TestRunResultCheckpointProgressiveDisclosure:
+    def test_checkpoint_gap_is_visible_without_changing_execution_status(self):
+        log = RunLog(
+            graph_name="test",
+            run_id="run-123",
+            total_duration_ms=10.0,
+            steps=(),
+        )
+        result = _make_result(
+            log=log,
+            checkpoint_ok=False,
+            checkpoint_errors=("RuntimeError: disk full",),
+        )
+
+        assert result.status == RunStatus.COMPLETED
+        assert "checkpoint gap" in result.summary().lower()
+        assert "checkpoint_ok=False" in repr(result)
+        assert "RuntimeError: disk full" in repr(result)
+        html = result._repr_html_()
+        assert html is not None
+        assert "Checkpoint" in html
+        assert "gap" in html.lower()
+
+    def test_plain_repr_mode_keeps_checkpoint_gap_visible(self, monkeypatch):
+        monkeypatch.setenv("HYPERGRAPH_DISPLAY", "plain")
+        result = _make_result(
+            checkpoint_ok=False,
+            checkpoint_errors=("RuntimeError: disk full",),
+        )
+
+        assert result._repr_html_() is None
+        assert "checkpoint_ok=False" in repr(result)
+
+    def test_healthy_result_does_not_report_a_checkpoint_gap(self):
+        result = _make_result()
+
+        assert "checkpoint gap" not in result.summary().lower()
+        assert "checkpoint_ok=False" not in repr(result)
 
 
 # === MapResult Unit Tests ===
@@ -307,6 +370,82 @@ class TestMapResultAggregateStatus:
         assert mr.failures == []
 
 
+class TestMapResultCheckpointEvidence:
+    def test_empty_and_healthy_maps_have_clean_checkpoint_evidence(self):
+        empty = _make_map_result([])
+        healthy = _make_map_result([_make_result(), _make_result()])
+
+        assert empty.checkpoint_ok is True
+        assert empty.checkpoint_errors == ()
+        assert healthy.checkpoint_ok is True
+        assert healthy.checkpoint_errors == ()
+        assert "checkpoint gap" not in healthy.summary().lower()
+        assert "checkpoint gap" not in repr(healthy).lower()
+
+        healthy_dict = healthy.to_dict()
+        assert healthy_dict["checkpoint_ok"] is True
+        assert healthy_dict["checkpoint_errors"] == []
+        json.dumps(healthy_dict)
+
+    def test_aggregate_errors_follow_stable_item_order(self):
+        results = [
+            _make_result(
+                checkpoint_ok=False,
+                checkpoint_errors=("item 0 first", "item 0 second"),
+            ),
+            _make_result(),
+            _make_result(
+                checkpoint_ok=False,
+                checkpoint_errors=("item 2",),
+            ),
+        ]
+        mapped = _make_map_result(results)
+
+        assert mapped.status == RunStatus.COMPLETED
+        assert mapped.checkpoint_ok is False
+        assert mapped.checkpoint_errors == (
+            "item 0 first",
+            "item 0 second",
+            "item 2",
+        )
+
+    def test_checkpoint_gap_is_visible_in_summary_text_and_html(self):
+        mapped = _make_map_result(
+            [
+                _make_result(
+                    checkpoint_ok=False,
+                    checkpoint_errors=("item 0",),
+                ),
+                _make_result(),
+                _make_result(
+                    checkpoint_ok=False,
+                    checkpoint_errors=("item 2",),
+                ),
+            ]
+        )
+
+        assert "2 items with checkpoint gaps" in mapped.summary().lower()
+        assert "2 items with checkpoint gaps" in repr(mapped).lower()
+        html = mapped._repr_html_()
+        assert html is not None
+        assert "Checkpoint gaps" in html
+        assert "2 items" in html
+
+    def test_plain_repr_mode_keeps_map_checkpoint_gap_visible(self, monkeypatch):
+        monkeypatch.setenv("HYPERGRAPH_DISPLAY", "plain")
+        mapped = _make_map_result(
+            [
+                _make_result(
+                    checkpoint_ok=False,
+                    checkpoint_errors=("item 0",),
+                )
+            ]
+        )
+
+        assert mapped._repr_html_() is None
+        assert "1 item with checkpoint gaps" in repr(mapped).lower()
+
+
 class TestMapResultProgressiveDisclosure:
     def test_summary(self):
         items = [
@@ -337,6 +476,23 @@ class TestMapResultProgressiveDisclosure:
         assert len(d["items"]) == 1
         # Items delegate to RunResult.to_dict()
         assert d["items"][0]["status"] == "completed"
+
+    def test_to_dict_preserves_item_checkpoint_evidence(self):
+        healthy = _make_result()
+        unhealthy = _make_result(
+            checkpoint_ok=False,
+            checkpoint_errors=("RuntimeError: disk full",),
+        )
+
+        d = _make_map_result([healthy, unhealthy]).to_dict()
+
+        assert d["items"][0]["checkpoint_ok"] is True
+        assert d["items"][0]["checkpoint_errors"] == []
+        assert d["items"][1]["checkpoint_ok"] is False
+        assert d["items"][1]["checkpoint_errors"] == ["RuntimeError: disk full"]
+        assert d["checkpoint_ok"] is False
+        assert d["checkpoint_errors"] == ["RuntimeError: disk full"]
+        json.dumps(d)
 
     def test_repr(self):
         items = [_make_result(), _make_result()]
@@ -671,8 +827,6 @@ class TestMapLog:
 
     def test_map_log_to_dict(self):
         """to_dict() is JSON serializable."""
-        import json
-
         log = _make_run_log()
         r = _make_result(log=log)
         mr = _make_map_result([r])

--- a/tests/test_runners/test_interrupt_batch_planning.py
+++ b/tests/test_runners/test_interrupt_batch_planning.py
@@ -1,0 +1,68 @@
+"""Interrupt batch planning happens once, in the runner (issue #147).
+
+``plan_interrupt_batch`` isolates one interrupt per superstep BEFORE the
+runner captures ``ready_node_names`` for checkpoint metadata, so the
+checkpoint-recorded batch always equals the executed batch.
+"""
+
+from __future__ import annotations
+
+from hypergraph import AsyncRunner, Graph, InterruptNode, node
+from hypergraph.checkpointers import MemoryCheckpointer
+from hypergraph.checkpointers.types import StepStatus
+from hypergraph.runners._shared.helpers import plan_interrupt_batch
+
+
+@node(output_name="side_out")
+def side(x: int) -> int:
+    return x + 1
+
+
+@node(output_name="other_out")
+def other(x: int) -> int:
+    return x + 2
+
+
+def _always_pause(draft: str) -> str | None:
+    return None
+
+
+def _make_interrupt() -> InterruptNode:
+    return InterruptNode(_always_pause, name="approval", output_name="decision")
+
+
+class TestPlanInterruptBatch:
+    def test_no_interrupts_pass_through(self):
+        graph = Graph([side, other])
+        nodes = list(graph._nodes.values())
+        assert plan_interrupt_batch(nodes) is nodes
+
+    def test_interrupt_batch_isolates_first_interrupt(self):
+        graph = Graph([side, _make_interrupt()])
+        nodes = list(graph._nodes.values())
+        planned = plan_interrupt_batch(nodes)
+        assert len(planned) == 1
+        assert planned[0].name == "approval"
+        assert planned[0].is_interrupt
+
+
+class TestCheckpointBatchMatchesExecutedBatch:
+    async def test_recorded_superstep_batch_equals_executed_batch(self):
+        """A ready non-interrupt sibling must not appear in the paused superstep's records."""
+        checkpointer = MemoryCheckpointer()
+        runner = AsyncRunner(checkpointer=checkpointer)
+        graph = Graph([_make_interrupt(), side])
+
+        result = await runner.run(
+            graph,
+            {"draft": "please review", "x": 1},
+            workflow_id="wf-interrupt-batch",
+        )
+
+        assert result.paused
+        steps = await checkpointer.get_steps("wf-interrupt-batch")
+        superstep0 = [s for s in steps if s.superstep == 0]
+        # Executed batch was exactly [approval]; the deferred sibling `side`
+        # must not be recorded as part of this superstep.
+        assert [s.node_name for s in superstep0] == ["approval"]
+        assert superstep0[0].status == StepStatus.PAUSED

--- a/tests/test_runners/test_interrupt_batch_planning.py
+++ b/tests/test_runners/test_interrupt_batch_planning.py
@@ -66,3 +66,52 @@ class TestCheckpointBatchMatchesExecutedBatch:
         # must not be recorded as part of this superstep.
         assert [s.node_name for s in superstep0] == ["approval"]
         assert superstep0[0].status == StepStatus.PAUSED
+
+    async def test_nested_pause_preserves_completed_sibling_across_resume(self):
+        """A sibling completed beside a pausing GraphNode must not run twice."""
+
+        @node(output_name="side_out")
+        async def side_effect(x: int) -> int:
+            executions.append(x)
+            return x + 1
+
+        executions: list[int] = []
+        checkpointer = MemoryCheckpointer()
+        runner = AsyncRunner(checkpointer=checkpointer)
+        inner = Graph([_make_interrupt()], name="review")
+        graph = Graph([inner.as_node(name="review"), side_effect], name="outer")
+
+        paused = await runner.run(
+            graph,
+            {"draft": "please review", "x": 1},
+            workflow_id="wf-nested-pause-sibling",
+        )
+
+        assert paused.paused
+        assert paused["side_out"] == 2
+        assert executions == [1]
+        paused_steps = await checkpointer.get_steps("wf-nested-pause-sibling")
+        assert [(step.node_name, step.status) for step in paused_steps] == [
+            ("review", StepStatus.PAUSED),
+            ("side_effect", StepStatus.COMPLETED),
+        ]
+
+        assert paused.pause is not None
+        resumed = await runner.run(
+            graph,
+            {paused.pause.response_key: "approved"},
+            workflow_id="wf-nested-pause-sibling",
+        )
+
+        assert resumed.completed
+        assert resumed["decision"] == "approved"
+        assert resumed["side_out"] == 2
+        assert executions == [1]
+        all_steps = await checkpointer.get_steps("wf-nested-pause-sibling")
+        assert [step.status for step in all_steps if step.node_name == "review"] == [
+            StepStatus.PAUSED,
+            StepStatus.COMPLETED,
+        ]
+        assert [step.status for step in all_steps if step.node_name == "side_effect"] == [
+            StepStatus.COMPLETED,
+        ]

--- a/tests/test_runners/test_typed_side_channels.py
+++ b/tests/test_runners/test_typed_side_channels.py
@@ -20,6 +20,8 @@ from hypergraph.runners._shared.helpers import get_ready_nodes, initialize_state
 from hypergraph.runners._shared.types import (
     ExecutionContext,
     GraphState,
+    PauseExecution,
+    PauseInfo,
 )
 from hypergraph.runners.async_.executors import AsyncFunctionNodeExecutor
 from hypergraph.runners.async_.superstep import run_superstep_async
@@ -144,3 +146,22 @@ class TestGraphStateStopFields:
         copied = GraphState().copy()
         assert copied.stopped is False
         assert copied.stop_info is None
+
+
+# === PauseExecution constructor params (B1.1c) ===
+
+
+class TestPauseExecutionTypedFields:
+    def _pause_info(self) -> PauseInfo:
+        return PauseInfo(node_name="approval", output_param="decision", value="draft")
+
+    def test_defaults(self):
+        pause = PauseExecution(self._pause_info())
+        assert pause.partial_state is None
+        assert pause.stopped is False
+
+    def test_constructor_params_are_stored(self):
+        state = GraphState(values={"a": 1})
+        pause = PauseExecution(self._pause_info(), partial_state=state, stopped=True)
+        assert pause.partial_state is state
+        assert pause.stopped is True

--- a/tests/test_runners/test_typed_side_channels.py
+++ b/tests/test_runners/test_typed_side_channels.py
@@ -12,6 +12,8 @@ Pins the typed replacements for the old dynamically-attached attributes:
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from hypergraph import Graph, node
@@ -123,6 +125,115 @@ class TestSuperstepErrorMetadataAsync:
         assert "bad exploded" in str(err.node_errors["bad_node"])
         assert not hasattr(err, "_attempted_node_names")
         assert not hasattr(err, "_node_errors")
+
+
+class TestAsyncSuperstepControlFlowPriority:
+    async def test_cancelled_error_dominates_earlier_ordinary_exception(self):
+        @node(output_name="ordinary_out")
+        async def ordinary_failure(x: int) -> int:
+            await asyncio.sleep(0)
+            raise ValueError(f"ordinary failure: {x}")
+
+        @node(output_name="cancelled_out")
+        async def cancelled_failure(x: int) -> int:
+            await asyncio.sleep(0)
+            raise asyncio.CancelledError(f"cancelled: {x}")
+
+        graph = Graph([ordinary_failure, cancelled_failure])
+        state = initialize_state(graph, {"x": 5})
+        ready = get_ready_nodes(graph, state)
+        assert [node.name for node in ready] == ["ordinary_failure", "cancelled_failure"]
+
+        with pytest.raises(asyncio.CancelledError):
+            await run_superstep_async(
+                graph,
+                state,
+                ready,
+                {"x": 5},
+                {type(ordinary_failure): AsyncFunctionNodeExecutor()},
+                ExecutionContext(),
+            )
+
+    async def test_pause_dominates_earlier_ordinary_exception(self):
+        pause = PauseExecution(PauseInfo(node_name="approval", output_param="decision", value="draft"))
+
+        @node(output_name="ordinary_out")
+        async def ordinary_failure(x: int) -> int:
+            await asyncio.sleep(0)
+            raise ValueError(f"ordinary failure: {x}")
+
+        @node(output_name="decision")
+        async def pause_execution(x: int) -> str:
+            await asyncio.sleep(0)
+            raise pause
+
+        graph = Graph([ordinary_failure, pause_execution])
+        state = initialize_state(graph, {"x": 5})
+        ready = get_ready_nodes(graph, state)
+        assert [node.name for node in ready] == ["ordinary_failure", "pause_execution"]
+
+        with pytest.raises(PauseExecution) as exc_info:
+            await run_superstep_async(
+                graph,
+                state,
+                ready,
+                {"x": 5},
+                {type(ordinary_failure): AsyncFunctionNodeExecutor()},
+                ExecutionContext(),
+            )
+
+        assert exc_info.value is pause
+
+
+class TestAsyncSuperstepNestedExecutionError:
+    async def test_existing_execution_error_is_wrapped_without_mutation(self):
+        cause = ValueError("inner exploded")
+        inner_state = GraphState(values={"inner_partial": 1})
+        inner_error = ExecutionError(
+            cause,
+            inner_state,
+            attempted_node_names=("inner_node",),
+            node_errors={"inner_node": cause},
+        )
+        original_attempted = inner_error.attempted_node_names
+        original_node_errors = dict(inner_error.node_errors)
+
+        @node(output_name="bad_out")
+        async def nested_failure(x: int) -> int:
+            await asyncio.sleep(0)
+            raise inner_error
+
+        @node(output_name="good_out")
+        async def successful_sibling(x: int) -> int:
+            await asyncio.sleep(0)
+            return x + 1
+
+        graph = Graph([nested_failure, successful_sibling])
+        state = initialize_state(graph, {"x": 5})
+        ready = get_ready_nodes(graph, state)
+        assert [node.name for node in ready] == ["nested_failure", "successful_sibling"]
+
+        with pytest.raises(ExecutionError) as exc_info:
+            await run_superstep_async(
+                graph,
+                state,
+                ready,
+                {"x": 5},
+                {type(nested_failure): AsyncFunctionNodeExecutor()},
+                ExecutionContext(),
+            )
+
+        outer_error = exc_info.value
+        assert outer_error is not inner_error
+        assert outer_error.__cause__ is inner_error
+        assert outer_error.partial_state.values["good_out"] == 6
+        assert outer_error.attempted_node_names == ("nested_failure", "successful_sibling")
+        assert outer_error.node_errors == {"nested_failure": inner_error}
+        assert outer_error not in outer_error.node_errors.values()
+        assert inner_error.partial_state is inner_state
+        assert inner_error.attempted_node_names == original_attempted
+        assert inner_error.node_errors == original_node_errors
+        assert inner_error.__cause__ is cause
 
 
 # === GraphState stop fields (B1.1b) ===

--- a/tests/test_runners/test_typed_side_channels.py
+++ b/tests/test_runners/test_typed_side_channels.py
@@ -121,3 +121,26 @@ class TestSuperstepErrorMetadataAsync:
         assert "bad exploded" in str(err.node_errors["bad_node"])
         assert not hasattr(err, "_attempted_node_names")
         assert not hasattr(err, "_node_errors")
+
+
+# === GraphState stop fields (B1.1b) ===
+
+
+class TestGraphStateStopFields:
+    def test_defaults(self):
+        state = GraphState()
+        assert state.stopped is False
+        assert state.stop_info is None
+
+    def test_copy_carries_stop_fields(self):
+        state = GraphState()
+        state.stopped = True
+        state.stop_info = {"reason": "user pressed stop"}
+        copied = state.copy()
+        assert copied.stopped is True
+        assert copied.stop_info == {"reason": "user pressed stop"}
+
+    def test_copy_default_stop_fields(self):
+        copied = GraphState().copy()
+        assert copied.stopped is False
+        assert copied.stop_info is None

--- a/tests/test_runners/test_typed_side_channels.py
+++ b/tests/test_runners/test_typed_side_channels.py
@@ -1,0 +1,123 @@
+"""Typed side-channel fields replacing runner monkey-patches (issue #146, audit R2).
+
+Pins the typed replacements for the old dynamically-attached attributes:
+
+- ``ExecutionError.attempted_node_names`` / ``.node_errors`` (constructor params,
+  formerly ``_attempted_node_names`` / ``_node_errors`` monkey-patches)
+- ``GraphState.stopped`` / ``.stop_info`` (real fields, formerly ``_stopped`` /
+  ``_stop_info`` monkey-patches; must flow through ``copy()``)
+- ``PauseExecution.partial_state`` / ``.stopped`` (constructor params, formerly
+  ``_partial_state`` / ``_stopped`` monkey-patches)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hypergraph import Graph, node
+from hypergraph.exceptions import ExecutionError
+from hypergraph.runners._shared.helpers import get_ready_nodes, initialize_state
+from hypergraph.runners._shared.types import (
+    ExecutionContext,
+    GraphState,
+)
+from hypergraph.runners.async_.executors import AsyncFunctionNodeExecutor
+from hypergraph.runners.async_.superstep import run_superstep_async
+from hypergraph.runners.sync.executors import SyncFunctionNodeExecutor
+from hypergraph.runners.sync.superstep import run_superstep_sync
+
+# === Fixtures ===
+
+
+@node(output_name="ok_out")
+def ok_node(x: int) -> int:
+    return x + 1
+
+
+@node(output_name="bad_out")
+def bad_node(x: int) -> int:
+    raise ValueError("bad exploded")
+
+
+# === ExecutionError constructor metadata (B1.1a) ===
+
+
+class TestExecutionErrorConstructor:
+    def test_defaults_are_empty_and_fresh(self):
+        cause = ValueError("boom")
+        err = ExecutionError(cause, GraphState())
+        assert err.attempted_node_names == ()
+        assert err.node_errors == {}
+        assert err.__cause__ is cause
+
+    def test_constructor_params_are_stored(self):
+        cause = ValueError("boom")
+        state = GraphState(values={"x": 1})
+        err = ExecutionError(
+            cause,
+            state,
+            attempted_node_names=("a", "b"),
+            node_errors={"b": cause},
+        )
+        assert err.partial_state is state
+        assert err.attempted_node_names == ("a", "b")
+        assert err.node_errors == {"b": cause}
+
+    def test_node_errors_default_is_not_shared(self):
+        first = ExecutionError(ValueError("x"), GraphState())
+        second = ExecutionError(ValueError("y"), GraphState())
+        assert first.node_errors is not second.node_errors
+
+
+class TestSuperstepErrorMetadataSync:
+    def test_failing_superstep_surfaces_attempted_and_node_errors(self):
+        graph = Graph([ok_node, bad_node])
+        state = initialize_state(graph, {"x": 5})
+        ready = get_ready_nodes(graph, state)
+        assert {n.name for n in ready} == {"ok_node", "bad_node"}
+
+        executor = SyncFunctionNodeExecutor()
+        with pytest.raises(ExecutionError) as exc_info:
+            run_superstep_sync(
+                graph,
+                state,
+                ready,
+                {"x": 5},
+                {type(ok_node): executor},
+                ExecutionContext(),
+            )
+
+        err = exc_info.value
+        assert "bad_node" in err.attempted_node_names
+        assert isinstance(err.node_errors["bad_node"], ValueError)
+        assert "bad exploded" in str(err.node_errors["bad_node"])
+        # The old monkey-patch channel must be gone.
+        assert not hasattr(err, "_attempted_node_names")
+        assert not hasattr(err, "_node_errors")
+
+
+class TestSuperstepErrorMetadataAsync:
+    async def test_failing_superstep_surfaces_attempted_and_node_errors(self):
+        graph = Graph([ok_node, bad_node])
+        state = initialize_state(graph, {"x": 5})
+        ready = get_ready_nodes(graph, state)
+        assert {n.name for n in ready} == {"ok_node", "bad_node"}
+
+        executor = AsyncFunctionNodeExecutor()
+        with pytest.raises(ExecutionError) as exc_info:
+            await run_superstep_async(
+                graph,
+                state,
+                ready,
+                {"x": 5},
+                {type(ok_node): executor},
+                ExecutionContext(),
+            )
+
+        err = exc_info.value
+        # Async attempts the full ready batch concurrently.
+        assert set(err.attempted_node_names) == {"ok_node", "bad_node"}
+        assert isinstance(err.node_errors["bad_node"], ValueError)
+        assert "bad exploded" in str(err.node_errors["bad_node"])
+        assert not hasattr(err, "_attempted_node_names")
+        assert not hasattr(err, "_node_errors")

--- a/tests/test_stop_and_stream.py
+++ b/tests/test_stop_and_stream.py
@@ -1021,3 +1021,70 @@ class TestEdgeCases:
         assert result["result"] == 10
         assert result.stopped is False
         assert call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# 15. StreamingChunkEvent correlation fields (issue #110)
+# ---------------------------------------------------------------------------
+
+
+class CorrelationCollector:
+    """Captures full StreamingChunkEvents plus node span ids."""
+
+    def __init__(self):
+        self.chunk_events: list[StreamingChunkEvent] = []
+        self.node_spans: dict[str, str] = {}
+
+    def on_event(self, event):
+        from hypergraph.events.types import NodeStartEvent
+
+        if isinstance(event, StreamingChunkEvent):
+            self.chunk_events.append(event)
+        elif isinstance(event, NodeStartEvent):
+            self.node_spans[event.node_name] = event.span_id
+
+    def shutdown(self):
+        pass
+
+
+def _make_streaming_graph() -> Graph:
+    @node(output_name="out")
+    def streamer(x: int, ctx: NodeContext) -> int:
+        ctx.stream(f"chunk-{x}")
+        return x
+
+    return Graph([streamer], name="stream_graph")
+
+
+def _assert_chunk_correlated(collector: CorrelationCollector, workflow_id: str) -> None:
+    [event] = collector.chunk_events
+    assert event.chunk == "chunk-7"
+    assert event.node_name == "streamer"
+    assert event.graph_name == "stream_graph"
+    assert event.workflow_id == f"{workflow_id}/0"
+    assert event.item_index == 0
+    assert event.parent_span_id == collector.node_spans["streamer"]
+
+
+class TestStreamingChunkCorrelation:
+    def test_sync_chunk_carries_correlation_fields(self):
+        collector = CorrelationCollector()
+        SyncRunner().map(
+            _make_streaming_graph(),
+            {"x": [7]},
+            map_over="x",
+            workflow_id="wf-stream-sync",
+            event_processors=[collector],
+        )
+        _assert_chunk_correlated(collector, "wf-stream-sync")
+
+    async def test_async_chunk_carries_correlation_fields(self):
+        collector = CorrelationCollector()
+        await AsyncRunner().map(
+            _make_streaming_graph(),
+            {"x": [7]},
+            map_over="x",
+            workflow_id="wf-stream-async",
+            event_processors=[collector],
+        )
+        _assert_chunk_correlated(collector, "wf-stream-async")


### PR DESCRIPTION
## Problem / Bug / Challenge

Runner internals mixed typed execution state with ad-hoc side channels. That let nested asynchronous checkpoint failures disappear, allowed an ordinary node failure to mask concurrent cancellation/pause by graph order, and mutated inner `ExecutionError` objects while re-attributing an outer failure. Durability gaps were also absent from serialization and progressive displays.

Part of #182.

## Before / After

**Before:**

```python
result = await runner.run(outer_graph, error_handling="continue")
"checkpoint_ok" in result.to_dict()  # False
# Nested async save failures had no result-level signal.

# The ordinary ValueError could be wrapped in ExecutionError solely because
# it appeared first in graph order alongside cancellation.
```

**After:**

```python
result = await runner.run(outer_graph, error_handling="continue")
result.checkpoint_ok          # False
result.checkpoint_errors      # ("...save failure...",)
result.to_dict()["checkpoint_ok"]  # False

batch = await runner.map(
    outer_graph, {"x": items}, map_over="x", error_handling="continue"
)
batch.checkpoint_ok           # aggregate across items
batch.checkpoint_errors       # stable, flattened evidence
```

Nested durability evidence propagates exactly once across completion, mapping, pause, stop, and failure. Within the same async superstep, concurrent cancellation or pause takes priority over ordinary exceptions, and outer failures now use fresh `ExecutionError` instances while preserving inner attribution and successful sibling state. Streaming chunk events also gain correlation fields.

A nested GraphNode pause now carries successful sibling state into the pause checkpoint, so side-effecting siblings are recorded once and do not re-run on resume. Custom checkpoint-capable async runner overrides opt into a typed sink protocol; unsafe nonparticipating overrides fail before invocation instead of losing evidence silently.

## Test Plan

- [x] `uv run pytest -W error -W 'ignore::pytest.PytestUnraisableExceptionWarning'` — 2,998 passed after updating onto merged #192
- [x] 126 focused tests covering nested/mapped durability, pause/stop/failure paths, sibling state across resume, custom runner forwarding/rejection, cancellation priority, fresh error identity/state, serialization, repr/HTML, and docs
- [x] Combined Wave-2 integration tree — 3,025 passed
- [x] `uv run pre-commit run --all-files` on the combined tree
