### PR TITLE
feat: ambient OTel span-context activation for node bodies

### DIFF
--- a/docs/05-how-to/observe-execution.md
+++ b/docs/05-how-to/observe-execution.md
@@ -128,6 +128,53 @@ graph outer
         └── node double
 ```
 
+### Ambient Context: Third-Party Telemetry Nests Under Node Spans
+
+While a run executes, `OpenTelemetryProcessor` makes its spans the **ambient
+OTel context** for the code they cover — the run root around the run, each
+node span around that node's body. Any OTel-instrumented library called
+inside a node (an openinference-instrumented OpenAI client, an agent SDK, a
+database driver) parents its spans under the node span automatically, with
+zero coupling on either side:
+
+```python
+from opentelemetry import trace
+from hypergraph import Graph, SyncRunner, node
+from hypergraph.events.otel import OpenTelemetryProcessor
+
+tracer = trace.get_tracer("my.instrumentation")
+
+@node(output_name="answer")
+def call_llm(prompt: str) -> str:
+    # Any instrumented call here — this explicit span stands in for one —
+    # picks up the node span as its parent from the ambient context.
+    with tracer.start_as_current_span("ChatCompletion"):
+        return llm.complete(prompt)
+
+SyncRunner().run(Graph([call_llm], name="rag"), {"prompt": "hi"},
+                 event_processors=[OpenTelemetryProcessor()])
+```
+
+```text
+graph rag
+└── node call_llm
+    └── ChatCompletion        ← nested under the node, same trace
+```
+
+Without ambient activation the `ChatCompletion` span would attach to
+whatever context was current before `.run()` — a sibling of the node at
+best, a separate trace when no outer span existed. Activation holds for
+`SyncRunner`, `AsyncRunner` (concurrent nodes each get their own context —
+no cross-node or cross-map-item leakage), and per-item map runs. The
+previous ambient context is restored when the run ends, including on
+failure. Runs without an `OpenTelemetryProcessor` never touch OTel context
+(nothing is imported or attached).
+
+Span *parentage* is unchanged by activation — hypergraph still parents its
+own run and node spans explicitly, so exported span structure is identical
+to before; activation only changes what
+`opentelemetry.context.get_current()` returns inside the bracketed code.
+
 To correlate your own logging with the current node span from inside a node body, call `current_node_span()`:
 
 ```python

--- a/docs/06-api-reference/events.md
+++ b/docs/06-api-reference/events.md
@@ -31,7 +31,12 @@ Two contracts hold everywhere processors appear:
 1. **Processors observe only, and are failure-isolated.** A processor never
    changes execution, and dispatch is best-effort: if a processor raises, the
    error is logged and the run continues (`EventDispatcher(strict=True)`
-   propagates instead, for tests that want loud failures).
+   propagates instead, for tests that want loud failures). One deliberate
+   observability-plane effect exists: `OpenTelemetryProcessor` makes its run
+   and node spans the ambient OTel context around the code they cover, so
+   third-party instrumentation inside node bodies nests under the node span
+   (see [Observe Execution](../05-how-to/observe-execution.md#ambient-context-third-party-telemetry-nests-under-node-spans)).
+   Workflow behavior — routing, values, results — is never affected.
 2. **Graph-carried processors merge with call-site processors — never
    replace.** Runners dispatch to
    `[*graph.default_event_processors, *event_processors]`: carrying processors

--- a/src/hypergraph/events/otel.py
+++ b/src/hypergraph/events/otel.py
@@ -102,10 +102,12 @@ class OpenTelemetryProcessor(TypedEventProcessor):
                 consulted nor modified.
         """
         _require_opentelemetry()
+        from opentelemetry import context as otel_context
         from opentelemetry import trace
         from opentelemetry.trace import Link, Status, StatusCode
 
         self._trace = trace
+        self._context_api = otel_context
         if tracer_provider is not None:
             self._tracer = tracer_provider.get_tracer(tracer_name)
         else:
@@ -116,8 +118,64 @@ class OpenTelemetryProcessor(TypedEventProcessor):
         self._StatusCode = StatusCode
         self._spans: dict[str, Any] = {}
         self._contexts: dict[str, Any] = {}
+        self._tokens: dict[str, Any] = {}
         self._workflow_span_contexts: OrderedDict[str, Any] = OrderedDict()
         self._workflow_span_contexts_lock = Lock()
+
+    # -- Ambient context activation -------------------------------------------
+    #
+    # Beyond projecting events into spans, this processor makes each span the
+    # AMBIENT OTel context for the code it covers: the run root around the run,
+    # each node span around that node's body. Third-party instrumentation
+    # (openinference, agent SDKs) that starts spans inside a node body then
+    # parents them under the node span automatically — zero coupling.
+    #
+    # This works because event dispatch brackets execution IN the executing
+    # context: the sync runner emits node start/end synchronously around the
+    # executor call in one thread, and the async runner emits them inside the
+    # same per-node asyncio task that awaits the executor (each task owns a
+    # contextvars copy, so concurrent nodes and concurrent map items cannot
+    # see each other's attach). Span parentage bookkeeping (explicit
+    # ``context=parent_ctx`` at span creation) is unchanged — activation only
+    # changes what ``opentelemetry.context.get_current()`` returns inside the
+    # bracketed code.
+
+    def _attach_ambient(self, span_id: str) -> None:
+        """Make the span's context ambient; remember the token for detach."""
+        ctx = self._contexts.get(span_id)
+        if ctx is None:
+            return
+        self._tokens[span_id] = self._context_api.attach(ctx)
+
+    def _detach_ambient(self, span_id: str) -> None:
+        """Restore the previous ambient context.
+
+        Only called from event handlers that run in the same context that
+        attached (run end, node end, node error — guaranteed by the runner
+        templates). If that invariant ever breaks, ``opentelemetry.context``
+        logs a loud "Failed to detach context" error rather than raising.
+        """
+        token = self._tokens.pop(span_id, None)
+        if token is None:
+            return
+        self._context_api.detach(token)
+
+    def _detach_ambient_if_current(self, span_id: str) -> None:
+        """Detach only when this execution unit provably owns the attach.
+
+        Used where cross-context arrival is NORMAL: an async pause raises out
+        of the node's asyncio task without a node end/error event, so the
+        InterruptEvent (and shutdown) observe the token from a different
+        context whose contextvars copy is already gone. Detaching there would
+        make OTel log "Failed to detach context" on a healthy path; dropping
+        the token is safe because the attach only ever mutated the dead task's
+        context copy.
+        """
+        token = self._tokens.pop(span_id, None)
+        if token is None:
+            return
+        if self._context_api.get_current() is self._contexts.get(span_id):
+            self._context_api.detach(token)
 
     def _get_linked_workflow_context(self, workflow_id: str | None) -> Any | None:
         """Return a recent workflow span context, or None if evicted/missing."""
@@ -177,6 +235,7 @@ class OpenTelemetryProcessor(TypedEventProcessor):
         )
         self._spans[event.span_id] = span
         self._contexts[event.span_id] = self._trace.set_span_in_context(span)
+        self._attach_ambient(event.span_id)
 
         if event.is_resume:
             span.add_event(
@@ -205,6 +264,7 @@ class OpenTelemetryProcessor(TypedEventProcessor):
             )
 
     def on_run_end(self, event: RunEndEvent) -> None:
+        self._detach_ambient(event.span_id)
         span = self._spans.pop(event.span_id, None)
         self._contexts.pop(event.span_id, None)
         if span is None:
@@ -258,8 +318,10 @@ class OpenTelemetryProcessor(TypedEventProcessor):
         )
         self._spans[event.span_id] = span
         self._contexts[event.span_id] = self._trace.set_span_in_context(span)
+        self._attach_ambient(event.span_id)
 
     def on_node_end(self, event: NodeEndEvent) -> None:
+        self._detach_ambient(event.span_id)
         span = self._spans.pop(event.span_id, None)
         self._contexts.pop(event.span_id, None)
         if span is None:
@@ -275,6 +337,7 @@ class OpenTelemetryProcessor(TypedEventProcessor):
         span.end()
 
     def on_node_error(self, event: NodeErrorEvent) -> None:
+        self._detach_ambient(event.span_id)
         span = self._spans.pop(event.span_id, None)
         self._contexts.pop(event.span_id, None)
         if span is None:
@@ -365,6 +428,10 @@ class OpenTelemetryProcessor(TypedEventProcessor):
         # InterruptEvent should normally reuse the paused node span id.
         # If a fallback run span id slips through, don't end the parent span early.
         if event.span_id in self._spans and event.span_id != event.parent_span_id:
+            # An async pause raises out of the node's task without a node
+            # end/error event, so this event arrives in the run's context —
+            # the node's context copy died with its task (drop the token).
+            self._detach_ambient_if_current(event.span_id)
             paused_span = self._spans.pop(event.span_id)
             self._contexts.pop(event.span_id, None)
             paused_span.end()
@@ -385,6 +452,13 @@ class OpenTelemetryProcessor(TypedEventProcessor):
 
     def shutdown(self) -> None:
         """End any remaining spans while preserving bounded lineage history."""
+        # Leftover tokens exist only on abnormal exits (e.g. BaseException
+        # escaping the run template). Detach newest-first, and only where this
+        # execution unit owns the attach — cross-context leftovers died with
+        # their task's context copy and are dropped.
+        for span_id in reversed(list(self._tokens)):
+            self._detach_ambient_if_current(span_id)
+        self._tokens.clear()
         for span in self._spans.values():
             span.end()
         self._spans.clear()

--- a/tests/test_run_log/test_otel_ambient_context.py
+++ b/tests/test_run_log/test_otel_ambient_context.py
@@ -1,0 +1,382 @@
+"""Ambient OTel context activation around run roots and node bodies.
+
+The OpenTelemetryProcessor makes each span it creates the AMBIENT OTel
+context for the code that span covers, so third-party instrumentation
+(openinference, agent SDKs) started inside a node body parents under the
+node span with zero coupling. These tests prove the falsifiers via exporter
+read-back on LOCAL TracerProvider instances — no global provider is mutated.
+
+Time budget: rendezvous waits are bounded by asyncio.wait_for(timeout=5);
+the subprocess purity test is one interpreter start (<5s).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from hypergraph import AsyncRunner, Graph, SyncRunner, interrupt, node
+
+try:
+    from opentelemetry import context as otel_context
+    from opentelemetry.context import Context
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+    try:
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+    except ImportError:  # pragma: no cover - compatibility with older sdk layout
+        from opentelemetry.sdk.trace.export.in_memory import InMemorySpanExporter
+
+    HAS_OTEL_SDK = True
+except ImportError:
+    HAS_OTEL_SDK = False
+
+requires_otel = pytest.mark.skipif(not HAS_OTEL_SDK, reason="opentelemetry-sdk not installed")
+
+
+def _local_provider():
+    """A private SDK TracerProvider with an in-memory exporter attached."""
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return provider, exporter
+
+
+def _by_name(spans, name):
+    matches = [s for s in spans if s.name == name]
+    assert len(matches) == 1, f"expected exactly one {name!r} span, got {len(matches)}"
+    return matches[0]
+
+
+def _assert_no_detach_failures(caplog):
+    """The loud OTel 'Failed to detach context' error must never fire."""
+    failures = [r for r in caplog.records if "Failed to detach context" in r.getMessage()]
+    assert failures == [], failures
+
+
+@requires_otel
+class TestNodeBodyNesting:
+    """Falsifier 1: an instrumented call inside a node body parents to the node span."""
+
+    def test_sync_node_body_span_parents_to_node_span(self):
+        from hypergraph.events.otel import OpenTelemetryProcessor
+
+        provider, exporter = _local_provider()
+        tracer = provider.get_tracer("test.instrumentation")
+
+        @node(output_name="doubled")
+        def double(x: int) -> int:
+            with tracer.start_as_current_span("inner-llm-call"):
+                return x * 2
+
+        result = SyncRunner().run(
+            Graph([double], name="nest_sync"),
+            {"x": 2},
+            event_processors=[OpenTelemetryProcessor(tracer_provider=provider)],
+        )
+
+        assert result.completed
+        spans = exporter.get_finished_spans()
+        node_span = _by_name(spans, "node double")
+        inner = _by_name(spans, "inner-llm-call")
+        assert inner.parent is not None
+        assert inner.parent.span_id == node_span.context.span_id
+        assert inner.context.trace_id == node_span.context.trace_id
+
+    async def test_async_node_body_span_parents_to_node_span(self):
+        from hypergraph.events.otel import OpenTelemetryProcessor
+
+        provider, exporter = _local_provider()
+        tracer = provider.get_tracer("test.instrumentation")
+
+        @node(output_name="doubled")
+        async def double(x: int) -> int:
+            with tracer.start_as_current_span("inner-llm-call"):
+                return x * 2
+
+        result = await AsyncRunner().run(
+            Graph([double], name="nest_async"),
+            {"x": 2},
+            event_processors=[OpenTelemetryProcessor(tracer_provider=provider)],
+        )
+
+        assert result.completed
+        spans = exporter.get_finished_spans()
+        node_span = _by_name(spans, "node double")
+        inner = _by_name(spans, "inner-llm-call")
+        assert inner.parent is not None
+        assert inner.parent.span_id == node_span.context.span_id
+        assert inner.context.trace_id == node_span.context.trace_id
+
+
+@requires_otel
+class TestPreexistingRootNotInherited:
+    """The observed bug shape: with an ambient root active before .run(), a
+    node-body span used to flatten to that root as a sibling of the node."""
+
+    def test_node_body_span_does_not_flatten_to_the_pre_run_root(self):
+        from hypergraph.events.otel import OpenTelemetryProcessor
+
+        provider, exporter = _local_provider()
+        tracer = provider.get_tracer("test.instrumentation")
+
+        @node(output_name="doubled")
+        def call_llm(x: int) -> int:
+            with tracer.start_as_current_span("ChatCompletion"):
+                return x * 2
+
+        with tracer.start_as_current_span("host-root"):
+            result = SyncRunner().run(
+                Graph([call_llm], name="bracketed"),
+                {"x": 2},
+                event_processors=[OpenTelemetryProcessor(tracer_provider=provider)],
+            )
+
+        assert result.completed
+        spans = exporter.get_finished_spans()
+        host_root = _by_name(spans, "host-root")
+        node_span = _by_name(spans, "node call_llm")
+        inner = _by_name(spans, "ChatCompletion")
+        # Nested under the node — NOT a sibling hanging off the host root.
+        assert inner.parent.span_id == node_span.context.span_id
+        assert inner.parent.span_id != host_root.context.span_id
+        # And the whole run still joins the host's trace.
+        assert {s.context.trace_id for s in spans} == {host_root.context.trace_id}
+
+
+@requires_otel
+class TestConcurrentIsolation:
+    """Falsifier 2: concurrent contexts never leak into each other."""
+
+    async def test_map_concurrent_items_no_cross_item_bleed(self):
+        """Two map items provably in flight together; each inner span parents
+        to ITS OWN item's node span."""
+        from hypergraph.events.otel import OpenTelemetryProcessor
+
+        provider, exporter = _local_provider()
+        tracer = provider.get_tracer("test.instrumentation")
+        entered = 0
+        all_in = asyncio.Event()
+
+        @node(output_name="doubled")
+        async def double(x: int) -> int:
+            nonlocal entered
+            entered += 1
+            if entered == 2:
+                all_in.set()
+            # Rendezvous: both items are inside their node bodies before either
+            # creates its inner span — real concurrency, bounded at 5s.
+            await asyncio.wait_for(all_in.wait(), timeout=5)
+            with tracer.start_as_current_span("inner-llm-call") as inner:
+                inner.set_attribute("test.x", x)
+            return x * 2
+
+        results = await AsyncRunner().map(
+            Graph([double], name="nest_map"),
+            {"x": [10, 20]},
+            map_over="x",
+            event_processors=[OpenTelemetryProcessor(tracer_provider=provider)],
+        )
+
+        assert results.completed
+        spans = exporter.get_finished_spans()
+        node_by_item = {s.attributes["hypergraph.item_index"]: s for s in spans if s.name == "node double"}
+        assert sorted(node_by_item) == [0, 1]
+        inner_by_x = {s.attributes["test.x"]: s for s in spans if s.name == "inner-llm-call"}
+        assert sorted(inner_by_x) == [10, 20]
+
+        # x=10 is item 0, x=20 is item 1: each inner parents to its own node span.
+        assert inner_by_x[10].parent.span_id == node_by_item[0].context.span_id
+        assert inner_by_x[20].parent.span_id == node_by_item[1].context.span_id
+        assert node_by_item[0].context.span_id != node_by_item[1].context.span_id
+
+    async def test_concurrent_nodes_in_one_run_do_not_inherit_each_other(self):
+        """Two parallel nodes of ONE run, in flight together: each node body's
+        inner span parents to its own node span."""
+        from hypergraph.events.otel import OpenTelemetryProcessor
+
+        provider, exporter = _local_provider()
+        tracer = provider.get_tracer("test.instrumentation")
+        entered = 0
+        all_in = asyncio.Event()
+
+        async def _instrumented(name: str, x: int) -> int:
+            nonlocal entered
+            entered += 1
+            if entered == 2:
+                all_in.set()
+            await asyncio.wait_for(all_in.wait(), timeout=5)
+            with tracer.start_as_current_span(f"inner-{name}"):
+                return x
+
+        @node(output_name="a_out")
+        async def branch_a(x: int) -> int:
+            return await _instrumented("a", x)
+
+        @node(output_name="b_out")
+        async def branch_b(x: int) -> int:
+            return await _instrumented("b", x)
+
+        result = await AsyncRunner().run(
+            Graph([branch_a, branch_b], name="parallel"),
+            {"x": 1},
+            event_processors=[OpenTelemetryProcessor(tracer_provider=provider)],
+        )
+
+        assert result.completed
+        spans = exporter.get_finished_spans()
+        assert _by_name(spans, "inner-a").parent.span_id == _by_name(spans, "node branch_a").context.span_id
+        assert _by_name(spans, "inner-b").parent.span_id == _by_name(spans, "node branch_b").context.span_id
+
+
+@requires_otel
+class TestSingleTrace:
+    """Falsifier 3: with no ambient context before .run(), one run = one trace."""
+
+    def test_all_spans_share_one_trace_without_preexisting_context(self):
+        from hypergraph.events.otel import OpenTelemetryProcessor
+
+        provider, exporter = _local_provider()
+        tracer = provider.get_tracer("test.instrumentation")
+
+        @node(output_name="doubled")
+        def double(x: int) -> int:
+            with tracer.start_as_current_span("inner-llm-call"):
+                return x * 2
+
+        # Explicitly empty ambient context: no pre-existing root to inherit —
+        # the bracketless fragmentation case.
+        token = otel_context.attach(Context())
+        try:
+            result = SyncRunner().run(
+                Graph([double], name="one_trace"),
+                {"x": 3},
+                event_processors=[OpenTelemetryProcessor(tracer_provider=provider)],
+            )
+        finally:
+            otel_context.detach(token)
+
+        assert result.completed
+        spans = exporter.get_finished_spans()
+        assert {s.name for s in spans} == {"graph one_trace", "node double", "inner-llm-call"}
+        trace_ids = {s.context.trace_id for s in spans}
+        assert len(trace_ids) == 1, f"run fragmented into {len(trace_ids)} traces"
+        assert _by_name(spans, "inner-llm-call").parent.span_id == _by_name(spans, "node double").context.span_id
+
+
+@requires_otel
+class TestFailureDetach:
+    """Falsifier 4: a raising node leaves no leaked ambient context."""
+
+    def test_sync_raising_node_restores_context(self, caplog):
+        from hypergraph.events.otel import OpenTelemetryProcessor
+
+        provider, _ = _local_provider()
+
+        @node(output_name="value")
+        def boom(x: int) -> int:
+            raise ValueError("boom")
+
+        before = otel_context.get_current()
+        with caplog.at_level(logging.ERROR, logger="opentelemetry.context"), pytest.raises(ValueError, match="boom"):
+            SyncRunner().run(
+                Graph([boom], name="fail_sync"),
+                {"x": 1},
+                event_processors=[OpenTelemetryProcessor(tracer_provider=provider)],
+            )
+
+        assert otel_context.get_current() == before
+        _assert_no_detach_failures(caplog)
+
+    async def test_async_raising_node_restores_context(self, caplog):
+        from hypergraph.events.otel import OpenTelemetryProcessor
+
+        provider, _ = _local_provider()
+
+        @node(output_name="value")
+        async def boom(x: int) -> int:
+            raise ValueError("boom")
+
+        before = otel_context.get_current()
+        with caplog.at_level(logging.ERROR, logger="opentelemetry.context"), pytest.raises(ValueError, match="boom"):
+            await AsyncRunner().run(
+                Graph([boom], name="fail_async"),
+                {"x": 1},
+                event_processors=[OpenTelemetryProcessor(tracer_provider=provider)],
+            )
+
+        assert otel_context.get_current() == before
+        _assert_no_detach_failures(caplog)
+
+    async def test_async_pause_restores_context_without_detach_noise(self, caplog):
+        """An async pause raises out of the node's task with no node end/error
+        event — the token is dropped, never cross-context-detached."""
+        from hypergraph.events.otel import OpenTelemetryProcessor
+
+        provider, exporter = _local_provider()
+
+        @interrupt(output_name="decision")
+        def approval(draft: str) -> str | None:
+            return None
+
+        before = otel_context.get_current()
+        with caplog.at_level(logging.ERROR, logger="opentelemetry.context"):
+            result = await AsyncRunner().run(
+                Graph([approval], name="pause_flow"),
+                {"draft": "v1"},
+                event_processors=[OpenTelemetryProcessor(tracer_provider=provider)],
+            )
+
+        assert result.paused
+        assert otel_context.get_current() == before
+        _assert_no_detach_failures(caplog)
+        run_span = _by_name(exporter.get_finished_spans(), "graph pause_flow")
+        assert dict(run_span.attributes)["hypergraph.run.outcome"] == "paused"
+
+
+@requires_otel
+class TestZeroCostWithoutProcessor:
+    """Falsifier 5: no OpenTelemetryProcessor → no context attach, no import."""
+
+    def test_no_processor_attaches_no_context(self):
+        seen: list = []
+
+        @node(output_name="doubled")
+        def double(x: int) -> int:
+            seen.append(otel_context.get_current())
+            return x * 2
+
+        before = otel_context.get_current()
+        result = SyncRunner().run(Graph([double], name="plain"), {"x": 2})
+
+        assert result.completed
+        assert seen == [before]  # node body saw the untouched ambient context
+        assert otel_context.get_current() == before
+
+
+def test_no_processor_run_imports_no_opentelemetry():
+    """Running without a processor must not import opentelemetry at all."""
+    code = textwrap.dedent(
+        """
+        import sys
+
+        from hypergraph import Graph, SyncRunner, node
+
+        @node(output_name="doubled")
+        def double(x: int) -> int:
+            return x * 2
+
+        result = SyncRunner().run(Graph([double], name="pure"), {"x": 2})
+        assert result.completed
+        loaded = [m for m in sys.modules if m == "opentelemetry" or m.startswith("opentelemetry.")]
+        assert not loaded, f"opentelemetry imported on the uninstrumented hot path: {loaded}"
+        """
+    )
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, timeout=120)
+    assert proc.returncode == 0, proc.stderr


### PR DESCRIPTION
Stacked on #198 (base: feat/instrumented-runtime). Born from the bracketless-tracing research (sp T20/T21): hypergraph's OTel processor parented spans via private bookkeeping only, so telemetry emitted INSIDE a node body (openinference, agent SDKs) attached to whatever context was ambient before `.run()` — under a bracketless host there is no root to inherit and node-body spans fragment into separate traces.

## Mechanism
Attach/detach pairs inside `OpenTelemetryProcessor` at the existing dispatch points — run root and each node span become the ambient OTel context around the code they cover. Dispatch already brackets execution in the executing context (sync: same thread; async: `emit_async` awaited inline in the per-node task, own contextvars copy — concurrent nodes/map items stay isolated). Async pauses die with their task, so interrupt/shutdown use a same-context probe and drop tokens they cannot legally detach. Span parentage bookkeeping is byte-unchanged; runners and dispatcher untouched — the whole mechanism is processor-local, and runs without the processor never import or touch OTel context (subprocess-proven).

## Proof
11 new tests, all exporter read-back: node-body spans parent to their node span (sync / async / concurrent map, no cross-item bleed) · one trace with no pre-existing ambient context (the fragmentation case dead) · the exact T20 bug shape (pre-existing host root; inner span must not flatten to it) · raising nodes restore context with zero "Failed to detach" noise · zero-cost falsifiers. Full suite 2983 passed + `-W error` CI-parity green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)