### PR TITLE
feat(checkpoint): land production checkpointer semantics

### DIFF
--- a/docs/05-how-to/batch-processing.md
+++ b/docs/05-how-to/batch-processing.md
@@ -423,7 +423,7 @@ retried = await runner.run(
 )
 ```
 
-If you pass runtime values with an existing workflow ID, `run()` raises `InputOverrideRequiresForkError`.
+If you pass runtime values while resuming an ordinary active or failed workflow ID, `run()` raises `InputOverrideRequiresForkError`. Stopped workflows use the explicit-signal rule above, and paused workflows accept interrupt responses.
 If graph structure changed for an existing workflow ID, `run()` raises `GraphChangedError`.
 
 ### Resuming Batches

--- a/docs/05-how-to/batch-processing.md
+++ b/docs/05-how-to/batch-processing.md
@@ -182,7 +182,7 @@ This keeps the core logic small and reusable instead of mixing per-item logic wi
 results = runner.map(graph, {"text": texts}, map_over="text")
 
 # Quick overview
-print(results.summary())    # "5 items | 5 completed | 42ms"
+print(results.summary())    # "5 items | 5 completed | avg 42ms/item"
 
 # Collect values across all items by key
 word_counts = results["word_count"]  # [2, 2, 2]
@@ -194,6 +194,7 @@ word_counts = results.get("word_count", 0)  # [2, 2, 0, 2, ...]
 results.run_id              # Unique batch ID
 results.total_duration_ms   # Wall-clock time for the entire batch
 results.map_over            # ("text",)
+results.restored_count      # Checkpoint-skipped successes (subset of completed)
 
 # JSON-serializable export (for logging, dashboards, agents)
 results.to_dict()           # Full batch metadata + per-item results
@@ -345,11 +346,12 @@ See [Checkpointers](../06-api-reference/checkpointers.md) for the `Checkpointer`
 `run()` now uses strict, git-like lineage semantics when a checkpointer is configured:
 
 - Same `workflow_id` means "same lineage"
-- Resume is strict: no new runtime values
+- Resume is strict: active/failed runs reject new runtime values; paused runs accept interrupt responses
+- A stopped run requires a non-empty runtime mapping to resume, or `override_workflow=True` to fork
 - Structural graph changes require fork
 - Completed workflows are terminal (fork to branch)
 
-When `workflow_id` is omitted and a checkpointer exists, `run()` auto-generates one and returns it in `result.workflow_id`.
+When `workflow_id` is omitted on a fresh or retry run and a checkpointer exists, `run()` generates a generic ID and returns it in `result.workflow_id`. A `fork_from=` call instead derives `{source}-fork-{hex}`.
 
 ```python
 result = await runner.run(graph, {"x": 5})  # auto-id when checkpointer is set
@@ -380,7 +382,23 @@ await runner.run(Graph([double, triple]), {"x": 5}, workflow_id="job-1")
 # await runner.run(Graph([double, triple]), workflow_id="job-1")
 ```
 
-Resume is intended for ACTIVE/PAUSED/FAILED workflows (for example: still-running work, interrupt-paused workflows, or retry after failure), not for appending new work to completed lineages.
+Ordinary resume covers ACTIVE/PAUSED/FAILED workflows (for example: still-running work, interrupt-paused workflows, or retry after failure). STOPPED workflows use the explicit-signal rule below. Completed lineages remain terminal.
+
+A persisted `STOPPED` workflow needs an explicit signal. `None` and `{}` raise `WorkflowStoppedError` before a new run event or persistence write. Pass any non-empty, otherwise-valid runtime mapping to resume the same ID, or use `override_workflow=True` to leave the source untouched and create a fork:
+
+```python
+# Same lineage
+resumed = await runner.run(graph, {"x": 2}, workflow_id="stopped-job")
+
+# New source-derived lineage
+forked = await runner.run(
+    graph,
+    {"x": 2},
+    workflow_id="stopped-job",
+    override_workflow=True,
+)
+assert forked.workflow_id.startswith("stopped-job-fork-")
+```
 
 #### Fork (new workflow_id, optional overrides)
 
@@ -393,6 +411,7 @@ forked = await runner.run(
     fork_from="job-1",
 )
 assert forked["tripled"] == 600
+assert forked.workflow_id.startswith("job-1-fork-")
 ```
 
 Retry is symmetrical:
@@ -435,9 +454,13 @@ results = await runner.map(
 # batch-retry/0 → skipped (already COMPLETED)
 # batch-retry/1 → re-executed (was FAILED)
 # batch-retry/2 → skipped (already COMPLETED)
+
+assert [item.restored for item in results] == [True, False, True]
+assert results.restored_count == 2
+assert results[0].log.steps[0].status == "restored"
 ```
 
-This makes it safe to retry large batches — you only pay for the items that actually need re-processing.
+Restored items remain included in completed counts, but are also reported as a separate subset in `MapResult`, `MapLog`, parent events, and telemetry. Average item duration uses only freshly executed completed items with real logs, so a fully restored batch omits the average instead of displaying fake `0ms` work. This makes it safe to retry large batches — you only pay for the items that actually need re-processing, and the result shows which items were skipped.
 
 ## When to Use Map vs Loop
 

--- a/docs/05-how-to/debug-workflows.md
+++ b/docs/05-how-to/debug-workflows.md
@@ -98,7 +98,7 @@ log_dict = result.log.to_dict()
 results = runner.map(graph, {"x": [1, 2, 3]}, map_over="x")
 
 # Batch-level overview
-print(results.summary())  # "3 items | 3 completed | 12ms"
+print(results.summary())  # "3 items | 3 completed | avg 4ms/item"
 
 # Per-item RunLogs
 for i, r in enumerate(results):
@@ -110,7 +110,7 @@ if results.failed:
         print(f"Failed: {f.error}")
 ```
 
-`results.log` also returns a single batch-level `MapLog` (`graph_name`, `total_duration_ms`, `items` — a tuple of the per-item `RunLog`s, plus an aggregate `.errors`), for when you want one object instead of iterating `results` yourself.
+`results.log` also returns a single batch-level `MapLog` (`graph_name`, `total_duration_ms`, `items` — a tuple of the per-item `RunLog`s, plus aggregate `.errors` and `restored_count`), for when you want one object instead of iterating `results` yourself. A checkpoint-skipped item has `RunResult.restored=True` and a visible synthetic `NodeRecord(status="restored")`; terminal and HTML views show it as restored, never as failed or as fake `0ms` work.
 
 ### runner.map() vs map_over for debugging
 
@@ -185,6 +185,7 @@ cp.runs()                             # List all runs
 cp.get_run("my-run-1")                # Run metadata (status, duration, counts)
 cp.values("my-run-1")                 # {"doubled": 10, "tripled": 30}
 cp.steps("my-run-1")                  # Step records with timing
+cp.steps("my-run-1", show_internal=True)  # Include retention carriers
 cp.stats("my-run-1")                  # Per-node duration/frequency breakdown
 cp.checkpoint("my-run-1")             # Full snapshot (values + steps)
 
@@ -202,7 +203,7 @@ cp.state("my-run-1", superstep=1)     # {"doubled": 10}
 cp.lineage("my-run-1")
 ```
 
-The sync read methods (`runs()`, `get_run()`, `values()`, `steps()`, `search()`, `stats()`, `checkpoint()`) work without async/await, making them ideal for debugging scripts and notebooks. No `initialize()` call needed.
+The sync read methods (`runs()`, `get_run()`, `values()`, `steps()`, `search()`, `stats()`, `checkpoint()`) work without async/await, making them ideal for debugging scripts and notebooks. No `initialize()` call needed. Public step/checkpoint/search/statistics views hide `__retained_state__` / `RetentionBaseline` compaction carriers by default; state reconstruction still folds those internal rows. Use `show_internal=True` only to inspect retention internals.
 
 #### Interrupt Steps
 
@@ -258,7 +259,7 @@ cp = SqliteCheckpointer(
 
 ### Without workflow_id
 
-For `runner.run()`, if a checkpointer is configured and you omit `workflow_id`, hypergraph auto-generates one and persists the run. This reduces boilerplate while keeping runs addressable.
+For a fresh `runner.run()` (or `retry_from=`), if a checkpointer is configured and you omit `workflow_id`, hypergraph generates a generic `run-...` ID and persists the run. `fork_from=` instead derives `{source}-fork-{hex}`; an explicit target remains exact.
 
 ```python
 # Auto-generated workflow_id (when checkpointer exists)

--- a/docs/06-api-reference/checkpointers.md
+++ b/docs/06-api-reference/checkpointers.md
@@ -60,13 +60,15 @@ Every checkpointer implements the same contract, so runners don't need to know w
 | `create_run(run_id, ...)` | Create or reset a run record at run start. |
 | `update_run_status(run_id, status, ...)` | Update lifecycle status with duration/counts. |
 | `get_state(run_id, superstep=None)` | Fold step values into accumulated state. `None` means latest. |
-| `get_steps(run_id, superstep=None)` | Raw step records through a superstep. |
+| `get_steps(run_id, superstep=None, show_internal=False)` | Public step records through a superstep. Set `show_internal=True` to include retention carriers. |
 | `get_checkpoint(run_id, superstep=None)` | `Checkpoint` (values + steps) for forking — has a default implementation built from `get_state`/`get_steps`. |
-| `list_runs(status=None, parent_run_id=None, limit=100)` | List runs, optionally filtered. |
-| `count_runs(status=None, parent_run_id=None, retry_of=None)` | Count without materializing full run objects. |
+| `list_runs(status=None, graph_name=None, since=None, parent_run_id=<omitted>, limit=100)` | List runs with composable filters. Omit `parent_run_id` for all runs; pass `None` for top-level runs only. |
+| `count_runs(status=None, parent_run_id=<omitted>, retry_of=None)` | Count with the same omitted/all versus explicit-`None`/top-level parent filter. |
 | `search_async(query, field=None, limit=20)` | FTS search over step values. Returns `[]` if unsupported. |
 
-Steps are the source of truth — state is always computed by folding steps, never stored as a separate mutable blob. This is what makes time-travel (`get_state(run_id, superstep=3)`) and forking from an arbitrary point possible.
+`graph_name`, `since`, `status`, and `parent_run_id` compose with AND before `limit` is applied. `since` is inclusive; naive datetimes mean UTC and aware datetimes are normalized to UTC. The same rules apply to SQLite's sync `runs()` adapter.
+
+Steps are the source of truth — state is always computed by folding steps, never stored as a separate mutable blob. Public step views hide internal `__retained_state__` / `RetentionBaseline` carrier rows by default, while state reconstruction folds the raw internal stream. This keeps `latest` and `windowed` retention reconstructible without showing phantom nodes in checkpoints, search, statistics, or lineage views. Use `show_internal=True` only when debugging the retention mechanism itself.
 
 ## CheckpointPolicy
 
@@ -137,10 +139,10 @@ checkpointer.get_run(retried.workflow_id).retry_of  # "job-1"
 ```
 
 {% hint style="warning" %}
-`fork_workflow_async`/`retry_workflow_async` (called internally by `run(fork_from=...)`) fall back to a `{source}-fork-{hex}` / `{source}-retry-{n}` name **only when `workflow_id` is `None`**. In practice, `run()` always auto-generates a `workflow_id` (`run-YYYYMMDD-hex`) before the fork/retry branch runs, so calling `runner.run(graph, fork_from="job-1")` without an explicit `workflow_id=` produces an auto-generated id, not a `job-1-fork-...` name. Pass `workflow_id=` explicitly if you want a specific, readable name for the new run.
+`runner.run(graph, fork_from="job-1")` derives a source-readable target such as `job-1-fork-a1b2c3`. An explicit `workflow_id=` remains exact. A nested source such as `job-1/0` cannot be implicitly promoted to a top-level fork; top-level callers must provide an explicit slash-free target. `retry_from=` deliberately keeps the generic `run-YYYYMMDD-hex` runner naming behavior.
 {% endhint %}
 
-Call the checkpointer's own `fork_workflow`/`retry_workflow` (sync) or `fork_workflow_async`/`retry_workflow_async` directly to get the `{source}-fork-{hex}` naming convention:
+The checkpointer's own `fork_workflow`/`retry_workflow` (sync) and `fork_workflow_async`/`retry_workflow_async` use source-derived names when their target is omitted:
 
 ```python
 fork_id, fork_checkpoint = checkpointer.fork_workflow("job-1")
@@ -171,7 +173,8 @@ Use this to audit which forks/retries came from which source run, and their stat
 | Error | Raised when |
 |---|---|
 | `WorkflowAlreadyRunningError` | A second `run()` starts for a `workflow_id` that already has an active run. At most one active `run()` per `workflow_id` — use different `workflow_id`s for concurrent runs. |
-| `WorkflowForkError` | An explicit `checkpoint=` is passed to fork into a `workflow_id` that already exists. Use a new `workflow_id` for the fork. |
+| `WorkflowForkError` | A fork targets an existing workflow, or a nested source is used without an explicit top-level target. |
+| `WorkflowStoppedError` | A stopped workflow is rerun without either a non-empty runtime value mapping or `override_workflow=True`. The rejection happens before new run events or persistence writes. |
 
 ```python
 from hypergraph.exceptions import WorkflowForkError

--- a/docs/06-api-reference/events.md
+++ b/docs/06-api-reference/events.md
@@ -80,8 +80,8 @@ class RunEndEvent(BaseEvent):
     batch_failed_items: int | None
     batch_paused_items: int | None
     batch_stopped_items: int | None
-    batch_restored_items: int | None
     batch_outcome: str | None
+    batch_restored_items: int | None
 ```
 
 For map parents, `batch_completed_items` remains inclusive of checkpoint-restored successes and `batch_restored_items` reports that subset. OpenTelemetry processors export the same value as `hypergraph.batch.restored_items`. Restored children were skipped, so they do not emit new child execution events.

--- a/docs/06-api-reference/events.md
+++ b/docs/06-api-reference/events.md
@@ -80,8 +80,11 @@ class RunEndEvent(BaseEvent):
     batch_failed_items: int | None
     batch_paused_items: int | None
     batch_stopped_items: int | None
+    batch_restored_items: int | None
     batch_outcome: str | None
 ```
+
+For map parents, `batch_completed_items` remains inclusive of checkpoint-restored successes and `batch_restored_items` reports that subset. OpenTelemetry processors export the same value as `hypergraph.batch.restored_items`. Restored children were skipped, so they do not emit new child execution events.
 
 ### NodeStartEvent
 

--- a/docs/06-api-reference/runners.md
+++ b/docs/06-api-reference/runners.md
@@ -52,7 +52,7 @@ class SyncRunner:
 
 **Args:**
 - `cache` — Optional [cache backend](../03-patterns/08-caching.md) for node result caching. Nodes opt in with `@node(..., cache=True)`. Supports `InMemoryCache`, `DiskCache`, or any `CacheBackend` implementation.
-- `checkpointer` — Optional [checkpointer](../05-how-to/batch-processing.md#checkpointing-with-map) for persistent run history. For `run()`, enables strict lineage semantics (resume/fork) and auto-generates `workflow_id` when omitted. For `map()`, persistence is enabled when `workflow_id` is provided. Requires `SqliteCheckpointer` or any `SyncCheckpointerProtocol` implementation.
+- `checkpointer` — Optional [checkpointer](../05-how-to/batch-processing.md#checkpointing-with-map) for persistent run history. For `run()`, enables strict lineage semantics, generic IDs for fresh/retry runs, and source-derived IDs for `fork_from`. For `map()`, persistence is enabled when `workflow_id` is provided. Requires `SqliteCheckpointer` or any `SyncCheckpointerProtocol` implementation.
 - `show_progress` — If `True`, automatically attaches a Rich progress processor to `run()` and `map()` calls. Per-call `show_progress` overrides this default.
 
 ### run()
@@ -94,12 +94,13 @@ Execute a graph once.
 - `event_processors` - Optional list of [event processors](events.md) to observe execution
 - `checkpoint` - Optional low-level checkpoint snapshot (`values + steps`) for explicit fork restores.
 - `workflow_id` - Optional workflow identifier for lineage tracking. With a checkpointer:
-  - omitted: auto-generated for `run()`
-  - existing: strict resume only (no runtime values; same graph structure). Existing persisted workflows may be `active`, `paused`, or `failed`; completed workflows are terminal.
+  - omitted on a fresh or retry run: a generic `run-...` ID is generated
+  - omitted with `fork_from`: a `{source}-fork-{hex}` ID is derived
+  - existing: strict resume only (same graph structure). Active/failed runs reject fresh values, paused runs accept interrupt responses, and stopped runs require a non-empty runtime mapping; completed workflows are terminal.
   - new + `checkpoint`: explicit fork
-- `override_workflow` - Convenience shortcut for existing `workflow_id`s. When `True` and the `workflow_id` already exists, `run()` auto-forks from that workflow (generates a new workflow ID and uses its checkpoint) instead of raising strict resume errors.
-- `fork_from` - Workflow ID to fork from directly (no manual checkpoint plumbing). Requires a checkpointer.
-- `retry_from` - Workflow ID to retry from directly (records retry lineage metadata). Requires a checkpointer.
+- `override_workflow` - Convenience shortcut for existing `workflow_id`s. When `True`, `run()` creates a source-derived fork and leaves the source row unchanged.
+- `fork_from` - Workflow ID to fork from directly (no manual checkpoint plumbing). Without `workflow_id=`, the target is `{source}-fork-{hex}`. Requires a checkpointer.
+- `retry_from` - Workflow ID to retry from directly (records retry lineage metadata). Without `workflow_id=`, runner naming remains generic `run-...`. Requires a checkpointer.
 - Lineage hashing: checkpoint compatibility uses a structural hash; a separate code hash is recorded for observability/caching workflows.
 - `**input_values` - Input shorthand for flat graph input names. Use `values` for dotted/nested inputs or names that match runner options.
 
@@ -109,6 +110,7 @@ Execute a graph once.
 - `MissingInputError` - Required input not provided
 - `IncompatibleRunnerError` - Graph contains async nodes
 - `GraphConfigError` - If graph is cyclic and has no configured entrypoint
+- `WorkflowStoppedError` - A stopped persisted workflow is rerun without a non-empty runtime mapping or `override_workflow=True`
 - `ValueError` - If runtime `select` or `entrypoint` overrides are passed
 - Node execution errors (e.g., `ValueError`, `TypeError`) when `error_handling="raise"` (the default)
 
@@ -644,7 +646,7 @@ class AsyncRunner:
 
 **Args:**
 - `cache` — Optional [cache backend](../03-patterns/08-caching.md) for node result caching. Nodes opt in with `@node(..., cache=True)`.
-- `checkpointer` — Optional checkpointer for persistent run history. For `run()`, enables strict lineage semantics (resume/fork) and auto-generates `workflow_id` when omitted. For `map()`, persistence is enabled when `workflow_id` is provided. Requires `SqliteCheckpointer` or any `Checkpointer` implementation.
+- `checkpointer` — Optional checkpointer for persistent run history. For `run()`, enables strict lineage semantics, generic IDs for fresh/retry runs, and source-derived IDs for `fork_from`. For `map()`, persistence is enabled when `workflow_id` is provided. Requires `SqliteCheckpointer` or any `Checkpointer` implementation.
 - `show_progress` — If `True`, automatically attaches a Rich progress processor to `run()` and `map()` calls. Per-call `show_progress` overrides this default.
 
 ### run()
@@ -687,12 +689,13 @@ Execute a graph asynchronously.
 - `event_processors` - Optional list of [event processors](events.md) to observe execution (supports `AsyncEventProcessor`)
 - `checkpoint` - Optional low-level checkpoint snapshot (`values + steps`) for explicit fork restores.
 - `workflow_id` - Optional workflow identifier for lineage tracking. With a checkpointer:
-  - omitted: auto-generated for `run()`
-  - existing: strict resume only (no runtime values; same graph structure). Existing persisted workflows may be `active`, `paused`, or `failed`; completed workflows are terminal.
+  - omitted on a fresh or retry run: a generic `run-...` ID is generated
+  - omitted with `fork_from`: a `{source}-fork-{hex}` ID is derived
+  - existing: strict resume only (same graph structure). Active/failed runs reject fresh values, paused runs accept interrupt responses, and stopped runs require a non-empty runtime mapping; completed workflows are terminal.
   - new + `checkpoint`: explicit fork
-- `override_workflow` - Convenience shortcut for existing `workflow_id`s. When `True` and the `workflow_id` already exists, `run()` auto-forks from that workflow (generates a new workflow ID and uses its checkpoint) instead of raising strict resume errors.
-- `fork_from` - Workflow ID to fork from directly (no manual checkpoint plumbing). Requires a checkpointer.
-- `retry_from` - Workflow ID to retry from directly (records retry lineage metadata). Requires a checkpointer.
+- `override_workflow` - Convenience shortcut for existing `workflow_id`s. When `True`, `run()` creates a source-derived fork and leaves the source row unchanged.
+- `fork_from` - Workflow ID to fork from directly (no manual checkpoint plumbing). Without `workflow_id=`, the target is `{source}-fork-{hex}`. Requires a checkpointer.
+- `retry_from` - Workflow ID to retry from directly (records retry lineage metadata). Without `workflow_id=`, runner naming remains generic `run-...`. Requires a checkpointer.
 - Lineage hashing: checkpoint compatibility uses a structural hash; a separate code hash is recorded for observability/caching workflows.
 - `**input_values` - Input shorthand for flat graph input names. Use `values` for dotted/nested inputs or names that match runner options.
 
@@ -860,6 +863,7 @@ class RunResult:
     log: RunLog | None          # Execution trace, if collected
     checkpoint_ok: bool         # False when a best-effort async step save failed
     checkpoint_errors: tuple[str, ...]  # String-only checkpoint save errors
+    restored: bool              # True only for a checkpoint-skipped map child
 ```
 
 With async checkpoint durability, step saves are best-effort: a persistence gap
@@ -911,8 +915,10 @@ This is useful for debugging — you can inspect which nodes completed successfu
 result.summary()   # "3 nodes | 12ms | 0 errors | slowest: generate (8ms)"
 
 # JSON-serializable metadata (no raw values or exception objects)
-result.to_dict()   # {"status": "completed", "run_id": "run-abc", "checkpoint_ok": True, "checkpoint_errors": [], "log": {...}}
+result.to_dict()   # {"status": "completed", "run_id": "run-abc", "checkpoint_ok": True, "checkpoint_errors": [], "restored": False, "log": {...}}
 ```
+
+A checkpoint-skipped map child remains `status=COMPLETED` for compatibility but has `restored=True`. Its summary, repr, HTML, serialized metadata, and synthetic `RunLog` all disclose restoration rather than reporting a fake execution duration.
 
 ---
 
@@ -943,15 +949,18 @@ results.failed       # True if any failed
 results.partial      # True if some items completed and some failed
 results.stopped      # True if any item stopped and none failed/paused
 results.failures     # List of failed RunResult items
+results.restored_count  # Restored successes (a subset of completed items)
 
 # Derived durability aggregation (properties, not dataclass fields)
 results.checkpoint_ok      # True only when every item persisted successfully
 results.checkpoint_errors  # Tuple of save errors in stable item order
 
 # Progressive disclosure
-results.summary()    # "3 items | 3 completed | 12ms"
+results.summary()    # "3 items | 3 completed | avg 12ms/item"
 results.to_dict()    # JSON-serializable batch metadata + per-item results
 ```
+
+Completed counts stay inclusive of restored successes. Duration averages use only freshly executed completed items with real logs; a fully restored map omits the average. `results.log` exposes the same `restored_count` and per-item provenance through `MapLog`.
 
 ### Attributes
 
@@ -1176,7 +1185,7 @@ graph = Graph([process]).bind(x=5)  # bound=5
 
 Checkpoint lineage has two different input rules:
 
-- **Strict resume**: using an existing `workflow_id` resumes persisted state and rejects fresh runtime inputs, because new inputs would silently rewrite history. Interrupt response payloads are the exception; pass the paused response key/value to resolve the pending interrupt.
+- **Strict resume**: using an existing `workflow_id` resumes persisted state and ordinarily rejects fresh runtime inputs, because new inputs would silently rewrite history. Interrupt response payloads resolve paused runs. A stopped run instead requires an explicit signal: pass any non-empty valid runtime mapping to resume the same lineage, or pass `override_workflow=True` to create a source-derived fork. `None` and `{}` raise `WorkflowStoppedError` before execution events or persistence writes.
 - **Fork/retry**: `fork_from` and `retry_from` create a new lineage from a checkpoint, so runtime inputs may override restored values for the new run.
 
 See [Run Lineage](../05-how-to/batch-processing.md#run-lineage-resume-vs-fork). For the `Checkpointer` ABC, `CheckpointPolicy`, backend comparison, and the no-checkpointer re-drive alternative, see [Checkpointers](checkpointers.md).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- **Truthful restored-map provenance** — checkpoint-skipped map children now return `RunResult(restored=True)` with a visible non-error `NodeRecord(status="restored")`. `MapResult.restored_count`, `MapLog.restored_count`, `RunEndEvent.batch_restored_items`, and `hypergraph.batch.restored_items` expose the restored subset while completed counts stay inclusive. Duration averages include only fresh completed items with real logs.
+
+- **Internal-step inspection escape hatch** — `get_steps(..., show_internal=True)`, SQLite `steps(...)`, and `RunInspector.steps(...)` can expose retention carrier rows for debugging; public views hide them by default while state reconstruction still folds them.
+
+- **`WorkflowStoppedError`** — a bare rerun of a persisted stopped workflow now fails before events or persistence writes. Pass a non-empty runtime mapping to resume the same lineage, or `override_workflow=True` to fork.
+
 - **HyperTable child fingerprints** — child rows now have real fingerprints computed from the child's source inputs, child graph node hashes, and component config hashes (scoped to the child graph, not the parent). Re-inserting a parent skips children whose inputs and graph definition haven't changed. Makes insert naturally resumable after crashes.
 
 - **HyperTable `on_error` policy** — `HyperTable(..., on_error="store")` writes error rows instead of raising on derivation failure. Error rows preserve source columns and identity with `_status="error"` and `_error="{ExceptionType}: {message}"`. Successful siblings are unaffected. Error rows are retried (not skipped) on the next insert/sync. Default `on_error="raise"` preserves backward compatibility. Works for both parent and child rows, and with both `SyncRunner` and `AsyncRunner`.
@@ -15,6 +21,10 @@
 - **Reserved column name validation** — identity and source columns named `_status`, `_error`, `_row_fingerprint`, `_write_gen`, `_parent_id`, or `_provenance_*` are rejected at graph analysis time with a clear error message.
 
 ### Fixed
+
+- **Checkpointer run-filter parity** — async Memory/SQLite and SQLite sync reads now compose `graph_name`, inclusive UTC-normalized `since`, status, and parent filters before limit. Omitting `parent_run_id` returns all runs; explicit `None` returns top-level runs only. `count_runs()` uses the same three-state parent contract.
+
+- **Source-derived fork IDs** — before, `runner.run(..., fork_from="job-1")` generated an unrelated `run-...` ID; now it yields `job-1-fork-<hex>`. Explicit targets remain exact, retries keep generic runner IDs, and missing/nested implicit sources fail without creating a run.
 
 - **`set_children` parent scoping** — the cleanup predicate in `set_children` now includes `_parent_id`, preventing accidental deletion of another parent's children when child identity values overlap.
 

--- a/src/hypergraph/__init__.py
+++ b/src/hypergraph/__init__.py
@@ -38,6 +38,7 @@ from hypergraph.exceptions import (
     WorkflowAlreadyCompletedError,
     WorkflowAlreadyRunningError,
     WorkflowForkError,
+    WorkflowStoppedError,
 )
 from hypergraph.graph import Graph, GraphConfigError, InputSpec
 from hypergraph.nodes import (
@@ -114,6 +115,7 @@ __all__ = [
     "WorkflowForkError",
     "InputOverrideRequiresForkError",
     "WorkflowAlreadyRunningError",
+    "WorkflowStoppedError",
     # RunLog
     "RunLog",
     "MapLog",

--- a/src/hypergraph/_repr.py
+++ b/src/hypergraph/_repr.py
@@ -576,7 +576,7 @@ def html_filter_paginate_script(
         "for(var i=0;i<all.length;i++){"
         "var it=all[i];"
         f"var st=(it.getAttribute('{_html.escape(status_attr, quote=True)}')||'');"
-        "if(want==='all'||st===want)filtered.push(it);"
+        "if(want==='all'||st.split(/\\s+/).indexOf(want)>=0)filtered.push(it);"
         "}"
         "var total=filtered.length;"
         "var pages=(size<0)?1:Math.max(1,Math.ceil(total/size));"

--- a/src/hypergraph/_repr.py
+++ b/src/hypergraph/_repr.py
@@ -252,6 +252,7 @@ STATUS_COLORS: dict[str, str] = {
     "failed": ALIGNUI_WIDGET_THEME["error_text"],
     "partial": ALIGNUI_WIDGET_THEME["warning_text"],
     "cached": ALIGNUI_WIDGET_THEME["info_text"],
+    "restored": ALIGNUI_WIDGET_THEME["info_text"],
     "active": ALIGNUI_WIDGET_THEME["warning_text"],
     "paused": ALIGNUI_WIDGET_THEME["feature_text"],
 }
@@ -261,6 +262,7 @@ _BADGE_BG: dict[str, str] = {
     "failed": ALIGNUI_WIDGET_THEME["error_bg"],
     "partial": ALIGNUI_WIDGET_THEME["warning_bg"],
     "cached": ALIGNUI_WIDGET_THEME["info_bg"],
+    "restored": ALIGNUI_WIDGET_THEME["info_bg"],
     "active": ALIGNUI_WIDGET_THEME["warning_bg"],
     "paused": ALIGNUI_WIDGET_THEME["feature_bg"],
 }
@@ -510,7 +512,7 @@ def html_filter_paginate_controls(
     default_page_size: int,
 ) -> str:
     """Render reusable filter + pagination controls for list-like widgets."""
-    status_order = ["completed", "failed", "active", "paused", "partial", "cached"]
+    status_order = ["completed", "restored", "failed", "active", "paused", "partial", "cached"]
     status_options = []
     for status in status_order:
         n = counts.get(status, 0)

--- a/src/hypergraph/checkpointers/base.py
+++ b/src/hypergraph/checkpointers/base.py
@@ -5,10 +5,19 @@ from __future__ import annotations
 import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Literal
 
 from hypergraph.checkpointers.types import Checkpoint, Run, StepRecord, WorkflowStatus
+
+_UNSET = object()
+
+
+def _normalize_since(value: datetime) -> datetime:
+    """Return an aware UTC boundary for run-list filtering."""
+    if value.tzinfo is None or value.utcoffset() is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
 
 
 @dataclass
@@ -175,14 +184,19 @@ class Checkpointer(ABC):
         self,
         *,
         status: WorkflowStatus | None = None,
-        parent_run_id: str | None = None,
+        graph_name: str | None = None,
+        since: datetime | None = None,
+        parent_run_id: str | None | object = _UNSET,
         limit: int | None = 100,
     ) -> list[Run]:
         """List runs, optionally filtered by status and/or parent.
 
         Args:
             status: Filter to runs with this status (None = all).
-            parent_run_id: Filter to children of this run (None = no filter).
+            graph_name: Filter to runs for this graph.
+            since: Inclusive creation-time boundary. Naive values mean UTC.
+            parent_run_id: Filter by parent relationship. Omitted means all,
+                None means top-level, and a run id means direct children.
             limit: Max results to return. ``None`` returns all matches.
         """
         ...
@@ -191,7 +205,7 @@ class Checkpointer(ABC):
         self,
         *,
         status: WorkflowStatus | None = None,
-        parent_run_id: str | None = None,
+        parent_run_id: str | None | object = _UNSET,
         retry_of: str | None = None,
     ) -> int:
         """Count runs matching a small set of backend-neutral filters.

--- a/src/hypergraph/checkpointers/base.py
+++ b/src/hypergraph/checkpointers/base.py
@@ -236,7 +236,10 @@ class Checkpointer(ABC):
         Backends with efficient query support should override this to avoid
         materializing full run objects for simple counting operations.
         """
-        runs = await self.list_runs(status=status, parent_run_id=parent_run_id, limit=None)
+        if parent_run_id is _UNSET:
+            runs = await self.list_runs(status=status, limit=None)
+        else:
+            runs = await self.list_runs(status=status, parent_run_id=parent_run_id, limit=None)
         if retry_of is not None:
             runs = [run for run in runs if run.retry_of == retry_of]
         return len(runs)

--- a/src/hypergraph/checkpointers/base.py
+++ b/src/hypergraph/checkpointers/base.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Literal
 
 from hypergraph.checkpointers.types import Checkpoint, Run, StepRecord, WorkflowStatus
+from hypergraph.exceptions import WorkflowForkError
 
 _UNSET = object()
 
@@ -18,6 +19,19 @@ def _normalize_since(value: datetime) -> datetime:
     if value.tzinfo is None or value.utcoffset() is None:
         return value.replace(tzinfo=timezone.utc)
     return value.astimezone(timezone.utc)
+
+
+def _resolve_fork_workflow_id(source_run_id: str, workflow_id: str | None) -> str:
+    """Keep an explicit target or derive one for a top-level source."""
+    if workflow_id is not None:
+        return workflow_id
+    if "/" in source_run_id:
+        raise WorkflowForkError(
+            f"Cannot auto-derive a top-level workflow_id from nested source {source_run_id!r}.\n\n"
+            "How to fix:\n"
+            "  Top-level callers should pass an explicit slash-free workflow_id for the new fork."
+        )
+    return f"{source_run_id}-fork-{uuid.uuid4().hex[:6]}"
 
 
 @dataclass
@@ -157,8 +171,11 @@ class Checkpointer(ABC):
         superstep: int | None = None,
     ) -> tuple[str, Checkpoint]:
         """Prepare a fork by materializing a checkpoint and suggested workflow_id."""
+        source = await self.get_run_async(source_run_id)
+        if source is None:
+            raise ValueError(f"Unknown source workflow_id: {source_run_id!r}")
+        new_workflow_id = _resolve_fork_workflow_id(source_run_id, workflow_id)
         checkpoint = await self.get_checkpoint(source_run_id, superstep=superstep)
-        new_workflow_id = workflow_id or f"{source_run_id}-fork-{uuid.uuid4().hex[:6]}"
         return new_workflow_id, checkpoint
 
     async def retry_workflow_async(

--- a/src/hypergraph/checkpointers/base.py
+++ b/src/hypergraph/checkpointers/base.py
@@ -125,8 +125,14 @@ class Checkpointer(ABC):
         ...
 
     @abstractmethod
-    async def get_steps(self, run_id: str, *, superstep: int | None = None) -> list[StepRecord]:
-        """Get step records through a superstep (None = all)."""
+    async def get_steps(
+        self,
+        run_id: str,
+        *,
+        superstep: int | None = None,
+        show_internal: bool = False,
+    ) -> list[StepRecord]:
+        """Get step records through a superstep, hiding internal carriers by default."""
         ...
 
     async def get_checkpoint(self, run_id: str, *, superstep: int | None = None) -> Checkpoint:

--- a/src/hypergraph/checkpointers/inspection.py
+++ b/src/hypergraph/checkpointers/inspection.py
@@ -36,7 +36,13 @@ class RunInspector(Protocol):
         limit: int | None = 100,
     ) -> list[Run]: ...
 
-    def steps(self, run_id: str, *, superstep: int | None = None) -> list[StepRecord]: ...
+    def steps(
+        self,
+        run_id: str,
+        *,
+        superstep: int | None = None,
+        show_internal: bool = False,
+    ) -> list[StepRecord]: ...
 
     def state(self, run_id: str, *, superstep: int | None = None) -> dict[str, Any]: ...
 
@@ -81,8 +87,14 @@ class SqliteRunInspector:
             kwargs["parent_run_id"] = parent_run_id
         return self.checkpointer.runs(**kwargs)
 
-    def steps(self, run_id: str, *, superstep: int | None = None) -> list[StepRecord]:
-        return self.checkpointer.steps(run_id, superstep=superstep)
+    def steps(
+        self,
+        run_id: str,
+        *,
+        superstep: int | None = None,
+        show_internal: bool = False,
+    ) -> list[StepRecord]:
+        return self.checkpointer.steps(run_id, superstep=superstep, show_internal=show_internal)
 
     def state(self, run_id: str, *, superstep: int | None = None) -> dict[str, Any]:
         return self.checkpointer.state(run_id, superstep=superstep)

--- a/src/hypergraph/checkpointers/memory.py
+++ b/src/hypergraph/checkpointers/memory.py
@@ -6,7 +6,7 @@ from dataclasses import replace
 from datetime import datetime, timezone
 from typing import Any
 
-from hypergraph.checkpointers.base import Checkpointer
+from hypergraph.checkpointers.base import _UNSET, Checkpointer, _normalize_since
 from hypergraph.checkpointers.types import Run, StepRecord, StepStatus, WorkflowStatus
 
 _BASELINE_NODE_NAME = "__retained_state__"
@@ -110,13 +110,20 @@ class MemoryCheckpointer(Checkpointer):
         self,
         *,
         status: WorkflowStatus | None = None,
-        parent_run_id: str | None = None,
+        graph_name: str | None = None,
+        since: datetime | None = None,
+        parent_run_id: str | None | object = _UNSET,
         limit: int | None = 100,
     ) -> list[Run]:
         runs = list(self._runs.values())
         if status is not None:
             runs = [run for run in runs if run.status == status]
-        if parent_run_id is not None:
+        if graph_name is not None:
+            runs = [run for run in runs if run.graph_name == graph_name]
+        if since is not None:
+            boundary = _normalize_since(since)
+            runs = [run for run in runs if run.created_at >= boundary]
+        if parent_run_id is not _UNSET:
             runs = [run for run in runs if run.parent_run_id == parent_run_id]
 
         runs.sort(key=lambda run: run.created_at, reverse=True)
@@ -128,7 +135,7 @@ class MemoryCheckpointer(Checkpointer):
         self,
         *,
         status: WorkflowStatus | None = None,
-        parent_run_id: str | None = None,
+        parent_run_id: str | None | object = _UNSET,
         retry_of: str | None = None,
     ) -> int:
         runs = self._runs.values()
@@ -136,7 +143,7 @@ class MemoryCheckpointer(Checkpointer):
             1
             for run in runs
             if (status is None or run.status == status)
-            and (parent_run_id is None or run.parent_run_id == parent_run_id)
+            and (parent_run_id is _UNSET or run.parent_run_id == parent_run_id)
             and (retry_of is None or run.retry_of == retry_of)
         )
 

--- a/src/hypergraph/checkpointers/memory.py
+++ b/src/hypergraph/checkpointers/memory.py
@@ -131,7 +131,7 @@ class MemoryCheckpointer(Checkpointer):
         if status is not None:
             runs = [run for run in runs if run.status == status]
         if graph_name is not None:
-            runs = [run for run in runs if run.graph_name == graph_name]
+            runs = [run for run in runs if (run.graph_name or "") == graph_name]
         if since is not None:
             boundary = _normalize_since(since)
             runs = [run for run in runs if run.created_at >= boundary]

--- a/src/hypergraph/checkpointers/memory.py
+++ b/src/hypergraph/checkpointers/memory.py
@@ -10,6 +10,7 @@ from hypergraph.checkpointers.base import _UNSET, Checkpointer, _normalize_since
 from hypergraph.checkpointers.types import Run, StepRecord, StepStatus, WorkflowStatus
 
 _BASELINE_NODE_NAME = "__retained_state__"
+_BASELINE_NODE_TYPE = "RetentionBaseline"
 
 
 def _step_sort_key(record: StepRecord) -> tuple[datetime, datetime, int, str]:
@@ -91,16 +92,27 @@ class MemoryCheckpointer(Checkpointer):
 
     async def get_state(self, run_id: str, *, superstep: int | None = None) -> dict[str, Any]:
         state: dict[str, Any] = {}
-        for step in await self.get_steps(run_id, superstep=superstep):
+        records = list(self._steps.get(run_id, {}).values())
+        if superstep is not None:
+            records = [record for record in records if record.superstep <= superstep]
+        for step in sorted(records, key=_step_sort_key):
             if step.values:
                 state.update(step.values)
         return state
 
-    async def get_steps(self, run_id: str, *, superstep: int | None = None) -> list[StepRecord]:
+    async def get_steps(
+        self,
+        run_id: str,
+        *,
+        superstep: int | None = None,
+        show_internal: bool = False,
+    ) -> list[StepRecord]:
         run_steps = self._steps.get(run_id, {})
         records = list(run_steps.values())
         if superstep is not None:
             records = [record for record in records if record.superstep <= superstep]
+        if not show_internal:
+            records = [record for record in records if record.node_name != _BASELINE_NODE_NAME and record.node_type != _BASELINE_NODE_TYPE]
         return sorted(records, key=_step_sort_key)
 
     async def get_run_async(self, run_id: str) -> Run | None:

--- a/src/hypergraph/checkpointers/sqlite.py
+++ b/src/hypergraph/checkpointers/sqlite.py
@@ -38,6 +38,10 @@ _STEP_TIME_ORDER_DESC = "COALESCE(completed_at, created_at) DESC, created_at DES
 _STEP_TIME_ORDER_DESC_WITH_ALIAS = "COALESCE(s.completed_at, s.created_at) DESC, s.created_at DESC, s.id DESC"
 _RETENTION_BASELINE_NODE_NAME = "__retained_state__"
 _RETENTION_BASELINE_NODE_TYPE = "RetentionBaseline"
+_PUBLIC_STEP_FILTER = f"node_name != '{_RETENTION_BASELINE_NODE_NAME}' AND (node_type IS NULL OR node_type != '{_RETENTION_BASELINE_NODE_TYPE}')"
+_PUBLIC_STEP_FILTER_WITH_ALIAS = (
+    f"s.node_name != '{_RETENTION_BASELINE_NODE_NAME}' AND (s.node_type IS NULL OR s.node_type != '{_RETENTION_BASELINE_NODE_TYPE}')"
+)
 _RETENTION_ROW_COLS = "id, step_index, superstep, node_name, values_data, created_at, completed_at"
 _DELETE_BATCH_SIZE = 500
 
@@ -163,7 +167,7 @@ class SqliteCheckpointer(Checkpointer):
         try:
             db = self._sync_db()
             (stats["run_count"],) = db.execute("SELECT COUNT(*) FROM runs").fetchone()
-            (stats["step_count"],) = db.execute("SELECT COUNT(*) FROM steps").fetchone()
+            (stats["step_count"],) = db.execute(f"SELECT COUNT(*) FROM steps WHERE {_PUBLIC_STEP_FILTER}").fetchone()
         except Exception:
             stats["run_count"] = None
             stats["step_count"] = None
@@ -438,21 +442,28 @@ class SqliteCheckpointer(Checkpointer):
                     state.update(values)
         return state
 
-    async def get_steps(self, run_id: str, *, superstep: int | None = None) -> list[StepRecord]:
+    async def get_steps(
+        self,
+        run_id: str,
+        *,
+        superstep: int | None = None,
+        show_internal: bool = False,
+    ) -> list[StepRecord]:
         """Get step records in execution order."""
         await self._ensure_db()
 
+        conditions = ["run_id = ?"]
+        params: list[Any] = [run_id]
         if superstep is not None:
-            cursor = await self._db.execute(
-                f"SELECT {_STEPS_COLS} FROM steps WHERE run_id = ? AND superstep <= ? ORDER BY {_STEP_TIME_ORDER}",
-                (run_id, superstep),
-            )
-        else:
-            cursor = await self._db.execute(
-                f"SELECT {_STEPS_COLS} FROM steps WHERE run_id = ? ORDER BY {_STEP_TIME_ORDER}",
-                (run_id,),
-            )
+            conditions.append("superstep <= ?")
+            params.append(superstep)
+        if not show_internal:
+            conditions.append(_PUBLIC_STEP_FILTER)
 
+        cursor = await self._db.execute(
+            f"SELECT {_STEPS_COLS} FROM steps WHERE {' AND '.join(conditions)} ORDER BY {_STEP_TIME_ORDER}",
+            params,
+        )
         rows = await cursor.fetchall()
         return StepTable(self._row_to_step(row) for row in rows)
 
@@ -591,7 +602,7 @@ class SqliteCheckpointer(Checkpointer):
             f"""
             SELECT {cols} FROM steps s
             JOIN steps_fts fts ON s.id = fts.rowid
-            WHERE steps_fts MATCH ?
+            WHERE steps_fts MATCH ? AND {_PUBLIC_STEP_FILTER_WITH_ALIAS}
             ORDER BY {_STEP_TIME_ORDER_DESC_WITH_ALIAS}
             LIMIT ?
             """,
@@ -700,19 +711,26 @@ class SqliteCheckpointer(Checkpointer):
                     state.update(values)
         return state
 
-    def steps(self, run_id: str, *, superstep: int | None = None) -> list[StepRecord]:
+    def steps(
+        self,
+        run_id: str,
+        *,
+        superstep: int | None = None,
+        show_internal: bool = False,
+    ) -> list[StepRecord]:
         """Get step records synchronously."""
         db = self._sync_db()
+        conditions = ["run_id = ?"]
+        params: list[Any] = [run_id]
         if superstep is not None:
-            cursor = db.execute(
-                f"SELECT {_STEPS_COLS} FROM steps WHERE run_id = ? AND superstep <= ? ORDER BY {_STEP_TIME_ORDER}",
-                (run_id, superstep),
-            )
-        else:
-            cursor = db.execute(
-                f"SELECT {_STEPS_COLS} FROM steps WHERE run_id = ? ORDER BY {_STEP_TIME_ORDER}",
-                (run_id,),
-            )
+            conditions.append("superstep <= ?")
+            params.append(superstep)
+        if not show_internal:
+            conditions.append(_PUBLIC_STEP_FILTER)
+        cursor = db.execute(
+            f"SELECT {_STEPS_COLS} FROM steps WHERE {' AND '.join(conditions)} ORDER BY {_STEP_TIME_ORDER}",
+            params,
+        )
         return StepTable(self._row_to_step(row) for row in cursor.fetchall())
 
     def get_run(self, run_id: str) -> Run | None:
@@ -864,7 +882,7 @@ class SqliteCheckpointer(Checkpointer):
             f"""
             SELECT {cols} FROM steps s
             JOIN steps_fts fts ON s.id = fts.rowid
-            WHERE steps_fts MATCH ?
+            WHERE steps_fts MATCH ? AND {_PUBLIC_STEP_FILTER_WITH_ALIAS}
             ORDER BY {_STEP_TIME_ORDER_DESC_WITH_ALIAS}
             LIMIT ?
             """,
@@ -883,7 +901,7 @@ class SqliteCheckpointer(Checkpointer):
         """Get per-node duration/frequency stats for a run."""
         db = self._sync_db()
         cursor = db.execute(
-            """
+            f"""
             SELECT node_name, node_type,
                    COUNT(*) as step_runs,
                    SUM(duration_ms) as total_ms,
@@ -891,7 +909,7 @@ class SqliteCheckpointer(Checkpointer):
                    MAX(duration_ms) as max_ms,
                    SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) as errors,
                    SUM(cached) as cache_hits
-            FROM steps WHERE run_id = ?
+            FROM steps WHERE run_id = ? AND {_PUBLIC_STEP_FILTER}
             GROUP BY node_name
             ORDER BY total_ms DESC
             """,

--- a/src/hypergraph/checkpointers/sqlite.py
+++ b/src/hypergraph/checkpointers/sqlite.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 from hypergraph.checkpointers._migrate import ensure_schema
-from hypergraph.checkpointers.base import _UNSET, Checkpointer, CheckpointPolicy, _normalize_since
+from hypergraph.checkpointers.base import _UNSET, Checkpointer, CheckpointPolicy, _normalize_since, _resolve_fork_workflow_id
 from hypergraph.checkpointers.presenters import render_checkpointer_explorer_html
 from hypergraph.checkpointers.serializers import JsonSerializer, Serializer
 from hypergraph.checkpointers.types import (
@@ -466,22 +466,6 @@ class SqliteCheckpointer(Checkpointer):
         )
         rows = await cursor.fetchall()
         return StepTable(self._row_to_step(row) for row in rows)
-
-    async def fork_workflow_async(
-        self,
-        source_run_id: str,
-        *,
-        workflow_id: str | None = None,
-        superstep: int | None = None,
-    ) -> tuple[str, Checkpoint]:
-        """Prepare a fork checkpoint + target workflow id."""
-        await self._ensure_db()
-        source = await self.get_run_async(source_run_id)
-        if source is None:
-            raise ValueError(f"Unknown source workflow_id: {source_run_id!r}")
-        checkpoint = await self.get_checkpoint(source_run_id, superstep=superstep)
-        new_workflow_id = workflow_id or f"{source_run_id}-fork-{uuid.uuid4().hex[:6]}"
-        return new_workflow_id, checkpoint
 
     async def retry_workflow_async(
         self,
@@ -947,8 +931,8 @@ class SqliteCheckpointer(Checkpointer):
         """Prepare a fork checkpoint + target workflow id (sync)."""
         if self.get_run(source_run_id) is None:
             raise ValueError(f"Unknown source workflow_id: {source_run_id!r}")
+        new_workflow_id = _resolve_fork_workflow_id(source_run_id, workflow_id)
         checkpoint = self.checkpoint(source_run_id, superstep=superstep)
-        new_workflow_id = workflow_id or f"{source_run_id}-fork-{uuid.uuid4().hex[:6]}"
         return new_workflow_id, checkpoint
 
     def retry_workflow(

--- a/src/hypergraph/checkpointers/sqlite.py
+++ b/src/hypergraph/checkpointers/sqlite.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 from hypergraph.checkpointers._migrate import ensure_schema
-from hypergraph.checkpointers.base import Checkpointer, CheckpointPolicy
+from hypergraph.checkpointers.base import _UNSET, Checkpointer, CheckpointPolicy, _normalize_since
 from hypergraph.checkpointers.presenters import render_checkpointer_explorer_html
 from hypergraph.checkpointers.serializers import JsonSerializer, Serializer
 from hypergraph.checkpointers.types import (
@@ -40,9 +40,6 @@ _RETENTION_BASELINE_NODE_NAME = "__retained_state__"
 _RETENTION_BASELINE_NODE_TYPE = "RetentionBaseline"
 _RETENTION_ROW_COLS = "id, step_index, superstep, node_name, values_data, created_at, completed_at"
 _DELETE_BATCH_SIZE = 500
-
-# Sentinel for "parameter not provided" — distinct from None (which means "top-level only")
-_UNSET = object()
 
 
 def _parse_dt(value: str | None) -> datetime | None:
@@ -512,7 +509,9 @@ class SqliteCheckpointer(Checkpointer):
         self,
         *,
         status: WorkflowStatus | None = None,
-        parent_run_id: str | None = None,
+        graph_name: str | None = None,
+        since: datetime | None = None,
+        parent_run_id: str | None | object = _UNSET,
         limit: int | None = 100,
     ) -> list[Run]:
         """List runs, optionally filtered by status and/or parent."""
@@ -524,9 +523,18 @@ class SqliteCheckpointer(Checkpointer):
         if status is not None:
             conditions.append("status = ?")
             params.append(status.value)
-        if parent_run_id is not None:
-            conditions.append("parent_run_id = ?")
-            params.append(parent_run_id)
+        if graph_name is not None:
+            conditions.append("graph_name = ?")
+            params.append(graph_name)
+        if since is not None:
+            conditions.append("created_at >= ?")
+            params.append(_normalize_since(since).isoformat())
+        if parent_run_id is not _UNSET:
+            if parent_run_id is None:
+                conditions.append("parent_run_id IS NULL")
+            else:
+                conditions.append("parent_run_id = ?")
+                params.append(parent_run_id)
 
         where = f" WHERE {' AND '.join(conditions)}" if conditions else ""
         query = f"SELECT {_RUNS_COLS} FROM runs{where} ORDER BY created_at DESC"
@@ -542,7 +550,7 @@ class SqliteCheckpointer(Checkpointer):
         self,
         *,
         status: WorkflowStatus | None = None,
-        parent_run_id: str | None = None,
+        parent_run_id: str | None | object = _UNSET,
         retry_of: str | None = None,
     ) -> int:
         """Count runs without materializing full run records."""
@@ -553,9 +561,12 @@ class SqliteCheckpointer(Checkpointer):
         if status is not None:
             conditions.append("status = ?")
             params.append(status.value)
-        if parent_run_id is not None:
-            conditions.append("parent_run_id = ?")
-            params.append(parent_run_id)
+        if parent_run_id is not _UNSET:
+            if parent_run_id is None:
+                conditions.append("parent_run_id IS NULL")
+            else:
+                conditions.append("parent_run_id = ?")
+                params.append(parent_run_id)
         if retry_of is not None:
             conditions.append("retry_of = ?")
             params.append(retry_of)
@@ -742,7 +753,7 @@ class SqliteCheckpointer(Checkpointer):
             params.append(graph_name)
         if since is not None:
             conditions.append("created_at >= ?")
-            params.append(since.isoformat())
+            params.append(_normalize_since(since).isoformat())
         if parent_run_id is not _UNSET:
             if parent_run_id is None:
                 conditions.append("parent_run_id IS NULL")

--- a/src/hypergraph/events/otel.py
+++ b/src/hypergraph/events/otel.py
@@ -193,6 +193,7 @@ class OpenTelemetryProcessor(TypedEventProcessor):
                 "hypergraph.batch.failed_items": event.batch_failed_items,
                 "hypergraph.batch.paused_items": event.batch_paused_items,
                 "hypergraph.batch.stopped_items": event.batch_stopped_items,
+                "hypergraph.batch.restored_items": event.batch_restored_items,
                 "hypergraph.batch.outcome": event.batch_outcome,
             },
         )

--- a/src/hypergraph/events/types.py
+++ b/src/hypergraph/events/types.py
@@ -106,8 +106,8 @@ class RunEndEvent(BaseEvent):
     batch_failed_items: int | None = None
     batch_paused_items: int | None = None
     batch_stopped_items: int | None = None
-    batch_restored_items: int | None = None
     batch_outcome: str | None = None
+    batch_restored_items: int | None = None
 
     def __post_init__(self) -> None:
         # Coerce string status values to RunStatus enum

--- a/src/hypergraph/events/types.py
+++ b/src/hypergraph/events/types.py
@@ -106,6 +106,7 @@ class RunEndEvent(BaseEvent):
     batch_failed_items: int | None = None
     batch_paused_items: int | None = None
     batch_stopped_items: int | None = None
+    batch_restored_items: int | None = None
     batch_outcome: str | None = None
 
     def __post_init__(self) -> None:

--- a/src/hypergraph/exceptions.py
+++ b/src/hypergraph/exceptions.py
@@ -131,6 +131,20 @@ class WorkflowAlreadyCompletedError(Exception):
         super().__init__(f"Workflow '{workflow_id}' is already completed. Fork to create a new lineage.")
 
 
+class WorkflowStoppedError(Exception):
+    """Raised when a stopped workflow is rerun without an explicit signal."""
+
+    def __init__(self, workflow_id: str) -> None:
+        self.workflow_id = workflow_id
+        super().__init__(
+            f"Workflow '{workflow_id}' is stopped and cannot resume without an explicit signal.\n\n"
+            "The stopped workflow keeps its partial checkpoint state and lineage.\n\n"
+            "How to fix:\n"
+            "  Pass a non-empty runtime value mapping to resume the same workflow_id, "
+            "or pass override_workflow=True to fork a new lineage."
+        )
+
+
 class GraphChangedError(Exception):
     """Raised when graph structure changed for an existing workflow lineage."""
 

--- a/src/hypergraph/runners/_shared/event_helpers.py
+++ b/src/hypergraph/runners/_shared/event_helpers.py
@@ -264,5 +264,6 @@ def build_run_end_event(
         batch_failed_items=batch_summary.failed_items if batch_summary is not None else None,
         batch_paused_items=batch_summary.paused_items if batch_summary is not None else None,
         batch_stopped_items=batch_summary.stopped_items if batch_summary is not None else None,
+        batch_restored_items=batch_summary.restored_items if batch_summary is not None else None,
         batch_outcome=batch_summary.outcome if batch_summary is not None else None,
     )

--- a/src/hypergraph/runners/_shared/event_metadata.py
+++ b/src/hypergraph/runners/_shared/event_metadata.py
@@ -43,6 +43,7 @@ class BatchSummary:
     failed_items: int
     paused_items: int
     stopped_items: int
+    restored_items: int
     outcome: str
 
     @classmethod
@@ -55,12 +56,14 @@ class BatchSummary:
         failed_items = sum(1 for result in results if result.status == RunStatus.FAILED)
         paused_items = sum(1 for result in results if result.status == RunStatus.PAUSED)
         stopped_items = sum(1 for result in results if result.status == RunStatus.STOPPED)
+        restored_items = sum(1 for result in results if result.restored)
         return cls(
             total_items=total_items,
             completed_items=completed_items,
             failed_items=failed_items,
             paused_items=paused_items,
             stopped_items=stopped_items,
+            restored_items=restored_items,
             outcome=aggregate_run_status(results).value,
         )
 

--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -262,7 +262,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
         resume_checkpoint = None
         skip_missing_input_validation = False
         if checkpointer is not None and _validation_ctx is None:
-            if workflow_id is None:
+            if workflow_id is None and fork_from is None:
                 workflow_id = generate_workflow_id()
             if fork_from is not None and retry_from is not None:
                 raise ValueError("Cannot pass both fork_from and retry_from. Choose one lineage source.")

--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -19,6 +19,7 @@ from hypergraph.exceptions import (
     WorkflowAlreadyCompletedError,
     WorkflowAlreadyRunningError,
     WorkflowForkError,
+    WorkflowStoppedError,
 )
 from hypergraph.runners._shared.event_metadata import (
     DEFAULT_RUN_CONTEXT,
@@ -288,7 +289,10 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                     previous_hash = (existing_run.config or {}).get("graph_struct_hash")
                     if previous_hash is not None and previous_hash != graph_hash:
                         raise GraphChangedError(workflow_id)
-                    if normalized_values and not is_interrupt_resume_payload(graph, normalized_values):
+                    if existing_run.status.value == "stopped":
+                        if not normalized_values:
+                            raise WorkflowStoppedError(workflow_id)
+                    elif normalized_values and not is_interrupt_resume_payload(graph, normalized_values):
                         raise InputOverrideRequiresForkError(workflow_id)
                     if existing_run.status.value == "completed":
                         raise WorkflowAlreadyCompletedError(workflow_id)

--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -57,6 +57,7 @@ from hypergraph.runners._shared.types import (
     RunResult,
     RunStatus,
     _generate_run_id,
+    build_restored_run_log,
 )
 from hypergraph.runners._shared.validation import (
     precompute_input_validation,
@@ -728,6 +729,8 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                     status=RunStatus.COMPLETED,
                     run_id=restore_run_id,
                     workflow_id=restore_run_id,
+                    log=build_restored_run_log(graph.name or "", restore_run_id),
+                    restored=True,
                 )
 
             try:

--- a/src/hypergraph/runners/_shared/template_sync.py
+++ b/src/hypergraph/runners/_shared/template_sync.py
@@ -18,6 +18,7 @@ from hypergraph.exceptions import (
     WorkflowAlreadyCompletedError,
     WorkflowAlreadyRunningError,
     WorkflowForkError,
+    WorkflowStoppedError,
 )
 from hypergraph.runners._shared.event_metadata import (
     DEFAULT_RUN_CONTEXT,
@@ -268,7 +269,10 @@ class SyncRunnerTemplate(BaseRunner, ABC):
                     previous_hash = (existing_run.config or {}).get("graph_struct_hash")
                     if previous_hash is not None and previous_hash != graph_hash:
                         raise GraphChangedError(workflow_id)
-                    if normalized_values and not is_interrupt_resume_payload(graph, normalized_values):
+                    if existing_run.status.value == "stopped":
+                        if not normalized_values:
+                            raise WorkflowStoppedError(workflow_id)
+                    elif normalized_values and not is_interrupt_resume_payload(graph, normalized_values):
                         raise InputOverrideRequiresForkError(workflow_id)
                     if existing_run.status.value == "completed":
                         raise WorkflowAlreadyCompletedError(workflow_id)

--- a/src/hypergraph/runners/_shared/template_sync.py
+++ b/src/hypergraph/runners/_shared/template_sync.py
@@ -244,9 +244,12 @@ class SyncRunnerTemplate(BaseRunner, ABC):
             validate_node_types(graph, self.supported_node_types)
             validate_delegated_runners(graph, self.capabilities)
 
-        if self._checkpointer is not None and _validation_ctx is None and workflow_id is None:
+        if self._checkpointer is not None and _validation_ctx is None and workflow_id is None and fork_from is None:
             workflow_id = generate_workflow_id()
-        sync_cp = self._get_sync_checkpointer(workflow_id)
+        sync_checkpointer_key = workflow_id
+        if sync_checkpointer_key is None:
+            sync_checkpointer_key = fork_from if fork_from is not None else retry_from
+        sync_cp = self._get_sync_checkpointer(sync_checkpointer_key)
         if _validation_ctx is None and (fork_from is not None or retry_from is not None) and sync_cp is None:
             raise ValueError("fork_from/retry_from require a checkpointer and workflow persistence to be enabled.")
         resume_checkpoint = None

--- a/src/hypergraph/runners/_shared/template_sync.py
+++ b/src/hypergraph/runners/_shared/template_sync.py
@@ -47,7 +47,16 @@ from hypergraph.runners._shared.input_normalization import (
     runner_option_names,
 )
 from hypergraph.runners._shared.run_log import RunLogCollector
-from hypergraph.runners._shared.types import ErrorHandling, GraphState, MapResult, PauseExecution, RunResult, RunStatus, _generate_run_id
+from hypergraph.runners._shared.types import (
+    ErrorHandling,
+    GraphState,
+    MapResult,
+    PauseExecution,
+    RunResult,
+    RunStatus,
+    _generate_run_id,
+    build_restored_run_log,
+)
 from hypergraph.runners._shared.validation import (
     precompute_input_validation,
     resolve_runtime_selected,
@@ -666,6 +675,8 @@ class SyncRunnerTemplate(BaseRunner, ABC):
                             status=RunStatus.COMPLETED,
                             run_id=restore_run_id,
                             workflow_id=restore_run_id,
+                            log=build_restored_run_log(graph.name or "", restore_run_id),
+                            restored=True,
                         )
                     )
                     continue

--- a/src/hypergraph/runners/_shared/types.py
+++ b/src/hypergraph/runners/_shared/types.py
@@ -656,8 +656,10 @@ def _map_items_drilldown(
     total = len(results)
     status_counts: dict[str, int] = {"all": total}
     for result in results:
-        display_status = "restored" if result.restored else result.status.value
-        status_counts[display_status] = status_counts.get(display_status, 0) + 1
+        status = result.status.value
+        status_counts[status] = status_counts.get(status, 0) + 1
+        if result.restored:
+            status_counts["restored"] = status_counts.get("restored", 0) + 1
 
     # Intelligent default: moderate batches open at 50, larger ones at 100 to
     # reduce unnecessary paging while keeping the view readable.
@@ -673,12 +675,13 @@ def _map_items_drilldown(
     parts: list[str] = []
     for i, r in enumerate(results):
         display_status = "restored" if r.restored else r.status.value
+        filter_status = f"{r.status.value} restored" if r.restored else r.status.value
         dur = duration_html(r.log.total_duration_ms) if r.log and not r.restored else "—"
         err_label = f' — <span style="color:{ERROR_COLOR}">{type(r.error).__name__}</span>' if r.error else ""
         summary = f"Item {i}: {status_badge(display_status)} {dur}{err_label}"
         # Render the full RunResult HTML inside each item's expandable section.
         item_html = html_detail(summary, r._repr_html_(), state_key=f"item-{i}")
-        parts.append(f'<div data-hg-map-item="1" data-status="{display_status}" style="display:block">{item_html}</div>')
+        parts.append(f'<div data-hg-map-item="1" data-status="{filter_status}" style="display:block">{item_html}</div>')
 
     controls = html_filter_paginate_controls(
         filter_id=filter_id,
@@ -1484,23 +1487,26 @@ class MapLog:
         trace_items = []
         n_items = len(self.items)
         status_counts: dict[str, int] = {"all": n_items}
-        n_completed = 0
         for i, log in enumerate(self.items):
             restored = self._restored_flags[i]
             status = "restored" if restored else ("failed" if log.errors else "completed")
+            filter_status = "completed restored" if restored else status
             if not log.errors:
-                n_completed += 1
-            status_counts[status] = status_counts.get(status, 0) + 1
+                status_counts["completed"] = status_counts.get("completed", 0) + 1
+            else:
+                status_counts["failed"] = status_counts.get("failed", 0) + 1
+            if restored:
+                status_counts["restored"] = status_counts.get("restored", 0) + 1
             n_nodes = len({s.node_name for s in log.steps})
             duration = duration_html(None if restored else log.total_duration_ms)
             rows.append([str(i), duration, status_badge(status), str(n_nodes)])
-            row_attrs.append({"data-hg-map-log-item": "1", "data-status": status})
+            row_attrs.append({"data-hg-map-log-item": "1", "data-status": filter_status})
 
             summary = f'Item {i}: {status_badge(status)} {duration} <span style="color:{MUTED_COLOR}">({plural(n_nodes, "node")})</span>'
             trace_detail = html_detail(summary, log._repr_html_(), state_key=f"map-log-item-{i}")
             trace_items.append(
                 '<div data-hg-map-log-item="1" '
-                f'data-status="{status}" '
+                f'data-status="{filter_status}" '
                 'style="display:block; margin:0 0 8px 0; padding:6px 8px; '
                 f"border:1px solid {BORDER_COLOR}; border-radius:10px; "
                 f'background:{SURFACE_COLOR}">'

--- a/src/hypergraph/runners/_shared/types.py
+++ b/src/hypergraph/runners/_shared/types.py
@@ -454,9 +454,7 @@ class MapResult:
     def _timed_completed_items(self) -> tuple[RunResult, ...]:
         """Fresh completed items whose real execution logs can be averaged."""
         return tuple(
-            result
-            for result in self.results
-            if result.status == RunStatus.COMPLETED and not result.restored and _has_fresh_completed_work(result.log)
+            result for result in self.results if result.status == RunStatus.COMPLETED and not result.restored and _has_timed_work(result.log)
         )
 
     @property
@@ -483,7 +481,7 @@ class MapResult:
             items=tuple(r.log if r.log is not None else _build_map_item_placeholder_log(r, self.graph_name) for r in self.results),
             _item_restored=tuple(result.restored for result in self.results),
             _item_timed=tuple(
-                result.status == RunStatus.COMPLETED and not result.restored and _has_fresh_completed_work(result.log) for result in self.results
+                result.status == RunStatus.COMPLETED and not result.restored and _has_timed_work(result.log) for result in self.results
             ),
         )
 
@@ -1219,8 +1217,9 @@ class RunLog:
     def __repr__(self) -> str:
         """Concise repr for REPL/debugger."""
         n_restored = sum(1 for step in self.steps if step.status == "restored")
-        restored = f", restored={n_restored}" if n_restored else ""
-        return f"RunLog(graph={self.graph_name!r}, steps={len(self.steps)}, duration={_format_duration(self.total_duration_ms)}{restored})"
+        if n_restored:
+            return f"RunLog(graph={self.graph_name!r}, steps={len(self.steps)}, restored={n_restored})"
+        return f"RunLog(graph={self.graph_name!r}, steps={len(self.steps)}, duration={_format_duration(self.total_duration_ms)})"
 
     def _repr_pretty_(self, pretty_printer: Any, cycle: bool) -> None:
         """Show full table in IPython/Jupyter notebooks."""
@@ -1322,9 +1321,9 @@ def _build_map_item_placeholder_log(result: RunResult, graph_name: str) -> RunLo
     )
 
 
-def _has_fresh_completed_work(log: RunLog | None) -> bool:
-    """Whether a run log contains completed work that was not a cache hit."""
-    return log is not None and any(step.status == "completed" and not step.cached for step in log.steps)
+def _has_timed_work(log: RunLog | None) -> bool:
+    """Whether a real, non-error run log contains work that was not cached."""
+    return log is not None and not log.errors and any(not step.cached for step in log.steps)
 
 
 # ---------------------------------------------------------------------------
@@ -1357,10 +1356,7 @@ class MapLog:
     def _timed_flags(self) -> tuple[bool, ...]:
         if len(self._item_timed) == len(self.items):
             return self._item_timed
-        return tuple(
-            not restored and not log.errors and _has_fresh_completed_work(log)
-            for log, restored in zip(self.items, self._restored_flags, strict=False)
-        )
+        return tuple(not restored and _has_timed_work(log) for log, restored in zip(self.items, self._restored_flags, strict=False))
 
     @property
     def restored_count(self) -> int:

--- a/src/hypergraph/runners/_shared/types.py
+++ b/src/hypergraph/runners/_shared/types.py
@@ -187,6 +187,9 @@ class RunResult:
             itself still completes; check this flag to detect gaps in the
             persisted history.
         checkpoint_errors: String reprs of failed background step-saves.
+        restored: Whether this completed map child was skipped because its
+            checkpoint was restored. Other resume/cache/missing-log paths are
+            always False.
     """
 
     values: dict[str, Any]
@@ -198,6 +201,7 @@ class RunResult:
     log: RunLog | None = None
     checkpoint_ok: bool = True
     checkpoint_errors: tuple[str, ...] = ()
+    restored: bool = False
 
     @property
     def stopped(self) -> bool:
@@ -221,7 +225,9 @@ class RunResult:
 
     def summary(self) -> str:
         """One-line overview: 'completed | 3 nodes | 12ms' or 'failed: ValueError'."""
-        if self.log:
+        if self.restored:
+            summary = "restored from checkpoint"
+        elif self.log:
             summary = self.log.summary()
         elif self.error:
             summary = f"{self.status.value}: {type(self.error).__name__}: {self.error}"
@@ -245,6 +251,7 @@ class RunResult:
             "workflow_id": self.workflow_id,
             "checkpoint_ok": self.checkpoint_ok,
             "checkpoint_errors": list(self.checkpoint_errors),
+            "restored": self.restored,
         }
         if self.log:
             d["log"] = self.log.to_dict()
@@ -275,6 +282,7 @@ class RunResult:
             f"values={_compact_value(self.values)}, "
             f"run_id={self.run_id!r}, "
             f"workflow_id={self.workflow_id!r}, "
+            f"restored={self.restored}, "
             f"error={_compact_value(self.error)}, "
             f"pause={_compact_value(self.pause)}"
             f"{checkpoint}"
@@ -308,7 +316,9 @@ class RunResult:
             return None
 
         kvs = [html_kv("Status", status_badge(self.status.value))]
-        if self.log:
+        if self.restored:
+            kvs.append(html_kv("Restored", status_badge("restored")))
+        if self.log and not self.restored:
             kvs.append(html_kv("Duration", duration_html(self.log.total_duration_ms)))
             kvs.append(html_kv("Nodes", str(len({s.node_name for s in self.log.steps}))))
             n_errors = len(self.log.errors)
@@ -436,6 +446,16 @@ class MapResult:
         return [r for r in self.results if r.status == RunStatus.FAILED]
 
     @property
+    def restored_count(self) -> int:
+        """Number of completed items restored without child execution."""
+        return sum(1 for result in self.results if result.restored)
+
+    @property
+    def _timed_completed_items(self) -> tuple[RunResult, ...]:
+        """Fresh completed items whose real execution logs can be averaged."""
+        return tuple(result for result in self.results if result.status == RunStatus.COMPLETED and not result.restored and result.log is not None)
+
+    @property
     def checkpoint_ok(self) -> bool:
         """Whether every item persisted all best-effort async checkpoints."""
         return all(result.checkpoint_ok for result in self.results)
@@ -457,6 +477,8 @@ class MapResult:
             graph_name=self.graph_name,
             total_duration_ms=self.total_duration_ms,
             items=tuple(r.log if r.log is not None else _build_map_item_placeholder_log(r, self.graph_name) for r in self.results),
+            _item_restored=tuple(result.restored for result in self.results),
+            _item_timed=tuple(result.status == RunStatus.COMPLETED and not result.restored and result.log is not None for result in self.results),
         )
 
     def get(self, key: str, default: Any = None) -> list[Any]:
@@ -473,6 +495,7 @@ class MapResult:
         n_failed = sum(1 for r in self.results if r.status == RunStatus.FAILED)
         n_paused = sum(1 for r in self.results if r.status == RunStatus.PAUSED)
         n_stopped = sum(1 for r in self.results if r.status == RunStatus.STOPPED)
+        n_restored = self.restored_count
         parts = [plural(n, "item")]
         status_parts = []
         if n_completed:
@@ -483,15 +506,17 @@ class MapResult:
             status_parts.append(f"{n_paused} paused")
         if n_stopped:
             status_parts.append(f"{n_stopped} stopped")
+        if n_restored:
+            status_parts.append(f"{n_restored} restored")
         if status_parts:
             parts.append(", ".join(status_parts))
         checkpoint_gap_count = self._checkpoint_gap_count
         if checkpoint_gap_count:
             parts.append(f"{plural(checkpoint_gap_count, 'item')} with checkpoint gaps")
-        if n_completed > 0:
-            completed_items = [r for r in self.results if r.status == RunStatus.COMPLETED]
-            completed_ms = sum(r.log.total_duration_ms for r in completed_items if r.log)
-            avg = completed_ms / n_completed
+        timed_completed_items = self._timed_completed_items
+        if timed_completed_items:
+            completed_ms = sum(result.log.total_duration_ms for result in timed_completed_items if result.log is not None)
+            avg = completed_ms / len(timed_completed_items)
             parts.append(f"avg {_format_duration(avg)}/item")
         return " | ".join(parts)
 
@@ -509,6 +534,7 @@ class MapResult:
             "checkpoint_errors": list(self.checkpoint_errors),
             "item_count": len(self.results),
             "completed_count": n_completed,
+            "restored_count": self.restored_count,
             "failed_count": n_failed,
             "items": [item.to_dict() for item in self.results],
         }
@@ -519,6 +545,7 @@ class MapResult:
         n_failed = sum(1 for r in self.results if r.status == RunStatus.FAILED)
         n_paused = sum(1 for r in self.results if r.status == RunStatus.PAUSED)
         n_stopped = sum(1 for r in self.results if r.status == RunStatus.STOPPED)
+        n_restored = self.restored_count
         parts = []
         if n_completed:
             parts.append(f"{n_completed} completed")
@@ -528,14 +555,16 @@ class MapResult:
             parts.append(f"{n_paused} paused")
         if n_stopped:
             parts.append(f"{n_stopped} stopped")
+        if n_restored:
+            parts.append(f"{n_restored} restored")
         status = ", ".join(parts) if parts else "empty"
         checkpoint_gap_count = self._checkpoint_gap_count
         checkpoint_part = f", {plural(checkpoint_gap_count, 'item')} with checkpoint gaps" if checkpoint_gap_count else ""
         avg_part = ""
-        if n_completed > 0:
-            completed_items = [r for r in self.results if r.status == RunStatus.COMPLETED]
-            completed_ms = sum(r.log.total_duration_ms for r in completed_items if r.log)
-            avg = completed_ms / n_completed
+        timed_completed_items = self._timed_completed_items
+        if timed_completed_items:
+            completed_ms = sum(result.log.total_duration_ms for result in timed_completed_items if result.log is not None)
+            avg = completed_ms / len(timed_completed_items)
             avg_part = f", avg {_format_duration(avg)}/item"
         return f"MapResult({plural(n, 'item')}: {status}{checkpoint_part}{avg_part}, map_over={self.map_over!r})"
 
@@ -564,6 +593,7 @@ class MapResult:
         n = len(self.results)
         n_completed = sum(1 for r in self.results if r.status == RunStatus.COMPLETED)
         n_failed = sum(1 for r in self.results if r.status == RunStatus.FAILED)
+        n_restored = self.restored_count
         kvs = [
             html_kv("Items", str(n)),
             html_kv("Status", status_badge(self.status.value)),
@@ -572,6 +602,8 @@ class MapResult:
             kvs.append(html_kv("Completed", str(n_completed)))
         if n_failed:
             kvs.append(html_kv("Failed", f'<span style="color:{ERROR_COLOR}">{n_failed}</span>'))
+        if n_restored:
+            kvs.append(html_kv("Restored", str(n_restored)))
         checkpoint_gap_count = self._checkpoint_gap_count
         if checkpoint_gap_count:
             kvs.append(
@@ -580,10 +612,10 @@ class MapResult:
                     f'<span style="color:{ERROR_COLOR}">{plural(checkpoint_gap_count, "item")}</span>',
                 )
             )
-        if n_completed > 0:
-            completed_items = [r for r in self.results if r.status == RunStatus.COMPLETED]
-            completed_ms = sum(r.log.total_duration_ms for r in completed_items if r.log)
-            avg = completed_ms / n_completed
+        timed_completed_items = self._timed_completed_items
+        if timed_completed_items:
+            completed_ms = sum(result.log.total_duration_ms for result in timed_completed_items if result.log is not None)
+            avg = completed_ms / len(timed_completed_items)
             kvs.append(html_kv("Avg/item", duration_html(avg)))
         body = " &nbsp;|&nbsp; ".join(kvs)
 
@@ -623,10 +655,9 @@ def _map_items_drilldown(
 
     total = len(results)
     status_counts: dict[str, int] = {"all": total}
-    for status in RunStatus:
-        count = sum(1 for r in results if r.status == status)
-        if count:
-            status_counts[status.value] = count
+    for result in results:
+        display_status = "restored" if result.restored else result.status.value
+        status_counts[display_status] = status_counts.get(display_status, 0) + 1
 
     # Intelligent default: moderate batches open at 50, larger ones at 100 to
     # reduce unnecessary paging while keeping the view readable.
@@ -641,12 +672,13 @@ def _map_items_drilldown(
 
     parts: list[str] = []
     for i, r in enumerate(results):
-        dur = duration_html(r.log.total_duration_ms) if r.log else "—"
+        display_status = "restored" if r.restored else r.status.value
+        dur = duration_html(r.log.total_duration_ms) if r.log and not r.restored else "—"
         err_label = f' — <span style="color:{ERROR_COLOR}">{type(r.error).__name__}</span>' if r.error else ""
-        summary = f"Item {i}: {status_badge(r.status.value)} {dur}{err_label}"
+        summary = f"Item {i}: {status_badge(display_status)} {dur}{err_label}"
         # Render the full RunResult HTML inside each item's expandable section.
         item_html = html_detail(summary, r._repr_html_(), state_key=f"item-{i}")
-        parts.append(f'<div data-hg-map-item="1" data-status="{r.status.value}" style="display:block">{item_html}</div>')
+        parts.append(f'<div data-hg-map-item="1" data-status="{display_status}" style="display:block">{item_html}</div>')
 
     controls = html_filter_paginate_controls(
         filter_id=filter_id,
@@ -934,7 +966,7 @@ class NodeRecord:
         node_name: Name of the executed node.
         superstep: Parallel execution round (0-indexed).
         duration_ms: Wall-clock execution time in milliseconds.
-        status: "completed", "failed", or "paused".
+        status: "completed", "failed", "paused", or "restored".
         span_id: Correlates with OTel traces.
         error: Error message if status is "failed".
         cached: Whether this was a cache hit.
@@ -944,7 +976,7 @@ class NodeRecord:
     node_name: str
     superstep: int
     duration_ms: float
-    status: Literal["completed", "failed", "paused"]
+    status: Literal["completed", "failed", "paused", "restored"]
     span_id: str
     error: str | None = None
     cached: bool = False
@@ -956,7 +988,8 @@ class NodeRecord:
 
     def __repr__(self) -> str:
         status = "cached" if self.cached else self.status
-        parts = [f"NodeRecord: {self.node_name}", status, _format_duration(self.duration_ms), f"superstep {self.superstep}"]
+        duration = "—" if self.status == "restored" else _format_duration(self.duration_ms)
+        parts = [f"NodeRecord: {self.node_name}", status, duration, f"superstep {self.superstep}"]
         if self.error:
             parts.append(f"error: {self.error[:60]}")
         if self.decision is not None:
@@ -1027,6 +1060,8 @@ def _compute_node_stats(steps: tuple[NodeRecord, ...]) -> dict[str, NodeStats]:
     """Aggregate per-node stats from step records."""
     accumulators: dict[str, dict[str, Any]] = {}
     for step in steps:
+        if step.status == "restored":
+            continue
         acc = accumulators.setdefault(step.node_name, {"count": 0, "total_ms": 0.0, "errors": 0, "cached": 0})
         acc["count"] += 1
         acc["total_ms"] += step.duration_ms
@@ -1076,10 +1111,11 @@ class RunLog:
         """One-line overview string."""
         n_errors = len(self.errors)
         n_nodes = len({s.node_name for s in self.steps})
+        n_restored = sum(1 for step in self.steps if step.status == "restored")
         slowest = max(self.timing.items(), key=lambda x: x[1]) if self.timing else ("", 0)
         parts = [
             plural(n_nodes, "node"),
-            _format_duration(self.total_duration_ms),
+            f"{n_restored} restored" if n_restored else _format_duration(self.total_duration_ms),
             plural(n_errors, "error"),
         ]
         if slowest[1] > 0:
@@ -1125,12 +1161,9 @@ class RunLog:
     def __str__(self) -> str:
         """Formatted table output for terminal / print()."""
         n_errors = len(self.errors)
-        header = (
-            f"RunLog: {self.graph_name} | "
-            f"{_format_duration(self.total_duration_ms)} | "
-            f"{plural(len({s.node_name for s in self.steps}), 'node')} | "
-            f"{plural(n_errors, 'error')}"
-        )
+        n_restored = sum(1 for step in self.steps if step.status == "restored")
+        duration = f"{n_restored} restored" if n_restored else _format_duration(self.total_duration_ms)
+        header = f"RunLog: {self.graph_name} | {duration} | {plural(len({s.node_name for s in self.steps}), 'node')} | {plural(n_errors, 'error')}"
 
         has_decisions = any(s.decision is not None for s in self.steps)
         lines = [header, ""]
@@ -1143,11 +1176,13 @@ class RunLog:
         lines.append("  ".join("─" * 16 for _ in cols))
 
         for i, step in enumerate(self.steps):
-            dur = _format_duration(step.duration_ms) if step.status != "failed" or step.duration_ms > 0 else "—"
+            dur = "—" if step.status == "restored" or (step.status == "failed" and step.duration_ms == 0) else _format_duration(step.duration_ms)
             if step.status == "completed":
                 status = "completed"
             elif step.status == "paused":
                 status = "paused"
+            elif step.status == "restored":
+                status = "restored"
             else:
                 status = f"FAILED: {step.error or 'unknown'}"
             if step.cached:
@@ -1174,7 +1209,9 @@ class RunLog:
 
     def __repr__(self) -> str:
         """Concise repr for REPL/debugger."""
-        return f"RunLog(graph={self.graph_name!r}, steps={len(self.steps)}, duration={_format_duration(self.total_duration_ms)})"
+        n_restored = sum(1 for step in self.steps if step.status == "restored")
+        restored = f", restored={n_restored}" if n_restored else ""
+        return f"RunLog(graph={self.graph_name!r}, steps={len(self.steps)}, duration={_format_duration(self.total_duration_ms)}{restored})"
 
     def _repr_pretty_(self, pretty_printer: Any, cycle: bool) -> None:
         """Show full table in IPython/Jupyter notebooks."""
@@ -1205,7 +1242,7 @@ class RunLog:
         rows = []
         for i, step in enumerate(self.steps):
             status = "cached" if step.cached else step.status
-            dur = duration_html(step.duration_ms)
+            dur = duration_html(None if step.status == "restored" else step.duration_ms)
             row = [str(i), _code(step.node_name), status_badge(status), dur]
             if has_decisions:
                 if step.decision is not None:
@@ -1215,9 +1252,11 @@ class RunLog:
                     row.append("")
             rows.append(row)
         n_errors = len(self.errors)
+        n_restored = sum(1 for step in self.steps if step.status == "restored")
+        duration = f"{n_restored} restored" if n_restored else duration_html(self.total_duration_ms)
         title = (
             f"RunLog: {self.graph_name} &nbsp; "
-            f"{duration_html(self.total_duration_ms)} &nbsp; "
+            f"{duration} &nbsp; "
             f"{plural(len({s.node_name for s in self.steps}), 'node')} &nbsp; "
             f"{plural(n_errors, 'error')}"
         )
@@ -1228,8 +1267,28 @@ class RunLog:
         )
 
 
+def build_restored_run_log(graph_name: str, run_id: str) -> RunLog:
+    """Build visible, non-error evidence for a checkpoint-restored map child."""
+    return RunLog(
+        graph_name=graph_name,
+        run_id=run_id,
+        total_duration_ms=0.0,
+        steps=(
+            NodeRecord(
+                node_name="map_item",
+                superstep=0,
+                duration_ms=0.0,
+                status="restored",
+                span_id="restored-checkpoint",
+            ),
+        ),
+    )
+
+
 def _build_map_item_placeholder_log(result: RunResult, graph_name: str) -> RunLog:
     """Create a synthetic per-item log when map item trace is unavailable."""
+    if result.restored:
+        return build_restored_run_log(graph_name, result.run_id)
     if result.status == RunStatus.FAILED:
         error_text = None
         if result.error is not None:
@@ -1271,6 +1330,29 @@ class MapLog:
     graph_name: str
     total_duration_ms: float
     items: tuple[RunLog, ...]
+    _item_restored: tuple[bool, ...] = field(default=(), repr=False, compare=False)
+    _item_timed: tuple[bool, ...] = field(default=(), repr=False, compare=False)
+
+    @property
+    def _restored_flags(self) -> tuple[bool, ...]:
+        if len(self._item_restored) == len(self.items):
+            return self._item_restored
+        return tuple(any(step.status == "restored" for step in log.steps) for log in self.items)
+
+    @property
+    def _timed_flags(self) -> tuple[bool, ...]:
+        if len(self._item_timed) == len(self.items):
+            return self._item_timed
+        return tuple(bool(log.steps) and not restored and not log.errors for log, restored in zip(self.items, self._restored_flags, strict=False))
+
+    @property
+    def restored_count(self) -> int:
+        """Number of item logs representing checkpoint restoration."""
+        return sum(self._restored_flags)
+
+    @property
+    def _timed_success_items(self) -> tuple[RunLog, ...]:
+        return tuple(log for log, timed in zip(self.items, self._timed_flags, strict=False) if timed)
 
     @property
     def errors(self) -> tuple[NodeRecord, ...]:
@@ -1288,17 +1370,20 @@ class MapLog:
         n = len(self.items)
         n_succeeded = sum(1 for log in self.items if not log.errors)
         n_errors = len(self.errors)
+        n_restored = self.restored_count
         parts = [plural(n, "item")]
         status_parts = []
         if n_succeeded:
             status_parts.append(f"{n_succeeded} completed")
         if n_errors:
             status_parts.append(plural(n_errors, "error"))
+        if n_restored:
+            status_parts.append(f"{n_restored} restored")
         if status_parts:
             parts.append(", ".join(status_parts))
-        if n_succeeded > 0:
-            succeeded_items = [log for log in self.items if not log.errors]
-            avg = sum(log.total_duration_ms for log in succeeded_items) / n_succeeded
+        timed_success_items = self._timed_success_items
+        if timed_success_items:
+            avg = sum(log.total_duration_ms for log in timed_success_items) / len(timed_success_items)
             parts.append(f"avg {_format_duration(avg)}/item")
         return " | ".join(parts)
 
@@ -1307,6 +1392,7 @@ class MapLog:
         return {
             "graph_name": self.graph_name,
             "total_duration_ms": self.total_duration_ms,
+            "restored_count": self.restored_count,
             "items": [log.to_dict() for log in self.items],
         }
 
@@ -1323,12 +1409,17 @@ class MapLog:
         """Per-item table with footer."""
         n_errors = len(self.errors)
         n_succeeded = sum(1 for log in self.items if not log.errors)
+        n_restored = self.restored_count
         avg_part = ""
-        if n_succeeded > 0:
-            succeeded_items = [log for log in self.items if not log.errors]
-            avg = sum(log.total_duration_ms for log in succeeded_items) / n_succeeded
+        timed_success_items = self._timed_success_items
+        if timed_success_items:
+            avg = sum(log.total_duration_ms for log in timed_success_items) / len(timed_success_items)
             avg_part = f" | avg {_format_duration(avg)}/item"
-        header = f"MapLog: {self.graph_name} | {plural(len(self.items), 'item')} ({n_succeeded} succeeded) | {plural(n_errors, 'error')}{avg_part}"
+        restored_part = f", {n_restored} restored" if n_restored else ""
+        header = (
+            f"MapLog: {self.graph_name} | {plural(len(self.items), 'item')} "
+            f"({n_succeeded} succeeded{restored_part}) | {plural(n_errors, 'error')}{avg_part}"
+        )
         lines = [header, ""]
 
         cols = ["  Item", "Duration", "Status", "Nodes"]
@@ -1337,8 +1428,9 @@ class MapLog:
 
         display_items = self.items[:_MAX_MAP_LOG_ROWS]
         for i, log in enumerate(display_items):
-            dur = _format_duration(log.total_duration_ms)
-            status = "FAILED" if log.errors else "completed"
+            restored = self._restored_flags[i]
+            dur = "—" if restored else _format_duration(log.total_duration_ms)
+            status = "restored" if restored else ("FAILED" if log.errors else "completed")
             n_nodes = len({s.node_name for s in log.steps})
             row = [f"  {i:>4}", f"{dur:<16}", f"{status:<16}", str(n_nodes)]
             lines.append("  ".join(f"{c:<16}" for c in row).rstrip())
@@ -1353,7 +1445,10 @@ class MapLog:
         return "\n".join(lines)
 
     def __repr__(self) -> str:
-        return f"MapLog(graph={self.graph_name!r}, items={len(self.items)}, duration={_format_duration(self.total_duration_ms)})"
+        return (
+            f"MapLog(graph={self.graph_name!r}, items={len(self.items)}, restored={self.restored_count}, "
+            f"duration={_format_duration(self.total_duration_ms)})"
+        )
 
     def _repr_pretty_(self, pretty_printer: Any, cycle: bool) -> None:
         """Show table in IPython/Jupyter notebooks."""
@@ -1391,19 +1486,17 @@ class MapLog:
         status_counts: dict[str, int] = {"all": n_items}
         n_completed = 0
         for i, log in enumerate(self.items):
-            status = "failed" if log.errors else "completed"
-            if status == "completed":
+            restored = self._restored_flags[i]
+            status = "restored" if restored else ("failed" if log.errors else "completed")
+            if not log.errors:
                 n_completed += 1
             status_counts[status] = status_counts.get(status, 0) + 1
             n_nodes = len({s.node_name for s in log.steps})
-            rows.append([str(i), duration_html(log.total_duration_ms), status_badge(status), str(n_nodes)])
+            duration = duration_html(None if restored else log.total_duration_ms)
+            rows.append([str(i), duration, status_badge(status), str(n_nodes)])
             row_attrs.append({"data-hg-map-log-item": "1", "data-status": status})
 
-            summary = (
-                f"Item {i}: {status_badge(status)} "
-                f"{duration_html(log.total_duration_ms)} "
-                f'<span style="color:{MUTED_COLOR}">({plural(n_nodes, "node")})</span>'
-            )
+            summary = f'Item {i}: {status_badge(status)} {duration} <span style="color:{MUTED_COLOR}">({plural(n_nodes, "node")})</span>'
             trace_detail = html_detail(summary, log._repr_html_(), state_key=f"map-log-item-{i}")
             trace_items.append(
                 '<div data-hg-map-log-item="1" '
@@ -1415,10 +1508,9 @@ class MapLog:
             )
 
         avg_part = ""
-        n_succeeded = n_completed
-        if n_succeeded > 0:
-            succeeded_items = [log for log in self.items if not log.errors]
-            avg = sum(log.total_duration_ms for log in succeeded_items) / n_succeeded
+        timed_success_items = self._timed_success_items
+        if timed_success_items:
+            avg = sum(log.total_duration_ms for log in timed_success_items) / len(timed_success_items)
             avg_part = f" &nbsp; avg {duration_html(avg)}/item"
 
         title = f"MapLog: {self.graph_name} ({plural(n_items, 'item')}){avg_part}"

--- a/src/hypergraph/runners/_shared/types.py
+++ b/src/hypergraph/runners/_shared/types.py
@@ -453,7 +453,11 @@ class MapResult:
     @property
     def _timed_completed_items(self) -> tuple[RunResult, ...]:
         """Fresh completed items whose real execution logs can be averaged."""
-        return tuple(result for result in self.results if result.status == RunStatus.COMPLETED and not result.restored and result.log is not None)
+        return tuple(
+            result
+            for result in self.results
+            if result.status == RunStatus.COMPLETED and not result.restored and _has_fresh_completed_work(result.log)
+        )
 
     @property
     def checkpoint_ok(self) -> bool:
@@ -478,7 +482,9 @@ class MapResult:
             total_duration_ms=self.total_duration_ms,
             items=tuple(r.log if r.log is not None else _build_map_item_placeholder_log(r, self.graph_name) for r in self.results),
             _item_restored=tuple(result.restored for result in self.results),
-            _item_timed=tuple(result.status == RunStatus.COMPLETED and not result.restored and result.log is not None for result in self.results),
+            _item_timed=tuple(
+                result.status == RunStatus.COMPLETED and not result.restored and _has_fresh_completed_work(result.log) for result in self.results
+            ),
         )
 
     def get(self, key: str, default: Any = None) -> list[Any]:
@@ -1316,6 +1322,11 @@ def _build_map_item_placeholder_log(result: RunResult, graph_name: str) -> RunLo
     )
 
 
+def _has_fresh_completed_work(log: RunLog | None) -> bool:
+    """Whether a run log contains completed work that was not a cache hit."""
+    return log is not None and any(step.status == "completed" and not step.cached for step in log.steps)
+
+
 # ---------------------------------------------------------------------------
 # MapLog — batch-level execution trace
 # ---------------------------------------------------------------------------
@@ -1346,7 +1357,10 @@ class MapLog:
     def _timed_flags(self) -> tuple[bool, ...]:
         if len(self._item_timed) == len(self.items):
             return self._item_timed
-        return tuple(bool(log.steps) and not restored and not log.errors for log, restored in zip(self.items, self._restored_flags, strict=False))
+        return tuple(
+            not restored and not log.errors and _has_fresh_completed_work(log)
+            for log, restored in zip(self.items, self._restored_flags, strict=False)
+        )
 
     @property
     def restored_count(self) -> int:

--- a/tests/events/test_types.py
+++ b/tests/events/test_types.py
@@ -58,6 +58,17 @@ class TestEventImmutability:
             e = cls(run_id="r1")
             assert e.run_id == "r1"
 
+    def test_run_end_discloses_restored_batch_subset(self):
+        event = RunEndEvent(
+            run_id="map-1",
+            batch_total_items=3,
+            batch_completed_items=3,
+            batch_restored_items=2,
+        )
+
+        assert event.batch_completed_items == 3
+        assert event.batch_restored_items == 2
+
 
 # ---------------------------------------------------------------------------
 # TypedEventProcessor dispatch

--- a/tests/events/test_types.py
+++ b/tests/events/test_types.py
@@ -69,6 +69,29 @@ class TestEventImmutability:
         assert event.batch_completed_items == 3
         assert event.batch_restored_items == 2
 
+    def test_run_end_preserves_existing_positional_batch_outcome(self):
+        event = RunEndEvent(
+            "run-1",
+            "span-1",
+            None,
+            None,
+            None,
+            0.0,
+            "graph",
+            "completed",
+            None,
+            1.0,
+            2,
+            2,
+            0,
+            0,
+            0,
+            "completed",
+        )
+
+        assert event.batch_outcome == "completed"
+        assert event.batch_restored_items is None
+
 
 # ---------------------------------------------------------------------------
 # TypedEventProcessor dispatch

--- a/tests/test_checkpointer/test_resume.py
+++ b/tests/test_checkpointer/test_resume.py
@@ -5,6 +5,8 @@ import pytest_asyncio
 
 from hypergraph import AsyncRunner, Graph, SyncRunner, node
 from hypergraph.checkpointers import SqliteCheckpointer, WorkflowStatus
+from hypergraph.events import EventProcessor
+from hypergraph.events.types import NodeStartEvent, RunEndEvent, RunStartEvent
 from hypergraph.exceptions import (
     GraphChangedError,
     InputOverrideRequiresForkError,
@@ -14,6 +16,19 @@ from hypergraph.exceptions import (
 from hypergraph.runners._shared.types import RunStatus
 
 aiosqlite = pytest.importorskip("aiosqlite")
+
+
+class EventCollector(EventProcessor):
+    """Collect execution events without adding behavior to the runner."""
+
+    def __init__(self):
+        self.events: list[object] = []
+
+    def on_event(self, event):
+        self.events.append(event)
+
+    def of_type(self, event_type):
+        return [event for event in self.events if isinstance(event, event_type)]
 
 
 # --- Shared nodes ---
@@ -306,23 +321,49 @@ class TestAsyncMapResume:
         call_count = 0
 
         # Resume: all 3 completed, should skip all
+        collector = EventCollector()
         result = await runner.map(
             graph,
             {"x": [10, 20, 30]},
             map_over="x",
             workflow_id="batch-1",
+            event_processors=[collector],
         )
         assert call_count == 0
         assert len(result.results) == 3
         # Restored results should have correct values
         assert all(r["doubled"] is not None for r in result.results)
+        assert result.restored_count == 3
+        assert all(r.restored for r in result.results)
+        assert all(r.log is not None for r in result.results)
+        assert all(r.log.steps[0].status == "restored" for r in result.results if r.log is not None)
+        assert "3 restored" in result.summary()
+        assert "avg" not in result.summary()
+        assert result.to_dict()["restored_count"] == 3
+        assert result.log.restored_count == 3
+        assert "avg" not in result.log.summary()
+
+        starts = collector.of_type(RunStartEvent)
+        ends = collector.of_type(RunEndEvent)
+        assert len(starts) == 1
+        assert starts[0].is_map
+        assert collector.of_type(NodeStartEvent) == []
+        assert len(ends) == 1
+        assert ends[0].batch_completed_items == 3
+        assert ends[0].batch_restored_items == 3
+
+        parent = checkpointer.get_run("batch-1")
+        assert parent is not None
+        assert parent.status == WorkflowStatus.COMPLETED
 
     async def test_map_reruns_failed_items(self, checkpointer):
         """Failed items are re-executed on resume (only COMPLETED are skipped)."""
         should_fail = True
+        calls: list[int] = []
 
         @node(output_name="result")
         def flaky(x: int) -> int:
+            calls.append(x)
             if x == 20 and should_fail:
                 raise ValueError("transient failure")
             return x * 2
@@ -333,27 +374,50 @@ class TestAsyncMapResume:
         # First run: item 1 (x=20) fails
         result1 = await runner.map(
             graph,
-            {"x": [10, 20, 30]},
+            {"x": [10, 20]},
             map_over="x",
             workflow_id="batch-retry",
             error_handling="continue",
         )
         statuses = [r.status for r in result1.results]
         assert statuses[1] == RunStatus.FAILED  # x=20 failed
+        assert all(not result.restored for result in result1.results)
 
         # Now make it succeed
         should_fail = False
+        calls.clear()
+        collector = EventCollector()
 
-        # Resume: x=10 and x=30 skip (completed), x=20 re-runs (was failed)
+        # Resume: x=10 skips (completed), x=20 re-runs (was failed)
         result2 = await runner.map(
             graph,
-            {"x": [10, 20, 30]},
+            {"x": [10, 20]},
             map_over="x",
             workflow_id="batch-retry",
             error_handling="continue",
+            event_processors=[collector],
         )
         statuses2 = [r.status for r in result2.results]
         assert all(s == RunStatus.COMPLETED for s in statuses2)
+        assert calls == [20]
+        assert [result.restored for result in result2.results] == [True, False]
+        assert result2.results[0].log is not None
+        assert result2.results[0].log.steps[0].status == "restored"
+        assert result2.results[1].log is not None
+        assert all(step.status != "restored" for step in result2.results[1].log.steps)
+        assert result2.restored_count == 1
+        assert "1 restored" in result2.summary()
+
+        starts = collector.of_type(RunStartEvent)
+        assert len([event for event in starts if event.is_map]) == 1
+        assert len([event for event in starts if not event.is_map]) == 1
+        parent_end = next(event for event in collector.of_type(RunEndEvent) if event.batch_total_items is not None)
+        assert parent_end.batch_completed_items == 2
+        assert parent_end.batch_restored_items == 1
+
+        parent = checkpointer.get_run("batch-retry")
+        assert parent is not None
+        assert parent.status == WorkflowStatus.COMPLETED
 
     async def test_map_no_checkpointer_no_skip(self):
         """Without checkpointer, map always runs all items."""
@@ -568,16 +632,47 @@ class TestSyncMapResume:
         assert call_count == 3
 
         call_count = 0
-        result = runner.map(graph, {"x": [10, 20, 30]}, map_over="x", workflow_id="sync-batch")
+        collector = EventCollector()
+        result = runner.map(
+            graph,
+            {"x": [10, 20, 30]},
+            map_over="x",
+            workflow_id="sync-batch",
+            event_processors=[collector],
+        )
         assert call_count == 0
         assert len(result.results) == 3
+        assert result.restored_count == 3
+        assert all(r.restored for r in result.results)
+        assert all(r.log is not None for r in result.results)
+        assert all(r.log.steps[0].status == "restored" for r in result.results if r.log is not None)
+        assert "3 restored" in result.summary()
+        assert "avg" not in result.summary()
+        assert result.to_dict()["restored_count"] == 3
+        assert result.log.restored_count == 3
+        assert "avg" not in result.log.summary()
+
+        starts = collector.of_type(RunStartEvent)
+        ends = collector.of_type(RunEndEvent)
+        assert len(starts) == 1
+        assert starts[0].is_map
+        assert collector.of_type(NodeStartEvent) == []
+        assert len(ends) == 1
+        assert ends[0].batch_completed_items == 3
+        assert ends[0].batch_restored_items == 3
+
+        parent = sync_checkpointer.get_run("sync-batch")
+        assert parent is not None
+        assert parent.status == WorkflowStatus.COMPLETED
 
     def test_map_reruns_failed_items(self, sync_checkpointer):
         """Sync mirror: failed items are re-executed on resume."""
         should_fail = True
+        calls: list[int] = []
 
         @node(output_name="result")
         def flaky(x: int) -> int:
+            calls.append(x)
             if x == 20 and should_fail:
                 raise ValueError("transient failure")
             return x * 2
@@ -587,22 +682,45 @@ class TestSyncMapResume:
 
         result1 = runner.map(
             graph,
-            {"x": [10, 20, 30]},
+            {"x": [10, 20]},
             map_over="x",
             workflow_id="sync-retry",
             error_handling="continue",
         )
         assert result1.results[1].status == RunStatus.FAILED
+        assert all(not result.restored for result in result1.results)
 
         should_fail = False
+        calls.clear()
+        collector = EventCollector()
         result2 = runner.map(
             graph,
-            {"x": [10, 20, 30]},
+            {"x": [10, 20]},
             map_over="x",
             workflow_id="sync-retry",
             error_handling="continue",
+            event_processors=[collector],
         )
         assert all(r.status == RunStatus.COMPLETED for r in result2.results)
+        assert calls == [20]
+        assert [result.restored for result in result2.results] == [True, False]
+        assert result2.results[0].log is not None
+        assert result2.results[0].log.steps[0].status == "restored"
+        assert result2.results[1].log is not None
+        assert all(step.status != "restored" for step in result2.results[1].log.steps)
+        assert result2.restored_count == 1
+        assert "1 restored" in result2.summary()
+
+        starts = collector.of_type(RunStartEvent)
+        assert len([event for event in starts if event.is_map]) == 1
+        assert len([event for event in starts if not event.is_map]) == 1
+        parent_end = next(event for event in collector.of_type(RunEndEvent) if event.batch_total_items is not None)
+        assert parent_end.batch_completed_items == 2
+        assert parent_end.batch_restored_items == 1
+
+        parent = sync_checkpointer.get_run("sync-retry")
+        assert parent is not None
+        assert parent.status == WorkflowStatus.COMPLETED
 
     def test_map_resume_matches_completed_items_by_input_identity(self, sync_checkpointer):
         """Sync mirror: reordered inputs should restore by input identity."""

--- a/tests/test_checkpointer/test_sqlite.py
+++ b/tests/test_checkpointer/test_sqlite.py
@@ -629,8 +629,8 @@ class TestRetentionPolicyBehavior:
         await checkpointer.save_step(_make_step(run_id="wf-latest", superstep=1, node_name="a", index=2, values={"x": 3}))
 
         steps = checkpointer.steps("wf-latest")
-        live_steps = [s for s in steps if s.node_type != "RetentionBaseline"]
-        assert {(s.node_name, s.superstep) for s in live_steps} == {("a", 1), ("b", 0)}
+        assert {(s.node_name, s.superstep) for s in steps} == {("a", 1), ("b", 0)}
+        assert any(s.node_type == "RetentionBaseline" for s in checkpointer.steps("wf-latest", show_internal=True))
         assert checkpointer.state("wf-latest") == {"x": 3, "y": 2}
 
     @pytest.mark.parametrize("latest_status", [StepStatus.FAILED, StepStatus.PAUSED])
@@ -662,9 +662,9 @@ class TestRetentionPolicyBehavior:
         await checkpointer.save_step(_make_step(run_id="wf-windowed", superstep=2, node_name="c", index=2, values={"z": 3}))
 
         steps = checkpointer.steps("wf-windowed")
-        live_steps = [s for s in steps if s.node_type != "RetentionBaseline"]
-        assert {s.superstep for s in live_steps} == {1, 2}
-        assert {s.node_name for s in live_steps} == {"b", "c"}
+        assert {s.superstep for s in steps} == {1, 2}
+        assert {s.node_name for s in steps} == {"b", "c"}
+        assert any(s.node_type == "RetentionBaseline" for s in checkpointer.steps("wf-windowed", show_internal=True))
         assert checkpointer.state("wf-windowed") == {"x": 1, "y": 2, "z": 3}
 
     async def test_windowed_retention_preserves_folded_state_across_pruned_supersteps(self, checkpointer):
@@ -688,9 +688,9 @@ class TestRetentionPolicyBehavior:
         cp.save_step_sync(_make_step(run_id="wf-sync", superstep=1, node_name="b", index=1, values={"y": 2}))
 
         steps = cp.steps("wf-sync")
-        live_steps = [s for s in steps if s.node_type != "RetentionBaseline"]
-        assert len(live_steps) == 1
-        assert live_steps[0].superstep == 1
+        assert len(steps) == 1
+        assert steps[0].superstep == 1
+        assert any(s.node_type == "RetentionBaseline" for s in cp.steps("wf-sync", show_internal=True))
         assert cp.state("wf-sync") == {"x": 1, "y": 2}
         if cp._sync_conn:
             cp._sync_conn.close()

--- a/tests/test_checkpointer/test_ticket183_semantics.py
+++ b/tests/test_checkpointer/test_ticket183_semantics.py
@@ -6,7 +6,16 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from hypergraph.checkpointers import MemoryCheckpointer, SqliteCheckpointer, WorkflowStatus
+from hypergraph import AsyncRunner, Graph, SyncRunner, node
+from hypergraph.checkpointers import (
+    CheckpointPolicy,
+    MemoryCheckpointer,
+    SqliteCheckpointer,
+    SqliteRunInspector,
+    StepRecord,
+    StepStatus,
+    WorkflowStatus,
+)
 
 
 @pytest.fixture(params=["memory", "sqlite"])
@@ -72,3 +81,160 @@ async def test_async_run_filters_distinguish_omitted_parent_from_none(async_chec
     if isinstance(async_checkpointer, SqliteCheckpointer):
         for since in (boundary, equivalent_offset, naive_utc):
             assert {run.id for run in async_checkpointer.runs(since=since, limit=None)} == expected_since
+
+
+async def test_retention_carriers_are_hidden_but_state_remains_folded(async_checkpointer):
+    run_id = "retention-source"
+    async_checkpointer.policy = CheckpointPolicy(durability="sync", retention="latest")
+    await async_checkpointer.create_run(run_id)
+    await async_checkpointer.save_step(
+        StepRecord(
+            run_id=run_id,
+            superstep=0,
+            node_name="a",
+            index=0,
+            status=StepStatus.COMPLETED,
+            input_versions={},
+            values={"x": 1},
+            node_type=None,
+        )
+    )
+    await async_checkpointer.save_step(
+        StepRecord(
+            run_id=run_id,
+            superstep=0,
+            node_name="b",
+            index=1,
+            status=StepStatus.COMPLETED,
+            input_versions={},
+            values={"y": 2},
+            node_type=None,
+        )
+    )
+    await async_checkpointer.save_step(
+        StepRecord(
+            run_id=run_id,
+            superstep=1,
+            node_name="a",
+            index=2,
+            status=StepStatus.COMPLETED,
+            input_versions={},
+            values={"x": 3},
+            node_type=None,
+        )
+    )
+
+    public_latest = await async_checkpointer.get_steps(run_id)
+    assert {step.node_name for step in public_latest} == {"a", "b"}
+    assert all(step.node_type != "RetentionBaseline" for step in public_latest)
+
+    internal_latest = await async_checkpointer.get_steps(run_id, show_internal=True)
+    assert any(step.node_name == "__retained_state__" for step in internal_latest)
+    assert any(step.node_type == "RetentionBaseline" for step in internal_latest)
+    assert any(step.node_name == "b" and step.node_type is None for step in public_latest)
+    assert await async_checkpointer.get_state(run_id) == {"x": 3, "y": 2}
+
+    async_checkpointer.policy = CheckpointPolicy(durability="sync", retention="windowed", window=1)
+    await async_checkpointer.save_step(
+        StepRecord(
+            run_id=run_id,
+            superstep=2,
+            node_name="c",
+            index=3,
+            status=StepStatus.COMPLETED,
+            input_versions={},
+            values={"z": 4},
+            node_type=None,
+        )
+    )
+
+    async_checkpointer.policy = CheckpointPolicy(durability="sync", retention="full")
+    await async_checkpointer.save_step(
+        StepRecord(
+            run_id=run_id,
+            superstep=3,
+            node_name="__retained_state__",
+            index=4,
+            status=StepStatus.COMPLETED,
+            input_versions={},
+            values={"name_carrier": 5},
+            node_type="LegacyCarrier",
+        )
+    )
+    await async_checkpointer.save_step(
+        StepRecord(
+            run_id=run_id,
+            superstep=4,
+            node_name="legacy-carrier",
+            index=5,
+            status=StepStatus.COMPLETED,
+            input_versions={},
+            values={"type_carrier": 6},
+            node_type="RetentionBaseline",
+        )
+    )
+
+    public_windowed = await async_checkpointer.get_steps(run_id)
+    internal_windowed = await async_checkpointer.get_steps(run_id, show_internal=True)
+    assert [step.node_name for step in public_windowed] == ["c"]
+    assert any(step.node_name == "__retained_state__" for step in internal_windowed)
+    assert any(step.node_name == "legacy-carrier" for step in internal_windowed)
+    expected_state = {
+        "x": 3,
+        "y": 2,
+        "z": 4,
+        "name_carrier": 5,
+        "type_carrier": 6,
+    }
+    assert await async_checkpointer.get_state(run_id) == expected_state
+
+    checkpoint = await async_checkpointer.get_checkpoint(run_id)
+    assert [step.node_name for step in checkpoint.steps] == ["c"]
+    assert checkpoint.values == expected_state
+
+    calls = 0
+
+    @node(output_name="total")
+    def add_retained_values(
+        x: int,
+        y: int,
+        z: int,
+        name_carrier: int,
+        type_carrier: int,
+    ) -> int:
+        nonlocal calls
+        calls += 1
+        return x + y + z + name_carrier + type_carrier
+
+    resumed = await AsyncRunner(checkpointer=async_checkpointer).run(
+        Graph([add_retained_values]),
+        checkpoint=checkpoint,
+        workflow_id="retention-fork",
+    )
+    assert resumed["total"] == 20
+    assert calls == 1
+
+    if isinstance(async_checkpointer, SqliteCheckpointer):
+        assert [step.node_name for step in async_checkpointer.steps(run_id)] == ["c"]
+        assert any(step.node_name == "__retained_state__" for step in async_checkpointer.steps(run_id, show_internal=True))
+        assert async_checkpointer.state(run_id) == expected_state
+        assert [step.node_name for step in async_checkpointer.checkpoint(run_id).steps] == ["c"]
+        assert async_checkpointer.search("__retained_state__", field="node_name") == []
+        assert await async_checkpointer.search_async("__retained_state__", field="node_name") == []
+        assert async_checkpointer.search('"legacy-carrier"', field="node_name") == []
+        assert "__retained_state__" not in async_checkpointer.stats(run_id)
+        assert "legacy-carrier" not in async_checkpointer.stats(run_id)
+
+        inspector = SqliteRunInspector(async_checkpointer)
+        assert [step.node_name for step in inspector.steps(run_id)] == ["c"]
+        assert len(inspector.steps(run_id, show_internal=True)) == len(internal_windowed)
+        lineage = inspector.lineage(run_id)
+        assert [step.node_name for step in lineage.steps_by_run[run_id]] == ["c"]
+
+        sync_result = SyncRunner(checkpointer=async_checkpointer).run(
+            Graph([add_retained_values]),
+            checkpoint=async_checkpointer.checkpoint(run_id),
+            workflow_id="sync-retention-fork",
+        )
+        assert sync_result["total"] == 20
+        assert calls == 2

--- a/tests/test_checkpointer/test_ticket183_semantics.py
+++ b/tests/test_checkpointer/test_ticket183_semantics.py
@@ -1,0 +1,74 @@
+"""Outcome-level regression tests for the checkpointer-facing #183 contract."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from hypergraph.checkpointers import MemoryCheckpointer, SqliteCheckpointer, WorkflowStatus
+
+
+@pytest.fixture(params=["memory", "sqlite"])
+async def async_checkpointer(request: pytest.FixtureRequest, tmp_path):
+    checkpointer = MemoryCheckpointer() if request.param == "memory" else SqliteCheckpointer(str(tmp_path / "runs.db"))
+
+    try:
+        yield checkpointer
+    finally:
+        await checkpointer.close()
+
+
+async def test_async_run_filters_distinguish_omitted_parent_from_none(async_checkpointer):
+    assert (
+        await async_checkpointer.list_runs(
+            graph_name="missing",
+            since=datetime.now(timezone.utc),
+            parent_run_id=None,
+            limit=None,
+        )
+        == []
+    )
+    assert await async_checkpointer.count_runs(parent_run_id=None) == 0
+
+    parent = await async_checkpointer.create_run("parent", graph_name="alpha")
+    child_a = await async_checkpointer.create_run("child-a", graph_name="alpha", parent_run_id=parent.id)
+    await async_checkpointer.create_run("child-b", graph_name="beta", parent_run_id=parent.id)
+    await async_checkpointer.create_run("unrelated", graph_name="alpha")
+    await async_checkpointer.update_run_status(child_a.id, WorkflowStatus.COMPLETED)
+
+    all_runs = await async_checkpointer.list_runs(limit=None)
+    top_level = await async_checkpointer.list_runs(parent_run_id=None, limit=None)
+    children = await async_checkpointer.list_runs(parent_run_id=parent.id, limit=None)
+
+    assert {run.id for run in all_runs} == {"parent", "child-a", "child-b", "unrelated"}
+    assert {run.id for run in top_level} == {"parent", "unrelated"}
+    assert {run.id for run in children} == {"child-a", "child-b"}
+    assert await async_checkpointer.count_runs() == 4
+    assert await async_checkpointer.count_runs(parent_run_id=None) == 2
+    assert await async_checkpointer.count_runs(parent_run_id=parent.id) == 2
+
+    alpha_runs = await async_checkpointer.list_runs(graph_name="alpha", limit=None)
+    assert {run.id for run in alpha_runs} == {"parent", "child-a", "unrelated"}
+    assert [run.created_at for run in alpha_runs] == sorted((run.created_at for run in alpha_runs), reverse=True)
+    assert [run.id for run in await async_checkpointer.list_runs(graph_name="alpha", limit=1)] == ["unrelated"]
+
+    boundary = child_a.created_at
+    equivalent_offset = boundary.astimezone(timezone(timedelta(hours=5, minutes=30)))
+    naive_utc = boundary.astimezone(timezone.utc).replace(tzinfo=None)
+    expected_since = {"child-a", "child-b", "unrelated"}
+    for since in (boundary, equivalent_offset, naive_utc):
+        filtered = await async_checkpointer.list_runs(since=since, limit=None)
+        assert {run.id for run in filtered} == expected_since
+        composed = await async_checkpointer.list_runs(
+            status=WorkflowStatus.COMPLETED,
+            graph_name="alpha",
+            since=since,
+            parent_run_id=parent.id,
+            limit=1,
+        )
+        assert [run.id for run in composed] == ["child-a"]
+
+    if isinstance(async_checkpointer, SqliteCheckpointer):
+        for since in (boundary, equivalent_offset, naive_utc):
+            assert {run.id for run in async_checkpointer.runs(since=since, limit=None)} == expected_since

--- a/tests/test_checkpointer/test_ticket183_semantics.py
+++ b/tests/test_checkpointer/test_ticket183_semantics.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -16,6 +17,8 @@ from hypergraph.checkpointers import (
     StepStatus,
     WorkflowStatus,
 )
+from hypergraph.exceptions import WorkflowForkError
+from hypergraph.runners import RunStatus
 
 
 @pytest.fixture(params=["memory", "sqlite"])
@@ -26,6 +29,17 @@ async def async_checkpointer(request: pytest.FixtureRequest, tmp_path):
         yield checkpointer
     finally:
         await checkpointer.close()
+
+
+@pytest.fixture
+def sync_checkpointer(tmp_path):
+    checkpointer = SqliteCheckpointer(str(tmp_path / "sync-runs.db"))
+    checkpointer._sync_db()
+    try:
+        yield checkpointer
+    finally:
+        if checkpointer._sync_conn is not None:
+            checkpointer._sync_conn.close()
 
 
 async def test_async_run_filters_distinguish_omitted_parent_from_none(async_checkpointer):
@@ -238,3 +252,193 @@ async def test_retention_carriers_are_hidden_but_state_remains_folded(async_chec
         )
         assert sync_result["total"] == 20
         assert calls == 2
+
+
+async def test_async_fork_ids_are_source_derived_and_retry_ids_stay_generic(async_checkpointer):
+    @node(output_name="doubled")
+    def double(x: int) -> int:
+        return x * 2
+
+    runner = AsyncRunner(checkpointer=async_checkpointer)
+    graph = Graph([double])
+    await runner.run(graph, {"x": 1}, workflow_id="source-a")
+    await runner.run(graph, {"x": 2}, workflow_id="source-b")
+    source_a_before = await async_checkpointer.get_run_async("source-a")
+    source_b_before = await async_checkpointer.get_run_async("source-b")
+
+    direct_id, _ = await async_checkpointer.fork_workflow_async("source-a")
+    assert re.fullmatch(r"source-a-fork-[0-9a-f]{6}", direct_id)
+
+    fork_a = await runner.run(graph, {"x": 10}, fork_from="source-a")
+    fork_b = await runner.run(graph, {"x": 20}, fork_from="source-b")
+    explicit = await runner.run(
+        graph,
+        {"x": 30},
+        fork_from="source-a",
+        workflow_id="exact-fork-target",
+    )
+
+    assert re.fullmatch(r"source-a-fork-[0-9a-f]{6}", fork_a.workflow_id or "")
+    assert re.fullmatch(r"source-b-fork-[0-9a-f]{6}", fork_b.workflow_id or "")
+    assert explicit.workflow_id == "exact-fork-target"
+    assert (await async_checkpointer.get_run_async(fork_a.workflow_id)).forked_from == "source-a"
+    assert (await async_checkpointer.get_run_async(fork_b.workflow_id)).forked_from == "source-b"
+    assert await async_checkpointer.get_run_async("source-a") == source_a_before
+    assert await async_checkpointer.get_run_async("source-b") == source_b_before
+
+    should_fail = True
+
+    @node(output_name="seed")
+    def seed(x: int) -> int:
+        return x
+
+    @node(output_name="out")
+    def flaky(seed: int) -> int:
+        if should_fail:
+            raise RuntimeError("transient")
+        return seed * 10
+
+    retry_graph = Graph([seed, flaky])
+    failed = await runner.run(
+        retry_graph,
+        {"x": 5},
+        workflow_id="async-retry-source",
+        error_handling="continue",
+    )
+    assert failed.status == RunStatus.FAILED
+    should_fail = False
+
+    retried = await runner.run(retry_graph.with_entrypoint("flaky"), retry_from="async-retry-source")
+    assert (retried.workflow_id or "").startswith("run-")
+    assert not (retried.workflow_id or "").startswith("async-retry-source-")
+
+
+async def test_async_fork_rejects_missing_and_nested_sources(async_checkpointer):
+    @node(output_name="doubled")
+    def double(x: int) -> int:
+        return x * 2
+
+    runner = AsyncRunner(checkpointer=async_checkpointer)
+    graph = Graph([double])
+    await runner.map(graph, {"x": [1]}, map_over="x", workflow_id="nested-parent")
+
+    count_before = await async_checkpointer.count_runs()
+    with pytest.raises((ValueError, WorkflowForkError), match="Unknown source"):
+        await runner.run(graph, {"x": 2}, fork_from="missing-source")
+    assert await async_checkpointer.count_runs() == count_before
+
+    with pytest.raises(WorkflowForkError, match="How to fix:"):
+        await runner.run(graph, {"x": 3}, fork_from="nested-parent/0")
+    assert await async_checkpointer.count_runs() == count_before
+
+    explicit_id, checkpoint = await async_checkpointer.fork_workflow_async(
+        "nested-parent/0",
+        workflow_id="explicit-nested-target",
+    )
+    assert explicit_id == "explicit-nested-target"
+    assert checkpoint.source_run_id == "nested-parent/0"
+    assert await async_checkpointer.count_runs() == count_before
+
+    explicit = await runner.run(
+        graph,
+        {"x": 4},
+        fork_from="nested-parent/0",
+        workflow_id="runner-nested-target",
+    )
+    assert explicit.workflow_id == "runner-nested-target"
+    assert (await async_checkpointer.get_run_async("runner-nested-target")).forked_from == "nested-parent/0"
+
+
+def test_sync_fork_ids_are_source_derived_and_retry_ids_stay_generic(sync_checkpointer):
+    @node(output_name="doubled")
+    def double(x: int) -> int:
+        return x * 2
+
+    runner = SyncRunner(checkpointer=sync_checkpointer)
+    graph = Graph([double])
+    runner.run(graph, {"x": 1}, workflow_id="sync-source-a")
+    runner.run(graph, {"x": 2}, workflow_id="sync-source-b")
+    source_a_before = sync_checkpointer.get_run("sync-source-a")
+    source_b_before = sync_checkpointer.get_run("sync-source-b")
+
+    direct_id, _ = sync_checkpointer.fork_workflow("sync-source-a")
+    assert re.fullmatch(r"sync-source-a-fork-[0-9a-f]{6}", direct_id)
+
+    fork_a = runner.run(graph, {"x": 10}, fork_from="sync-source-a")
+    fork_b = runner.run(graph, {"x": 20}, fork_from="sync-source-b")
+    explicit = runner.run(
+        graph,
+        {"x": 30},
+        fork_from="sync-source-a",
+        workflow_id="sync-exact-fork-target",
+    )
+
+    assert re.fullmatch(r"sync-source-a-fork-[0-9a-f]{6}", fork_a.workflow_id or "")
+    assert re.fullmatch(r"sync-source-b-fork-[0-9a-f]{6}", fork_b.workflow_id or "")
+    assert explicit.workflow_id == "sync-exact-fork-target"
+    assert sync_checkpointer.get_run(fork_a.workflow_id).forked_from == "sync-source-a"
+    assert sync_checkpointer.get_run(fork_b.workflow_id).forked_from == "sync-source-b"
+    assert sync_checkpointer.get_run("sync-source-a") == source_a_before
+    assert sync_checkpointer.get_run("sync-source-b") == source_b_before
+
+    should_fail = True
+
+    @node(output_name="seed")
+    def seed(x: int) -> int:
+        return x
+
+    @node(output_name="out")
+    def flaky(seed: int) -> int:
+        if should_fail:
+            raise RuntimeError("transient")
+        return seed * 10
+
+    retry_graph = Graph([seed, flaky])
+    failed = runner.run(
+        retry_graph,
+        {"x": 5},
+        workflow_id="sync-retry-source",
+        error_handling="continue",
+    )
+    assert failed.status == RunStatus.FAILED
+    should_fail = False
+
+    retried = runner.run(retry_graph.with_entrypoint("flaky"), retry_from="sync-retry-source")
+    assert (retried.workflow_id or "").startswith("run-")
+    assert not (retried.workflow_id or "").startswith("sync-retry-source-")
+
+
+def test_sync_fork_rejects_missing_and_nested_sources(sync_checkpointer):
+    @node(output_name="doubled")
+    def double(x: int) -> int:
+        return x * 2
+
+    runner = SyncRunner(checkpointer=sync_checkpointer)
+    graph = Graph([double])
+    runner.map(graph, {"x": [1]}, map_over="x", workflow_id="sync-nested-parent")
+
+    count_before = len(sync_checkpointer.runs(limit=None))
+    with pytest.raises((ValueError, WorkflowForkError), match="Unknown source"):
+        runner.run(graph, {"x": 2}, fork_from="sync-missing-source")
+    assert len(sync_checkpointer.runs(limit=None)) == count_before
+
+    with pytest.raises(WorkflowForkError, match="How to fix:"):
+        runner.run(graph, {"x": 3}, fork_from="sync-nested-parent/0")
+    assert len(sync_checkpointer.runs(limit=None)) == count_before
+
+    explicit_id, checkpoint = sync_checkpointer.fork_workflow(
+        "sync-nested-parent/0",
+        workflow_id="sync-explicit-nested-target",
+    )
+    assert explicit_id == "sync-explicit-nested-target"
+    assert checkpoint.source_run_id == "sync-nested-parent/0"
+    assert len(sync_checkpointer.runs(limit=None)) == count_before
+
+    explicit = runner.run(
+        graph,
+        {"x": 4},
+        fork_from="sync-nested-parent/0",
+        workflow_id="sync-runner-nested-target",
+    )
+    assert explicit.workflow_id == "sync-runner-nested-target"
+    assert sync_checkpointer.get_run("sync-runner-nested-target").forked_from == "sync-nested-parent/0"

--- a/tests/test_checkpointer/test_ticket183_semantics.py
+++ b/tests/test_checkpointer/test_ticket183_semantics.py
@@ -136,6 +136,15 @@ async def test_default_count_runs_omits_parent_filter_for_third_party_backends()
     assert checkpointer.seen_parent_run_id is None
 
 
+async def test_empty_graph_name_filter_matches_existing_sync_semantics(async_checkpointer):
+    await async_checkpointer.create_run("unnamed")
+    await async_checkpointer.create_run("named", graph_name="named")
+
+    assert [run.id for run in await async_checkpointer.list_runs(graph_name="", limit=None)] == ["unnamed"]
+    if isinstance(async_checkpointer, SqliteCheckpointer):
+        assert [run.id for run in async_checkpointer.runs(graph_name="", limit=None)] == ["unnamed"]
+
+
 async def test_retention_carriers_are_hidden_but_state_remains_folded(async_checkpointer):
     run_id = "retention-source"
     async_checkpointer.policy = CheckpointPolicy(durability="sync", retention="latest")

--- a/tests/test_checkpointer/test_ticket183_semantics.py
+++ b/tests/test_checkpointer/test_ticket183_semantics.py
@@ -9,6 +9,7 @@ import pytest
 
 from hypergraph import AsyncRunner, Graph, SyncRunner, node
 from hypergraph.checkpointers import (
+    Checkpointer,
     CheckpointPolicy,
     MemoryCheckpointer,
     SqliteCheckpointer,
@@ -95,6 +96,44 @@ async def test_async_run_filters_distinguish_omitted_parent_from_none(async_chec
     if isinstance(async_checkpointer, SqliteCheckpointer):
         for since in (boundary, equivalent_offset, naive_utc):
             assert {run.id for run in async_checkpointer.runs(since=since, limit=None)} == expected_since
+
+
+async def test_default_count_runs_omits_parent_filter_for_third_party_backends():
+    backend_unset = object()
+
+    class ThirdPartyCheckpointer(MemoryCheckpointer):
+        count_runs = Checkpointer.count_runs
+
+        def __init__(self):
+            super().__init__()
+            self.seen_parent_run_id: object | str | None = None
+
+        async def list_runs(
+            self,
+            *,
+            status=None,
+            graph_name=None,
+            since=None,
+            parent_run_id=backend_unset,
+            limit=100,
+        ):
+            self.seen_parent_run_id = parent_run_id
+            if parent_run_id is not backend_unset:
+                return []
+            return await super().list_runs(
+                status=status,
+                graph_name=graph_name,
+                since=since,
+                limit=limit,
+            )
+
+    checkpointer = ThirdPartyCheckpointer()
+    await checkpointer.create_run("run-1")
+
+    assert await checkpointer.count_runs() == 1
+    assert checkpointer.seen_parent_run_id is backend_unset
+    assert await checkpointer.count_runs(parent_run_id=None) == 0
+    assert checkpointer.seen_parent_run_id is None
 
 
 async def test_retention_carriers_are_hidden_but_state_remains_folded(async_checkpointer):

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 import ast
 import inspect
 from pathlib import Path
+from typing import get_args, get_type_hints
 
-from hypergraph import Graph, MapResult, RunResult
+from hypergraph import Graph, MapResult, RunResult, WorkflowStoppedError
+from hypergraph.checkpointers import Checkpointer, MemoryCheckpointer, SqliteCheckpointer, SqliteRunInspector
+from hypergraph.events import RunEndEvent
+from hypergraph.runners._shared.types import NodeRecord
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -164,3 +168,51 @@ def test_streaming_chunk_event_docs_mirror_correlation_fields() -> None:
     assert "`item_index`" in streaming
     assert "`parent_span_id`" in streaming
     assert "span of the emitting node" in streaming
+
+
+def test_checkpointer_semantics_docs_mirror_high_drift_surfaces() -> None:
+    checkpointers = _read("docs/06-api-reference/checkpointers.md")
+    runners = _read("docs/06-api-reference/runners.md")
+    events = _read("docs/06-api-reference/events.md")
+    batch = _read("docs/05-how-to/batch-processing.md")
+
+    for get_steps in (
+        Checkpointer.get_steps,
+        MemoryCheckpointer.get_steps,
+        SqliteCheckpointer.get_steps,
+        SqliteCheckpointer.steps,
+        SqliteRunInspector.steps,
+    ):
+        assert inspect.signature(get_steps).parameters["show_internal"].default is False
+    assert "show_internal=True" in checkpointers
+    assert "retention carriers" in checkpointers
+
+    list_runs = inspect.signature(Checkpointer.list_runs).parameters
+    count_runs = inspect.signature(Checkpointer.count_runs).parameters
+    assert {"graph_name", "since", "parent_run_id"} <= set(list_runs)
+    assert list_runs["parent_run_id"].default is not None
+    assert count_runs["parent_run_id"].default is not None
+    assert "Omit `parent_run_id` for all runs" in checkpointers
+    assert "explicit-`None`/top-level" in checkpointers
+
+    assert RunResult.__dataclass_fields__["restored"].default is False
+    assert isinstance(inspect.getattr_static(MapResult, "restored_count"), property)
+    assert "restored" in get_args(get_type_hints(NodeRecord)["status"])
+    assert "restored: bool" in _scoped_section(runners, "## RunResult")
+    assert "restored_count" in _scoped_section(runners, "## MapResult")
+    assert "fully restored map omits the average" in runners
+
+    assert "batch_restored_items" in RunEndEvent.__dataclass_fields__
+    assert "batch_restored_items: int | None" in events
+    assert "hypergraph.batch.restored_items" in events
+    assert "Restored children" in events
+
+    assert issubclass(WorkflowStoppedError, Exception)
+    assert "WorkflowStoppedError" in runners
+    assert "non-empty runtime mapping" in batch
+    assert "before a new run event or persistence write" in batch
+
+    assert "{source}-fork-{hex}" in runners
+    assert "generic `run-...`" in runners
+    assert "job-1-fork-a1b2c3" in checkpointers
+    assert "nested source" in checkpointers

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -204,6 +204,8 @@ def test_checkpointer_semantics_docs_mirror_high_drift_surfaces() -> None:
 
     assert "batch_restored_items" in RunEndEvent.__dataclass_fields__
     assert "batch_restored_items: int | None" in events
+    run_end_event = _scoped_section(events, "### RunEndEvent")
+    assert run_end_event.index("batch_outcome: str | None") < run_end_event.index("batch_restored_items: int | None")
     assert "hypergraph.batch.restored_items" in events
     assert "Restored children" in events
 

--- a/tests/test_map_result.py
+++ b/tests/test_map_result.py
@@ -447,6 +447,69 @@ class TestMapResultCheckpointEvidence:
 
 
 class TestMapResultProgressiveDisclosure:
+    def test_restored_items_are_counted_without_diluting_fresh_duration(self):
+        fresh_log = RunLog(
+            graph_name="test",
+            run_id="fresh",
+            total_duration_ms=100.0,
+            steps=(
+                NodeRecord(
+                    node_name="work",
+                    superstep=0,
+                    duration_ms=100.0,
+                    status="completed",
+                    span_id="fresh-span",
+                ),
+            ),
+        )
+        restored_log = RunLog(
+            graph_name="test",
+            run_id="restored",
+            total_duration_ms=0.0,
+            steps=(
+                NodeRecord(
+                    node_name="map_item",
+                    superstep=0,
+                    duration_ms=0.0,
+                    status="restored",
+                    span_id="restored-checkpoint",
+                ),
+            ),
+        )
+        fresh = RunResult(values={"x": 1}, status=RunStatus.COMPLETED, log=fresh_log)
+        restored = RunResult(
+            values={"x": 2},
+            status=RunStatus.COMPLETED,
+            log=restored_log,
+            restored=True,
+        )
+        mapped = _make_map_result([fresh, restored], total_duration_ms=125.0)
+
+        assert "2 completed" in mapped.summary()
+        assert "1 restored" in mapped.summary()
+        assert "avg 100ms/item" in mapped.summary()
+        assert mapped.restored_count == 1
+        assert mapped.to_dict()["restored_count"] == 1
+        assert mapped.to_dict()["items"][1]["restored"] is True
+        assert "restored" in restored.summary().lower()
+        assert "restored=true" in repr(restored).lower()
+        assert "restored" in str(restored_log).lower()
+        assert "failed" not in str(restored_log).lower()
+        assert "1 restored" in mapped.log.summary()
+        assert "avg 100ms/item" in mapped.log.summary()
+        assert "restored" in str(mapped.log).lower()
+        assert "restored" in (mapped._repr_html_() or "").lower()
+        assert "restored" in (restored._repr_html_() or "").lower()
+
+        same_log_but_not_restored = RunResult(
+            values={"x": 2},
+            status=RunStatus.COMPLETED,
+            log=restored_log,
+        )
+        without_explicit_flag = _make_map_result([fresh, same_log_but_not_restored])
+        assert "restored" not in without_explicit_flag.summary().lower()
+        assert "avg 50ms/item" in without_explicit_flag.summary()
+
     def test_summary(self):
         items = [
             _make_result(),
@@ -458,8 +521,7 @@ class TestMapResultProgressiveDisclosure:
         assert "3 items" in s
         assert "2 completed" in s
         assert "1 failed" in s
-        assert "avg" in s
-        assert "/item" in s
+        assert "avg" not in s
 
     def test_to_dict_envelope(self):
         items = [_make_result()]

--- a/tests/test_map_result.py
+++ b/tests/test_map_result.py
@@ -498,7 +498,13 @@ class TestMapResultProgressiveDisclosure:
         assert "1 restored" in mapped.log.summary()
         assert "avg 100ms/item" in mapped.log.summary()
         assert "restored" in str(mapped.log).lower()
-        assert "restored" in (mapped._repr_html_() or "").lower()
+        mapped_html = mapped._repr_html_() or ""
+        map_log_html = mapped.log._repr_html_() or ""
+        assert "restored" in mapped_html.lower()
+        assert "Completed (2)" in mapped_html
+        assert "Restored (1)" in mapped_html
+        assert "Completed (2)" in map_log_html
+        assert "Restored (1)" in map_log_html
         assert "restored" in (restored._repr_html_() or "").lower()
 
         same_log_but_not_restored = RunResult(

--- a/tests/test_map_result.py
+++ b/tests/test_map_result.py
@@ -528,6 +528,8 @@ class TestMapResultProgressiveDisclosure:
         assert mapped.to_dict()["items"][1]["restored"] is True
         assert "restored" in restored.summary().lower()
         assert "restored=true" in repr(restored).lower()
+        assert "restored=1" in repr(restored_log).lower()
+        assert "duration=0ms" not in repr(restored_log).lower()
         assert "restored" in str(restored_log).lower()
         assert "failed" not in str(restored_log).lower()
         assert "1 restored" in mapped.log.summary()
@@ -549,7 +551,8 @@ class TestMapResultProgressiveDisclosure:
         )
         without_explicit_flag = _make_map_result([fresh, same_log_but_not_restored])
         assert "restored" not in without_explicit_flag.summary().lower()
-        assert "avg 100ms/item" in without_explicit_flag.summary()
+        assert "avg 50ms/item" in without_explicit_flag.summary()
+        assert "avg 50ms/item" in without_explicit_flag.log.summary()
 
     def test_summary(self):
         items = [

--- a/tests/test_map_result.py
+++ b/tests/test_map_result.py
@@ -447,6 +447,41 @@ class TestMapResultCheckpointEvidence:
 
 
 class TestMapResultProgressiveDisclosure:
+    def test_fully_cached_items_do_not_report_an_average(self):
+        cached_log = RunLog(
+            graph_name="test",
+            run_id="cached",
+            total_duration_ms=0.0,
+            steps=(
+                NodeRecord(
+                    node_name="work",
+                    superstep=0,
+                    duration_ms=0.0,
+                    status="completed",
+                    span_id="cached-span",
+                    cached=True,
+                ),
+            ),
+        )
+        mapped = _make_map_result([_make_result(log=cached_log), _make_result(log=cached_log)])
+
+        assert "avg" not in mapped.summary()
+        assert "avg" not in mapped.log.summary()
+        assert "avg" not in MapLog(graph_name="test", total_duration_ms=0.0, items=(cached_log, cached_log)).summary()
+
+    def test_empty_item_logs_do_not_report_an_average(self):
+        empty_log = RunLog(
+            graph_name="test",
+            run_id="empty",
+            total_duration_ms=0.0,
+            steps=(),
+        )
+        mapped = _make_map_result([_make_result(log=empty_log)])
+
+        assert "avg" not in mapped.summary()
+        assert "avg" not in mapped.log.summary()
+        assert "avg" not in MapLog(graph_name="test", total_duration_ms=0.0, items=(empty_log,)).summary()
+
     def test_restored_items_are_counted_without_diluting_fresh_duration(self):
         fresh_log = RunLog(
             graph_name="test",
@@ -514,7 +549,7 @@ class TestMapResultProgressiveDisclosure:
         )
         without_explicit_flag = _make_map_result([fresh, same_log_but_not_restored])
         assert "restored" not in without_explicit_flag.summary().lower()
-        assert "avg 50ms/item" in without_explicit_flag.summary()
+        assert "avg 100ms/item" in without_explicit_flag.summary()
 
     def test_summary(self):
         items = [

--- a/tests/test_run_log/test_otel_processor.py
+++ b/tests/test_run_log/test_otel_processor.py
@@ -150,11 +150,36 @@ class TestOTelProcessor:
         assert attrs["hypergraph.batch.total_items"] == 3
         assert attrs["hypergraph.batch.completed_items"] == 2
         assert attrs["hypergraph.batch.failed_items"] == 1
+        assert attrs["hypergraph.batch.restored_items"] == 0
         assert attrs["hypergraph.batch.outcome"] == "partial"
         assert map_span.status.status_code == StatusCode.UNSET
 
         child_item_spans = [span for span in spans if span.name.startswith("graph ") and span.attributes.get("hypergraph.item_index") is not None]
         assert sorted(span.attributes["hypergraph.item_index"] for span in child_item_spans) == [0, 1, 2]
+
+    def test_restored_batch_subset_is_exported(self, sqlite_checkpointer):
+        """A fully restored map keeps completed inclusive and exports its subset."""
+        from hypergraph.events.otel import OpenTelemetryProcessor
+
+        runner = SyncRunner(checkpointer=sqlite_checkpointer)
+        graph = Graph([double])
+        runner.map(graph, {"x": [1, 2]}, map_over="x", workflow_id="otel-restored")
+
+        processor = OpenTelemetryProcessor()
+        resumed = runner.map(
+            graph,
+            {"x": [1, 2]},
+            map_over="x",
+            workflow_id="otel-restored",
+            event_processors=[processor],
+        )
+
+        assert resumed.restored_count == 2
+        spans = self.exporter.get_finished_spans()
+        map_span = next(span for span in spans if span.attributes.get("hypergraph.is_map") is True)
+        attrs = dict(map_span.attributes)
+        assert attrs["hypergraph.batch.completed_items"] == 2
+        assert attrs["hypergraph.batch.restored_items"] == 2
 
     def test_forked_run_adds_lineage_link_when_source_span_is_known(self, sqlite_checkpointer):
         """Forked runs link back to the source run span when both are in-process."""

--- a/tests/test_runners/test_types.py
+++ b/tests/test_runners/test_types.py
@@ -69,6 +69,12 @@ class TestRunResult:
         )
         assert result.workflow_id == "workflow-123"
 
+    def test_fresh_result_is_not_restored(self):
+        result = RunResult(values={}, status=RunStatus.COMPLETED)
+
+        assert result.restored is False
+        assert result.to_dict()["restored"] is False
+
     def test_dict_like_access(self):
         result = RunResult(
             values={"x": 42, "y": "hello"},
@@ -311,6 +317,18 @@ class TestGraphState:
 
 
 class TestMapResult:
+    def test_batch_restored_count_is_completed_subset(self):
+        results = (
+            RunResult(values={}, status=RunStatus.COMPLETED, restored=True),
+            RunResult(values={}, status=RunStatus.COMPLETED),
+        )
+
+        summary = BatchSummary.from_results(results)
+
+        assert summary.completed_items == 2
+        assert summary.restored_items == 1
+        assert summary.outcome == "completed"
+
     def test_batch_summary_uses_map_result_status_precedence(self):
         cases = [
             ((), RunStatus.COMPLETED),

--- a/tests/test_stop_and_stream.py
+++ b/tests/test_stop_and_stream.py
@@ -33,6 +33,7 @@ from hypergraph import (
     StreamingChunkEvent,
     SyncRunner,
     WorkflowAlreadyRunningError,
+    WorkflowStoppedError,
     node,
     route,
 )
@@ -55,6 +56,19 @@ class ChunkCollector:
             self.chunks.append(event.chunk)
         elif isinstance(event, StopRequestedEvent):
             self.stop_events.append(event)
+
+    def shutdown(self):
+        pass
+
+
+class EventCollector:
+    """Collect every dispatched event for lifecycle rejection assertions."""
+
+    def __init__(self):
+        self.events: list[Any] = []
+
+    def on_event(self, event):
+        self.events.append(event)
 
     def shutdown(self):
         pass
@@ -444,6 +458,193 @@ class TestStoppedStatus:
 
 
 class TestResumeAfterStop:
+    @pytest.mark.asyncio
+    async def test_async_bare_stopped_rerun_requires_explicit_signal(self, tmp_path):
+        from hypergraph.checkpointers import SqliteCheckpointer, WorkflowStatus
+
+        node_started = asyncio.Event()
+        release_node = asyncio.Event()
+        call_count = 0
+
+        @node(output_name="doubled")
+        async def double_after_release(x: int, ctx: NodeContext) -> int:
+            nonlocal call_count
+            call_count += 1
+            node_started.set()
+            await release_node.wait()
+            return x * 2
+
+        workflow_id = "stopped-explicit-signal"
+        graph = Graph([double_after_release])
+        checkpointer = SqliteCheckpointer(str(tmp_path / "stopped-explicit-signal.db"))
+        try:
+            runner = AsyncRunner(checkpointer=checkpointer)
+
+            async def stop_after_start():
+                await node_started.wait()
+                runner.stop(workflow_id)
+                release_node.set()
+
+            stop_task = asyncio.create_task(stop_after_start())
+            stopped = await runner.run(graph, {"x": 1}, workflow_id=workflow_id)
+            await stop_task
+
+            assert stopped.status == RunStatus.STOPPED
+            assert call_count == 1
+            stored_before = await checkpointer.get_run_async(workflow_id)
+            assert stored_before is not None
+            assert stored_before.status == WorkflowStatus.STOPPED
+            stored_snapshot = stored_before.to_dict()
+
+            collector = EventCollector()
+            with pytest.raises(WorkflowStoppedError) as exc_info:
+                await runner.run(graph, workflow_id=workflow_id, event_processors=[collector])
+
+            message = str(exc_info.value)
+            assert workflow_id in message
+            assert "How to fix:" in message
+            assert "non-empty" in message
+            assert "override_workflow=True" in message
+            assert collector.events == []
+            assert call_count == 1
+            stored_after_rejection = await checkpointer.get_run_async(workflow_id)
+            assert stored_after_rejection is not None
+            assert stored_after_rejection.to_dict() == stored_snapshot
+
+            with pytest.raises(WorkflowStoppedError):
+                await runner.run(graph, {}, workflow_id=workflow_id)
+
+            resumed = await runner.run(graph, {"x": 2}, workflow_id=workflow_id)
+
+            assert resumed.workflow_id == workflow_id
+            assert resumed["doubled"] == 4
+            assert call_count == 2
+
+            await checkpointer.update_run_status(workflow_id, WorkflowStatus.STOPPED)
+            same_value_signal = await runner.run(graph, {"x": 2}, workflow_id=workflow_id)
+            assert same_value_signal.workflow_id == workflow_id
+            assert same_value_signal["doubled"] == 4
+        finally:
+            await checkpointer.close()
+
+    def test_sync_bare_stopped_rerun_requires_explicit_signal(self, tmp_path):
+        from hypergraph.checkpointers import SqliteCheckpointer, WorkflowStatus
+
+        node_started = threading.Event()
+        release_node = threading.Event()
+        call_count = 0
+
+        @node(output_name="doubled")
+        def double_after_release(x: int, ctx: NodeContext) -> int:
+            nonlocal call_count
+            call_count += 1
+            node_started.set()
+            assert release_node.wait(timeout=2.0)
+            return x * 2
+
+        workflow_id = "sync-stopped-explicit-signal"
+        graph = Graph([double_after_release])
+        checkpointer = SqliteCheckpointer(str(tmp_path / "sync-stopped-explicit-signal.db"))
+        try:
+            runner = SyncRunner(checkpointer=checkpointer)
+
+            def stop_after_start():
+                assert node_started.wait(timeout=2.0)
+                runner.stop(workflow_id)
+                release_node.set()
+
+            stop_thread = threading.Thread(target=stop_after_start)
+            stop_thread.start()
+            stopped = runner.run(graph, {"x": 1}, workflow_id=workflow_id)
+            stop_thread.join(timeout=2.0)
+            assert not stop_thread.is_alive()
+
+            assert stopped.status == RunStatus.STOPPED
+            assert call_count == 1
+            stored_before = checkpointer.get_run(workflow_id)
+            assert stored_before is not None
+            assert stored_before.status == WorkflowStatus.STOPPED
+            stored_snapshot = stored_before.to_dict()
+
+            collector = EventCollector()
+            with pytest.raises(WorkflowStoppedError):
+                runner.run(graph, workflow_id=workflow_id, event_processors=[collector])
+
+            assert collector.events == []
+            assert call_count == 1
+            stored_after_rejection = checkpointer.get_run(workflow_id)
+            assert stored_after_rejection is not None
+            assert stored_after_rejection.to_dict() == stored_snapshot
+
+            resumed = runner.run(graph, {"x": 2}, workflow_id=workflow_id)
+            assert resumed.workflow_id == workflow_id
+            assert resumed["doubled"] == 4
+            assert call_count == 2
+        finally:
+            if checkpointer._sync_conn is not None:
+                checkpointer._sync_conn.close()
+
+    @pytest.mark.asyncio
+    async def test_stopped_parent_with_completed_graphnode_resumes_coherently(self, tmp_path):
+        from hypergraph.checkpointers import SqliteCheckpointer, WorkflowStatus
+
+        outer_node_started = asyncio.Event()
+        release_outer_node = asyncio.Event()
+        finish_calls = 0
+
+        @node(output_name="doubled")
+        def child_double(x: int) -> int:
+            return x * 2
+
+        @node(output_name="final")
+        async def finish(doubled: int, resume_token: int, ctx: NodeContext) -> int:
+            nonlocal finish_calls
+            finish_calls += 1
+            outer_node_started.set()
+            await release_outer_node.wait()
+            return doubled + resume_token
+
+        child = Graph([child_double], name="child-graph").as_node(name="child")
+        graph = Graph([child, finish], name="outer-graph")
+        workflow_id = "stopped-nested"
+        checkpointer = SqliteCheckpointer(str(tmp_path / "stopped-nested.db"))
+        try:
+            runner = AsyncRunner(checkpointer=checkpointer)
+
+            async def stop_after_outer_node_starts():
+                await outer_node_started.wait()
+                runner.stop(workflow_id)
+                release_outer_node.set()
+
+            stop_task = asyncio.create_task(stop_after_outer_node_starts())
+            stopped = await runner.run(
+                graph,
+                {"x": 1, "resume_token": 0},
+                workflow_id=workflow_id,
+            )
+            await stop_task
+
+            assert stopped.status == RunStatus.STOPPED
+            child_before = await checkpointer.get_run_async(f"{workflow_id}/child")
+            assert child_before is not None
+            assert child_before.status == WorkflowStatus.COMPLETED
+            assert child_before.parent_run_id == workflow_id
+
+            with pytest.raises(WorkflowStoppedError):
+                await runner.run(graph, workflow_id=workflow_id)
+
+            resumed = await runner.run(graph, {"resume_token": 1}, workflow_id=workflow_id)
+            assert resumed.workflow_id == workflow_id
+            assert resumed["final"] == 3
+            assert finish_calls == 2
+
+            child_after = await checkpointer.get_run_async(f"{workflow_id}/child")
+            assert child_after is not None
+            assert child_after.to_dict() == child_before.to_dict()
+            assert child_after.parent_run_id == workflow_id
+        finally:
+            await checkpointer.close()
+
     @pytest.mark.asyncio
     async def test_resume_after_stop_with_checkpointer(self, tmp_path):
         """Stop mid-generation, then re-run fresh to verify clean restart."""


### PR DESCRIPTION
## Problem / Bug / Challenge

Issue #183 locks five production-readiness decisions at the checkpointer boundary. The existing surfaces disagreed across Memory/SQLite and sync/async runners, ambiguous STOPPED reruns could overwrite lineage, retention carriers leaked through public inspection, restored map children looked like fake 0 ms execution, and implicit fork IDs were unrelated to their source.

This PR implements D2, D3, D13, D16, and D18 together so their shared runner/checkpointer contracts remain coherent. The pre-existing compacted-retention no-input fork gap discovered during adversarial validation is deliberately separated into #195.

## Before / After

**Before:**

```python
await checkpointer.list_runs(parent_run_id=None)  # all runs, including children
runner.run(graph, {}, workflow_id="stopped-job") # silently overwrote STOPPED as COMPLETED
await checkpointer.get_steps("job")               # exposed __retained_state__
results.summary()                                  # "2 completed | avg 50ms/item" (one item was restored)
runner.run(graph, values, fork_from="source")     # generic run-... id
```

**After:**

```python
await checkpointer.list_runs()                    # all runs
await checkpointer.list_runs(parent_run_id=None)  # top-level runs only

runner.run(graph, {}, workflow_id="stopped-job") # raises WorkflowStoppedError
runner.run(graph, {"x": 2}, workflow_id="stopped-job")  # explicit same-lineage resume

await checkpointer.get_steps("job")                       # public steps only
await checkpointer.get_steps("job", show_internal=True)   # includes retention carriers

results.restored_count                             # 1; completed remains inclusive
results.summary()                                  # "2 completed, 1 restored | avg 100ms/item"

runner.run(graph, values, fork_from="source").workflow_id
# source-fork-a1b2c3
```

Additional compatibility details:

- `RunEndEvent.batch_restored_items` is appended after the legacy positional fields and exported to OpenTelemetry as `hypergraph.batch.restored_items`.
- Fully cached, empty-log, and fully restored maps omit duration averages; explicit `RunResult.restored` remains the provenance authority.
- Memory, SQLite async, and SQLite sync now agree on parent, graph-name, and UTC-normalized inclusive `since` filters.
- Explicit fork targets and retry naming remain unchanged.

## Test Plan

- [x] RED→GREEN outcome regressions for D2, D3, D13, D16, and D18
- [x] Independent read-only Codex ship review: no remaining P0–P2 findings
- [x] `uv run pytest -W error -W 'ignore::pytest.PytestUnraisableExceptionWarning' tests/test_checkpointer tests/test_stop_and_stream.py tests/test_map_result.py tests/test_runners/test_types.py tests/events tests/test_run_log/test_otel_processor.py tests/test_docs_contract.py` — 516 passed
- [x] `uv run pytest -W error -W 'ignore::pytest.PytestUnraisableExceptionWarning'` — 3,050 passed, 0 skipped
- [x] `uv run pre-commit run --all-files`
- [x] Python 3.10 targeted compatibility probe — 113 passed

Implements #183.

Closes #128
Closes #141
Closes #144
Closes #175
