### PR TITLE
refactor(persistence): make Wave 3b policy structural

### DIFF
--- a/src/hypergraph/_repr.py
+++ b/src/hypergraph/_repr.py
@@ -247,25 +247,21 @@ _BORDER_LIGHT = ALIGNUI_WIDGET_THEME["border_sub"]
 _LINK = ALIGNUI_WIDGET_THEME["link"]
 _ERROR_BG = ALIGNUI_WIDGET_THEME["error_bg"]
 
-STATUS_COLORS: dict[str, str] = {
-    "completed": ALIGNUI_WIDGET_THEME["success_text"],
-    "failed": ALIGNUI_WIDGET_THEME["error_text"],
-    "partial": ALIGNUI_WIDGET_THEME["warning_text"],
-    "cached": ALIGNUI_WIDGET_THEME["info_text"],
-    "restored": ALIGNUI_WIDGET_THEME["info_text"],
-    "active": ALIGNUI_WIDGET_THEME["warning_text"],
-    "paused": ALIGNUI_WIDGET_THEME["feature_text"],
+STATUS_PALETTE: dict[str, tuple[str, str]] = {
+    "completed": (ALIGNUI_WIDGET_THEME["success_text"], ALIGNUI_WIDGET_THEME["success_bg"]),
+    "failed": (ALIGNUI_WIDGET_THEME["error_text"], ALIGNUI_WIDGET_THEME["error_bg"]),
+    "partial": (ALIGNUI_WIDGET_THEME["warning_text"], ALIGNUI_WIDGET_THEME["warning_bg"]),
+    "cached": (ALIGNUI_WIDGET_THEME["info_text"], ALIGNUI_WIDGET_THEME["info_bg"]),
+    "restored": (ALIGNUI_WIDGET_THEME["info_text"], ALIGNUI_WIDGET_THEME["info_bg"]),
+    "active": (ALIGNUI_WIDGET_THEME["warning_text"], ALIGNUI_WIDGET_THEME["warning_bg"]),
+    "paused": (ALIGNUI_WIDGET_THEME["feature_text"], ALIGNUI_WIDGET_THEME["feature_bg"]),
+    # Preserve the explorer's established stopped badge instead of inventing
+    # a new theme treatment during the ownership refactor.
+    "stopped": ("#92400e", "#fff7ed"),
 }
 
-_BADGE_BG: dict[str, str] = {
-    "completed": ALIGNUI_WIDGET_THEME["success_bg"],
-    "failed": ALIGNUI_WIDGET_THEME["error_bg"],
-    "partial": ALIGNUI_WIDGET_THEME["warning_bg"],
-    "cached": ALIGNUI_WIDGET_THEME["info_bg"],
-    "restored": ALIGNUI_WIDGET_THEME["info_bg"],
-    "active": ALIGNUI_WIDGET_THEME["warning_bg"],
-    "paused": ALIGNUI_WIDGET_THEME["feature_bg"],
-}
+STATUS_COLORS: dict[str, str] = {status: colors[0] for status, colors in STATUS_PALETTE.items()}
+_BADGE_BG: dict[str, str] = {status: colors[1] for status, colors in STATUS_PALETTE.items()}
 
 # Shared inline styles
 _FONT = FONT_MONO_STYLE

--- a/src/hypergraph/checkpointers/_assets/__init__.py
+++ b/src/hypergraph/checkpointers/_assets/__init__.py
@@ -1,0 +1,1 @@
+"""Packaged offline assets for checkpointer presenters."""

--- a/src/hypergraph/checkpointers/_assets/explorer.js
+++ b/src/hypergraph/checkpointers/_assets/explorer.js
@@ -1,0 +1,290 @@
+/* hypergraph-checkpointer-explorer */
+(function(){
+  "use strict";
+  var script=document.currentScript;
+  var root=script&&script.parentElement;
+  if(!root) throw new Error("Checkpointer explorer asset has no owning root.");
+  if(root.__hgExplorerBound) return;
+  var dataEl=root.querySelector("[data-hg-explorer-data]");
+  var configEl=root.querySelector("[data-hg-explorer-config]");
+  var headerEl=root.querySelector("[data-hg-explorer-header]");
+  var runListEl=root.querySelector("[data-hg-explorer-runs]");
+  var emptyEl=root.querySelector("[data-hg-explorer-empty]");
+  var summaryEl=root.querySelector("[data-hg-explorer-summary]");
+  var navEl=root.querySelector("[data-hg-explorer-nav]");
+  var bodyEl=root.querySelector("[data-hg-explorer-body]");
+  if(!dataEl||!configEl||!headerEl||!runListEl||!emptyEl||!summaryEl||!navEl||!bodyEl) {
+    throw new Error("Checkpointer explorer markup is incomplete.");
+  }
+  var data=JSON.parse(dataEl.textContent||"{}");
+  var config=JSON.parse(configEl.textContent||"{}");
+  var runs=(data.runs||[]);
+  var stepsByRun=(data.steps_by_run||{});
+  var statusColors=config.status_palette;
+  var defaultStatusColors=config.default_status_colors;
+  if(!statusColors||!defaultStatusColors) {
+    throw new Error("Checkpointer explorer status palette is missing.");
+  }
+  root.__hgExplorerBound=true;
+  var runsById={};
+  var childrenByParent={};
+  for(var i=0;i<runs.length;i++) {
+    var run=runs[i];
+    runsById[run.id]=run;
+    if(run.parent_run_id) {
+      if(!childrenByParent[run.parent_run_id]) childrenByParent[run.parent_run_id]=[];
+      childrenByParent[run.parent_run_id].push(run.id);
+    }
+  }
+  var state={runId:data.initial_run_id||null, panel:"overview", stepIndex:null};
+  var esc=function(value){
+    return String(value===undefined||value===null?"":value)
+      .replace(/&/g,"&amp;")
+      .replace(/</g,"&lt;")
+      .replace(/>/g,"&gt;")
+      .replace(/"/g,"&quot;")
+      .replace(/'/g,"&#39;");
+  };
+  var fmtDuration=function(ms){
+    if(ms===null||ms===undefined||ms==="") return "—";
+    var n=Number(ms);
+    if(!isFinite(n)||n<=0) return "0ms";
+    if(n<1000) return n.toFixed(n<10?2:(n<100?1:0))+"ms";
+    return (n/1000).toFixed((n/1000)<10?2:1)+"s";
+  };
+  var fmtDate=function(value){
+    if(!value) return "—";
+    var d=new Date(value);
+    if(isNaN(d.getTime())) return esc(value);
+    return esc(d.toISOString().replace("T"," ").replace("Z"," UTC"));
+  };
+  var badge=function(status){
+    var colors=statusColors[status]||defaultStatusColors;
+    return '<span style="display:inline-block; padding:2px 8px; border-radius:999px; font-size:0.85em; font-weight:600; color:'+colors[0]+'; background:'+colors[1]+'">'+esc(status)+'</span>';
+  };
+  var runButton=function(run){
+    var active=state.runId===run.id;
+    var stepCount=(stepsByRun[run.id]||[]).length;
+    var childCount=(childrenByParent[run.id]||[]).length;
+    return (
+      '<button type="button" data-run-target="'+esc(run.id)+'" style="text-align:left; padding:10px 12px; border-radius:10px; border:1px solid '+(active?'#2563eb':'#e5e7eb')+'; background:'+(active?'#eff6ff':'#ffffff')+'; cursor:pointer">' +
+      '<div style="display:flex; justify-content:space-between; gap:8px; align-items:center">' +
+      '<span style="font-weight:700; font-family:ui-monospace, monospace; color:#111827">'+esc(run.id)+'</span>' +
+      badge(run.status) +
+      '</div>' +
+      '<div style="margin-top:6px; color:#6b7280; font-size:0.88em">' +
+      esc(run.graph_name||'unnamed') + ' | ' + stepCount + ' step' + (stepCount===1?'':'s') +
+      (childCount?(' | '+childCount+' child run'+(childCount===1?'':'s')):'') +
+      '</div>' +
+      '</button>'
+    );
+  };
+  var relatedLineage=function(run){
+    var ids=[];
+    var seen={};
+    var current=run;
+    while(current){
+      if(seen[current.id]) break;
+      seen[current.id]=true;
+      ids.unshift(current.id);
+      var parentId=current.forked_from||current.retry_of;
+      current=parentId ? runsById[parentId] : null;
+    }
+    var descendants=[];
+    for(var i=0;i<runs.length;i++) {
+      var candidate=runs[i];
+      var p=candidate.forked_from||candidate.retry_of;
+      if(p===run.id) descendants.push(candidate.id);
+    }
+    return {ancestors:ids, descendants:descendants};
+  };
+  var summaryCard=function(label, value){
+    return '<div style="border:1px solid #e5e7eb; border-radius:10px; background:#ffffff; padding:10px 12px">' +
+      '<div style="color:#6b7280; font-size:0.82em">'+esc(label)+'</div>' +
+      '<div style="margin-top:4px; color:#111827; font-weight:700">'+value+'</div></div>';
+  };
+  var renderRunList=function(){
+    if(!runs.length){
+      runListEl.innerHTML='';
+      emptyEl.style.display='block';
+      return;
+    }
+    emptyEl.style.display='none';
+    runListEl.innerHTML=runs.map(runButton).join('');
+  };
+  var renderHeader=function(run){
+    if(!run){
+      headerEl.innerHTML='<div style="color:#6b7280">No run selected.</div>';
+      summaryEl.innerHTML='';
+      navEl.innerHTML='';
+      bodyEl.innerHTML='<div style="color:#6b7280">Select a run to inspect it.</div>';
+      return;
+    }
+    var lineageParent=run.forked_from||run.retry_of;
+    headerEl.innerHTML =
+      '<div style="display:flex; justify-content:space-between; gap:12px; flex-wrap:wrap; align-items:flex-start">' +
+      '<div>' +
+      '<div style="font-family:ui-monospace, monospace; font-size:1.05em; font-weight:700; color:#111827">'+esc(run.id)+'</div>' +
+      '<div style="margin-top:6px; color:#6b7280">'+esc(run.graph_name||'unnamed graph')+'</div>' +
+      '</div>' +
+      '<div style="display:flex; gap:8px; flex-wrap:wrap; align-items:center">' +
+      badge(run.status) +
+      (lineageParent?'<button type="button" data-run-target="'+esc(lineageParent)+'" style="padding:6px 10px; border-radius:8px; border:1px solid #e5e7eb; background:#ffffff; cursor:pointer">Open source</button>':'') +
+      '</div></div>';
+    var steps=(stepsByRun[run.id]||[]);
+    var children=(childrenByParent[run.id]||[]);
+    summaryEl.innerHTML = [
+      summaryCard('Duration', esc(fmtDuration(run.duration_ms))),
+      summaryCard('Steps', esc(String(steps.length||run.node_count||0))),
+      summaryCard('Errors', esc(String(run.error_count||0))),
+      summaryCard('Children', esc(String(children.length)))
+    ].join('');
+    var panels=[['overview','Overview'],['steps','Steps'],['lineage','Lineage']];
+    navEl.innerHTML=panels.map(function(pair){
+      var active=state.panel===pair[0];
+      return '<button type="button" data-panel="'+pair[0]+'" style="padding:6px 10px; border-radius:8px; border:1px solid '+(active?'#2563eb':'#e5e7eb')+'; background:'+(active?'#eff6ff':'#ffffff')+'; cursor:pointer">'+pair[1]+'</button>';
+    }).join('');
+  };
+  var renderOverview=function(run){
+    var steps=(stepsByRun[run.id]||[]);
+    var children=(childrenByParent[run.id]||[]);
+    var items=[
+      ['Created', fmtDate(run.created_at)],
+      ['Completed', fmtDate(run.completed_at)],
+      ['Parent Run', run.parent_run_id?'<button type="button" data-run-target="'+esc(run.parent_run_id)+'" style="padding:0; border:none; background:none; color:#2563eb; cursor:pointer; font-family:ui-monospace, monospace">'+esc(run.parent_run_id)+'</button>':'—'],
+      ['Forked From', run.forked_from?'<button type="button" data-run-target="'+esc(run.forked_from)+'" style="padding:0; border:none; background:none; color:#2563eb; cursor:pointer; font-family:ui-monospace, monospace">'+esc(run.forked_from)+(run.fork_superstep!==null&&run.fork_superstep!==undefined?('@'+esc(run.fork_superstep)):'')+'</button>':'—'],
+      ['Retry Of', run.retry_of?'<button type="button" data-run-target="'+esc(run.retry_of)+'" style="padding:0; border:none; background:none; color:#2563eb; cursor:pointer; font-family:ui-monospace, monospace">'+esc(run.retry_of)+'</button>':'—']
+    ];
+    var meta='<div style="display:grid; grid-template-columns:minmax(140px, 180px) 1fr; gap:8px 12px">';
+    for(var i=0;i<items.length;i++) {
+      meta += '<div style="color:#6b7280">'+items[i][0]+'</div><div style="color:#111827">'+items[i][1]+'</div>';
+    }
+    meta += '</div>';
+    var childHtml = children.length
+      ? '<div style="margin-top:12px"><div style="font-weight:700; margin-bottom:6px">Child Runs</div>' +
+        children.map(function(id){ var child=runsById[id]; return child?'<div style="margin:4px 0"><button type="button" data-run-target="'+esc(id)+'" style="padding:0; border:none; background:none; color:#2563eb; cursor:pointer; font-family:ui-monospace, monospace">'+esc(id)+'</button> '+badge(child.status)+'</div>':''; }).join('') +
+        '</div>'
+      : '';
+    var stepSummary = steps.length
+      ? '<div style="margin-top:12px"><div style="font-weight:700; margin-bottom:6px">Recent Steps</div>' +
+        steps.slice(0,5).map(function(step){ return '<div style="margin:4px 0"><button type="button" data-panel="steps" data-step-index="'+esc(step.index)+'" style="padding:0; border:none; background:none; color:#2563eb; cursor:pointer">['+esc(step.index)+'] '+esc(step.node_name)+'</button> '+badge(step.cached?'cached':step.status)+'</div>'; }).join('') +
+        (steps.length>5?'<div style="color:#6b7280; margin-top:4px">+'+(steps.length-5)+' more steps</div>':'') + '</div>'
+      : '<div style="margin-top:12px; color:#6b7280">No steps loaded for this run.</div>';
+    return meta + childHtml + stepSummary;
+  };
+  var renderSteps=function(run){
+    var steps=(stepsByRun[run.id]||[]);
+    if(!steps.length) return '<div style="color:#6b7280">No steps loaded for this run.</div>';
+    if(state.stepIndex===null) state.stepIndex=steps[0].index;
+    var selected=null;
+    for(var i=0;i<steps.length;i++) if(steps[i].index===state.stepIndex) selected=steps[i];
+    if(!selected) selected=steps[0];
+    var rows = steps.map(function(step){
+      var active=selected&&selected.index===step.index;
+      return '<tr data-step-index="'+esc(step.index)+'" style="cursor:pointer; background:'+(active?'#eff6ff':'transparent')+'">' +
+        '<td style="padding:6px 8px; border-bottom:1px solid #f3f4f6">'+esc(step.index)+'</td>' +
+        '<td style="padding:6px 8px; border-bottom:1px solid #f3f4f6">'+esc(step.node_name)+'</td>' +
+        '<td style="padding:6px 8px; border-bottom:1px solid #f3f4f6">'+badge(step.cached?'cached':step.status)+'</td>' +
+        '<td style="padding:6px 8px; border-bottom:1px solid #f3f4f6">'+esc(fmtDuration(step.duration_ms))+'</td>' +
+        '<td style="padding:6px 8px; border-bottom:1px solid #f3f4f6">'+esc(step.superstep)+'</td>' +
+        '</tr>';
+    }).join('');
+    var pretty=function(value){ return esc(JSON.stringify(value, null, 2)); };
+    return '<div style="display:grid; grid-template-columns:minmax(280px, 1fr) minmax(260px, 1fr); gap:12px">' +
+      '<div><table style="width:100%; border-collapse:collapse; font-size:0.92em"><thead><tr>' +
+      '<th style="text-align:left; padding:6px 8px; border-bottom:2px solid #e5e7eb">#</th>' +
+      '<th style="text-align:left; padding:6px 8px; border-bottom:2px solid #e5e7eb">Node</th>' +
+      '<th style="text-align:left; padding:6px 8px; border-bottom:2px solid #e5e7eb">Status</th>' +
+      '<th style="text-align:left; padding:6px 8px; border-bottom:2px solid #e5e7eb">Duration</th>' +
+      '<th style="text-align:left; padding:6px 8px; border-bottom:2px solid #e5e7eb">Superstep</th>' +
+      '</tr></thead><tbody>'+rows+'</tbody></table></div>' +
+      '<div style="border:1px solid #e5e7eb; border-radius:10px; background:#ffffff; padding:10px 12px">' +
+      '<div style="font-weight:700; margin-bottom:8px">Step Detail</div>' +
+      '<div style="display:grid; grid-template-columns:110px 1fr; gap:6px 10px">' +
+      '<div style="color:#6b7280">Node</div><div>'+esc(selected.node_name)+'</div>' +
+      '<div style="color:#6b7280">Status</div><div>'+badge(selected.cached?'cached':selected.status)+'</div>' +
+      '<div style="color:#6b7280">Superstep</div><div>'+esc(selected.superstep)+'</div>' +
+      '<div style="color:#6b7280">Duration</div><div>'+esc(fmtDuration(selected.duration_ms))+'</div>' +
+      '<div style="color:#6b7280">Decision</div><div>'+esc(selected.decision===null||selected.decision===undefined?'—':JSON.stringify(selected.decision))+'</div>' +
+      '<div style="color:#6b7280">Child Run</div><div>'+(selected.child_run_id?'<button type="button" data-run-target="'+esc(selected.child_run_id)+'" style="padding:0; border:none; background:none; color:#2563eb; cursor:pointer; font-family:ui-monospace, monospace">'+esc(selected.child_run_id)+'</button>':'—')+'</div>' +
+      '</div>' +
+      '<div style="margin-top:10px">' +
+      '<div style="font-weight:700; margin-bottom:4px">Input Versions</div>' +
+      '<pre style="margin:0; padding:8px; border-radius:8px; background:#f8fafc; overflow:auto">'+pretty(selected.input_versions||{})+'</pre>' +
+      '</div>' +
+      '<div style="margin-top:10px">' +
+      '<div style="font-weight:700; margin-bottom:4px">Values</div>' +
+      '<pre style="margin:0; padding:8px; border-radius:8px; background:#f8fafc; overflow:auto">'+pretty(selected.values||{})+'</pre>' +
+      '</div>' +
+      '<div style="margin-top:10px">' +
+      '<div style="font-weight:700; margin-bottom:4px">Error</div>' +
+      '<pre style="margin:0; padding:8px; border-radius:8px; background:#f8fafc; overflow:auto">'+esc(selected.error||'')+'</pre>' +
+      '</div></div></div>';
+  };
+  var renderLineage=function(run){
+    var rel=relatedLineage(run);
+    var ancestorHtml=rel.ancestors.length
+      ? rel.ancestors.map(function(id){
+          var item=runsById[id];
+          if(!item) return '';
+          var selected=(id===run.id);
+          return '<div style="margin:4px 0">'+(selected?'&rarr; ':'')+'<button type="button" data-run-target="'+esc(id)+'" style="padding:0; border:none; background:none; color:#2563eb; cursor:pointer; font-family:ui-monospace, monospace">'+esc(id)+'</button> '+badge(item.status)+'</div>';
+        }).join('')
+      : '<div style="color:#6b7280">No lineage in loaded data.</div>';
+    var descendantHtml=rel.descendants.length
+      ? rel.descendants.map(function(id){
+          var item=runsById[id];
+          return item?'<div style="margin:4px 0"><button type="button" data-run-target="'+esc(id)+'" style="padding:0; border:none; background:none; color:#2563eb; cursor:pointer; font-family:ui-monospace, monospace">'+esc(id)+'</button> '+badge(item.status)+'</div>':'';
+        }).join('')
+      : '<div style="color:#6b7280">No direct fork/retry descendants in loaded data.</div>';
+    return '<div style="display:grid; grid-template-columns:minmax(220px, 1fr) minmax(220px, 1fr); gap:12px">' +
+      '<div style="border:1px solid #e5e7eb; border-radius:10px; background:#ffffff; padding:10px 12px"><div style="font-weight:700; margin-bottom:8px">Ancestry</div>'+ancestorHtml+'</div>' +
+      '<div style="border:1px solid #e5e7eb; border-radius:10px; background:#ffffff; padding:10px 12px"><div style="font-weight:700; margin-bottom:8px">Descendants</div>'+descendantHtml+'</div>' +
+      '</div>';
+  };
+  var renderBody=function(run){
+    if(!run) {
+      bodyEl.innerHTML='<div style="color:#6b7280">Select a run to inspect it.</div>';
+      return;
+    }
+    if(state.panel==='steps') {
+      bodyEl.innerHTML=renderSteps(run);
+      return;
+    }
+    if(state.panel==='lineage') {
+      bodyEl.innerHTML=renderLineage(run);
+      return;
+    }
+    bodyEl.innerHTML=renderOverview(run);
+  };
+  var render=function(){
+    renderRunList();
+    var run=state.runId ? runsById[state.runId] : null;
+    renderHeader(run);
+    renderBody(run);
+  };
+  root.addEventListener('click', function(event){
+    var runTarget=event.target.closest('[data-run-target]');
+    if(runTarget){
+      state.runId=runTarget.getAttribute('data-run-target');
+      state.stepIndex=null;
+      render();
+      return;
+    }
+    var panelTarget=event.target.closest('[data-panel]');
+    if(panelTarget){
+      state.panel=panelTarget.getAttribute('data-panel');
+      var stepIndex=panelTarget.getAttribute('data-step-index');
+      state.stepIndex=stepIndex!==null?Number(stepIndex):state.stepIndex;
+      render();
+      return;
+    }
+    var stepTarget=event.target.closest('[data-step-index]');
+    if(stepTarget){
+      state.panel='steps';
+      state.stepIndex=Number(stepTarget.getAttribute('data-step-index'));
+      render();
+    }
+  });
+  render();
+})();

--- a/src/hypergraph/checkpointers/_assets/explorer.js
+++ b/src/hypergraph/checkpointers/_assets/explorer.js
@@ -18,21 +18,35 @@
   }
   var data=JSON.parse(dataEl.textContent||"{}");
   var config=JSON.parse(configEl.textContent||"{}");
-  var runs=(data.runs||[]);
-  var stepsByRun=(data.steps_by_run||{});
+  var hasOwn=Object.prototype.hasOwnProperty;
+  var ownValue=function(object, key){
+    return object&&hasOwn.call(object,key)?object[key]:undefined;
+  };
+  var runs=Array.isArray(data.runs)?data.runs:[];
+  var stepsByRun=data.steps_by_run&&typeof data.steps_by_run==="object"?data.steps_by_run:null;
+  var stepsFor=function(runId){
+    var steps=ownValue(stepsByRun,runId);
+    return Array.isArray(steps)?steps:[];
+  };
   var statusColors=config.status_palette;
   var defaultStatusColors=config.default_status_colors;
   if(!statusColors||!defaultStatusColors) {
     throw new Error("Checkpointer explorer status palette is missing.");
   }
-  root.__hgExplorerBound=true;
-  var runsById={};
-  var childrenByParent={};
+  var runsById=Object.create(null);
+  var childrenByParent=Object.create(null);
+  var runFor=function(runId){
+    return ownValue(runsById,runId)||null;
+  };
+  var childrenFor=function(runId){
+    var children=ownValue(childrenByParent,runId);
+    return Array.isArray(children)?children:[];
+  };
   for(var i=0;i<runs.length;i++) {
     var run=runs[i];
     runsById[run.id]=run;
     if(run.parent_run_id) {
-      if(!childrenByParent[run.parent_run_id]) childrenByParent[run.parent_run_id]=[];
+      if(!hasOwn.call(childrenByParent,run.parent_run_id)) childrenByParent[run.parent_run_id]=[];
       childrenByParent[run.parent_run_id].push(run.id);
     }
   }
@@ -64,10 +78,10 @@
   };
   var runButton=function(run){
     var active=state.runId===run.id;
-    var stepCount=(stepsByRun[run.id]||[]).length;
-    var childCount=(childrenByParent[run.id]||[]).length;
+    var stepCount=stepsFor(run.id).length;
+    var childCount=childrenFor(run.id).length;
     return (
-      '<button type="button" data-run-target="'+esc(run.id)+'" style="text-align:left; padding:10px 12px; border-radius:10px; border:1px solid '+(active?'#2563eb':'#e5e7eb')+'; background:'+(active?'#eff6ff':'#ffffff')+'; cursor:pointer">' +
+      '<button type="button" data-run-target="'+esc(run.id)+'" aria-label="'+esc(run.id)+'" style="text-align:left; padding:10px 12px; border-radius:10px; border:1px solid '+(active?'#2563eb':'#e5e7eb')+'; background:'+(active?'#eff6ff':'#ffffff')+'; cursor:pointer">' +
       '<div style="display:flex; justify-content:space-between; gap:8px; align-items:center">' +
       '<span style="font-weight:700; font-family:ui-monospace, monospace; color:#111827">'+esc(run.id)+'</span>' +
       badge(run.status) +
@@ -81,14 +95,14 @@
   };
   var relatedLineage=function(run){
     var ids=[];
-    var seen={};
+    var seen=Object.create(null);
     var current=run;
     while(current){
       if(seen[current.id]) break;
       seen[current.id]=true;
       ids.unshift(current.id);
       var parentId=current.forked_from||current.retry_of;
-      current=parentId ? runsById[parentId] : null;
+      current=parentId?runFor(parentId):null;
     }
     var descendants=[];
     for(var i=0;i<runs.length;i++) {
@@ -131,8 +145,8 @@
       badge(run.status) +
       (lineageParent?'<button type="button" data-run-target="'+esc(lineageParent)+'" style="padding:6px 10px; border-radius:8px; border:1px solid #e5e7eb; background:#ffffff; cursor:pointer">Open source</button>':'') +
       '</div></div>';
-    var steps=(stepsByRun[run.id]||[]);
-    var children=(childrenByParent[run.id]||[]);
+    var steps=stepsFor(run.id);
+    var children=childrenFor(run.id);
     summaryEl.innerHTML = [
       summaryCard('Duration', esc(fmtDuration(run.duration_ms))),
       summaryCard('Steps', esc(String(steps.length||run.node_count||0))),
@@ -146,8 +160,8 @@
     }).join('');
   };
   var renderOverview=function(run){
-    var steps=(stepsByRun[run.id]||[]);
-    var children=(childrenByParent[run.id]||[]);
+    var steps=stepsFor(run.id);
+    var children=childrenFor(run.id);
     var items=[
       ['Created', fmtDate(run.created_at)],
       ['Completed', fmtDate(run.completed_at)],
@@ -162,7 +176,7 @@
     meta += '</div>';
     var childHtml = children.length
       ? '<div style="margin-top:12px"><div style="font-weight:700; margin-bottom:6px">Child Runs</div>' +
-        children.map(function(id){ var child=runsById[id]; return child?'<div style="margin:4px 0"><button type="button" data-run-target="'+esc(id)+'" style="padding:0; border:none; background:none; color:#2563eb; cursor:pointer; font-family:ui-monospace, monospace">'+esc(id)+'</button> '+badge(child.status)+'</div>':''; }).join('') +
+        children.map(function(id){ var child=runFor(id); return child?'<div style="margin:4px 0"><button type="button" data-run-target="'+esc(id)+'" style="padding:0; border:none; background:none; color:#2563eb; cursor:pointer; font-family:ui-monospace, monospace">'+esc(id)+'</button> '+badge(child.status)+'</div>':''; }).join('') +
         '</div>'
       : '';
     var stepSummary = steps.length
@@ -173,7 +187,7 @@
     return meta + childHtml + stepSummary;
   };
   var renderSteps=function(run){
-    var steps=(stepsByRun[run.id]||[]);
+    var steps=stepsFor(run.id);
     if(!steps.length) return '<div style="color:#6b7280">No steps loaded for this run.</div>';
     if(state.stepIndex===null) state.stepIndex=steps[0].index;
     var selected=null;
@@ -225,7 +239,7 @@
     var rel=relatedLineage(run);
     var ancestorHtml=rel.ancestors.length
       ? rel.ancestors.map(function(id){
-          var item=runsById[id];
+          var item=runFor(id);
           if(!item) return '';
           var selected=(id===run.id);
           return '<div style="margin:4px 0">'+(selected?'&rarr; ':'')+'<button type="button" data-run-target="'+esc(id)+'" style="padding:0; border:none; background:none; color:#2563eb; cursor:pointer; font-family:ui-monospace, monospace">'+esc(id)+'</button> '+badge(item.status)+'</div>';
@@ -233,7 +247,7 @@
       : '<div style="color:#6b7280">No lineage in loaded data.</div>';
     var descendantHtml=rel.descendants.length
       ? rel.descendants.map(function(id){
-          var item=runsById[id];
+          var item=runFor(id);
           return item?'<div style="margin:4px 0"><button type="button" data-run-target="'+esc(id)+'" style="padding:0; border:none; background:none; color:#2563eb; cursor:pointer; font-family:ui-monospace, monospace">'+esc(id)+'</button> '+badge(item.status)+'</div>':'';
         }).join('')
       : '<div style="color:#6b7280">No direct fork/retry descendants in loaded data.</div>';
@@ -259,11 +273,11 @@
   };
   var render=function(){
     renderRunList();
-    var run=state.runId ? runsById[state.runId] : null;
+    var run=state.runId?runFor(state.runId):null;
     renderHeader(run);
     renderBody(run);
   };
-  root.addEventListener('click', function(event){
+  var onClick=function(event){
     var runTarget=event.target.closest('[data-run-target]');
     if(runTarget){
       state.runId=runTarget.getAttribute('data-run-target');
@@ -285,6 +299,8 @@
       state.stepIndex=Number(stepTarget.getAttribute('data-step-index'));
       render();
     }
-  });
+  };
   render();
+  root.addEventListener('click',onClick);
+  root.__hgExplorerBound=true;
 })();

--- a/src/hypergraph/checkpointers/_assets/explorer.js
+++ b/src/hypergraph/checkpointers/_assets/explorer.js
@@ -81,7 +81,7 @@
     var stepCount=stepsFor(run.id).length;
     var childCount=childrenFor(run.id).length;
     return (
-      '<button type="button" data-run-target="'+esc(run.id)+'" aria-label="'+esc(run.id)+'" style="text-align:left; padding:10px 12px; border-radius:10px; border:1px solid '+(active?'#2563eb':'#e5e7eb')+'; background:'+(active?'#eff6ff':'#ffffff')+'; cursor:pointer">' +
+      '<button type="button" data-run-target="'+esc(run.id)+'" style="text-align:left; padding:10px 12px; border-radius:10px; border:1px solid '+(active?'#2563eb':'#e5e7eb')+'; background:'+(active?'#eff6ff':'#ffffff')+'; cursor:pointer">' +
       '<div style="display:flex; justify-content:space-between; gap:8px; align-items:center">' +
       '<span style="font-weight:700; font-family:ui-monospace, monospace; color:#111827">'+esc(run.id)+'</span>' +
       badge(run.status) +

--- a/src/hypergraph/checkpointers/presenters.py
+++ b/src/hypergraph/checkpointers/presenters.py
@@ -3,15 +3,52 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterable
+from importlib.resources import files
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from hypergraph.checkpointers.types import Run, StepRecord
+    from hypergraph.checkpointers.types import Run, StepRecord, WorkflowStatus
 
 
 def _safe_json_payload(payload: dict[str, Any]) -> str:
     """Serialize JSON safely for embedding inside a script tag."""
     return json.dumps(payload).replace("<", "\\u003c").replace(">", "\\u003e").replace("&", "\\u0026")
+
+
+_EXPLORER_ASSET_MARKER = "/* hypergraph-checkpointer-explorer */"
+
+
+def _read_explorer_asset() -> str:
+    """Read and minimally validate the packaged offline explorer asset."""
+    source = files("hypergraph.checkpointers._assets").joinpath("explorer.js").read_text(encoding="utf-8")
+    if not source.startswith(_EXPLORER_ASSET_MARKER):
+        raise RuntimeError(
+            "The packaged checkpointer explorer asset is corrupt.\n\n"
+            "Expected explorer.js to contain the Hypergraph asset marker.\n\n"
+            "How to fix: Reinstall hypergraph from a complete wheel."
+        )
+    return source
+
+
+def _aggregate_workflow_status(
+    statuses: Iterable[WorkflowStatus],
+) -> WorkflowStatus:
+    """Return the canonical aggregate status for synthetic parent runs."""
+    from hypergraph.checkpointers.types import WorkflowStatus
+
+    distinct = frozenset(statuses)
+    if WorkflowStatus.ACTIVE in distinct:
+        return WorkflowStatus.ACTIVE
+    if WorkflowStatus.PAUSED in distinct:
+        return WorkflowStatus.PAUSED
+    if WorkflowStatus.PARTIAL in distinct or (WorkflowStatus.FAILED in distinct and len(distinct) > 1):
+        return WorkflowStatus.PARTIAL
+    if WorkflowStatus.FAILED in distinct:
+        return WorkflowStatus.FAILED
+    if WorkflowStatus.STOPPED in distinct:
+        return WorkflowStatus.STOPPED
+    return WorkflowStatus.COMPLETED
 
 
 def render_checkpointer_explorer_html(
@@ -28,10 +65,12 @@ def render_checkpointer_explorer_html(
 ) -> str:
     """Render a drill-through explorer for a checkpointer."""
     from hypergraph._repr import (
+        ALIGNUI_WIDGET_THEME,
         BORDER_COLOR,
         FONT_MONO_STYLE,
         MUTED_COLOR,
         PANEL_COLOR,
+        STATUS_PALETTE,
         TEXT_STRONG_COLOR,
         _code,
         html_kv,
@@ -59,16 +98,15 @@ def render_checkpointer_explorer_html(
         "initial_run_id": runs[0].id if runs else None,
         "run_limit": run_limit,
     }
+    config = {
+        "status_palette": STATUS_PALETTE,
+        "default_status_colors": (
+            ALIGNUI_WIDGET_THEME["text_soft"],
+            ALIGNUI_WIDGET_THEME["bg_soft"],
+        ),
+    }
 
     explorer_id = unique_dom_id("checkpointer-explorer", path)
-    data_id = f"{explorer_id}-data"
-    header_id = f"{explorer_id}-header"
-    run_list_id = f"{explorer_id}-runs"
-    empty_id = f"{explorer_id}-empty"
-    summary_id = f"{explorer_id}-summary"
-    panel_nav_id = f"{explorer_id}-nav"
-    panel_body_id = f"{explorer_id}-body"
-
     panel_style = f"border:1px solid {BORDER_COLOR}; border-radius:10px; background:{PANEL_COLOR}; padding:12px; min-height:120px"
     mono = FONT_MONO_STYLE
 
@@ -87,322 +125,22 @@ def render_checkpointer_explorer_html(
         f'<div data-hg-panel-title="Run Explorer" style="{mono}; font-weight:700; color:{TEXT_STRONG_COLOR}">Run Explorer</div>'
         f'<div style="color:{MUTED_COLOR}; font-size:0.85em">Explore: {_code(".runs()")} {_code(".steps(run_id)")} {_code(".search(query)")} {_code(".stats(run_id)")}</div>'
         f"</div>"
-        f'<div id="{run_list_id}" style="display:flex; flex-direction:column; gap:8px"></div>'
-        f'<div id="{empty_id}" style="display:none; color:{MUTED_COLOR}; {mono}">No runs available.</div>'
+        '<div data-hg-explorer-runs style="display:flex; flex-direction:column; gap:8px"></div>'
+        f'<div data-hg-explorer-empty style="display:none; color:{MUTED_COLOR}; {mono}">No runs available.</div>'
         f"</section>"
         f'<section style="display:flex; flex-direction:column; gap:12px">'
-        f'<div id="{header_id}" style="{panel_style}"></div>'
-        f'<div id="{summary_id}" style="display:grid; grid-template-columns:repeat(auto-fit, minmax(180px, 1fr)); gap:8px"></div>'
-        f'<div id="{panel_nav_id}" style="display:flex; gap:8px; flex-wrap:wrap"></div>'
-        f'<div id="{panel_body_id}" style="{panel_style}"></div>'
+        f'<div data-hg-explorer-header style="{panel_style}"></div>'
+        '<div data-hg-explorer-summary style="display:grid; grid-template-columns:repeat(auto-fit, minmax(180px, 1fr)); gap:8px"></div>'
+        '<div data-hg-explorer-nav style="display:flex; gap:8px; flex-wrap:wrap"></div>'
+        f'<div data-hg-explorer-body style="{panel_style}"></div>'
         f"</section>"
         f"</div>"
-        f'<script type="application/json" id="{data_id}">{_safe_json_payload(payload)}</script>'
-        f"<script>{_explorer_script(explorer_id, data_id, header_id, run_list_id, empty_id, summary_id, panel_nav_id, panel_body_id)}</script>"
+        f'<script type="application/json" data-hg-explorer-data>{_safe_json_payload(payload)}</script>'
+        f'<script type="application/json" data-hg-explorer-config>{_safe_json_payload(config)}</script>'
+        f"<script>{_read_explorer_asset()}</script>"
         f"</div>"
     )
     return theme_wrap(container, state_key=state_key)
-
-
-def _explorer_script(
-    explorer_id: str,
-    data_id: str,
-    header_id: str,
-    run_list_id: str,
-    empty_id: str,
-    summary_id: str,
-    panel_nav_id: str,
-    panel_body_id: str,
-) -> str:
-    """Inline JS for the checkpointer explorer."""
-    status_colors = {
-        "completed": ("#059669", "#ecfdf5"),
-        "failed": ("#dc2626", "#fef2f2"),
-        "active": ("#d97706", "#fffbeb"),
-        "paused": ("#7c3aed", "#f5f3ff"),
-        "stopped": ("#92400e", "#fff7ed"),
-        "partial": ("#d97706", "#fffbeb"),
-        "cached": ("#2563eb", "#eff6ff"),
-    }
-    return f"""
-(function(){{
-  var root=document.getElementById({json.dumps(explorer_id)});
-  var dataEl=document.getElementById({json.dumps(data_id)});
-  if(!root||!dataEl||root.__hgExplorerBound) return;
-  root.__hgExplorerBound=true;
-  var headerEl=document.getElementById({json.dumps(header_id)});
-  var runListEl=document.getElementById({json.dumps(run_list_id)});
-  var emptyEl=document.getElementById({json.dumps(empty_id)});
-  var summaryEl=document.getElementById({json.dumps(summary_id)});
-  var navEl=document.getElementById({json.dumps(panel_nav_id)});
-  var bodyEl=document.getElementById({json.dumps(panel_body_id)});
-  var data=JSON.parse(dataEl.textContent||"{{}}");
-  var runs=(data.runs||[]);
-  var stepsByRun=(data.steps_by_run||{{}});
-  var statusColors={json.dumps(status_colors)};
-  var runsById={{}};
-  var childrenByParent={{}};
-  for(var i=0;i<runs.length;i++) {{
-    var run=runs[i];
-    runsById[run.id]=run;
-    if(run.parent_run_id) {{
-      if(!childrenByParent[run.parent_run_id]) childrenByParent[run.parent_run_id]=[];
-      childrenByParent[run.parent_run_id].push(run.id);
-    }}
-  }}
-  var state={{runId:data.initial_run_id||null, panel:"overview", stepIndex:null}};
-  var esc=function(value){{
-    return String(value===undefined||value===null?"":value)
-      .replace(/&/g,"&amp;")
-      .replace(/</g,"&lt;")
-      .replace(/>/g,"&gt;")
-      .replace(/"/g,"&quot;")
-      .replace(/'/g,"&#39;");
-  }};
-  var fmtDuration=function(ms){{
-    if(ms===null||ms===undefined||ms==="") return "—";
-    var n=Number(ms);
-    if(!isFinite(n)||n<=0) return "0ms";
-    if(n<1000) return n.toFixed(n<10?2:(n<100?1:0))+"ms";
-    return (n/1000).toFixed((n/1000)<10?2:1)+"s";
-  }};
-  var fmtDate=function(value){{
-    if(!value) return "—";
-    var d=new Date(value);
-    if(isNaN(d.getTime())) return esc(value);
-    return esc(d.toISOString().replace("T"," ").replace("Z"," UTC"));
-  }};
-  var badge=function(status){{
-    var colors=statusColors[status]||["#6b7280","#f3f4f6"];
-    return '<span style="display:inline-block; padding:2px 8px; border-radius:999px; font-size:0.85em; font-weight:600; color:'+colors[0]+'; background:'+colors[1]+'">'+esc(status)+'</span>';
-  }};
-  var runButton=function(run){{
-    var active=state.runId===run.id;
-    var stepCount=(stepsByRun[run.id]||[]).length;
-    var childCount=(childrenByParent[run.id]||[]).length;
-    return (
-      '<button type="button" data-run-target="'+esc(run.id)+'" style="text-align:left; padding:10px 12px; border-radius:10px; border:1px solid '+(active?'#2563eb':'#e5e7eb')+'; background:'+(active?'#eff6ff':'#ffffff')+'; cursor:pointer">' +
-      '<div style="display:flex; justify-content:space-between; gap:8px; align-items:center">' +
-      '<span style="font-weight:700; font-family:ui-monospace, monospace; color:#111827">'+esc(run.id)+'</span>' +
-      badge(run.status) +
-      '</div>' +
-      '<div style="margin-top:6px; color:#6b7280; font-size:0.88em">' +
-      esc(run.graph_name||'unnamed') + ' | ' + stepCount + ' step' + (stepCount===1?'':'s') +
-      (childCount?(' | '+childCount+' child run'+(childCount===1?'':'s')):'') +
-      '</div>' +
-      '</button>'
-    );
-  }};
-  var relatedLineage=function(run){{
-    var ids=[];
-    var seen={{}};
-    var current=run;
-    while(current){{
-      if(seen[current.id]) break;
-      seen[current.id]=true;
-      ids.unshift(current.id);
-      var parentId=current.forked_from||current.retry_of;
-      current=parentId ? runsById[parentId] : null;
-    }}
-    var descendants=[];
-    for(var i=0;i<runs.length;i++) {{
-      var candidate=runs[i];
-      var p=candidate.forked_from||candidate.retry_of;
-      if(p===run.id) descendants.push(candidate.id);
-    }}
-    return {{ancestors:ids, descendants:descendants}};
-  }};
-  var summaryCard=function(label, value){{
-    return '<div style="border:1px solid #e5e7eb; border-radius:10px; background:#ffffff; padding:10px 12px">' +
-      '<div style="color:#6b7280; font-size:0.82em">'+esc(label)+'</div>' +
-      '<div style="margin-top:4px; color:#111827; font-weight:700">'+value+'</div></div>';
-  }};
-  var renderRunList=function(){{
-    if(!runs.length){{
-      runListEl.innerHTML='';
-      emptyEl.style.display='block';
-      return;
-    }}
-    emptyEl.style.display='none';
-    runListEl.innerHTML=runs.map(runButton).join('');
-  }};
-  var renderHeader=function(run){{
-    if(!run){{
-      headerEl.innerHTML='<div style="color:#6b7280">No run selected.</div>';
-      summaryEl.innerHTML='';
-      navEl.innerHTML='';
-      bodyEl.innerHTML='<div style="color:#6b7280">Select a run to inspect it.</div>';
-      return;
-    }}
-    var lineageParent=run.forked_from||run.retry_of;
-    headerEl.innerHTML =
-      '<div style="display:flex; justify-content:space-between; gap:12px; flex-wrap:wrap; align-items:flex-start">' +
-      '<div>' +
-      '<div style="font-family:ui-monospace, monospace; font-size:1.05em; font-weight:700; color:#111827">'+esc(run.id)+'</div>' +
-      '<div style="margin-top:6px; color:#6b7280">'+esc(run.graph_name||'unnamed graph')+'</div>' +
-      '</div>' +
-      '<div style="display:flex; gap:8px; flex-wrap:wrap; align-items:center">' +
-      badge(run.status) +
-      (lineageParent?'<button type="button" data-run-target="'+esc(lineageParent)+'" style="padding:6px 10px; border-radius:8px; border:1px solid #e5e7eb; background:#ffffff; cursor:pointer">Open source</button>':'') +
-      '</div></div>';
-    var steps=(stepsByRun[run.id]||[]);
-    var children=(childrenByParent[run.id]||[]);
-    summaryEl.innerHTML = [
-      summaryCard('Duration', esc(fmtDuration(run.duration_ms))),
-      summaryCard('Steps', esc(String(steps.length||run.node_count||0))),
-      summaryCard('Errors', esc(String(run.error_count||0))),
-      summaryCard('Children', esc(String(children.length)))
-    ].join('');
-    var panels=[['overview','Overview'],['steps','Steps'],['lineage','Lineage']];
-    navEl.innerHTML=panels.map(function(pair){{
-      var active=state.panel===pair[0];
-      return '<button type="button" data-panel="'+pair[0]+'" style="padding:6px 10px; border-radius:8px; border:1px solid '+(active?'#2563eb':'#e5e7eb')+'; background:'+(active?'#eff6ff':'#ffffff')+'; cursor:pointer">'+pair[1]+'</button>';
-    }}).join('');
-  }};
-  var renderOverview=function(run){{
-    var steps=(stepsByRun[run.id]||[]);
-    var children=(childrenByParent[run.id]||[]);
-    var items=[
-      ['Created', fmtDate(run.created_at)],
-      ['Completed', fmtDate(run.completed_at)],
-      ['Parent Run', run.parent_run_id?'<button type="button" data-run-target="'+esc(run.parent_run_id)+'" style="padding:0; border:none; background:none; color:#2563eb; cursor:pointer; font-family:ui-monospace, monospace">'+esc(run.parent_run_id)+'</button>':'—'],
-      ['Forked From', run.forked_from?'<button type="button" data-run-target="'+esc(run.forked_from)+'" style="padding:0; border:none; background:none; color:#2563eb; cursor:pointer; font-family:ui-monospace, monospace">'+esc(run.forked_from)+(run.fork_superstep!==null&&run.fork_superstep!==undefined?('@'+esc(run.fork_superstep)):'')+'</button>':'—'],
-      ['Retry Of', run.retry_of?'<button type="button" data-run-target="'+esc(run.retry_of)+'" style="padding:0; border:none; background:none; color:#2563eb; cursor:pointer; font-family:ui-monospace, monospace">'+esc(run.retry_of)+'</button>':'—']
-    ];
-    var meta='<div style="display:grid; grid-template-columns:minmax(140px, 180px) 1fr; gap:8px 12px">';
-    for(var i=0;i<items.length;i++) {{
-      meta += '<div style="color:#6b7280">'+items[i][0]+'</div><div style="color:#111827">'+items[i][1]+'</div>';
-    }}
-    meta += '</div>';
-    var childHtml = children.length
-      ? '<div style="margin-top:12px"><div style="font-weight:700; margin-bottom:6px">Child Runs</div>' +
-        children.map(function(id){{ var child=runsById[id]; return child?'<div style="margin:4px 0"><button type="button" data-run-target="'+esc(id)+'" style="padding:0; border:none; background:none; color:#2563eb; cursor:pointer; font-family:ui-monospace, monospace">'+esc(id)+'</button> '+badge(child.status)+'</div>':''; }}).join('') +
-        '</div>'
-      : '';
-    var stepSummary = steps.length
-      ? '<div style="margin-top:12px"><div style="font-weight:700; margin-bottom:6px">Recent Steps</div>' +
-        steps.slice(0,5).map(function(step){{ return '<div style="margin:4px 0"><button type="button" data-panel="steps" data-step-index="'+esc(step.index)+'" style="padding:0; border:none; background:none; color:#2563eb; cursor:pointer">['+esc(step.index)+'] '+esc(step.node_name)+'</button> '+badge(step.cached?'cached':step.status)+'</div>'; }}).join('') +
-        (steps.length>5?'<div style="color:#6b7280; margin-top:4px">+'+(steps.length-5)+' more steps</div>':'') + '</div>'
-      : '<div style="margin-top:12px; color:#6b7280">No steps loaded for this run.</div>';
-    return meta + childHtml + stepSummary;
-  }};
-  var renderSteps=function(run){{
-    var steps=(stepsByRun[run.id]||[]);
-    if(!steps.length) return '<div style="color:#6b7280">No steps loaded for this run.</div>';
-    if(state.stepIndex===null) state.stepIndex=steps[0].index;
-    var selected=null;
-    for(var i=0;i<steps.length;i++) if(steps[i].index===state.stepIndex) selected=steps[i];
-    if(!selected) selected=steps[0];
-    var rows = steps.map(function(step){{
-      var active=selected&&selected.index===step.index;
-      return '<tr data-step-index="'+esc(step.index)+'" style="cursor:pointer; background:'+(active?'#eff6ff':'transparent')+'">' +
-        '<td style="padding:6px 8px; border-bottom:1px solid #f3f4f6">'+esc(step.index)+'</td>' +
-        '<td style="padding:6px 8px; border-bottom:1px solid #f3f4f6">'+esc(step.node_name)+'</td>' +
-        '<td style="padding:6px 8px; border-bottom:1px solid #f3f4f6">'+badge(step.cached?'cached':step.status)+'</td>' +
-        '<td style="padding:6px 8px; border-bottom:1px solid #f3f4f6">'+esc(fmtDuration(step.duration_ms))+'</td>' +
-        '<td style="padding:6px 8px; border-bottom:1px solid #f3f4f6">'+esc(step.superstep)+'</td>' +
-        '</tr>';
-    }}).join('');
-    var pretty=function(value){{ return esc(JSON.stringify(value, null, 2)); }};
-    return '<div style="display:grid; grid-template-columns:minmax(280px, 1fr) minmax(260px, 1fr); gap:12px">' +
-      '<div><table style="width:100%; border-collapse:collapse; font-size:0.92em"><thead><tr>' +
-      '<th style="text-align:left; padding:6px 8px; border-bottom:2px solid #e5e7eb">#</th>' +
-      '<th style="text-align:left; padding:6px 8px; border-bottom:2px solid #e5e7eb">Node</th>' +
-      '<th style="text-align:left; padding:6px 8px; border-bottom:2px solid #e5e7eb">Status</th>' +
-      '<th style="text-align:left; padding:6px 8px; border-bottom:2px solid #e5e7eb">Duration</th>' +
-      '<th style="text-align:left; padding:6px 8px; border-bottom:2px solid #e5e7eb">Superstep</th>' +
-      '</tr></thead><tbody>'+rows+'</tbody></table></div>' +
-      '<div style="border:1px solid #e5e7eb; border-radius:10px; background:#ffffff; padding:10px 12px">' +
-      '<div style="font-weight:700; margin-bottom:8px">Step Detail</div>' +
-      '<div style="display:grid; grid-template-columns:110px 1fr; gap:6px 10px">' +
-      '<div style="color:#6b7280">Node</div><div>'+esc(selected.node_name)+'</div>' +
-      '<div style="color:#6b7280">Status</div><div>'+badge(selected.cached?'cached':selected.status)+'</div>' +
-      '<div style="color:#6b7280">Superstep</div><div>'+esc(selected.superstep)+'</div>' +
-      '<div style="color:#6b7280">Duration</div><div>'+esc(fmtDuration(selected.duration_ms))+'</div>' +
-      '<div style="color:#6b7280">Decision</div><div>'+esc(selected.decision===null||selected.decision===undefined?'—':JSON.stringify(selected.decision))+'</div>' +
-      '<div style="color:#6b7280">Child Run</div><div>'+(selected.child_run_id?'<button type="button" data-run-target="'+esc(selected.child_run_id)+'" style="padding:0; border:none; background:none; color:#2563eb; cursor:pointer; font-family:ui-monospace, monospace">'+esc(selected.child_run_id)+'</button>':'—')+'</div>' +
-      '</div>' +
-      '<div style="margin-top:10px">' +
-      '<div style="font-weight:700; margin-bottom:4px">Input Versions</div>' +
-      '<pre style="margin:0; padding:8px; border-radius:8px; background:#f8fafc; overflow:auto">'+pretty(selected.input_versions||{{}})+'</pre>' +
-      '</div>' +
-      '<div style="margin-top:10px">' +
-      '<div style="font-weight:700; margin-bottom:4px">Values</div>' +
-      '<pre style="margin:0; padding:8px; border-radius:8px; background:#f8fafc; overflow:auto">'+pretty(selected.values||{{}})+'</pre>' +
-      '</div>' +
-      '<div style="margin-top:10px">' +
-      '<div style="font-weight:700; margin-bottom:4px">Error</div>' +
-      '<pre style="margin:0; padding:8px; border-radius:8px; background:#f8fafc; overflow:auto">'+esc(selected.error||'')+'</pre>' +
-      '</div></div></div>';
-  }};
-  var renderLineage=function(run){{
-    var rel=relatedLineage(run);
-    var ancestorHtml=rel.ancestors.length
-      ? rel.ancestors.map(function(id){{
-          var item=runsById[id];
-          if(!item) return '';
-          var selected=(id===run.id);
-          return '<div style="margin:4px 0">'+(selected?'&rarr; ':'')+'<button type="button" data-run-target="'+esc(id)+'" style="padding:0; border:none; background:none; color:#2563eb; cursor:pointer; font-family:ui-monospace, monospace">'+esc(id)+'</button> '+badge(item.status)+'</div>';
-        }}).join('')
-      : '<div style="color:#6b7280">No lineage in loaded data.</div>';
-    var descendantHtml=rel.descendants.length
-      ? rel.descendants.map(function(id){{
-          var item=runsById[id];
-          return item?'<div style="margin:4px 0"><button type="button" data-run-target="'+esc(id)+'" style="padding:0; border:none; background:none; color:#2563eb; cursor:pointer; font-family:ui-monospace, monospace">'+esc(id)+'</button> '+badge(item.status)+'</div>':'';
-        }}).join('')
-      : '<div style="color:#6b7280">No direct fork/retry descendants in loaded data.</div>';
-    return '<div style="display:grid; grid-template-columns:minmax(220px, 1fr) minmax(220px, 1fr); gap:12px">' +
-      '<div style="border:1px solid #e5e7eb; border-radius:10px; background:#ffffff; padding:10px 12px"><div style="font-weight:700; margin-bottom:8px">Ancestry</div>'+ancestorHtml+'</div>' +
-      '<div style="border:1px solid #e5e7eb; border-radius:10px; background:#ffffff; padding:10px 12px"><div style="font-weight:700; margin-bottom:8px">Descendants</div>'+descendantHtml+'</div>' +
-      '</div>';
-  }};
-  var renderBody=function(run){{
-    if(!run) {{
-      bodyEl.innerHTML='<div style="color:#6b7280">Select a run to inspect it.</div>';
-      return;
-    }}
-    if(state.panel==='steps') {{
-      bodyEl.innerHTML=renderSteps(run);
-      return;
-    }}
-    if(state.panel==='lineage') {{
-      bodyEl.innerHTML=renderLineage(run);
-      return;
-    }}
-    bodyEl.innerHTML=renderOverview(run);
-  }};
-  var render=function(){{
-    renderRunList();
-    var run=state.runId ? runsById[state.runId] : null;
-    renderHeader(run);
-    renderBody(run);
-  }};
-  root.addEventListener('click', function(event){{
-    var runTarget=event.target.closest('[data-run-target]');
-    if(runTarget){{
-      state.runId=runTarget.getAttribute('data-run-target');
-      state.stepIndex=null;
-      render();
-      return;
-    }}
-    var panelTarget=event.target.closest('[data-panel]');
-    if(panelTarget){{
-      state.panel=panelTarget.getAttribute('data-panel');
-      var stepIndex=panelTarget.getAttribute('data-step-index');
-      state.stepIndex=stepIndex!==null?Number(stepIndex):state.stepIndex;
-      render();
-      return;
-    }}
-    var stepTarget=event.target.closest('[data-step-index]');
-    if(stepTarget){{
-      state.panel='steps';
-      state.stepIndex=Number(stepTarget.getAttribute('data-step-index'));
-      render();
-    }}
-  }});
-  render();
-}})();
-"""
 
 
 def render_step_record_html(step: Any) -> str:
@@ -514,20 +252,10 @@ def render_run_table_html(table: Any) -> str:
         return run.id
 
     def _synth_parent(group_id: str, members: list[Any]) -> Any:
-        from hypergraph.checkpointers.types import Run, WorkflowStatus
+        from hypergraph.checkpointers.types import Run
 
         statuses = {r.status for r in members}
-        status = WorkflowStatus.COMPLETED
-        if WorkflowStatus.ACTIVE in statuses:
-            status = WorkflowStatus.ACTIVE
-        elif WorkflowStatus.PAUSED in statuses:
-            status = WorkflowStatus.PAUSED
-        elif WorkflowStatus.PARTIAL in statuses or (WorkflowStatus.FAILED in statuses and len(statuses) > 1):
-            status = WorkflowStatus.PARTIAL
-        elif WorkflowStatus.FAILED in statuses:
-            status = WorkflowStatus.FAILED
-        elif WorkflowStatus.STOPPED in statuses:
-            status = WorkflowStatus.STOPPED
+        status = _aggregate_workflow_status(statuses)
         created = max((r.created_at for r in members), default=_utcnow())
         return Run(
             id=group_id,

--- a/src/hypergraph/checkpointers/presenters.py
+++ b/src/hypergraph/checkpointers/presenters.py
@@ -17,20 +17,20 @@ def _safe_json_payload(payload: dict[str, Any]) -> str:
     return json.dumps(payload).replace("<", "\\u003c").replace(">", "\\u003e").replace("&", "\\u0026")
 
 
-_EXPLORER_ASSET_SHA256 = "d6fcfe7189f28985a2940d802a5e07e7dcb5093c28e95641bc663121482009d3"
+_EXPLORER_ASSET_SHA256 = "9909428d38a1ec32738c16eb54d8a72f1f4bb6a38b03858709b86286c35b413d"
 
 
 def _read_explorer_asset() -> str:
-    """Read and validate the complete packaged offline explorer asset."""
-    source = files("hypergraph.checkpointers._assets").joinpath("explorer.js").read_text(encoding="utf-8")
-    digest = hashlib.sha256(source.encode("utf-8")).hexdigest()
+    """Read and validate the exact packaged offline explorer bytes."""
+    source = files("hypergraph.checkpointers._assets").joinpath("explorer.js").read_bytes()
+    digest = hashlib.sha256(source).hexdigest()
     if digest != _EXPLORER_ASSET_SHA256:
         raise RuntimeError(
             "The packaged checkpointer explorer asset is corrupt.\n\n"
             "The complete explorer.js content does not match this Hypergraph build.\n\n"
             "How to fix: Reinstall hypergraph from a complete wheel."
         )
-    return source
+    return source.decode("utf-8")
 
 
 def _aggregate_workflow_status(

--- a/src/hypergraph/checkpointers/presenters.py
+++ b/src/hypergraph/checkpointers/presenters.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from collections.abc import Iterable
 from importlib.resources import files
@@ -16,16 +17,17 @@ def _safe_json_payload(payload: dict[str, Any]) -> str:
     return json.dumps(payload).replace("<", "\\u003c").replace(">", "\\u003e").replace("&", "\\u0026")
 
 
-_EXPLORER_ASSET_MARKER = "/* hypergraph-checkpointer-explorer */"
+_EXPLORER_ASSET_SHA256 = "d6fcfe7189f28985a2940d802a5e07e7dcb5093c28e95641bc663121482009d3"
 
 
 def _read_explorer_asset() -> str:
-    """Read and minimally validate the packaged offline explorer asset."""
+    """Read and validate the complete packaged offline explorer asset."""
     source = files("hypergraph.checkpointers._assets").joinpath("explorer.js").read_text(encoding="utf-8")
-    if not source.startswith(_EXPLORER_ASSET_MARKER):
+    digest = hashlib.sha256(source.encode("utf-8")).hexdigest()
+    if digest != _EXPLORER_ASSET_SHA256:
         raise RuntimeError(
             "The packaged checkpointer explorer asset is corrupt.\n\n"
-            "Expected explorer.js to contain the Hypergraph asset marker.\n\n"
+            "The complete explorer.js content does not match this Hypergraph build.\n\n"
             "How to fix: Reinstall hypergraph from a complete wheel."
         )
     return source

--- a/src/hypergraph/checkpointers/sqlite.py
+++ b/src/hypergraph/checkpointers/sqlite.py
@@ -6,7 +6,8 @@ import asyncio
 import contextlib
 import json
 import uuid
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Literal
@@ -44,6 +45,100 @@ _PUBLIC_STEP_FILTER_WITH_ALIAS = (
 )
 _RETENTION_ROW_COLS = "id, step_index, superstep, node_name, values_data, created_at, completed_at"
 _DELETE_BATCH_SIZE = 500
+_STEP_UPSERT_SQL = """
+    INSERT INTO steps (
+        run_id, superstep, node_name, step_index, status,
+        input_versions, values_data, duration_ms, cached,
+        decision, error, node_type, created_at, completed_at, child_run_id, partial
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(run_id, superstep, node_name) DO UPDATE SET
+        status = excluded.status,
+        values_data = excluded.values_data,
+        duration_ms = excluded.duration_ms,
+        cached = excluded.cached,
+        decision = excluded.decision,
+        error = excluded.error,
+        node_type = excluded.node_type,
+        completed_at = excluded.completed_at,
+        partial = excluded.partial
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class _RetentionRow:
+    id: int
+    step_index: int
+    superstep: int
+    node_name: str
+    values_data: bytes | None
+    created_at: str | None
+    completed_at: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class _RetentionPlan:
+    kept_rows: tuple[_RetentionRow, ...]
+    dropped_rows: tuple[_RetentionRow, ...]
+    baseline_superstep: int
+
+
+def _decode_retention_rows(rows: Sequence[tuple[Any, ...]]) -> tuple[_RetentionRow, ...]:
+    decoded: list[_RetentionRow] = []
+    for row in rows:
+        row_id, step_index, superstep, node_name, values_data, created_at, completed_at = row
+        decoded.append(
+            _RetentionRow(
+                id=int(row_id),
+                step_index=int(step_index),
+                superstep=int(superstep),
+                node_name=str(node_name),
+                values_data=values_data,
+                created_at=created_at,
+                completed_at=completed_at,
+            )
+        )
+    return tuple(decoded)
+
+
+def _plan_retention(
+    rows: Sequence[_RetentionRow],
+    retention: Literal["full", "latest", "windowed"],
+    window: int | None,
+) -> _RetentionPlan | None:
+    if retention == "full":
+        return None
+
+    if retention == "latest":
+        latest_by_node: dict[str, _RetentionRow] = {}
+        for row in rows:
+            if row.node_name != _RETENTION_BASELINE_NODE_NAME:
+                latest_by_node[row.node_name] = row
+        kept_rows = tuple(latest_by_node.values())
+        kept_ids = {row.id for row in kept_rows}
+        dropped_rows = tuple(row for row in rows if row.id not in kept_ids)
+        return _RetentionPlan(
+            kept_rows=kept_rows,
+            dropped_rows=dropped_rows,
+            baseline_superstep=min((row.superstep for row in kept_rows), default=0) - 1,
+        )
+
+    if retention == "windowed" and window is not None:
+        non_baseline_rows = tuple(row for row in rows if row.node_name != _RETENTION_BASELINE_NODE_NAME)
+        if not non_baseline_rows:
+            return None
+        max_superstep = max(row.superstep for row in non_baseline_rows)
+        cutoff = max_superstep - window + 1
+        if cutoff <= 0:
+            return None
+        kept_rows = tuple(row for row in non_baseline_rows if row.superstep >= cutoff)
+        dropped_rows = tuple(row for row in rows if row.node_name == _RETENTION_BASELINE_NODE_NAME or row.superstep < cutoff)
+        return _RetentionPlan(
+            kept_rows=kept_rows,
+            dropped_rows=dropped_rows,
+            baseline_superstep=cutoff - 1,
+        )
+
+    return None
 
 
 def _parse_dt(value: str | None) -> datetime | None:
@@ -283,23 +378,7 @@ class SqliteCheckpointer(Checkpointer):
         decision_json = json.dumps(record.decision) if record.decision is not None else None
 
         await self._db.execute(
-            """
-            INSERT INTO steps (
-                run_id, superstep, node_name, step_index, status,
-                input_versions, values_data, duration_ms, cached,
-                decision, error, node_type, created_at, completed_at, child_run_id, partial
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(run_id, superstep, node_name) DO UPDATE SET
-                status = excluded.status,
-                values_data = excluded.values_data,
-                duration_ms = excluded.duration_ms,
-                cached = excluded.cached,
-                decision = excluded.decision,
-                error = excluded.error,
-                node_type = excluded.node_type,
-                completed_at = excluded.completed_at,
-                partial = excluded.partial
-            """,
+            _STEP_UPSERT_SQL,
             (
                 record.run_id,
                 record.superstep,
@@ -1021,23 +1100,7 @@ class SqliteCheckpointer(Checkpointer):
         decision_json = json.dumps(record.decision) if record.decision is not None else None
 
         db.execute(
-            """
-            INSERT INTO steps (
-                run_id, superstep, node_name, step_index, status,
-                input_versions, values_data, duration_ms, cached,
-                decision, error, node_type, created_at, completed_at, child_run_id, partial
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(run_id, superstep, node_name) DO UPDATE SET
-                status = excluded.status,
-                values_data = excluded.values_data,
-                duration_ms = excluded.duration_ms,
-                cached = excluded.cached,
-                decision = excluded.decision,
-                error = excluded.error,
-                node_type = excluded.node_type,
-                completed_at = excluded.completed_at,
-                partial = excluded.partial
-            """,
+            _STEP_UPSERT_SQL,
             (
                 record.run_id,
                 record.superstep,
@@ -1060,10 +1123,10 @@ class SqliteCheckpointer(Checkpointer):
         self._apply_retention_policy_sync(record.run_id)
         db.commit()
 
-    def _merge_retained_state(self, rows: list[tuple[Any, ...]]) -> dict[str, Any]:
+    def _merge_retained_state(self, rows: Sequence[_RetentionRow]) -> dict[str, Any]:
         state: dict[str, Any] = {}
         for row in rows:
-            values_blob = row[4]
+            values_blob = row.values_data
             if values_blob is None:
                 continue
             values = self._serializer.deserialize(values_blob)
@@ -1071,24 +1134,28 @@ class SqliteCheckpointer(Checkpointer):
                 state.update(values)
         return state
 
-    def _baseline_timestamp(self, kept_rows: list[tuple[Any, ...]], dropped_rows: list[tuple[Any, ...]]) -> datetime:
+    def _baseline_timestamp(
+        self,
+        kept_rows: Sequence[_RetentionRow],
+        dropped_rows: Sequence[_RetentionRow],
+    ) -> datetime:
         if kept_rows:
-            kept_times = [_parse_dt(row[6]) or _parse_dt(row[5]) for row in kept_rows]
+            kept_times = [_parse_dt(row.completed_at) or _parse_dt(row.created_at) for row in kept_rows]
             anchor = min(time for time in kept_times if time is not None)
             try:
                 return anchor - timedelta(microseconds=1)
             except OverflowError:
                 return anchor
 
-        dropped_times = [_parse_dt(row[6]) or _parse_dt(row[5]) for row in dropped_rows]
+        dropped_times = [_parse_dt(row.completed_at) or _parse_dt(row.created_at) for row in dropped_rows]
         return max((time for time in dropped_times if time is not None), default=datetime.now(timezone.utc))
 
     def _retention_baseline_params(
         self,
         run_id: str,
         *,
-        dropped_rows: list[tuple[Any, ...]],
-        kept_rows: list[tuple[Any, ...]],
+        dropped_rows: Sequence[_RetentionRow],
+        kept_rows: Sequence[_RetentionRow],
         baseline_superstep: int,
     ) -> tuple[Any, ...] | None:
         values = self._merge_retained_state(dropped_rows)
@@ -1100,7 +1167,7 @@ class SqliteCheckpointer(Checkpointer):
             run_id,
             baseline_superstep,
             _RETENTION_BASELINE_NODE_NAME,
-            min(int(row[1]) for row in dropped_rows),
+            min(row.step_index for row in dropped_rows),
             StepStatus.COMPLETED.value,
             "{}",
             self._serializer.serialize(values),
@@ -1125,46 +1192,27 @@ class SqliteCheckpointer(Checkpointer):
         for start in range(0, len(ids), _DELETE_BATCH_SIZE):
             yield ids[start : start + _DELETE_BATCH_SIZE]
 
-    @staticmethod
-    def _retention_baseline_insert_sql() -> str:
-        return """
-            INSERT INTO steps (
-                run_id, superstep, node_name, step_index, status,
-                input_versions, values_data, duration_ms, cached,
-                decision, error, node_type, created_at, completed_at, child_run_id, partial
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(run_id, superstep, node_name) DO UPDATE SET
-                status = excluded.status,
-                values_data = excluded.values_data,
-                duration_ms = excluded.duration_ms,
-                cached = excluded.cached,
-                decision = excluded.decision,
-                error = excluded.error,
-                node_type = excluded.node_type,
-                completed_at = excluded.completed_at,
-                partial = excluded.partial
-        """
-
-    async def _retention_rows_async(self, run_id: str) -> list[tuple[Any, ...]]:
+    async def _retention_rows_async(self, run_id: str) -> tuple[_RetentionRow, ...]:
         cursor = await self._db.execute(
             f"SELECT {_RETENTION_ROW_COLS} FROM steps WHERE run_id = ? ORDER BY {_STEP_TIME_ORDER}",
             (run_id,),
         )
-        return await cursor.fetchall()
+        return _decode_retention_rows(await cursor.fetchall())
 
-    def _retention_rows_sync(self, run_id: str) -> list[tuple[Any, ...]]:
+    def _retention_rows_sync(self, run_id: str) -> tuple[_RetentionRow, ...]:
         db = self._sync_db()
-        return db.execute(
+        rows = db.execute(
             f"SELECT {_RETENTION_ROW_COLS} FROM steps WHERE run_id = ? ORDER BY {_STEP_TIME_ORDER}",
             (run_id,),
         ).fetchall()
+        return _decode_retention_rows(rows)
 
     async def _compact_retention_async(
         self,
         run_id: str,
         *,
-        dropped_rows: list[tuple[Any, ...]],
-        kept_rows: list[tuple[Any, ...]],
+        dropped_rows: Sequence[_RetentionRow],
+        kept_rows: Sequence[_RetentionRow],
         baseline_superstep: int,
     ) -> None:
         if not dropped_rows:
@@ -1176,18 +1224,18 @@ class SqliteCheckpointer(Checkpointer):
             kept_rows=kept_rows,
             baseline_superstep=baseline_superstep,
         )
-        ids = [int(row[0]) for row in dropped_rows]
+        ids = [row.id for row in dropped_rows]
         for batch in self._delete_step_id_batches(ids):
             await self._db.execute(self._delete_steps_sql(batch), batch)
         if baseline_params is not None:
-            await self._db.execute(self._retention_baseline_insert_sql(), baseline_params)
+            await self._db.execute(_STEP_UPSERT_SQL, baseline_params)
 
     def _compact_retention_sync(
         self,
         run_id: str,
         *,
-        dropped_rows: list[tuple[Any, ...]],
-        kept_rows: list[tuple[Any, ...]],
+        dropped_rows: Sequence[_RetentionRow],
+        kept_rows: Sequence[_RetentionRow],
         baseline_superstep: int,
     ) -> None:
         if not dropped_rows:
@@ -1199,12 +1247,12 @@ class SqliteCheckpointer(Checkpointer):
             kept_rows=kept_rows,
             baseline_superstep=baseline_superstep,
         )
-        ids = [int(row[0]) for row in dropped_rows]
+        ids = [row.id for row in dropped_rows]
         db = self._sync_db()
         for batch in self._delete_step_id_batches(ids):
             db.execute(self._delete_steps_sql(batch), batch)
         if baseline_params is not None:
-            db.execute(self._retention_baseline_insert_sql(), baseline_params)
+            db.execute(_STEP_UPSERT_SQL, baseline_params)
 
     async def _apply_retention_policy_async(self, run_id: str) -> None:
         """Apply configured retention policy after persisting a step (async)."""
@@ -1213,39 +1261,13 @@ class SqliteCheckpointer(Checkpointer):
             return
 
         rows = await self._retention_rows_async(run_id)
-        if retention == "latest":
-            latest_by_node: dict[str, tuple[Any, ...]] = {}
-            for row in rows:
-                if row[3] == _RETENTION_BASELINE_NODE_NAME:
-                    continue
-                latest_by_node[str(row[3])] = row
-            kept_rows = list(latest_by_node.values())
-            kept_ids = {row[0] for row in kept_rows}
-            dropped_rows = [row for row in rows if row[0] not in kept_ids]
-            baseline_superstep = min((int(row[2]) for row in kept_rows), default=0) - 1
+        plan = _plan_retention(rows, retention, self.policy.window)
+        if plan is not None:
             await self._compact_retention_async(
                 run_id,
-                dropped_rows=dropped_rows,
-                kept_rows=kept_rows,
-                baseline_superstep=baseline_superstep,
-            )
-            return
-
-        if retention == "windowed" and self.policy.window is not None:
-            non_baseline_rows = [row for row in rows if row[3] != _RETENTION_BASELINE_NODE_NAME]
-            if not non_baseline_rows:
-                return
-            max_superstep = max(int(row[2]) for row in non_baseline_rows)
-            cutoff = max_superstep - self.policy.window + 1
-            if cutoff <= 0:
-                return
-            kept_rows = [row for row in rows if row[3] != _RETENTION_BASELINE_NODE_NAME and int(row[2]) >= cutoff]
-            dropped_rows = [row for row in rows if row[3] == _RETENTION_BASELINE_NODE_NAME or int(row[2]) < cutoff]
-            await self._compact_retention_async(
-                run_id,
-                dropped_rows=dropped_rows,
-                kept_rows=kept_rows,
-                baseline_superstep=cutoff - 1,
+                dropped_rows=plan.dropped_rows,
+                kept_rows=plan.kept_rows,
+                baseline_superstep=plan.baseline_superstep,
             )
 
     def _apply_retention_policy_sync(self, run_id: str) -> None:
@@ -1255,39 +1277,13 @@ class SqliteCheckpointer(Checkpointer):
             return
 
         rows = self._retention_rows_sync(run_id)
-        if retention == "latest":
-            latest_by_node: dict[str, tuple[Any, ...]] = {}
-            for row in rows:
-                if row[3] == _RETENTION_BASELINE_NODE_NAME:
-                    continue
-                latest_by_node[str(row[3])] = row
-            kept_rows = list(latest_by_node.values())
-            kept_ids = {row[0] for row in kept_rows}
-            dropped_rows = [row for row in rows if row[0] not in kept_ids]
-            baseline_superstep = min((int(row[2]) for row in kept_rows), default=0) - 1
+        plan = _plan_retention(rows, retention, self.policy.window)
+        if plan is not None:
             self._compact_retention_sync(
                 run_id,
-                dropped_rows=dropped_rows,
-                kept_rows=kept_rows,
-                baseline_superstep=baseline_superstep,
-            )
-            return
-
-        if retention == "windowed" and self.policy.window is not None:
-            non_baseline_rows = [row for row in rows if row[3] != _RETENTION_BASELINE_NODE_NAME]
-            if not non_baseline_rows:
-                return
-            max_superstep = max(int(row[2]) for row in non_baseline_rows)
-            cutoff = max_superstep - self.policy.window + 1
-            if cutoff <= 0:
-                return
-            kept_rows = [row for row in rows if row[3] != _RETENTION_BASELINE_NODE_NAME and int(row[2]) >= cutoff]
-            dropped_rows = [row for row in rows if row[3] == _RETENTION_BASELINE_NODE_NAME or int(row[2]) < cutoff]
-            self._compact_retention_sync(
-                run_id,
-                dropped_rows=dropped_rows,
-                kept_rows=kept_rows,
-                baseline_superstep=cutoff - 1,
+                dropped_rows=plan.dropped_rows,
+                kept_rows=plan.kept_rows,
+                baseline_superstep=plan.baseline_superstep,
             )
 
     def update_run_status_sync(

--- a/src/hypergraph/events/_progress_renderers.py
+++ b/src/hypergraph/events/_progress_renderers.py
@@ -1,0 +1,472 @@
+"""Output renderers for renderer-neutral progress tracker updates."""
+
+from __future__ import annotations
+
+import contextlib
+import html as _html
+import re
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Literal, Protocol
+
+from hypergraph._repr import (
+    ALIGNUI_WIDGET_THEME,
+    FONT_SANS_STYLE,
+    MUTED_COLOR,
+    STATUS_COLORS,
+    theme_wrap,
+)
+from hypergraph.events._progress_tracker import (
+    _ProgressMessage,
+    _ProgressUpdate,
+    _TaskKey,
+)
+from hypergraph.events.types import RunStatus
+
+
+class _ProgressRenderer(Protocol):
+    """Small lifecycle and update boundary shared by all output modes."""
+
+    def start(self) -> None: ...
+
+    def emit(self, update: _ProgressUpdate) -> None: ...
+
+    def flush(self) -> None: ...
+
+    def shutdown(self) -> None: ...
+
+    def take_async_flush(self) -> bool: ...
+
+
+def _require_rich() -> None:
+    try:
+        import rich  # noqa: F401
+    except ImportError:
+        raise ImportError(
+            "The 'rich' package is required for RichProgressProcessor. Install it with: pip install 'hypergraph[progress]' or pip install rich"
+        ) from None
+
+
+class _RichTTYRenderer:
+    """Render progress tasks through Rich's terminal Progress display."""
+
+    def __init__(self, *, transient: bool) -> None:
+        _require_rich()
+        from rich.progress import (
+            BarColumn,
+            MofNCompleteColumn,
+            Progress,
+            SpinnerColumn,
+            TextColumn,
+            TimeElapsedColumn,
+        )
+
+        self._progress = Progress(
+            SpinnerColumn(),
+            TextColumn("{task.description}"),
+            BarColumn(),
+            MofNCompleteColumn(),
+            TimeElapsedColumn(),
+            TextColumn("{task.fields[stats]}"),
+            transient=transient,
+            auto_refresh=True,
+        )
+        self._task_ids: dict[_TaskKey, Any] = {}
+
+    def start(self) -> None:
+        self._progress.start()
+
+    def emit(self, update: _ProgressUpdate) -> None:
+        if update.reset:
+            # Rich historically kept completed tasks visible across processor
+            # reuse; only logical ownership resets for the new root run.
+            self._task_ids.clear()
+        for key in update.removed:
+            task_id = self._task_ids.pop(key, None)
+            if task_id is not None:
+                self._progress.update(task_id, visible=False)
+        for task in update.tasks:
+            task_id = self._task_ids.get(task.key)
+            if task_id is None:
+                self._task_ids[task.key] = self._progress.add_task(
+                    task.description,
+                    total=task.total,
+                    stats=task.stats,
+                )
+            else:
+                self._progress.update(
+                    task_id,
+                    description=task.description,
+                    total=task.total,
+                    completed=task.completed,
+                    stats=task.stats,
+                )
+        if update.message is not None and update.message.kind == "run-end":
+            self._display_completion(update.message)
+
+    def _display_completion(self, message: _ProgressMessage) -> None:
+        if message.status == RunStatus.COMPLETED:
+            text = f"[bold green]✓ {message.name} completed![/bold green]"
+        elif message.status == RunStatus.PARTIAL:
+            text = f"[bold yellow]◐ {message.name} completed with failures[/bold yellow]"
+        elif message.status == RunStatus.PAUSED:
+            text = f"[bold yellow]‖ {message.name} paused[/bold yellow]"
+        elif message.status == RunStatus.STOPPED:
+            text = f"[bold yellow]◼ {message.name} stopped[/bold yellow]"
+        else:
+            text = f"[bold red]✗ {message.name} failed: {message.error}[/bold red]"
+        self._progress.console.print(text)
+
+    def flush(self) -> None:
+        return
+
+    def shutdown(self) -> None:
+        self._progress.stop()
+
+    def take_async_flush(self) -> bool:
+        return False
+
+
+@dataclass(slots=True)
+class _NotebookTask:
+    description: str
+    total: int
+    completed: int = 0
+    stats: str = ""
+    started_at: float = field(default_factory=time.monotonic)
+
+
+class _NotebookProgress:
+    """Notebook-native HTML task display with one stable display handle."""
+
+    def __init__(self, *, transient: bool, state_key: str) -> None:
+        self.transient = transient
+        self.state_key = state_key
+        self._tasks: dict[int, _NotebookTask] = {}
+        self._task_order: list[int] = []
+        self._next_task_id = 0
+        self._started = False
+        self._display_handle: Any = None
+
+    def start(self) -> None:
+        self._started = True
+        self.refresh()
+
+    def stop(self) -> None:
+        if self.transient and self._display_handle is not None:
+            from IPython.display import HTML
+
+            self._display_handle.update(HTML(""))
+        self._started = False
+
+    def reset(self) -> None:
+        self._tasks.clear()
+        self._task_order.clear()
+        self._next_task_id = 0
+        if self._display_handle is not None:
+            self.refresh()
+
+    def add_task(self, description: str, *, total: int, stats: str = "") -> int:
+        task_id = self._next_task_id
+        self._next_task_id += 1
+        self._tasks[task_id] = _NotebookTask(
+            description=description,
+            total=max(0, int(total or 0)),
+            stats=stats,
+        )
+        self._task_order.append(task_id)
+        return task_id
+
+    def remove_task(self, task_id: int) -> None:
+        self._tasks.pop(task_id, None)
+        with contextlib.suppress(ValueError):
+            self._task_order.remove(task_id)
+
+    def update(
+        self,
+        task_id: int,
+        *,
+        description: str | None = None,
+        total: int | None = None,
+        completed: int | None = None,
+        stats: str | None = None,
+    ) -> None:
+        task = self._tasks.get(task_id)
+        if task is None:
+            return
+        if description is not None:
+            task.description = description
+        if total is not None:
+            task.total = max(0, int(total))
+        if completed is not None:
+            task.completed = max(0, int(completed))
+        if task.total > 0:
+            task.completed = min(task.completed, task.total)
+        if stats is not None:
+            task.stats = stats
+
+    @staticmethod
+    def _format_elapsed(seconds: float) -> str:
+        total = max(0, int(seconds))
+        hours = total // 3600
+        minutes = (total % 3600) // 60
+        seconds = total % 60
+        return f"{hours}:{minutes:02d}:{seconds:02d}"
+
+    @staticmethod
+    def _stats_html(stats: str) -> str:
+        text = _html.escape(stats)
+        text = re.sub(
+            r"(\d+)✓",
+            f'<span style="color:{STATUS_COLORS["completed"]}">\\1✓</span>',
+            text,
+        )
+        text = re.sub(
+            r"(\d+)✗",
+            f'<span style="color:{STATUS_COLORS["failed"]}">\\1✗</span>',
+            text,
+        )
+        text = re.sub(
+            r"(\d+)◉",
+            f'<span style="color:{STATUS_COLORS["cached"]}">\\1◉</span>',
+            text,
+        )
+        return re.sub(
+            r"(~[0-9:.a-zA-Z]+)",
+            f'<span style="color:{STATUS_COLORS["partial"]}">\\1</span>',
+            text,
+        )
+
+    def _render_html(self) -> str:
+        rows: list[str] = []
+        now = time.monotonic()
+        for task_id in self._task_order:
+            task = self._tasks[task_id]
+            total = task.total if task.total > 0 else 1
+            fraction = max(0.0, min(1.0, task.completed / total))
+            description = _html.escape(task.description)
+            completed = task.completed if task.total > 0 else 0
+            rows.append(
+                '<div style="display:flex; align-items:center; margin:2px 0">'
+                f'<span style="{FONT_SANS_STYLE}; white-space:pre; width:168px; overflow:hidden; text-overflow:ellipsis; margin-right:4px; color:{ALIGNUI_WIDGET_THEME["text_strong"]}">{description}</span>'
+                f'<div style="width:300px; height:5px; border-radius:9999px; overflow:hidden; margin-right:10px; background:{ALIGNUI_WIDGET_THEME["border_soft"]}">'
+                f'<div style="height:100%; width:{fraction * 100:.2f}%; background:{ALIGNUI_WIDGET_THEME["success_base"]}"></div>'
+                "</div>"
+                f'<span style="{FONT_SANS_STYLE}; width:64px; text-align:right; margin-right:10px; color:{ALIGNUI_WIDGET_THEME["text_strong"]}; font-variant-numeric:tabular-nums">{completed}/{task.total}</span>'
+                f'<span style="{FONT_SANS_STYLE}; width:66px; margin-right:10px; color:{MUTED_COLOR}; font-variant-numeric:tabular-nums">{self._format_elapsed(now - task.started_at)}</span>'
+                f'<span style="{FONT_SANS_STYLE}; min-width:140px; color:{MUTED_COLOR}">{self._stats_html(task.stats)}</span>'
+                "</div>"
+            )
+        content = (
+            '<div style="display:inline-block; max-width:100%; '
+            f'{FONT_SANS_STYLE}; font-size:12px; line-height:1.3; color:{ALIGNUI_WIDGET_THEME["text_strong"]}">' + "".join(rows) + "</div>"
+        )
+        return theme_wrap(content, state_key=self.state_key)
+
+    def refresh(self) -> None:
+        from IPython.display import HTML, display
+
+        html = self._render_html()
+        if self._display_handle is None:
+            self._display_handle = display(HTML(html), display_id=True)
+        else:
+            self._display_handle.update(HTML(html))
+
+
+class _NotebookRenderer:
+    """Render tracker updates to a throttled notebook HTML display."""
+
+    _REFRESH_INTERVAL = 0.1
+
+    def __init__(self, *, transient: bool) -> None:
+        self._progress = _NotebookProgress(
+            transient=transient,
+            state_key=f"notebook-progress-{int(time.time() * 1000)}",
+        )
+        self._task_ids: dict[_TaskKey, int] = {}
+        self._last_refresh = 0.0
+        self._refresh_dirty = False
+        self._needs_async_flush = False
+
+    def start(self) -> None:
+        self._progress.start()
+
+    def emit(self, update: _ProgressUpdate) -> None:
+        if update.reset:
+            self._task_ids.clear()
+            self._refresh_dirty = False
+            self._progress.reset()
+
+        structural = False
+        for key in update.removed:
+            task_id = self._task_ids.pop(key, None)
+            if task_id is not None:
+                self._progress.remove_task(task_id)
+                structural = True
+        for task in update.tasks:
+            task_id = self._task_ids.get(task.key)
+            if task_id is None:
+                self._task_ids[task.key] = self._progress.add_task(
+                    task.description,
+                    total=task.total,
+                    stats=task.stats,
+                )
+                structural = True
+            else:
+                self._progress.update(
+                    task_id,
+                    description=task.description,
+                    total=task.total,
+                    completed=task.completed,
+                    stats=task.stats,
+                )
+
+        if structural:
+            self._refresh_structural()
+        elif update.tasks:
+            self._refresh()
+
+        if update.message is not None and update.message.kind == "run-end":
+            self.flush()
+            self._display_completion(update.message)
+
+    def _refresh(self) -> None:
+        now = time.monotonic()
+        if now - self._last_refresh >= self._REFRESH_INTERVAL:
+            self._progress.refresh()
+            self._last_refresh = now
+            self._refresh_dirty = False
+        else:
+            self._refresh_dirty = True
+
+    def _refresh_structural(self) -> None:
+        self._progress.refresh()
+        self._last_refresh = time.monotonic()
+        self._refresh_dirty = False
+        self._needs_async_flush = True
+
+    def _display_completion(self, message: _ProgressMessage) -> None:
+        from IPython.display import HTML, display
+
+        if message.status == RunStatus.COMPLETED:
+            color = STATUS_COLORS["completed"]
+            text = f"✓ {message.name} completed!"
+        elif message.status == RunStatus.PARTIAL:
+            color = STATUS_COLORS["partial"]
+            text = f"◐ {message.name} completed with failures"
+        elif message.status == RunStatus.PAUSED:
+            color = STATUS_COLORS["paused"]
+            text = f"‖ {message.name} paused"
+        elif message.status == RunStatus.STOPPED:
+            # Preserve the pre-refactor notebook completion foreground. Badge
+            # policy intentionally has a distinct canonical stopped color.
+            color = STATUS_COLORS["paused"]
+            text = f"◼ {message.name} stopped"
+        else:
+            color = STATUS_COLORS["failed"]
+            suffix = f": {message.error}" if message.error else ""
+            text = f"✗ {message.name} failed{suffix}"
+        html = f'<div style="{FONT_SANS_STYLE}; color:{color}; font-weight:700; padding:4px 0">{text}</div>'
+        display(HTML(theme_wrap(html)))
+
+    def flush(self) -> None:
+        if self._refresh_dirty:
+            self._progress.refresh()
+            self._last_refresh = time.monotonic()
+            self._refresh_dirty = False
+
+    def shutdown(self) -> None:
+        self.flush()
+        self._progress.stop()
+
+    def take_async_flush(self) -> bool:
+        needed = self._needs_async_flush
+        self._needs_async_flush = False
+        return needed
+
+
+_MAP_MILESTONES = frozenset({10, 25, 50, 75, 100})
+
+
+def _timestamp() -> str:
+    return datetime.now().strftime("[%H:%M:%S]")
+
+
+class _LogRenderer:
+    """Render the semantic transcript as exact flushed non-TTY log lines."""
+
+    def __init__(self) -> None:
+        self._logged_milestones: dict[str, set[int]] = {}
+
+    def start(self) -> None:
+        return
+
+    @staticmethod
+    def _print(message: str) -> None:
+        print(f"{_timestamp()} {message}", flush=True)
+
+    def emit(self, update: _ProgressUpdate) -> None:
+        if update.reset:
+            self._logged_milestones.clear()
+        message = update.message
+        if message is None:
+            return
+        if message.kind == "node-start":
+            self._print(f"▶ {message.name} started")
+        elif message.kind == "node-end":
+            suffix = " (cached)" if message.cached else ""
+            self._print(f"✓ {message.name} completed{suffix}")
+        elif message.kind == "node-error":
+            self._print(f"✗ {message.name} FAILED")
+        elif message.kind == "map-progress":
+            self._render_map_progress(message)
+        elif message.kind == "run-end":
+            self._display_completion(message)
+
+    def _render_map_progress(self, message: _ProgressMessage) -> None:
+        if message.scope_id is None or message.total == 0:
+            return
+        percent = int(message.completed * 100 / message.total)
+        logged = self._logged_milestones.setdefault(message.scope_id, set())
+        crossed = [milestone for milestone in _MAP_MILESTONES if percent >= milestone and milestone not in logged]
+        if not crossed:
+            return
+        milestone = max(crossed)
+        logged.update(item for item in _MAP_MILESTONES if item <= milestone)
+        self._print(f"◈ {message.name}: {milestone}% ({message.completed}/{message.total})")
+
+    def _display_completion(self, message: _ProgressMessage) -> None:
+        if message.status == RunStatus.COMPLETED:
+            text = f"✓ {message.name} completed!"
+        elif message.status == RunStatus.PARTIAL:
+            text = f"◐ {message.name} completed with failures"
+        elif message.status == RunStatus.PAUSED:
+            text = f"‖ {message.name} paused"
+        elif message.status == RunStatus.STOPPED:
+            text = f"◼ {message.name} stopped"
+        else:
+            suffix = f": {message.error}" if message.error else ""
+            text = f"✗ {message.name} failed{suffix}"
+        self._print(text)
+
+    def flush(self) -> None:
+        return
+
+    def shutdown(self) -> None:
+        return
+
+    def take_async_flush(self) -> bool:
+        return False
+
+
+def _make_progress_renderer(
+    mode: Literal["tty", "notebook", "non-tty"] | str,
+    *,
+    transient: bool,
+) -> _ProgressRenderer:
+    if mode == "tty":
+        return _RichTTYRenderer(transient=transient)
+    if mode == "notebook":
+        return _NotebookRenderer(transient=transient)
+    return _LogRenderer()

--- a/src/hypergraph/events/_progress_tracker.py
+++ b/src/hypergraph/events/_progress_tracker.py
@@ -1,0 +1,404 @@
+"""Renderer-neutral state transitions for progress event streams."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal, TypeAlias
+
+from hypergraph.events.types import RunStatus
+
+if TYPE_CHECKING:
+    from hypergraph.events.types import (
+        InnerCacheEvent,
+        NodeEndEvent,
+        NodeErrorEvent,
+        NodeStartEvent,
+        RunEndEvent,
+        RunStartEvent,
+    )
+
+
+_NodeKey: TypeAlias = tuple[str, str, int]
+_TaskKey: TypeAlias = str | _NodeKey
+
+
+@dataclass(frozen=True, slots=True)
+class _TaskView:
+    """Complete renderer-facing snapshot of one logical progress task."""
+
+    key: _TaskKey
+    description: str
+    total: int
+    completed: int = 0
+    stats: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class _ProgressMessage:
+    """Semantic transcript item interpreted by each output renderer."""
+
+    kind: Literal["node-start", "node-end", "node-error", "map-progress", "run-end"]
+    name: str
+    scope_id: str | None = None
+    cached: bool = False
+    completed: int = 0
+    total: int = 0
+    status: RunStatus | None = None
+    error: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _ProgressUpdate:
+    """One ordered state transition emitted through the renderer protocol."""
+
+    tasks: tuple[_TaskView, ...] = ()
+    removed: tuple[_TaskKey, ...] = ()
+    reset: bool = False
+    message: _ProgressMessage | None = None
+
+
+@dataclass(slots=True)
+class _SpanState:
+    depth: int = 0
+    parent_span_id: str | None = None
+    is_map: bool = False
+    map_size: int = 0
+    completed: int = 0
+    map_parent: str | None = None
+    failures: int = 0
+    succeeded: int = 0
+    node_bar_key: _NodeKey | None = None
+    display_name: str = "Map"
+    log_name: str = "Map"
+
+
+@dataclass(slots=True)
+class _NodeState:
+    total: int
+    name: str
+    depth: int
+    map_span_id: str | None
+    completed: int = 0
+    succeeded: int = 0
+    cached: int = 0
+    failures: int = 0
+    total_duration_ms: float = 0.0
+    inner_cache_hits: int = 0
+    inner_cache_refreshing: int = 0
+
+
+def _format_duration(ms: float) -> str:
+    if ms < 1000:
+        return f"{ms:.0f}ms"
+    return f"{ms / 1000:.1f}s"
+
+
+def _format_stats(
+    *,
+    succeeded: int = 0,
+    failures: int = 0,
+    cached: int = 0,
+    avg_ms: float | None = None,
+    inner_cache_hits: int = 0,
+    inner_cache_refreshing: int = 0,
+) -> str:
+    parts: list[str] = []
+    if succeeded:
+        parts.append(f"{succeeded}✓")
+    if failures:
+        parts.append(f"{failures}✗")
+    if cached:
+        parts.append(f"{cached}◉")
+    if avg_ms is not None:
+        parts.append(f"~{_format_duration(avg_ms)}")
+    if inner_cache_hits:
+        parts.append(f"{inner_cache_hits}↩")
+    if inner_cache_refreshing:
+        parts.append(f"{inner_cache_refreshing}↻")
+    return " ".join(parts)
+
+
+class _ProgressTracker:
+    """Own span/node/map decisions without presentation handles or modes."""
+
+    def __init__(self) -> None:
+        self.spans: dict[str, _SpanState] = {}
+        self.node_bars: dict[_NodeKey, _NodeState] = {}
+        self.map_children: dict[str, list[_NodeKey]] = {}
+
+    def _get_span(self, span_id: str) -> _SpanState:
+        if span_id not in self.spans:
+            self.spans[span_id] = _SpanState()
+        return self.spans[span_id]
+
+    def _get_depth(self, parent_span_id: str | None) -> int:
+        if parent_span_id is None:
+            return 0
+        parent = self.spans.get(parent_span_id)
+        if parent is None:
+            return 0
+        return parent.depth if parent.is_map else parent.depth + 1
+
+    def _find_map_ancestor(self, span_id: str) -> str | None:
+        info = self.spans.get(span_id)
+        if info is None:
+            return None
+        current = info.parent_span_id
+        while current is not None:
+            parent = self.spans.get(current)
+            if parent is None:
+                break
+            if parent.is_map:
+                return current
+            current = parent.parent_span_id
+        return None
+
+    def _get_node_total(self, span_id: str) -> int:
+        map_span = self._find_map_ancestor(span_id)
+        if map_span is None:
+            return 1
+        return self.spans[map_span].map_size or 1
+
+    @staticmethod
+    def _map_description(name: str, depth: int) -> str:
+        return f"{'  ' * depth}◈ {name}"
+
+    @staticmethod
+    def _child_description(name: str, depth: int, *, is_last: bool) -> str:
+        branch = "└─" if is_last else "├─"
+        return f"{'  ' * depth}{branch} {name}"
+
+    @staticmethod
+    def _node_description(name: str, depth: int) -> str:
+        return f"{'  ' * depth}{name}"
+
+    def _node_view(self, key: _NodeKey) -> _TaskView:
+        node = self.node_bars[key]
+        if node.map_span_id is None:
+            description = self._node_description(node.name, node.depth)
+        else:
+            children = self.map_children.get(node.map_span_id, [])
+            description = self._child_description(
+                node.name,
+                node.depth,
+                is_last=bool(children and children[-1] == key),
+            )
+        non_cached = node.succeeded + node.failures
+        avg_ms = node.total_duration_ms / non_cached if non_cached > 1 else None
+        return _TaskView(
+            key=key,
+            description=description,
+            total=node.total,
+            completed=node.completed,
+            stats=_format_stats(
+                succeeded=node.succeeded,
+                failures=node.failures,
+                cached=node.cached,
+                avg_ms=avg_ms,
+                inner_cache_hits=node.inner_cache_hits,
+                inner_cache_refreshing=node.inner_cache_refreshing,
+            ),
+        )
+
+    def _map_view(self, span_id: str) -> _TaskView:
+        info = self.spans[span_id]
+        return _TaskView(
+            key=span_id,
+            description=self._map_description(info.display_name, info.depth),
+            total=info.map_size,
+            completed=info.completed,
+            stats=_format_stats(
+                succeeded=info.succeeded,
+                failures=info.failures,
+            ),
+        )
+
+    def on_run_start(self, event: RunStartEvent) -> _ProgressUpdate:
+        reset = False
+        if event.parent_span_id is None and self.spans and event.span_id not in self.spans:
+            self.spans.clear()
+            self.node_bars.clear()
+            self.map_children.clear()
+            reset = True
+
+        info = self._get_span(event.span_id)
+        info.parent_span_id = event.parent_span_id
+        info.depth = self._get_depth(event.parent_span_id)
+        info.is_map = event.is_map
+
+        tasks: list[_TaskView] = []
+        removed: list[_TaskKey] = []
+        if event.is_map and event.map_size is not None:
+            info.map_size = event.map_size
+            replaced_name: str | None = None
+            if event.parent_span_id is not None:
+                parent_info = self.spans.get(event.parent_span_id)
+                if parent_info is not None and parent_info.node_bar_key is not None:
+                    old_key = parent_info.node_bar_key
+                    old_bar = self.node_bars.pop(old_key, None)
+                    if old_bar is not None:
+                        replaced_name = old_bar.name
+                        info.depth = old_bar.depth
+                        removed.append(old_key)
+                        for children in self.map_children.values():
+                            if old_key not in children:
+                                continue
+                            children.remove(old_key)
+                            if children:
+                                tasks.append(self._node_view(children[-1]))
+                    parent_info.node_bar_key = None
+
+            info.display_name = replaced_name or event.graph_name or "Map"
+            # Non-TTY historically did not create visual node bars, so map
+            # milestones used the graph name even when a visual bar was replaced.
+            info.log_name = event.graph_name or "Map"
+            tasks.append(self._map_view(event.span_id))
+
+        if event.parent_span_id is not None:
+            parent_info = self.spans.get(event.parent_span_id)
+            if parent_info is not None and parent_info.is_map:
+                info.map_parent = event.parent_span_id
+
+        return _ProgressUpdate(
+            tasks=tuple(tasks),
+            removed=tuple(removed),
+            reset=reset,
+        )
+
+    def on_node_start(self, event: NodeStartEvent) -> _ProgressUpdate:
+        info = self._get_span(event.span_id)
+        info.parent_span_id = event.parent_span_id
+        parent_info = self.spans.get(event.parent_span_id) if event.parent_span_id else None
+        node_depth = parent_info.depth if parent_info else 0
+        if parent_info and parent_info.map_parent:
+            node_depth += 1
+        info.depth = node_depth
+
+        key: _NodeKey = (event.graph_name, event.node_name, node_depth)
+        info.node_bar_key = key
+        total = self._get_node_total(event.span_id)
+        map_span = self._find_map_ancestor(event.span_id)
+        tasks: list[_TaskView] = []
+
+        node = self.node_bars.get(key)
+        if node is None:
+            node = _NodeState(
+                total=total,
+                name=event.node_name,
+                depth=node_depth,
+                map_span_id=map_span,
+            )
+            self.node_bars[key] = node
+            if map_span is not None:
+                children = self.map_children.setdefault(map_span, [])
+                previous = children[-1] if children else None
+                children.append(key)
+                if previous is not None:
+                    tasks.append(self._node_view(previous))
+            tasks.append(self._node_view(key))
+        elif node.total < total:
+            node.total = total
+            tasks.append(self._node_view(key))
+
+        message = None
+        if map_span is None:
+            message = _ProgressMessage(kind="node-start", name=event.node_name)
+        return _ProgressUpdate(tasks=tuple(tasks), message=message)
+
+    def on_node_end(self, event: NodeEndEvent) -> _ProgressUpdate:
+        span_info = self.spans.get(event.span_id)
+        node_depth = span_info.depth if span_info else 0
+        key: _NodeKey = (event.graph_name, event.node_name, node_depth)
+        node = self.node_bars.get(key)
+        tasks: tuple[_TaskView, ...] = ()
+        if node is not None:
+            node.completed += 1
+            if event.cached:
+                node.cached += 1
+            else:
+                node.succeeded += 1
+                node.total_duration_ms += event.duration_ms
+            tasks = (self._node_view(key),)
+
+        message = None
+        if self._find_map_ancestor(event.span_id) is None:
+            message = _ProgressMessage(
+                kind="node-end",
+                name=event.node_name,
+                cached=event.cached,
+            )
+        return _ProgressUpdate(tasks=tasks, message=message)
+
+    def on_node_error(self, event: NodeErrorEvent) -> _ProgressUpdate:
+        span_info = self.spans.get(event.span_id)
+        node_depth = span_info.depth if span_info else 0
+        key: _NodeKey = (event.graph_name, event.node_name, node_depth)
+        node = self.node_bars.get(key)
+        tasks: tuple[_TaskView, ...] = ()
+        if node is not None:
+            node.completed += 1
+            node.failures += 1
+            tasks = (self._node_view(key),)
+
+        message = None
+        if self._find_map_ancestor(event.span_id) is None:
+            message = _ProgressMessage(kind="node-error", name=event.node_name)
+        return _ProgressUpdate(tasks=tasks, message=message)
+
+    def on_inner_cache(self, event: InnerCacheEvent) -> _ProgressUpdate:
+        node: _NodeState | None = None
+        key: _NodeKey | None = None
+        if event.parent_span_id:
+            span_info = self.spans.get(event.parent_span_id)
+            if span_info is not None and span_info.node_bar_key is not None:
+                key = span_info.node_bar_key
+                node = self.node_bars.get(key)
+
+        if node is None:
+            for candidate_key, candidate in self.node_bars.items():
+                graph_name, node_name, _ = candidate_key
+                if node_name == event.node_name and (not event.graph_name or graph_name == event.graph_name):
+                    key = candidate_key
+                    node = candidate
+                    break
+
+        if node is None or key is None:
+            return _ProgressUpdate()
+        if event.hit:
+            node.inner_cache_hits += 1
+        if event.refreshing:
+            node.inner_cache_refreshing += 1
+        return _ProgressUpdate(tasks=(self._node_view(key),))
+
+    def on_run_end(self, event: RunEndEvent) -> _ProgressUpdate:
+        span_info = self.spans.get(event.span_id)
+        if span_info is None:
+            return _ProgressUpdate()
+
+        tasks: tuple[_TaskView, ...] = ()
+        message: _ProgressMessage | None = None
+        if span_info.map_parent:
+            map_info = self.spans.get(span_info.map_parent)
+            if map_info is not None:
+                map_info.completed += 1
+                if event.status in (RunStatus.FAILED, RunStatus.PARTIAL):
+                    map_info.failures += 1
+                elif event.status not in (RunStatus.PAUSED, RunStatus.STOPPED):
+                    map_info.succeeded += 1
+                tasks = (self._map_view(span_info.map_parent),)
+                message = _ProgressMessage(
+                    kind="map-progress",
+                    name=map_info.log_name,
+                    scope_id=span_info.map_parent,
+                    completed=map_info.completed,
+                    total=map_info.map_size,
+                )
+
+        if span_info.parent_span_id is None:
+            message = _ProgressMessage(
+                kind="run-end",
+                name=event.graph_name or "Run",
+                status=event.status,
+                error=event.error,
+            )
+        return _ProgressUpdate(tasks=tasks, message=message)

--- a/src/hypergraph/events/_progress_tracker.py
+++ b/src/hypergraph/events/_progress_tracker.py
@@ -62,7 +62,7 @@ class _SpanState:
     depth: int = 0
     parent_span_id: str | None = None
     is_map: bool = False
-    map_size: int = 0
+    map_size: int | None = None
     completed: int = 0
     map_parent: str | None = None
     failures: int = 0
@@ -202,6 +202,8 @@ class _ProgressTracker:
 
     def _map_view(self, span_id: str) -> _TaskView:
         info = self.spans[span_id]
+        if info.map_size is None:
+            raise RuntimeError("Cannot render progress for a map without a known size.")
         return _TaskView(
             key=span_id,
             description=self._map_description(info.display_name, info.depth),
@@ -379,7 +381,7 @@ class _ProgressTracker:
         message: _ProgressMessage | None = None
         if span_info.map_parent:
             map_info = self.spans.get(span_info.map_parent)
-            if map_info is not None:
+            if map_info is not None and map_info.map_size is not None:
                 map_info.completed += 1
                 if event.status in (RunStatus.FAILED, RunStatus.PARTIAL):
                     map_info.failures += 1

--- a/src/hypergraph/events/rich_progress.py
+++ b/src/hypergraph/events/rich_progress.py
@@ -1,19 +1,15 @@
-"""Rich-based hierarchical progress bar for graph execution."""
+"""Hierarchical progress event processor with pluggable output renderers."""
 
 from __future__ import annotations
 
-import contextlib
-import html as _html
-import re
 import sys
-import time
-from dataclasses import dataclass, field
-from datetime import datetime
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Literal
 
-from hypergraph._repr import ALIGNUI_WIDGET_THEME, FONT_MONO_STYLE, FONT_SANS_STYLE, MUTED_COLOR, STATUS_COLORS, theme_wrap
+from hypergraph.events._progress_renderers import (
+    _make_progress_renderer,
+)
+from hypergraph.events._progress_tracker import _ProgressTracker, _ProgressUpdate
 from hypergraph.events.processor import AsyncEventProcessor, TypedEventProcessor
-from hypergraph.events.types import RunStatus
 
 if TYPE_CHECKING:
     from hypergraph.events.types import (
@@ -26,215 +22,8 @@ if TYPE_CHECKING:
     )
 
 
-def _require_rich() -> None:
-    """Raise a clear error if rich is not installed."""
-    try:
-        import rich  # noqa: F401
-    except ImportError:
-        raise ImportError(
-            "The 'rich' package is required for RichProgressProcessor. Install it with: pip install 'hypergraph[progress]' or pip install rich"
-        ) from None
-
-
-def _patch_rich_jupyter() -> None:
-    """Add adaptive text color to Rich's Jupyter ``<pre>`` for dark notebooks."""
-    import rich.jupyter as rj
-
-    desired = (
-        '<pre style="white-space:pre;overflow-x:auto;line-height:normal;'
-        f"{FONT_MONO_STYLE};"
-        f'background:transparent;color:{ALIGNUI_WIDGET_THEME["text_strong"]}">{{code}}</pre>\n'
-    )
-    if getattr(rj, "_hypergraph_patched", False) and getattr(rj, "JUPYTER_HTML_FORMAT", None) == desired:
-        return
-    rj.JUPYTER_HTML_FORMAT = desired
-    rj._hypergraph_patched = True  # type: ignore[attr-defined]
-
-
-@dataclass
-class _SpanInfo:
-    """Tracking state for a single span (run or node)."""
-
-    depth: int = 0
-    parent_span_id: str | None = None
-    is_map: bool = False
-    map_size: int = 0
-    rich_task_id: Any = None  # Rich TaskID for map-level bars
-    node_count: int = 0  # Number of node-end events seen
-    map_parent: str | None = None  # Map span that owns this run
-    failures: int = 0  # Failed item count (for map spans)
-    succeeded: int = 0  # Succeeded item count (for map spans)
-    node_bar_key: _NodeKey | None = None  # Set by on_node_start, consumed by on_run_start/on_inner_cache
-
-
-@dataclass
-class _NodeBarInfo:
-    """Tracking state for a node progress bar."""
-
-    rich_task_id: Any = None  # Rich TaskID
-    total: int = 0
-    succeeded: int = 0
-    cached: int = 0
-    failures: int = 0
-    total_duration_ms: float = 0.0  # Sum of non-cached durations (for avg)
-    name: str = ""
-    depth: int = 0
-    map_span_id: str | None = None  # Parent map span (for tree chars)
-    inner_cache_hits: int = 0  # Inner (hypercache) cache hits inside this node
-    inner_cache_refreshing: int = 0  # Inner cache stale refreshes triggered inside this node
-
-
-# Notebook task model for HTML progress rendering.
-@dataclass
-class _NotebookTask:
-    description: str
-    total: int
-    completed: int = 0
-    stats: str = ""
-    started_at: float = field(default_factory=time.monotonic)
-
-
-class _NotebookConsole:
-    """Minimal console shim for compatibility with Rich Progress API."""
-
-    def print(self, *_args: Any, **_kwargs: Any) -> None:
-        return
-
-
-class _NotebookProgress:
-    """Notebook-native HTML progress renderer with stable display updates."""
-
-    def __init__(self, *, transient: bool = False, state_key: str = "notebook-progress") -> None:
-        self.transient = transient
-        self.state_key = state_key
-        self._tasks: dict[int, _NotebookTask] = {}
-        self._task_order: list[int] = []
-        self._next_task_id = 0
-        self._started = False
-        self._display_handle: Any = None
-        self.console = _NotebookConsole()
-
-    def start(self) -> None:
-        self._started = True
-        self.refresh()
-
-    def stop(self) -> None:
-        if self.transient and self._display_handle is not None:
-            from IPython.display import HTML
-
-            self._display_handle.update(HTML(""))
-        self._started = False
-
-    def reset(self) -> None:
-        self._tasks.clear()
-        self._task_order.clear()
-        self._next_task_id = 0
-        if self._display_handle is not None:
-            self.refresh()
-
-    def add_task(self, description: str, *, total: int, stats: str = "") -> int:
-        task_id = self._next_task_id
-        self._next_task_id += 1
-        self._tasks[task_id] = _NotebookTask(description=description, total=max(0, int(total or 0)), stats=stats)
-        self._task_order.append(task_id)
-        return task_id
-
-    def remove_task(self, task_id: int) -> None:
-        """Remove a task from the display."""
-        self._tasks.pop(task_id, None)
-        with contextlib.suppress(ValueError):
-            self._task_order.remove(task_id)
-
-    def update(
-        self,
-        task_id: int,
-        *,
-        description: str | None = None,
-        total: int | None = None,
-        stats: str | None = None,
-    ) -> None:
-        task = self._tasks.get(task_id)
-        if task is None:
-            return
-        if description is not None:
-            task.description = description
-        if total is not None:
-            task.total = max(0, int(total))
-            if task.total and task.completed > task.total:
-                task.completed = task.total
-        if stats is not None:
-            task.stats = stats
-
-    def advance(self, task_id: int, advance: int = 1) -> None:
-        task = self._tasks.get(task_id)
-        if task is None:
-            return
-        task.completed += int(advance)
-        if task.total > 0:
-            task.completed = min(task.completed, task.total)
-
-    def _format_elapsed(self, seconds: float) -> str:
-        total = max(0, int(seconds))
-        h = total // 3600
-        m = (total % 3600) // 60
-        s = total % 60
-        return f"{h}:{m:02d}:{s:02d}"
-
-    def _stats_html(self, stats: str) -> str:
-        txt = _html.escape(stats)
-        txt = re.sub(r"(\d+)✓", f'<span style="color:{STATUS_COLORS["completed"]}">\\1✓</span>', txt)
-        txt = re.sub(r"(\d+)✗", f'<span style="color:{STATUS_COLORS["failed"]}">\\1✗</span>', txt)
-        txt = re.sub(r"(\d+)◉", f'<span style="color:{STATUS_COLORS["cached"]}">\\1◉</span>', txt)
-        txt = re.sub(r"(~[0-9:.a-zA-Z]+)", f'<span style="color:{STATUS_COLORS["partial"]}">\\1</span>', txt)
-        return txt
-
-    def _render_html(self) -> str:
-        rows: list[str] = []
-        now = time.monotonic()
-        for task_id in self._task_order:
-            task = self._tasks[task_id]
-            total = task.total if task.total > 0 else 1
-            pct = max(0.0, min(1.0, task.completed / total))
-            pct_css = f"{pct * 100:.2f}%"
-            desc = _html.escape(task.description)
-            completed = task.completed if task.total > 0 else 0
-            elapsed = self._format_elapsed(now - task.started_at)
-            stats_html = self._stats_html(task.stats)
-            rows.append(
-                '<div style="display:flex; align-items:center; margin:2px 0">'
-                f'<span style="{FONT_SANS_STYLE}; white-space:pre; width:{_NB_DESC_WIDTH_PX}px; overflow:hidden; text-overflow:ellipsis; margin-right:4px; color:{ALIGNUI_WIDGET_THEME["text_strong"]}">{desc}</span>'
-                f'<div style="width:{_NB_BAR_WIDTH_PX}px; height:{_NB_BAR_HEIGHT_PX}px; border-radius:9999px; overflow:hidden; margin-right:10px; background:{ALIGNUI_WIDGET_THEME["border_soft"]}">'
-                f'<div style="height:100%; width:{pct_css}; background:{ALIGNUI_WIDGET_THEME["success_base"]}"></div>'
-                "</div>"
-                f'<span style="{FONT_SANS_STYLE}; width:{_NB_COUNT_WIDTH_PX}px; text-align:right; margin-right:10px; color:{ALIGNUI_WIDGET_THEME["text_strong"]}; font-variant-numeric:tabular-nums">{completed}/{task.total}</span>'
-                f'<span style="{FONT_SANS_STYLE}; width:{_NB_ELAPSED_WIDTH_PX}px; margin-right:10px; color:{MUTED_COLOR}; font-variant-numeric:tabular-nums">{elapsed}</span>'
-                f'<span style="{FONT_SANS_STYLE}; min-width:{_NB_STATS_MIN_WIDTH_PX}px; color:{MUTED_COLOR}">{stats_html}</span>'
-                "</div>"
-            )
-        content = (
-            '<div style="display:inline-block; max-width:100%; '
-            f'{FONT_SANS_STYLE}; font-size:{_NB_FONT_SIZE_PX}px; line-height:{_NB_LINE_HEIGHT}; color:{ALIGNUI_WIDGET_THEME["text_strong"]}">'
-            + "".join(rows)
-            + "</div>"
-        )
-        return theme_wrap(content, state_key=self.state_key)
-
-    def refresh(self) -> None:
-        from IPython.display import HTML, display
-
-        html = self._render_html()
-        if self._display_handle is None:
-            self._display_handle = display(HTML(html), display_id=True)
-        else:
-            self._display_handle.update(HTML(html))
-
-
-# Key type for node bar lookups: (graph_name, node_name, depth)
-_NodeKey = tuple[str, str, int]
-
-
 def _is_notebook() -> bool:
-    """Detect if running inside a Jupyter/IPython notebook kernel."""
+    """Detect whether execution is inside a Jupyter/IPython kernel."""
     try:
         from IPython import get_ipython
 
@@ -249,9 +38,9 @@ def _is_notebook() -> bool:
             return True
         if getattr(shell, "kernel", None) is not None:
             return True
-        cfg = getattr(shell, "config", {})
+        config = getattr(shell, "config", {})
         try:
-            if "IPKernelApp" in cfg:
+            if "IPKernelApp" in config:
                 return True
         except Exception:
             pass
@@ -269,82 +58,11 @@ def _detect_mode() -> Literal["tty", "notebook", "non-tty"]:
     return "non-tty"
 
 
-def _timestamp() -> str:
-    """Return current time as [HH:MM:SS]."""
-    return datetime.now().strftime("[%H:%M:%S]")
-
-
-def _format_duration(ms: float) -> str:
-    """Format milliseconds as a human-readable duration."""
-    if ms < 1000:
-        return f"{ms:.0f}ms"
-    return f"{ms / 1000:.1f}s"
-
-
-def _format_stats(
-    *,
-    succeeded: int = 0,
-    failures: int = 0,
-    cached: int = 0,
-    avg_ms: float | None = None,
-    inner_cache_hits: int = 0,
-    inner_cache_refreshing: int = 0,
-) -> str:
-    """Build a compact stats string like '95✓ 5✗ 10◉ ~45ms 3↩ 1↻'."""
-    parts: list[str] = []
-    if succeeded:
-        parts.append(f"{succeeded}✓")
-    if failures:
-        parts.append(f"{failures}✗")
-    if cached:
-        parts.append(f"{cached}◉")
-    if avg_ms is not None:
-        parts.append(f"~{_format_duration(avg_ms)}")
-    if inner_cache_hits:
-        parts.append(f"{inner_cache_hits}↩")
-    if inner_cache_refreshing:
-        parts.append(f"{inner_cache_refreshing}↻")
-    return " ".join(parts)
-
-
-# Milestones for map progress (percentages to log)
-_MAP_MILESTONES = frozenset({10, 25, 50, 75, 100})
-
-# Notebook HTML progress sizing (slightly compact).
-_NB_FONT_SIZE_PX = 12
-_NB_LINE_HEIGHT = 1.3
-_NB_DESC_WIDTH_PX = 168
-_NB_BAR_WIDTH_PX = 300
-_NB_BAR_HEIGHT_PX = 5
-_NB_COUNT_WIDTH_PX = 64
-_NB_ELAPSED_WIDTH_PX = 66
-_NB_STATS_MIN_WIDTH_PX = 140
-
-
-@dataclass
-class _NonTTYMapState:
-    """Track map progress for milestone logging."""
-
-    total: int = 0
-    completed: int = 0
-    name: str = ""
-    logged_milestones: set[int] = field(default_factory=set)
-
-
 class RichProgressProcessor(TypedEventProcessor, AsyncEventProcessor):
-    """Displays hierarchical progress bars using Rich.
+    """Track graph execution once and render it for the active output mode.
 
-    Tracks graph execution events and renders live progress bars with
-    proper nesting, tree structure, and per-node outcome stats.
-
-    In non-TTY environments (CI, piped output), falls back to simple
-    text milestone logging instead of Rich live progress bars.
-
-    Visual conventions (TTY mode)::
-
-        ◈ llm-pipeline  ━━━━━━━━━━  100/100  0:00:07  95✓ 5✗
-        ├─ classify     ━━━━━━━━━━  100/100  0:00:06  100✓
-        └─ generate     ━━━━━━━━━━  100/100  0:00:06  95✓ 5✗
+    Rich TTY, notebook HTML, and non-TTY logs consume the same renderer-neutral
+    state updates. Rich remains optional unless TTY mode is selected.
     """
 
     def __init__(
@@ -360,534 +78,50 @@ class RichProgressProcessor(TypedEventProcessor, AsyncEventProcessor):
             force_mode: Force output mode. "auto" detects environment.
         """
         mode = _detect_mode() if force_mode == "auto" else force_mode
-        self._tty_mode = mode in ("tty", "notebook")
-        self._notebook = mode == "notebook"
-
-        self._spans: dict[str, _SpanInfo] = {}
-        self._node_bars: dict[_NodeKey, _NodeBarInfo] = {}
+        self._tracker = _ProgressTracker()
+        self._renderer = _make_progress_renderer(mode, transient=transient)
         self._started = False
-        self._last_refresh: float = 0.0  # monotonic timestamp of last notebook refresh
-        self._refresh_dirty = False  # pending refresh not yet flushed
-        self._needs_async_flush = False  # set by _refresh_structural, cleared by on_event_async
-        self._manual_notebook_refresh = False
-        self._uses_rich_progress = False
-
-        # Tree structure: ordered child node keys per map span
-        self._map_children: dict[str, list[_NodeKey]] = {}
-
-        # Non-TTY state
-        self._nontty_map_states: dict[str, _NonTTYMapState] = {}  # span_id -> state
-
-        if mode == "tty":
-            _require_rich()
-            from rich.progress import (
-                BarColumn,
-                MofNCompleteColumn,
-                Progress,
-                SpinnerColumn,
-                TextColumn,
-                TimeElapsedColumn,
-            )
-
-            self._progress = Progress(
-                SpinnerColumn(),
-                TextColumn("{task.description}"),
-                BarColumn(),
-                MofNCompleteColumn(),
-                TimeElapsedColumn(),
-                TextColumn("{task.fields[stats]}"),
-                transient=transient,
-                auto_refresh=True,
-            )
-            self._uses_rich_progress = True
-        elif mode == "notebook":
-            self._progress = _NotebookProgress(
-                transient=transient,
-                state_key=f"notebook-progress-{int(time.time() * 1000)}",
-            )
-            # Notebook rendering is refreshed manually in a throttled way.
-            self._manual_notebook_refresh = True
-        else:
-            self._progress = None  # type: ignore[assignment]
-
-    def _print(self, msg: str) -> None:
-        """Print a plain-text message (non-TTY mode)."""
-        print(f"{_timestamp()} {msg}", flush=True)
-
-    # Minimum interval between notebook refreshes (seconds).
-    # Jupyter widget updates cost ~3-5ms each; at 100ms intervals we get
-    # smooth visuals without burning hundreds of ms on 300+ redraws.
-    _NOTEBOOK_REFRESH_INTERVAL = 0.1
-
-    def _refresh(self) -> None:
-        """Throttled refresh for notebook mode.
-
-        In TTY mode Rich auto-refreshes at ~10 Hz, so explicit refreshes
-        are unnecessary.  In notebook mode we refresh at most every 100 ms
-        to avoid flooding the IPython display protocol.
-        """
-        if not self._notebook or self._progress is None or not self._manual_notebook_refresh:
-            return
-        now = time.monotonic()
-        if now - self._last_refresh >= self._NOTEBOOK_REFRESH_INTERVAL:
-            self._progress.refresh()
-            self._last_refresh = now
-            self._refresh_dirty = False
-        else:
-            self._refresh_dirty = True
-
-    def _flush_refresh(self) -> None:
-        """Force a final refresh if any updates were throttled."""
-        if self._refresh_dirty and self._progress is not None and self._manual_notebook_refresh:
-            self._progress.refresh()
-            self._last_refresh = time.monotonic()
-            self._refresh_dirty = False
-
-    def _refresh_structural(self) -> None:
-        """Force refresh for structural changes (new bars, removed bars).
-
-        Bypasses the 100ms throttle since structural updates are infrequent
-        and must be visible immediately. Also signals the async path to yield
-        so Jupyter can flush IOPub.
-        """
-        if not self._notebook or self._progress is None:
-            return
-        self._progress.refresh()
-        self._last_refresh = time.monotonic()
-        self._refresh_dirty = False
-        self._needs_async_flush = True
 
     def _ensure_started(self) -> None:
-        """Start the Rich progress display if not already started."""
         if not self._started:
-            if self._notebook and self._uses_rich_progress:
-                _patch_rich_jupyter()
-            if self._tty_mode:
-                self._progress.start()
+            self._renderer.start()
             self._started = True
 
-    # -- Description builders --------------------------------------------------
-
-    def _make_map_description(self, name: str, depth: int) -> str:
-        """Build description for a map bar: '◈ name'."""
-        indent = "  " * depth
-        return f"{indent}◈ {name}"
-
-    def _make_child_description(self, name: str, depth: int, *, is_last: bool) -> str:
-        """Build description for a node under a map: '├─ name' or '└─ name'."""
-        indent = "  " * depth
-        branch = "└─" if is_last else "├─"
-        return f"{indent}{branch} {name}"
-
-    def _make_node_description(self, name: str, depth: int) -> str:
-        """Build description for a regular node (no map parent)."""
-        indent = "  " * depth
-        return f"{indent}{name}"
-
-    # -- Span helpers ----------------------------------------------------------
-
-    def _get_span(self, span_id: str) -> _SpanInfo:
-        """Get or create span info for a given span ID."""
-        if span_id not in self._spans:
-            self._spans[span_id] = _SpanInfo()
-        return self._spans[span_id]
-
-    def _get_depth(self, parent_span_id: str | None) -> int:
-        """Calculate depth from parent span chain."""
-        if parent_span_id is None:
-            return 0
-        parent = self._spans.get(parent_span_id)
-        if parent is None:
-            return 0
-        # If parent is a map span, depth stays the same as parent
-        if parent.is_map:
-            return parent.depth
-        # If parent is a run (non-map), add 1 for nesting
-        return parent.depth + 1
-
-    def _find_map_ancestor(self, span_id: str) -> str | None:
-        """Walk up the parent chain to find the nearest map span."""
-        info = self._spans.get(span_id)
-        if info is None:
-            return None
-        current = info.parent_span_id
-        while current is not None:
-            parent_info = self._spans.get(current)
-            if parent_info is None:
-                break
-            if parent_info.is_map:
-                return current
-            current = parent_info.parent_span_id
-        return None
-
-    def _get_node_total(self, span_id: str) -> int:
-        """Determine the total for a node bar based on map context."""
-        map_span = self._find_map_ancestor(span_id)
-        if map_span is not None:
-            return self._spans[map_span].map_size or 1
-        return 1
-
-    def _update_node_stats(self, bar: _NodeBarInfo) -> None:
-        """Recompute and push the stats field for a node bar."""
-        # Show average duration only for multi-item bars (maps), excluding cached
-        non_cached = bar.succeeded + bar.failures
-        avg_ms = bar.total_duration_ms / non_cached if non_cached > 1 else None
-        stats = _format_stats(
-            succeeded=bar.succeeded,
-            failures=bar.failures,
-            cached=bar.cached,
-            avg_ms=avg_ms,
-            inner_cache_hits=bar.inner_cache_hits,
-            inner_cache_refreshing=bar.inner_cache_refreshing,
-        )
-        self._progress.update(bar.rich_task_id, stats=stats)
-
-    def _update_map_stats(self, map_info: _SpanInfo) -> None:
-        """Recompute and push the stats field for a map bar."""
-        stats = _format_stats(succeeded=map_info.succeeded, failures=map_info.failures)
-        self._progress.update(map_info.rich_task_id, stats=stats)
-
-    # -- Tree management -------------------------------------------------------
-
-    def _register_map_child(self, map_span_id: str, key: _NodeKey, bar: _NodeBarInfo) -> str:
-        """Register a node bar as a child of a map span. Returns the description."""
-        children = self._map_children.setdefault(map_span_id, [])
-
-        # Update previous last child from └─ to ├─
-        if children:
-            prev_key = children[-1]
-            prev_bar = self._node_bars[prev_key]
-            prev_desc = self._make_child_description(prev_bar.name, prev_bar.depth, is_last=False)
-            self._progress.update(prev_bar.rich_task_id, description=prev_desc)
-
-        children.append(key)
-        return self._make_child_description(bar.name, bar.depth, is_last=True)
-
-    # -- Event handlers --------------------------------------------------------
+    def _emit(self, update: _ProgressUpdate) -> None:
+        self._renderer.emit(update)
 
     def on_run_start(self, event: RunStartEvent) -> None:
-        """Handle run start: track depth and create map bars."""
         self._ensure_started()
-        span = event.span_id
-        parent = event.parent_span_id
-
-        # New top-level run on a reused processor: clear old run state first.
-        if parent is None and self._spans and span not in self._spans:
-            self._spans.clear()
-            self._node_bars.clear()
-            self._map_children.clear()
-            self._nontty_map_states.clear()
-            self._refresh_dirty = False
-            if self._notebook and hasattr(self._progress, "reset"):
-                self._progress.reset()
-
-        info = self._get_span(span)
-        info.parent_span_id = parent
-        info.depth = self._get_depth(parent)
-        info.is_map = event.is_map
-
-        if event.is_map and event.map_size is not None:
-            info.map_size = event.map_size
-
-            # Detect and remove duplicate node bar from a GraphNode parent.
-            # When a GraphNode triggers runner.map(), we get both a NodeStartEvent
-            # (creating a 0/1 node bar) and this RunStartEvent(is_map=True).
-            # The map bar replaces the node bar at the same depth.
-            replaced_name: str | None = None
-            if parent is not None:
-                parent_info = self._spans.get(parent)
-                if parent_info is not None and parent_info.node_bar_key is not None:
-                    old_key = parent_info.node_bar_key
-                    old_bar = self._node_bars.pop(old_key, None)
-                    if old_bar is not None:
-                        replaced_name = old_bar.name
-                        # Use same depth as the removed bar
-                        info.depth = old_bar.depth
-                        # Hide in Rich TTY / remove from notebook
-                        if self._tty_mode:
-                            if self._notebook and hasattr(self._progress, "remove_task"):
-                                self._progress.remove_task(old_bar.rich_task_id)
-                            else:
-                                self._progress.update(old_bar.rich_task_id, visible=False)
-                        # Clean up _map_children references and fix tree markers
-                        for children in self._map_children.values():
-                            if old_key in children:
-                                children.remove(old_key)
-                                # Update new last child's marker from ├─ to └─
-                                if children:
-                                    last_key = children[-1]
-                                    last_bar = self._node_bars.get(last_key)
-                                    if last_bar is not None:
-                                        last_desc = self._make_child_description(last_bar.name, last_bar.depth, is_last=True)
-                                        self._progress.update(last_bar.rich_task_id, description=last_desc)
-                    parent_info.node_bar_key = None
-
-            if self._tty_mode:
-                # Use the parent node's public name if we replaced a bar, else graph name
-                bar_name = replaced_name or event.graph_name or "Map"
-                desc = self._make_map_description(bar_name, info.depth)
-                info.rich_task_id = self._progress.add_task(desc, total=event.map_size, stats="")
-                self._refresh_structural()
-            else:
-                name = replaced_name or event.graph_name or "Map"
-                self._nontty_map_states[span] = _NonTTYMapState(total=event.map_size, name=name)
-
-        # If this run is a child of a map, track the relationship
-        if parent is not None:
-            parent_info = self._spans.get(parent)
-            if parent_info is not None and parent_info.is_map:
-                info.map_parent = parent
+        self._emit(self._tracker.on_run_start(event))
 
     def on_node_start(self, event: NodeStartEvent) -> None:
-        """Handle node start: create or reuse progress bars."""
         self._ensure_started()
-        span = event.span_id
-        parent = event.parent_span_id
-
-        info = self._get_span(span)
-        info.parent_span_id = parent
-        # Node depth = run depth, +1 if inside a map (indent under map bar)
-        parent_info = self._spans.get(parent) if parent else None
-        node_depth = parent_info.depth if parent_info else 0
-        if parent_info and parent_info.map_parent:
-            node_depth += 1
-        info.depth = node_depth
-
-        key: _NodeKey = (event.graph_name, event.node_name, node_depth)
-        total = self._get_node_total(span)
-        map_span = self._find_map_ancestor(span)
-
-        # Record node bar key on span so on_run_start can find it
-        # (used to detect and remove duplicate bars for GraphNode maps)
-        info.node_bar_key = key
-
-        if self._tty_mode:
-            bar = self._node_bars.get(key)
-            if bar is None:
-                bar = _NodeBarInfo(
-                    total=total,
-                    name=event.node_name,
-                    depth=node_depth,
-                    map_span_id=map_span,
-                )
-
-                # Tree chars for map children, plain otherwise
-                desc = self._register_map_child(map_span, key, bar) if map_span else self._make_node_description(event.node_name, node_depth)
-
-                bar.rich_task_id = self._progress.add_task(desc, total=total, stats="")
-                self._node_bars[key] = bar
-                self._refresh_structural()
-            elif bar.total < total:
-                bar.total = total
-                self._progress.update(bar.rich_task_id, total=total)
-                self._refresh()
-        else:
-            # Non-TTY: log node start only for non-map runs
-            if not map_span:
-                self._print(f"▶ {event.node_name} started")
+        self._emit(self._tracker.on_node_start(event))
 
     def on_node_end(self, event: NodeEndEvent) -> None:
-        """Handle node end: advance progress bars and update stats."""
-        span = event.span_id
-        parent = event.parent_span_id
-        span_info = self._spans.get(span)
-        node_depth = span_info.depth if span_info else 0
-
-        if self._tty_mode:
-            key: _NodeKey = (event.graph_name, event.node_name, node_depth)
-            bar = self._node_bars.get(key)
-            if bar is not None:
-                if event.cached:
-                    bar.cached += 1
-                else:
-                    bar.succeeded += 1
-                    bar.total_duration_ms += event.duration_ms
-                self._progress.advance(bar.rich_task_id, 1)
-                self._update_node_stats(bar)
-                self._refresh()
-        else:
-            if not self._find_map_ancestor(span):
-                suffix = " (cached)" if event.cached else ""
-                self._print(f"✓ {event.node_name} completed{suffix}")
-
-        # Track node completions for map-item runs
-        if parent:
-            parent_info = self._spans.get(parent)
-            if parent_info is not None:
-                parent_info.node_count += 1
+        self._emit(self._tracker.on_node_end(event))
 
     def on_node_error(self, event: NodeErrorEvent) -> None:
-        """Handle node error: advance bar and update failure count."""
-        if self._tty_mode:
-            span_info = self._spans.get(event.span_id)
-            node_depth = span_info.depth if span_info else 0
-
-            key: _NodeKey = (event.graph_name, event.node_name, node_depth)
-            bar = self._node_bars.get(key)
-            if bar is not None:
-                bar.failures += 1
-                self._progress.advance(bar.rich_task_id, 1)
-                self._update_node_stats(bar)
-                self._refresh()
-        else:
-            if not self._find_map_ancestor(event.span_id):
-                self._print(f"✗ {event.node_name} FAILED")
+        self._emit(self._tracker.on_node_error(event))
 
     def on_inner_cache(self, event: InnerCacheEvent) -> None:
-        """Handle inner cache events: update live stats for the active node."""
-        if not self._tty_mode:
-            return
-        bar = None
-
-        if event.parent_span_id:
-            span_info = self._spans.get(event.parent_span_id)
-            if span_info is not None and span_info.node_bar_key is not None:
-                bar = self._node_bars.get(span_info.node_bar_key)
-
-        # Fallback for manually constructed events that omit span linkage.
-        if bar is None:
-            for key, candidate in self._node_bars.items():
-                graph_name, node_name, _ = key
-                if node_name == event.node_name and (not event.graph_name or graph_name == event.graph_name):
-                    bar = candidate
-                    break
-
-        if bar is None:
-            return
-
-        if event.hit:
-            bar.inner_cache_hits += 1
-        if event.refreshing:
-            bar.inner_cache_refreshing += 1
-        self._update_node_stats(bar)
-        self._refresh()
-
-    def _nontty_check_map_milestone(self, map_span_id: str) -> None:
-        """Log map progress at milestone percentages."""
-        state = self._nontty_map_states.get(map_span_id)
-        if state is None or state.total == 0:
-            return
-        pct = int(state.completed * 100 / state.total)
-        # Find the highest milestone we've crossed but haven't logged
-        milestone_to_log = 0
-        for m in _MAP_MILESTONES:
-            if pct >= m and m not in state.logged_milestones:
-                milestone_to_log = max(milestone_to_log, m)
-        if milestone_to_log > 0:
-            # Mark all milestones up to this one as logged
-            for m in _MAP_MILESTONES:
-                if m <= milestone_to_log:
-                    state.logged_milestones.add(m)
-            self._print(f"◈ {state.name}: {milestone_to_log}% ({state.completed}/{state.total})")
+        self._emit(self._tracker.on_inner_cache(event))
 
     def on_run_end(self, event: RunEndEvent) -> None:
-        """Handle run end: advance map bars and show completion."""
-        span_info = self._spans.get(event.span_id)
-        if span_info is None:
-            return
-
-        # If this run is a child of a map, advance the map bar
-        map_parent = span_info.map_parent
-        if map_parent:
-            map_info = self._spans.get(map_parent)
-            if map_info is not None:
-                if self._tty_mode and map_info.rich_task_id is not None:
-                    self._progress.advance(map_info.rich_task_id, 1)
-
-                    if event.status in (RunStatus.FAILED, RunStatus.PARTIAL):
-                        map_info.failures += 1
-                    elif event.status in (RunStatus.PAUSED, RunStatus.STOPPED):
-                        pass
-                    else:
-                        map_info.succeeded += 1
-                    self._update_map_stats(map_info)
-                    self._refresh()
-                elif not self._tty_mode:
-                    # Non-TTY: update map state and check milestones
-                    nontty_state = self._nontty_map_states.get(map_parent)
-                    if nontty_state is not None:
-                        nontty_state.completed += 1
-                        self._nontty_check_map_milestone(map_parent)
-
-        # If this is a root run (no parent), show completion
-        if span_info.parent_span_id is None:
-            self._flush_refresh()
-            if self._notebook:
-                self._display_themed_completion(event)
-            elif self._tty_mode:
-                if event.status == RunStatus.COMPLETED:
-                    self._progress.console.print(f"[bold green]✓ {event.graph_name or 'Run'} completed![/bold green]")
-                elif event.status == RunStatus.PARTIAL:
-                    self._progress.console.print(f"[bold yellow]◐ {event.graph_name or 'Run'} completed with failures[/bold yellow]")
-                elif event.status == RunStatus.PAUSED:
-                    self._progress.console.print(f"[bold yellow]‖ {event.graph_name or 'Run'} paused[/bold yellow]")
-                elif event.status == RunStatus.STOPPED:
-                    self._progress.console.print(f"[bold yellow]◼ {event.graph_name or 'Run'} stopped[/bold yellow]")
-                else:
-                    self._progress.console.print(f"[bold red]✗ {event.graph_name or 'Run'} failed: {event.error}[/bold red]")
-            else:
-                name = event.graph_name or "Run"
-                if event.status == RunStatus.COMPLETED:
-                    self._print(f"✓ {name} completed!")
-                elif event.status == RunStatus.PARTIAL:
-                    self._print(f"◐ {name} completed with failures")
-                elif event.status == RunStatus.PAUSED:
-                    self._print(f"‖ {name} paused")
-                elif event.status == RunStatus.STOPPED:
-                    self._print(f"◼ {name} stopped")
-                else:
-                    error_msg = f": {event.error}" if event.error else ""
-                    self._print(f"✗ {name} failed{error_msg}")
-
-    def _display_themed_completion(self, event: RunEndEvent) -> None:
-        """Display themed completion message in notebooks.
-
-        Uses CSS light-dark() so the message adapts to the notebook's
-        dark/light theme automatically.
-        """
-        from IPython.display import HTML, display
-
-        name = event.graph_name or "Run"
-        if event.status == RunStatus.COMPLETED:
-            color = STATUS_COLORS["completed"]
-            msg = f"✓ {name} completed!"
-        elif event.status == RunStatus.PARTIAL:
-            color = STATUS_COLORS["partial"]
-            msg = f"◐ {name} completed with failures"
-        elif event.status == RunStatus.PAUSED:
-            color = STATUS_COLORS["paused"]
-            msg = f"‖ {name} paused"
-        elif event.status == RunStatus.STOPPED:
-            color = STATUS_COLORS["paused"]
-            msg = f"◼ {name} stopped"
-        else:
-            color = STATUS_COLORS["failed"]
-            error_text = f": {event.error}" if event.error else ""
-            msg = f"✗ {name} failed{error_text}"
-        html = f'<div style="{FONT_SANS_STYLE}; color:{color}; font-weight:700; padding:4px 0">{msg}</div>'
-        display(HTML(theme_wrap(html)))
+        self._emit(self._tracker.on_run_end(event))
 
     def shutdown(self) -> None:
-        """Stop the Rich progress display."""
         if self._started:
-            self._flush_refresh()
-            if self._tty_mode:
-                self._progress.stop()
+            self._renderer.shutdown()
             self._started = False
 
     async def on_event_async(self, event: object) -> None:
-        """Async event handler — dispatches synchronously, yields on structural changes.
-
-        Only yields to the event loop after structural updates (bar creation/removal)
-        to flush Jupyter IOPub. High-frequency events (advance/stats) skip the yield.
-        """
+        """Dispatch synchronously, yielding only after structural notebook work."""
         self.on_event(event)
-        if self._needs_async_flush:
+        if self._renderer.take_async_flush():
             import asyncio
 
-            self._needs_async_flush = False
             await asyncio.sleep(0)
 
     async def shutdown_async(self) -> None:
-        """Async shutdown — delegates to sync cleanup."""
         self.shutdown()

--- a/src/hypergraph/events/rich_progress.py
+++ b/src/hypergraph/events/rich_progress.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Literal
 from hypergraph.events._progress_renderers import (
     _make_progress_renderer,
 )
-from hypergraph.events._progress_tracker import _ProgressTracker, _ProgressUpdate
+from hypergraph.events._progress_tracker import _ProgressTracker
 from hypergraph.events.processor import AsyncEventProcessor, TypedEventProcessor
 
 if TYPE_CHECKING:
@@ -87,28 +87,25 @@ class RichProgressProcessor(TypedEventProcessor, AsyncEventProcessor):
             self._renderer.start()
             self._started = True
 
-    def _emit(self, update: _ProgressUpdate) -> None:
-        self._renderer.emit(update)
-
     def on_run_start(self, event: RunStartEvent) -> None:
         self._ensure_started()
-        self._emit(self._tracker.on_run_start(event))
+        self._renderer.emit(self._tracker.on_run_start(event))
 
     def on_node_start(self, event: NodeStartEvent) -> None:
         self._ensure_started()
-        self._emit(self._tracker.on_node_start(event))
+        self._renderer.emit(self._tracker.on_node_start(event))
 
     def on_node_end(self, event: NodeEndEvent) -> None:
-        self._emit(self._tracker.on_node_end(event))
+        self._renderer.emit(self._tracker.on_node_end(event))
 
     def on_node_error(self, event: NodeErrorEvent) -> None:
-        self._emit(self._tracker.on_node_error(event))
+        self._renderer.emit(self._tracker.on_node_error(event))
 
     def on_inner_cache(self, event: InnerCacheEvent) -> None:
-        self._emit(self._tracker.on_inner_cache(event))
+        self._renderer.emit(self._tracker.on_inner_cache(event))
 
     def on_run_end(self, event: RunEndEvent) -> None:
-        self._emit(self._tracker.on_run_end(event))
+        self._renderer.emit(self._tracker.on_run_end(event))
 
     def shutdown(self) -> None:
         if self._started:

--- a/src/hypergraph/materialization/_hypertable.py
+++ b/src/hypergraph/materialization/_hypertable.py
@@ -7,6 +7,7 @@ from typing import Any
 from hypergraph import Graph
 from hypergraph.materialization._fingerprint import compute_definition_hash
 from hypergraph.materialization._hypertable_viz import render_hypertable
+from hypergraph.materialization._indexes import IndexPolicy
 from hypergraph.materialization._provenance import (
     Provenance,
     RebuildChildren,
@@ -139,6 +140,7 @@ class HyperTable:
         self._analyzed = False
         self._column_graphs: dict[int, Any] = {}
         self._provenance_obj: Provenance | None = None
+        self._indexes_obj: IndexPolicy | None = None
         self._journal_obj: RecipeJournal | None = None
         # Tables whose physical schema is known to hold the recipe-stamp column
         # (memoized so the additive evolution runs at most once per table).
@@ -202,12 +204,19 @@ class HyperTable:
             tuple(self._nodes),
             self._column_graphs,
         )
+        self._indexes_obj = IndexPolicy(self._store, self._spec, self._provenance_obj)
 
     @property
     def _provenance_policy(self) -> Provenance:
         if self._provenance_obj is None:
             raise RuntimeError("HyperTable provenance requested before graph analysis")
         return self._provenance_obj
+
+    @property
+    def _indexes(self) -> IndexPolicy:
+        if self._indexes_obj is None:
+            raise RuntimeError("HyperTable indexes requested before graph analysis")
+        return self._indexes_obj
 
     def _resolve_store(self):
         from hypergraph.materialization._table_store import TableStore
@@ -791,38 +800,6 @@ class HyperTable:
     # Materializing into external backends (Chroma, Azure Search) is an
     # application-layer concern, out of scope here.
 
-    def _resolve_index_table(self, on: str | None) -> TableSpec:
-        if on is None or on == self._spec.name:
-            return self._spec
-        for cs in self._spec.children:
-            if cs.name == on:
-                return cs
-        known = [self._spec.name, *(cs.name for cs in self._spec.children)]
-        raise ValueError(f"unknown table {on!r} for index; expected one of {known}")
-
-    def _index_recipe_fingerprint(self, spec: TableSpec, vector: str) -> str | None:
-        """The component-config + node-definition basis of the vector column's producing node."""
-        for c in self._provenance_policy.derived_columns(spec):
-            if c.name == vector and c.produced_by is not None:
-                return self._provenance_policy.node_recipe(c.produced_by)
-        return None
-
-    def _index_queryable_columns(self, spec: TableSpec) -> set[str]:
-        """Columns an index may reference: spec columns plus physical (metadata-evolved) ones."""
-        columns = {c.name for c in spec.columns if c.role != "internal"}
-        physical = self._store.open(self._spec, self._spec.children).get(spec.name, [])
-        columns.update(name for name in physical if not is_internal_column(name))
-        return columns
-
-    def _load_indexes(self) -> dict[str, dict[str, Any]]:
-        manifest = self._store.load_manifest(self._spec.name) or {}
-        return dict(manifest.get("indexes", {}))
-
-    def _save_indexes(self, indexes: dict[str, dict[str, Any]]) -> None:
-        manifest = self._store.load_manifest(self._spec.name) or {}
-        manifest["indexes"] = indexes
-        self._store.save_manifest(self._spec.name, manifest)
-
     def create_index(
         self,
         name: str,
@@ -834,52 +811,16 @@ class HyperTable:
     ) -> dict[str, Any]:
         """Record a named query spec: which table, which vector column, which row slice."""
         self._ensure_analyzed()
-        if not self._store.supports_manifests():
-            raise NotImplementedError(
-                f"{type(self._store).__name__} does not implement save_manifest/load_manifest, "
-                "so it cannot persist named indexes. Implement both manifest hooks to support "
-                "create_index, or use a store that does (e.g. LanceDBStore)."
-            )
-        spec = self._resolve_index_table(on)
-        if vector is None:
-            raise ValueError("create_index requires vector=<column>: v1 indexes are vector-search specs")
-        columns = self._index_queryable_columns(spec)
-        for label, col in (("vector", vector), ("text", text)):
-            if col is not None and col not in columns:
-                raise ValueError(f"{label} column {col!r} does not exist on table {spec.name!r}; known columns: {sorted(columns)}")
-        for col, _op, _val in _where_predicate(rows):
-            if col not in columns:
-                raise ValueError(f"rows filter column {col!r} does not exist on table {spec.name!r}; known columns: {sorted(columns)}")
-        index_spec = {
-            "name": name,
-            "on": spec.name,
-            "rows": rows,
-            "text": text,
-            "vector": vector,
-            "recipe_fingerprint": self._index_recipe_fingerprint(spec, vector),
-        }
-        indexes = self._load_indexes()
-        indexes[name] = index_spec
-        self._save_indexes(indexes)
-        return dict(index_spec)
+        return self._indexes.create(name, on=on, rows=rows, text=text, vector=vector)
 
     def list_indexes(self) -> list[dict[str, Any]]:
         """The persisted index specs, each with ``current``: does its recorded recipe match the recipe now?"""
         self._ensure_analyzed()
-        specs = []
-        for index_spec in self._load_indexes().values():
-            spec = self._resolve_index_table(index_spec.get("on"))
-            now = self._index_recipe_fingerprint(spec, index_spec["vector"])
-            specs.append({**index_spec, "current": now == index_spec.get("recipe_fingerprint")})
-        return specs
+        return self._indexes.list()
 
     def drop_index(self, name: str) -> None:
         self._ensure_analyzed()
-        indexes = self._load_indexes()
-        if name not in indexes:
-            raise KeyError(f"no index named {name!r}")
-        del indexes[name]
-        self._save_indexes(indexes)
+        self._indexes.drop(name)
 
     def search(
         self,
@@ -898,18 +839,7 @@ class HyperTable:
         ``station``) without minting a separate index.
         """
         self._ensure_analyzed()
-        indexes = self._load_indexes()
-        if index not in indexes:
-            raise KeyError(f"no index named {index!r}; known indexes: {sorted(indexes)}")
-        index_spec = indexes[index]
-        combined_where = [*_where_predicate(index_spec.get("rows")), *_where_predicate(where)]
-        hits = self._store.search(
-            index_spec["on"],
-            query_vector=list(query_vector),
-            vector_column=index_spec["vector"],
-            where=combined_where or None,
-            limit=limit,
-        )
+        hits = self._indexes.search(query_vector, index=index, limit=limit, where=where)
         results = []
         for row in hits:
             distance = row.pop("_distance", None)

--- a/src/hypergraph/materialization/_hypertable.py
+++ b/src/hypergraph/materialization/_hypertable.py
@@ -154,6 +154,7 @@ class HyperTable:
         self._components = _components or {}
         self._runner = _runner
         self._graph = _graph
+        self._map_over_nodes: list[Any] = []
         self._spec: TableSpec | None = None
         self._analyzed = False
         self._column_graphs: dict[int, Any] = {}
@@ -197,7 +198,7 @@ class HyperTable:
         if self._graph is not None:
             return
         plain_nodes = []
-        self._map_over_nodes = []
+        self._map_over_nodes.clear()
         for n in self._nodes:
             if hasattr(n, "_map_config") and n._map_config:
                 self._map_over_nodes.append(n)
@@ -212,7 +213,7 @@ class HyperTable:
                 self._graph = self._graph.bind(**root_binds)
 
     def _analyze_graph(self):
-        self._spec = analyze_table(self._graph, self._identity, self._components, getattr(self, "_map_over_nodes", []))
+        self._spec = analyze_table(self._graph, self._identity, self._components, self._map_over_nodes)
 
     def _resolve_store(self):
         from hypergraph.materialization._table_store import TableStore
@@ -839,7 +840,7 @@ class HyperTable:
         from hypergraph.viz.widget import render_flat_graph
 
         all_nodes = list(self._graph.nodes.values()) if isinstance(self._graph.nodes, dict) else []
-        for map_node in getattr(self, "_map_over_nodes", []):
+        for map_node in self._map_over_nodes:
             all_nodes.append(map_node)
         combined = _Graph(all_nodes, name=self._spec.name)
         if self._components:
@@ -914,7 +915,7 @@ class HyperTable:
         happens to appear first.
         """
         edges: list[tuple[str, str, tuple[str, ...]]] = []
-        map_nodes = getattr(self, "_map_over_nodes", [])
+        map_nodes = self._map_over_nodes
         for child_spec, map_node in zip(self._spec.children, map_nodes, strict=True):
             column = child_spec.map_input
             if not column:
@@ -941,7 +942,7 @@ class HyperTable:
         ir_builder then falls back to the container entrypoint (#169 behavior).
         """
         fields: dict[tuple[str, str], tuple[str, ...]] = {}
-        map_nodes = getattr(self, "_map_over_nodes", [])
+        map_nodes = self._map_over_nodes
         for child_spec, map_node in zip(self._spec.children, map_nodes, strict=True):
             if not child_spec.map_input:
                 continue

--- a/src/hypergraph/materialization/_hypertable.py
+++ b/src/hypergraph/materialization/_hypertable.py
@@ -19,11 +19,9 @@ from hypergraph.materialization._schema import (
     node_func,
 )
 from hypergraph.materialization._types import RecipeDrift, TableStatus
-from hypergraph.materialization._writes import (
-    RunGraph,
-    WriteOperation,
-    Writes,
-)
+from hypergraph.materialization._write_actions import RunGraph, WriteOperation
+from hypergraph.materialization._write_executor import WriteExecutor
+from hypergraph.materialization._writes import WritePlanner
 from hypergraph.materialization._writes import (
     dedup_child_rows as _dedup_child_rows,
 )
@@ -95,7 +93,8 @@ class HyperTable:
         self._column_graphs: dict[int, Any] = {}
         self._provenance_obj: Provenance | None = None
         self._indexes_obj: IndexPolicy | None = None
-        self._writes_obj: Writes | None = None
+        self._write_planner_obj: WritePlanner | None = None
+        self._write_executor_obj: WriteExecutor | None = None
 
     def bind(self, **components: Any) -> HyperTable:
         merged = {**self._components, **components}
@@ -152,17 +151,21 @@ class HyperTable:
             self._graph,
             self._spec,
             self._components,
-            tuple(self._nodes),
             self._column_graphs,
         )
         self._indexes_obj = IndexPolicy(self._store, self._spec, self._provenance_obj)
-        self._writes_obj = Writes(
+        self._write_planner_obj = WritePlanner(
             self._graph,
             self._spec,
             self._identity,
-            self._store,
             self._components,
             self._on_error,
+            self._provenance_obj,
+        )
+        self._write_executor_obj = WriteExecutor(
+            self._store,
+            self._spec,
+            self._identity,
             self._provenance_obj,
         )
 
@@ -179,10 +182,16 @@ class HyperTable:
         return self._indexes_obj
 
     @property
-    def _writes(self) -> Writes:
-        if self._writes_obj is None:
-            raise RuntimeError("HyperTable writes requested before graph analysis")
-        return self._writes_obj
+    def _write_planner(self) -> WritePlanner:
+        if self._write_planner_obj is None:
+            raise RuntimeError("HyperTable write planner requested before graph analysis")
+        return self._write_planner_obj
+
+    @property
+    def _write_executor(self) -> WriteExecutor:
+        if self._write_executor_obj is None:
+            raise RuntimeError("HyperTable write executor requested before graph analysis")
+        return self._write_executor_obj
 
     def _resolve_store(self):
         from hypergraph.materialization._table_store import TableStore
@@ -227,7 +236,7 @@ class HyperTable:
                         return complete.value
                     continue
             else:
-                response = self._writes.executor.apply(action)
+                response = self._write_executor.apply(action)
             try:
                 action = operation.send(response)
             except StopIteration as complete:
@@ -250,7 +259,7 @@ class HyperTable:
                         return complete.value
                     continue
             else:
-                response = self._writes.executor.apply(action)
+                response = self._write_executor.apply(action)
             try:
                 action = operation.send(response)
             except StopIteration as complete:
@@ -483,7 +492,7 @@ class HyperTable:
             def_hash = compute_definition_hash(node_func(c.produced_by))
             explained[c.name] = {
                 "provenance": def_hash,
-                "source": self._writes.journal.resolve(def_hash),
+                "source": self._write_executor.journal.resolve(def_hash),
             }
         return explained
 
@@ -495,12 +504,12 @@ class HyperTable:
         config/bound-value payload hash) and get the readable payload back.
         """
         self._ensure_analyzed()
-        return self._writes.journal.resolve(stamp)
+        return self._write_executor.journal.resolve(stamp)
 
     def journal_rows(self) -> list[dict[str, Any]]:
         """Every journaled ``(hash, kind, payload, first_seen_at)`` row — the raw recipe journal."""
         self._ensure_analyzed()
-        return self._writes.journal.rows()
+        return self._write_executor.journal.rows()
 
     def children(self, parent_id: str, *, include_status: bool = False) -> list[dict[str, Any]]:
         self._ensure_analyzed()
@@ -595,13 +604,13 @@ class HyperTable:
     def set_children(self, where: Any = None, **fields: Any) -> int:
         """Bulk metadata update for child rows matching a predicate."""
         self._ensure_analyzed()
-        operation = self._writes.plans.set_children(tuple(_where_predicate(where)), fields)
+        operation = self._write_planner.set_children(tuple(_where_predicate(where)), fields)
         return self._drive_sync(operation)
 
     def set(self, where: Any, **fields: Any) -> Any:
         """Bulk metadata update for all rows matching a predicate."""
         self._ensure_analyzed()
-        operation = self._writes.plans.set_rows(tuple(_where_predicate(where)), fields)
+        operation = self._write_planner.set_rows(tuple(_where_predicate(where)), fields)
         if self._is_async_runner():
             return self._drive_async(operation)
         return self._drive_sync(operation)
@@ -617,7 +626,7 @@ class HyperTable:
     def insert(self, *args, **kwargs) -> Any:
         self._require_runner()
         self._ensure_analyzed()
-        operation = self._writes.plans.insert(self._insert_items(*args, **kwargs))
+        operation = self._write_planner.insert(self._insert_items(*args, **kwargs))
         if self._is_async_runner():
             return self._drive_async(operation)
         return self._drive_sync(operation)
@@ -626,7 +635,7 @@ class HyperTable:
         """Update a row. Re-derives downstream if source columns changed."""
         self._require_runner()
         self._ensure_analyzed()
-        operation = self._writes.plans.update(identity_value, changes)
+        operation = self._write_planner.update(identity_value, changes)
         if self._is_async_runner():
             return self._drive_async(operation)
         return self._drive_sync(operation)
@@ -634,7 +643,7 @@ class HyperTable:
     def delete(self, identity_value: str) -> Any:
         """Delete a row and cascade-delete its children."""
         self._ensure_analyzed()
-        operation = self._writes.plans.delete(identity_value)
+        operation = self._write_planner.delete(identity_value)
         if self._is_async_runner():
             return self._drive_async(operation)
         return self._drive_sync(operation)
@@ -643,7 +652,7 @@ class HyperTable:
         """Reconcile: insert new, update changed, delete missing, skip unchanged."""
         self._require_runner()
         self._ensure_analyzed()
-        operation = self._writes.plans.sync(items)
+        operation = self._write_planner.sync(items)
         if self._is_async_runner():
             return self._drive_async(operation)
         return self._drive_sync(operation)
@@ -652,7 +661,7 @@ class HyperTable:
         """Re-derive one column for all rows using current bound components."""
         self._require_runner()
         self._ensure_analyzed()
-        operation = self._writes.plans.derive_column(column, backfill=False)
+        operation = self._write_planner.derive_column(column, backfill=False)
         if self._is_async_runner():
             return self._drive_async(operation)
         return self._drive_sync(operation)
@@ -661,7 +670,7 @@ class HyperTable:
         """Derive a new column for existing rows that have NULL."""
         self._require_runner()
         self._ensure_analyzed()
-        operation = self._writes.plans.derive_column(column, backfill=True)
+        operation = self._write_planner.derive_column(column, backfill=True)
         if self._is_async_runner():
             return self._drive_async(operation)
         return self._drive_sync(operation)

--- a/src/hypergraph/materialization/_hypertable.py
+++ b/src/hypergraph/materialization/_hypertable.py
@@ -2,27 +2,19 @@
 
 from __future__ import annotations
 
-import inspect
-import math
-import warnings
 from typing import Any
 
 from hypergraph import Graph
-from hypergraph.materialization._fingerprint import (
-    _component_config_hashes,
-    compute_child_fingerprint,
-    compute_column_provenance,
-    compute_definition_hash,
-    compute_recipe_fingerprint,
-    compute_row_fingerprint,
-    compute_table_recipe_fingerprint,
+from hypergraph.materialization._fingerprint import compute_definition_hash
+from hypergraph.materialization._hypertable_viz import render_hypertable
+from hypergraph.materialization._provenance import (
+    Provenance,
+    RebuildChildren,
+    ReconcileComplete,
+    ReconcileResult,
+    ReconcileUnavailable,
 )
-from hypergraph.materialization._recipe_journal import (
-    KIND_BOUND_VALUE,
-    KIND_COMPONENT_CONFIG,
-    KIND_NODE_SOURCE,
-    RecipeJournal,
-)
+from hypergraph.materialization._recipe_journal import RecipeJournal
 from hypergraph.materialization._schema import (
     RECIPE_COLUMN,
     STATUS_COLUMNS,
@@ -30,7 +22,6 @@ from hypergraph.materialization._schema import (
     analyze_table,
     input_names,
     is_internal_column,
-    item_schema_fields,
     node_func,
     python_type_to_arrow,
     return_type,
@@ -107,17 +98,6 @@ def _where_predicate(where: Any) -> list[tuple[str, str, Any]]:
     return list(where)
 
 
-def _split_boundary_provenance(value: Any) -> tuple[str | None, int | None]:
-    """Parse a stored boundary provenance ("<hash>#<item count>") into its parts."""
-    if not isinstance(value, str) or "#" not in value:
-        return None, None
-    prov, _, count = value.rpartition("#")
-    try:
-        return prov, int(count)
-    except ValueError:
-        return None, None
-
-
 class HyperTable:
     """A Hypergraph graph where each node output is a stored column."""
 
@@ -158,6 +138,7 @@ class HyperTable:
         self._spec: TableSpec | None = None
         self._analyzed = False
         self._column_graphs: dict[int, Any] = {}
+        self._provenance_obj: Provenance | None = None
         self._journal_obj: RecipeJournal | None = None
         # Tables whose physical schema is known to hold the recipe-stamp column
         # (memoized so the additive evolution runs at most once per table).
@@ -214,6 +195,19 @@ class HyperTable:
 
     def _analyze_graph(self):
         self._spec = analyze_table(self._graph, self._identity, self._components, self._map_over_nodes)
+        self._provenance_obj = Provenance(
+            self._graph,
+            self._spec,
+            self._components,
+            tuple(self._nodes),
+            self._column_graphs,
+        )
+
+    @property
+    def _provenance_policy(self) -> Provenance:
+        if self._provenance_obj is None:
+            raise RuntimeError("HyperTable provenance requested before graph analysis")
+        return self._provenance_obj
 
     def _resolve_store(self):
         from hypergraph.materialization._table_store import TableStore
@@ -265,20 +259,20 @@ class HyperTable:
             if col.name in outputs:
                 row[col.name] = outputs[col.name]
 
-        row["_row_fingerprint"] = self._compute_row_fingerprint(graph_inputs)
+        row["_row_fingerprint"] = self._provenance_policy.root_fingerprint(graph_inputs)
         row["_write_gen"] = write_gen
         self._stamp_recipe(row, self._spec.name)
 
         if provenances is None:
             values = {**{k: v for k, v in item.items() if k != self._identity}, **outputs}
-            provenances = {c.name: self._node_provenance(c.produced_by, values) for c in derived_cols}
+            provenances = {c.name: self._provenance_policy.node_provenance(c.produced_by, values) for c in derived_cols}
             for child_spec in self._spec.children:
-                bnode = self._boundary_node(child_spec)
+                bnode = self._provenance_policy.boundary_node(child_spec)
                 if bnode is None:
                     continue
-                prov = self._node_provenance(bnode, values)
+                prov = self._provenance_policy.node_provenance(bnode, values)
                 if prov is not None:
-                    provenances[child_spec.map_input] = self._boundary_provenance_value(prov, outputs.get(child_spec.map_input))
+                    provenances[child_spec.map_input] = self._provenance_policy.boundary_provenance_value(prov, outputs.get(child_spec.map_input))
         for name, prov in provenances.items():
             row[f"_provenance_{name}"] = prov
             node = self._provenance_node(name)
@@ -294,7 +288,7 @@ class HyperTable:
                 return c.produced_by
         for child_spec in self._spec.children:
             if child_spec.map_input == name:
-                return self._boundary_node(child_spec)
+                return self._provenance_policy.boundary_node(child_spec)
         return None
 
     def _write_error_row(
@@ -315,7 +309,7 @@ class HyperTable:
         for col in derived_cols:
             row[col.name] = None
 
-        row["_row_fingerprint"] = self._compute_row_fingerprint(graph_inputs)
+        row["_row_fingerprint"] = self._provenance_policy.root_fingerprint(graph_inputs)
         row["_write_gen"] = write_gen
         # An error row stamps the recipe it was ATTEMPTED under, so a recipe
         # change after a failure still reads as drift.
@@ -360,99 +354,7 @@ class HyperTable:
                 return return_type(c.produced_by)
         return str
 
-    # --- Per-column provenance (config-aware, value-chained) ---
-
-    def _derived_columns(self, spec: TableSpec | None = None) -> list:
-        spec = spec or self._spec
-        return [c for c in spec.columns if c.role == "derived"]
-
-    def _node_params(self, node: Any) -> Any:
-        func = node_func(node)
-        if func is not None:
-            return inspect.signature(func).parameters
-        # A GraphNode column producer has no signature; synthesize equivalent
-        # parameters from its projected input ports (cycle-internal values are
-        # not projected, so they never look like required columns) so provenance
-        # and dependency ordering treat it like any other producer.
-        params: dict[str, inspect.Parameter] = {}
-        for name in getattr(node, "inputs", ()):
-            default = inspect.Parameter.empty
-            if hasattr(node, "has_default_for") and node.has_default_for(name):
-                default = node.get_default_for(name)
-            params[name] = inspect.Parameter(name, inspect.Parameter.KEYWORD_ONLY, default=default)
-        return params
-
-    def _node_columns(self, node: Any, spec: TableSpec | None = None) -> list:
-        return [c for c in self._derived_columns(spec) if c.produced_by is node]
-
-    def _producing_node(self, column: str) -> Any:
-        for c in self._derived_columns():
-            if c.name == column:
-                return c.produced_by
-        raise KeyError(f"{column!r} is not a derived column")
-
-    def _nodes_in_dependency_order(self, spec: TableSpec | None = None) -> list:
-        """Producing nodes ordered so every node's column inputs are produced before it."""
-        derived = self._derived_columns(spec)
-        nodes: list = []
-        seen: set[int] = set()
-        for col in derived:
-            if id(col.produced_by) not in seen:
-                seen.add(id(col.produced_by))
-                nodes.append(col.produced_by)
-        derived_names = {c.name for c in derived}
-        placed: set[str] = set()
-        ordered: list = []
-        remaining = list(nodes)
-        while remaining:
-            progressed = False
-            for n in list(remaining):
-                deps = {p for p in self._node_params(n) if p in derived_names}
-                if deps <= placed:
-                    ordered.append(n)
-                    placed.update(c.name for c in self._node_columns(n, spec))
-                    remaining.remove(n)
-                    progressed = True
-            if not progressed:
-                ordered.extend(remaining)
-                break
-        return ordered
-
-    def _node_provenance(self, node: Any, values: dict[str, Any]) -> str | None:
-        """Provenance for a node's output columns; None if a required input is unavailable."""
-        params = self._node_params(node)
-        comp = {k: v for k, v in self._components.items() if k in params}
-        inputs: dict[str, Any] = {}
-        for name, param in params.items():
-            if name in comp:
-                continue
-            if name in values:
-                inputs[name] = values[name]
-            elif param.default is inspect.Parameter.empty:
-                return None
-        return compute_column_provenance(node_func(node) or node, inputs, _component_config_hashes(comp))
-
-    def _node_recipe(self, node: Any) -> str:
-        """Recipe identity for a node: hash(node code + consumed component configs), no input values."""
-        params = self._node_params(node)
-        comp = {k: v for k, v in self._components.items() if k in params}
-        return compute_recipe_fingerprint(node_func(node) or node, _component_config_hashes(comp))
-
     # --- Per-row recipe stamp (PRD 0027: drift = a stored-column comparison) ---
-
-    def _table_stamps_recipe(self) -> bool:
-        """Only deriving tables stamp: a plain table (no derived columns, no children) has no recipe."""
-        return bool(self._derived_columns() or self._spec.children)
-
-    def _current_recipe_fingerprint(self) -> str:
-        """The root table's recipe-only fingerprint under the CURRENT code + bindings."""
-        return compute_table_recipe_fingerprint(self._graph, self._components)
-
-    def _current_child_recipe_fingerprint(self, child_spec: TableSpec) -> str:
-        """A child table's recipe-only fingerprint, scoped to the child graph (mirrors the child row fingerprint)."""
-        child_graph = child_spec.child_graph
-        valid_inputs = set(child_graph.inputs.all) if child_graph is not None and hasattr(child_graph.inputs, "all") else set()
-        return compute_table_recipe_fingerprint(child_graph, self._components, valid_inputs)
 
     def _ensure_recipe_column(self, table_name: str) -> None:
         """Additively evolve the stamp column onto a pre-stamp physical table, once.
@@ -471,20 +373,16 @@ class HyperTable:
 
     def _stamp_recipe(self, row: dict[str, Any], table_name: str, *, child_spec: TableSpec | None = None) -> None:
         """Stamp the recipe-only fingerprint onto a row being assembled for write."""
-        if not self._table_stamps_recipe():
+        if not self._provenance_policy.table_stamps_recipe():
             return
         if child_spec is not None:
             if child_spec.child_graph is None:
                 return
-            fingerprint = self._current_child_recipe_fingerprint(child_spec)
+            fingerprint = self._provenance_policy.current_child_recipe_fingerprint(child_spec)
         else:
-            fingerprint = self._current_recipe_fingerprint()
+            fingerprint = self._provenance_policy.current_recipe_fingerprint()
         self._ensure_recipe_column(table_name)
         row[RECIPE_COLUMN] = fingerprint
-
-    def _row_missing_stamp(self, row: dict[str, Any]) -> bool:
-        stamp = row.get(RECIPE_COLUMN)
-        return self._table_stamps_recipe() and (not isinstance(stamp, str) or not stamp)
 
     def _refresh_missing_stamps(self, existing: dict[str, Any]) -> None:
         """Stamp a fingerprint-proven-current row (and its provable children) without deriving.
@@ -517,8 +415,8 @@ class HyperTable:
                 stamp = row.get(RECIPE_COLUMN)
                 if isinstance(stamp, str) and stamp:
                     continue
-                proven = row.get("_row_fingerprint") == self._compute_child_fingerprint(
-                    self._child_source_inputs_from_row(row, child_spec), child_spec
+                proven = row.get("_row_fingerprint") == self._provenance_policy.child_fingerprint(
+                    self._provenance_policy.child_source_inputs(row, child_spec), child_spec
                 )
                 if not proven:
                     continue
@@ -549,14 +447,14 @@ class HyperTable:
         root = self._table_recipe_drift(
             self._spec.name,
             self._identity,
-            self._current_recipe_fingerprint(),
+            self._provenance_policy.current_recipe_fingerprint(),
             child=False,
         )
         children = tuple(
             self._table_recipe_drift(
                 child_spec.name,
                 child_spec.identity,
-                self._current_child_recipe_fingerprint(child_spec),
+                self._provenance_policy.current_child_recipe_fingerprint(child_spec),
                 child=True,
             )
             for child_spec in self._spec.children
@@ -615,203 +513,54 @@ class HyperTable:
         under its payload hash. The returned definition hash is the key
         ``explain`` hands a reader to resolve the source.
         """
-        func = node_func(node)
-        def_hash = compute_definition_hash(func)
-        self._journal.record(def_hash, KIND_NODE_SOURCE, self._node_source(func))
-        params = self._node_params(node)
-        for name, comp in self._components.items():
-            if name not in params:
-                continue
-            payload, kind = self._component_payload(comp)
-            if payload is not None:
-                self._journal.record(compute_definition_hash(payload), kind, payload)
-        return def_hash
-
-    @staticmethod
-    def _node_source(func: Any) -> str:
-        try:
-            return inspect.getsource(func)
-        except (OSError, TypeError):
-            return repr(func)
-
-    @staticmethod
-    def _component_payload(comp: Any) -> tuple[str | None, str]:
-        """The readable recipe text a component contributes, plus its journal kind.
-
-        A component config (``_config()``/``__component_config__``) journals its
-        repr; a bound plain value (scalar/list/dict) journals its stable payload.
-        Objects without either contribute nothing to the fingerprint, so they
-        journal nothing — mirrors ``_component_config_hashes`` exactly.
-        """
-        config = getattr(comp, "__component_config__", None) or (comp._config() if hasattr(comp, "_config") else None)
-        if config is not None:
-            return str(config), KIND_COMPONENT_CONFIG
-        from hypergraph.materialization._fingerprint import _plain_value_payload
-
-        plain = _plain_value_payload(comp)
-        if plain is not None:
-            return plain, KIND_BOUND_VALUE
-        return None, KIND_BOUND_VALUE
-
-    def _column_graph(self, node: Any) -> Any:
-        """A cached single-node graph for column-scoped execution."""
-        graph = self._column_graphs.get(id(node))
-        if graph is None:
-            column_label = getattr(node_func(node), "__name__", None) or getattr(node, "name", "column")
-            graph = Graph([node], name=f"{self._spec.name}__{column_label}")
-            binds = {k: v for k, v in self._components.items() if k in set(graph.inputs.all)}
-            if binds:
-                graph = graph.bind(**binds)
-            self._column_graphs[id(node)] = graph
-        return graph
-
-    def _node_inputs(self, node: Any, values: dict[str, Any]) -> dict[str, Any]:
-        return {name: values[name] for name in self._node_params(node) if name not in self._components and name in values}
-
-    def _run_column_node(self, node: Any, values: dict[str, Any]) -> dict[str, Any]:
-        return self._extract_outputs(self._runner.run(self._column_graph(node), **self._node_inputs(node, values)))
-
-    async def _run_column_node_async(self, node: Any, values: dict[str, Any]) -> dict[str, Any]:
-        return self._extract_outputs(await self._runner.run(self._column_graph(node), **self._node_inputs(node, values)))
-
-    def _stored_values(self, row: dict[str, Any]) -> dict[str, Any]:
-        return {k: _normalize_value(v) for k, v in row.items() if not is_internal_column(k)}
-
-    def _node_is_fresh(self, node: Any, prov: str, existing: dict[str, Any], spec: TableSpec | None = None) -> bool:
-        return all(
-            existing.get(f"_provenance_{c.name}") == prov and not self._column_is_null(existing.get(c.name)) for c in self._node_columns(node, spec)
-        )
-
-    def _boundary_node(self, child_spec: TableSpec) -> Any:
-        """The root-graph node whose output is the child spec's mapped-items list."""
-        if not child_spec.map_input:
-            return None
-        nodes_dict = self._graph.nodes if isinstance(self._graph.nodes, dict) else {}
-        for n in nodes_dict.values():
-            if child_spec.map_input in (n.data_outputs if hasattr(n, "data_outputs") else ()):
-                return n
-        return None
+        entries = self._provenance_policy.recipe_entries(node)
+        for entry in entries:
+            self._journal.record(entry.hash, entry.kind, entry.payload)
+        return entries[0].hash
 
     def _stored_child_count(self, child_spec: TableSpec, parent_id: Any) -> int:
         rows = self._store.read_rows(child_spec.name, [("_parent_id", "eq", parent_id)])
         return len(_dedup_child_rows(rows, child_spec.identity))
 
-    def _boundary_provenance_value(self, prov: str, items: Any) -> str:
-        """Stored boundary provenance: recipe hash + how many items it produced.
+    def _start_reconcile(self, item: dict[str, Any], existing: dict[str, Any], spec: TableSpec | None = None):
+        target = spec or self._spec
+        boundary_counts = {child_spec.name: self._stored_child_count(child_spec, item[target.identity]) for child_spec in target.children}
+        incoming = {key: value for key, value in item.items() if key != target.identity}
+        return self._provenance_policy.start_reconcile(target, existing, incoming, boundary_counts)
 
-        The count is checked against the stored child rows on reconcile, so a
-        lost child row (crash leftover) forces the boundary node to re-run.
-        """
-        count = len(items) if isinstance(items, list) else 0
-        return f"{prov}#{count}"
-
-    def _boundary_freshness(
-        self, child_spec: TableSpec, item: dict[str, Any], existing: dict[str, Any], values: dict[str, Any]
-    ) -> tuple[Any, str, Any, bool] | None:
-        """Decide whether stored child rows can stand in for a boundary-node run.
-
-        Returns ``(boundary_node, provenance, stored_value, fresh)``, or None when
-        the boundary can't be reconciled column-scoped (full-run fallback).
-        """
-        bnode = self._boundary_node(child_spec)
-        if bnode is None or any(c.produced_by is bnode for c in self._derived_columns()):
-            return None
-        prov = self._node_provenance(bnode, values)
-        if prov is None:
-            return None
-        stored = existing.get(f"_provenance_{child_spec.map_input}")
-        stored_prov, stored_count = _split_boundary_provenance(stored)
-        fresh = stored_prov == prov and stored_count == self._stored_child_count(child_spec, item[self._identity])
-        return bnode, prov, stored, fresh
-
-    def _reconcile_columns(self, item: dict[str, Any], existing: dict[str, Any]) -> tuple[dict[str, Any], dict[str, str], dict[str, Any]] | None:
-        """Column-scoped upsert: reuse fresh columns, re-derive stale ones from stored upstream values.
-
-        Returns (outputs, provenances, child_plan), or None when a required input
-        is unavailable — the caller falls back to a full graph run. A child_plan
-        entry of None means: rebuild the mapped items from stored child rows
-        instead of re-running the boundary node.
-        """
-        values = self._stored_values(existing)
-        values.update({k: v for k, v in item.items() if k != self._identity})
-        outputs: dict[str, Any] = {}
-        provenances: dict[str, str] = {}
-        for node in self._nodes_in_dependency_order():
-            prov = self._node_provenance(node, values)
-            if prov is None:
+    def _reconcile_columns(self, item: dict[str, Any], existing: dict[str, Any], spec: TableSpec | None = None) -> ReconcileResult | None:
+        """Execute only runner calls requested by the shared pure reconcile plan."""
+        state = self._start_reconcile(item, existing, spec)
+        while True:
+            state, step = self._provenance_policy.next_reconcile_step(state)
+            if isinstance(step, ReconcileUnavailable):
                 return None
-            if self._node_is_fresh(node, prov, existing):
-                node_outputs = {c.name: _normalize_value(existing[c.name]) for c in self._node_columns(node)}
-            else:
-                node_outputs = self._run_column_node(node, values)
-            for c in self._node_columns(node):
-                if c.name in node_outputs:
-                    outputs[c.name] = node_outputs[c.name]
-                    values[c.name] = node_outputs[c.name]
-                provenances[c.name] = prov
-        child_plan: dict[str, Any] = {}
-        for child_spec in self._spec.children:
-            state = self._boundary_freshness(child_spec, item, existing, values)
-            if state is None:
-                return None
-            bnode, prov, stored, fresh = state
-            if fresh:
-                provenances[child_spec.map_input] = stored
-                child_plan[child_spec.name] = None
-            else:
-                items = self._run_column_node(bnode, values).get(child_spec.map_input)
-                items = items if isinstance(items, list) else []
-                provenances[child_spec.map_input] = self._boundary_provenance_value(prov, items)
-                child_plan[child_spec.name] = items
-        return outputs, provenances, child_plan
+            if isinstance(step, ReconcileComplete):
+                return step.result
+            node_outputs = self._extract_outputs(
+                self._runner.run(
+                    self._provenance_policy.column_graph(step.node),
+                    **step.input_values(),
+                )
+            )
+            state = self._provenance_policy.apply_reconcile_result(state, step, node_outputs)
 
-    async def _reconcile_columns_async(
-        self, item: dict[str, Any], existing: dict[str, Any]
-    ) -> tuple[dict[str, Any], dict[str, str], dict[str, Any]] | None:
-        """Async twin of ``_reconcile_columns`` — identical except the awaited node runs."""
-        values = self._stored_values(existing)
-        values.update({k: v for k, v in item.items() if k != self._identity})
-        outputs: dict[str, Any] = {}
-        provenances: dict[str, str] = {}
-        for node in self._nodes_in_dependency_order():
-            prov = self._node_provenance(node, values)
-            if prov is None:
+    async def _reconcile_columns_async(self, item: dict[str, Any], existing: dict[str, Any], spec: TableSpec | None = None) -> ReconcileResult | None:
+        """Async color of the same plan; only the requested runner call is awaited."""
+        state = self._start_reconcile(item, existing, spec)
+        while True:
+            state, step = self._provenance_policy.next_reconcile_step(state)
+            if isinstance(step, ReconcileUnavailable):
                 return None
-            if self._node_is_fresh(node, prov, existing):
-                node_outputs = {c.name: _normalize_value(existing[c.name]) for c in self._node_columns(node)}
-            else:
-                node_outputs = await self._run_column_node_async(node, values)
-            for c in self._node_columns(node):
-                if c.name in node_outputs:
-                    outputs[c.name] = node_outputs[c.name]
-                    values[c.name] = node_outputs[c.name]
-                provenances[c.name] = prov
-        child_plan: dict[str, Any] = {}
-        for child_spec in self._spec.children:
-            state = self._boundary_freshness(child_spec, item, existing, values)
-            if state is None:
-                return None
-            bnode, prov, stored, fresh = state
-            if fresh:
-                provenances[child_spec.map_input] = stored
-                child_plan[child_spec.name] = None
-            else:
-                boundary_outputs = await self._run_column_node_async(bnode, values)
-                items = boundary_outputs.get(child_spec.map_input)
-                items = items if isinstance(items, list) else []
-                provenances[child_spec.map_input] = self._boundary_provenance_value(prov, items)
-                child_plan[child_spec.name] = items
-        return outputs, provenances, child_plan
-
-    def _row_converged(self, row: dict[str, Any]) -> bool:
-        """All derived columns present with provenance matching the current recipe."""
-        values = self._stored_values(row)
-        for node in self._nodes_in_dependency_order():
-            prov = self._node_provenance(node, values)
-            for c in self._node_columns(node):
-                if prov is None or self._column_is_null(row.get(c.name)) or row.get(f"_provenance_{c.name}") != prov:
-                    return False
-        return True
+            if isinstance(step, ReconcileComplete):
+                return step.result
+            node_outputs = self._extract_outputs(
+                await self._runner.run(
+                    self._provenance_policy.column_graph(step.node),
+                    **step.input_values(),
+                )
+            )
+            state = self._provenance_policy.apply_reconcile_result(state, step, node_outputs)
 
     # --- Public API ---
 
@@ -834,134 +583,14 @@ class HyperTable:
 
     def visualize(self, *, include_children: bool = True, **kwargs) -> Any:
         self._ensure_analyzed()
-        if not include_children or not self._spec.children:
-            return self._graph.visualize(**kwargs)
-        from hypergraph.graph import Graph as _Graph
-        from hypergraph.viz.widget import render_flat_graph
-
-        all_nodes = list(self._graph.nodes.values()) if isinstance(self._graph.nodes, dict) else []
-        for map_node in self._map_over_nodes:
-            all_nodes.append(map_node)
-        combined = _Graph(all_nodes, name=self._spec.name)
-        if self._components:
-            valid_inputs = set(combined.inputs.all)
-            binds = {k: v for k, v in self._components.items() if k in valid_inputs}
-            if binds:
-                combined = combined.bind(**binds)
-
-        # The parent→mapped-child edge that auto-wiring can't infer: the mapped
-        # GraphNode consumes the parent's list column (map_input) through the
-        # derive lane, not through a name-matched input port, so no edge exists
-        # in the combined graph. Inject it as a viz-only fan-out edge here — the
-        # only place that holds both the producing node and the child spec.
-        extra_edges = self._fanout_viz_edges()
-
-        # `combined` is a throwaway Graph built fresh for this render (never
-        # cached, never the runtime graph), so mutating its nx_graph in place
-        # is safe. It must carry the same edges as the flat graph below:
-        # LayoutEstimator sizes off `combined.nx_graph`, not the flat graph, so
-        # without this the fan-out edge would render correctly but the iframe
-        # would still be sized as if the mapped node were a disconnected root
-        # (wrong width/height, e.g. clipped output).
-        for src_id, tgt_id, value_names in extra_edges:
-            if src_id in combined.nx_graph.nodes and tgt_id in combined.nx_graph.nodes and not combined.nx_graph.has_edge(src_id, tgt_id):
-                combined.nx_graph.add_edge(src_id, tgt_id, edge_type="data", value_names=list(value_names), is_map=True)
-
-        show_external_inputs = kwargs.pop("show_external_inputs", None)
-        show_inputs = kwargs.pop("show_inputs", None)
-        if show_external_inputs is not None:
-            if show_inputs is not None and show_inputs != show_external_inputs:
-                raise TypeError("Pass either show_inputs or show_external_inputs, not both.")
-            warnings.warn(
-                "show_external_inputs is deprecated; use show_inputs instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            show_inputs = show_external_inputs
-        if show_inputs is None:
-            show_inputs = True
-        kwargs.setdefault("depth", 1)
-
-        flat_graph = combined.to_flat_graph(extra_edges=extra_edges)
-
-        # Tag each injected fan-out edge with the mapped item's schema fields.
-        # The ir_builder reads ``map_fields`` to re-route the edge into the
-        # matching inner INPUT pill(s) when the container is expanded, and to
-        # mark those pills as map-fed (see ir_builder._build_ir_edge). Kept off
-        # ``extra_edges`` so ``to_flat_graph`` stays a generic viz affordance.
-        map_fields = self._fanout_map_fields()
-        for (src_id, tgt_id), field_names in map_fields.items():
-            if flat_graph.has_edge(src_id, tgt_id):
-                flat_graph[src_id][tgt_id]["map_fields"] = list(field_names)
-
-        return render_flat_graph(flat_graph, combined, show_inputs=show_inputs, **kwargs)
-
-    def _fanout_viz_edges(self) -> list[tuple[str, str, tuple[str, ...]]]:
-        """Viz-only ``(producer, mapped_node, (column,))`` edges for each child.
-
-        Pairs each child spec with the mapped GraphNode that maps its column and
-        the root node that produces that column, using hierarchical ids that
-        match ``to_flat_graph``. Empty when a producer or map node can't be
-        found, so viz degrades to the pre-fix disconnected view rather than
-        raising.
-
-        ``self._spec.children`` is built by ``analyze_table`` as
-        ``[_analyze_map_over(map_node, ...) for map_node in self._map_over_nodes]``
-        (one ``TableSpec`` per map node, same order, never filtered) — so the two
-        lists are always the same length and positionally aligned. Pairing by
-        position (rather than matching on ``column`` name) is required to keep
-        two children that map the *same* column name correctly attached to
-        their own map node instead of both resolving to whichever map node
-        happens to appear first.
-        """
-        edges: list[tuple[str, str, tuple[str, ...]]] = []
-        map_nodes = self._map_over_nodes
-        for child_spec, map_node in zip(self._spec.children, map_nodes, strict=True):
-            column = child_spec.map_input
-            if not column:
-                continue
-            producer = self._boundary_node(child_spec)
-            if producer is None:
-                continue
-            edges.append((producer.name, map_node.name, (column,)))
-        return edges
-
-    def _fanout_map_fields(self) -> dict[tuple[str, str], tuple[str, ...]]:
-        """``(producer, mapped_node) -> item-schema field names`` for each child.
-
-        The viz uses these to re-route the fan-out edge, when the container is
-        expanded, into the inner INPUT pill(s) fed by an item field — so the
-        unpack ``segment_pages ──pages──▶ [page_text] ──▶ embed_page`` is
-        visible instead of the edge landing on ``embed_page`` beside a
-        free-floating ``page_text`` input pill.
-
-        Field discovery priority (matches the fingerprinting/schema lanes):
-        the map node's ``_map_config["schema"]`` if set, else the producing
-        node's return annotation (``list[PageItem]`` where ``PageItem`` is a
-        TypedDict). A schema with no fields (``list[str]``) yields ``()`` — the
-        ir_builder then falls back to the container entrypoint (#169 behavior).
-        """
-        fields: dict[tuple[str, str], tuple[str, ...]] = {}
-        map_nodes = self._map_over_nodes
-        for child_spec, map_node in zip(self._spec.children, map_nodes, strict=True):
-            if not child_spec.map_input:
-                continue
-            producer = self._boundary_node(child_spec)
-            if producer is None:
-                continue
-            config = getattr(map_node, "_map_config", None) or {}
-            schema = config.get("schema")
-            if schema is None:
-                # ``return_type`` resolves the producer's annotation, which can
-                # raise on an unresolved forward reference. Viz must degrade to
-                # entrypoint routing on a valid table, never crash — so treat an
-                # unresolvable annotation as "no discoverable fields".
-                try:
-                    schema = return_type(producer)
-                except Exception:
-                    schema = None
-            fields[(producer.name, map_node.name)] = item_schema_fields(schema)
-        return fields
+        return render_hypertable(
+            self._graph,
+            self._spec,
+            self._map_over_nodes,
+            self._components,
+            include_children=include_children,
+            options=kwargs,
+        )
 
     def _read_projected(self, table_name: str, columns: list[str], where: Any = None) -> list[dict[str, Any]]:
         """Read only ``columns`` when the store can project; otherwise full rows.
@@ -1003,7 +632,7 @@ class HyperTable:
         root = self._classify_rows(
             rows,
             identity=self._identity,
-            fingerprint_of=lambda row: self._compute_row_fingerprint(self._source_inputs_from_row(row)),
+            fingerprint_of=lambda row: self._provenance_policy.root_fingerprint(self._source_inputs_from_row(row)),
             on_stale=lambda row: self._count_stale_columns(row, stale_column_counts),
         )
         children = tuple(self._child_status(child_spec) for child_spec in self._spec.children)
@@ -1016,11 +645,11 @@ class HyperTable:
 
     def _count_stale_columns(self, row: dict[str, Any], counts: dict[str, int], spec: TableSpec | None = None) -> None:
         """Attribute a stale row to the specific columns whose provenance no longer matches."""
-        values = self._stored_values(row)
-        for node in self._nodes_in_dependency_order(spec):
-            prov = self._node_provenance(node, values)
-            for c in self._node_columns(node, spec):
-                if prov is None or self._column_is_null(row.get(c.name)) or row.get(f"_provenance_{c.name}") != prov:
+        values = self._provenance_policy.stored_values(row)
+        for node in self._provenance_policy.nodes_in_dependency_order(spec):
+            prov = self._provenance_policy.node_provenance(node, values)
+            for c in self._provenance_policy.node_columns(node, spec):
+                if prov is None or self._provenance_policy.column_is_null(row.get(c.name)) or row.get(f"_provenance_{c.name}") != prov:
                     counts[c.name] = counts.get(c.name, 0) + 1
 
     def _child_status(self, child_spec: TableSpec) -> TableStatus:
@@ -1029,7 +658,9 @@ class HyperTable:
         counts = self._classify_rows(
             rows,
             identity=child_spec.identity,
-            fingerprint_of=lambda row: self._compute_child_fingerprint(self._child_source_inputs_from_row(row, child_spec), child_spec),
+            fingerprint_of=lambda row: self._provenance_policy.child_fingerprint(
+                self._provenance_policy.child_source_inputs(row, child_spec), child_spec
+            ),
             on_stale=lambda row: self._count_stale_columns(row, stale_column_counts, spec=child_spec),
         )
         return TableStatus(table=child_spec.name, stale_columns=tuple(sorted(stale_column_counts.items())), **counts)
@@ -1096,7 +727,7 @@ class HyperTable:
         if row is None:
             raise KeyError(identity_value)
         explained: dict[str, dict[str, str | None]] = {}
-        for c in self._derived_columns():
+        for c in self._provenance_policy.derived_columns():
             if c.produced_by is None:
                 continue
             def_hash = compute_definition_hash(node_func(c.produced_by))
@@ -1171,9 +802,9 @@ class HyperTable:
 
     def _index_recipe_fingerprint(self, spec: TableSpec, vector: str) -> str | None:
         """The component-config + node-definition basis of the vector column's producing node."""
-        for c in self._derived_columns(spec):
+        for c in self._provenance_policy.derived_columns(spec):
             if c.name == vector and c.produced_by is not None:
-                return self._node_recipe(c.produced_by)
+                return self._provenance_policy.node_recipe(c.produced_by)
         return None
 
     def _index_queryable_columns(self, spec: TableSpec) -> set[str]:
@@ -1400,7 +1031,7 @@ class HyperTable:
         """
         existing = self._store.read_one(self._spec.name, self._identity, item[self._identity])
         parent_skipped = False
-        if existing is not None and existing.get("_row_fingerprint") == self._compute_row_fingerprint(graph_inputs):
+        if existing is not None and existing.get("_row_fingerprint") == self._provenance_policy.root_fingerprint(graph_inputs):
             status = existing.get("_status")
             parent_skipped = status is None or status == "complete"
         return existing, parent_skipped
@@ -1435,7 +1066,7 @@ class HyperTable:
         item: dict[str, Any],
         graph_inputs: dict[str, Any],
         existing: dict[str, Any],
-        reconciled: tuple[dict[str, Any], dict[str, str], dict[str, Any]],
+        reconciled: ReconcileResult,
         parent_skipped: bool,
         write_gen: int,
     ) -> str:
@@ -1445,17 +1076,19 @@ class HyperTable:
         column must be persisted for a pre-provenance row); a skipped parent's
         stored row is left untouched so its old generation is never cleaned away.
         """
-        outputs, provenances, child_plan = reconciled
+        outputs = reconciled.output_values()
+        provenances = reconciled.provenance_values()
         identity_value = item[self._identity]
-        for child_spec in self._spec.children:
-            items = child_plan.get(child_spec.name)
-            if items is None:
-                items = self._rebuild_child_items(child_spec, identity_value)
+        for child_selection in reconciled.children:
+            child_spec = child_selection.spec
+            items = (
+                self._rebuild_child_items(child_spec, identity_value) if isinstance(child_selection, RebuildChildren) else list(child_selection.items)
+            )
             self._insert_children_items(identity_value, items, child_spec, write_gen)
         prov_changed = any(existing.get(f"_provenance_{name}") != prov for name, prov in provenances.items())
         # A pre-stamp parent row that reconciled clean is provably current:
         # rewrite it so the recipe stamp lands (same rule as provenance repair).
-        if not parent_skipped or prov_changed or self._row_missing_stamp(existing):
+        if not parent_skipped or prov_changed or self._provenance_policy.row_missing_stamp(existing, RECIPE_COLUMN):
             self._evolve_for_metadata(item)
             row = self._build_row(item, graph_inputs, outputs, write_gen, provenances=provenances)
             row["_status"] = "complete"
@@ -1470,22 +1103,24 @@ class HyperTable:
         item: dict[str, Any],
         graph_inputs: dict[str, Any],
         existing: dict[str, Any],
-        reconciled: tuple[dict[str, Any], dict[str, str], dict[str, Any]],
+        reconciled: ReconcileResult,
         parent_skipped: bool,
         write_gen: int,
     ) -> str:
         """Async twin of ``_apply_reconciled`` — identical except the awaited child runs."""
-        outputs, provenances, child_plan = reconciled
+        outputs = reconciled.output_values()
+        provenances = reconciled.provenance_values()
         identity_value = item[self._identity]
-        for child_spec in self._spec.children:
-            items = child_plan.get(child_spec.name)
-            if items is None:
-                items = self._rebuild_child_items(child_spec, identity_value)
+        for child_selection in reconciled.children:
+            child_spec = child_selection.spec
+            items = (
+                self._rebuild_child_items(child_spec, identity_value) if isinstance(child_selection, RebuildChildren) else list(child_selection.items)
+            )
             await self._insert_children_items_async(identity_value, items, child_spec, write_gen)
         prov_changed = any(existing.get(f"_provenance_{name}") != prov for name, prov in provenances.items())
         # A pre-stamp parent row that reconciled clean is provably current:
         # rewrite it so the recipe stamp lands (same rule as provenance repair).
-        if not parent_skipped or prov_changed or self._row_missing_stamp(existing):
+        if not parent_skipped or prov_changed or self._provenance_policy.row_missing_stamp(existing, RECIPE_COLUMN):
             self._evolve_for_metadata(item)
             row = self._build_row(item, graph_inputs, outputs, write_gen, provenances=provenances)
             row["_status"] = "complete"
@@ -1501,7 +1136,7 @@ class HyperTable:
         graph_inputs = self._extract_graph_inputs(item)
         existing, parent_skipped = self._plan_insert(item, graph_inputs)
         if parent_skipped and not self._spec.children:
-            if self._row_missing_stamp(existing):
+            if self._provenance_policy.row_missing_stamp(existing, RECIPE_COLUMN):
                 self._refresh_missing_stamps(existing)
             return "skipped"
 
@@ -1557,7 +1192,7 @@ class HyperTable:
         graph_inputs = self._extract_graph_inputs(item)
         existing, parent_skipped = self._plan_insert(item, graph_inputs)
         if parent_skipped and not self._spec.children:
-            if self._row_missing_stamp(existing):
+            if self._provenance_policy.row_missing_stamp(existing, RECIPE_COLUMN):
                 self._refresh_missing_stamps(existing)
             return "skipped"
 
@@ -1634,7 +1269,7 @@ class HyperTable:
         child_inputs = {
             col.name: child_item[col.name] for col in child_spec.columns if col.role == "source" and col.content_key and col.name in child_item
         }
-        new_fingerprint = self._compute_child_fingerprint(child_inputs, child_spec)
+        new_fingerprint = self._provenance_policy.child_fingerprint(child_inputs, child_spec)
 
         existing_children = self._store.read_rows(
             child_spec.name,
@@ -1646,7 +1281,7 @@ class HyperTable:
             if status is None or status == "complete":
                 bumped = dict(existing_child)
                 bumped["_write_gen"] = write_gen
-                if self._row_missing_stamp(bumped):
+                if self._provenance_policy.row_missing_stamp(bumped, RECIPE_COLUMN):
                     # The unchanged fingerprint proves this child current under
                     # today's child recipe — stamp the rewrite (pre-stamp store).
                     self._stamp_recipe(bumped, child_spec.name, child_spec=child_spec)
@@ -1694,9 +1329,9 @@ class HyperTable:
     def _child_provenances(self, child_spec: TableSpec, values: dict[str, Any]) -> dict[str, str]:
         """Per-column provenance for a child row, from the inner graph's nodes."""
         provenances: dict[str, str] = {}
-        for node in self._nodes_in_dependency_order(child_spec):
-            prov = self._node_provenance(node, values)
-            for c in self._node_columns(node, child_spec):
+        for node in self._provenance_policy.nodes_in_dependency_order(child_spec):
+            prov = self._provenance_policy.node_provenance(node, values)
+            for c in self._provenance_policy.node_columns(node, child_spec):
                 provenances[c.name] = prov
         return provenances
 
@@ -1729,23 +1364,9 @@ class HyperTable:
         Returns the new child row, or None when a required input is unavailable —
         the caller falls back to a full child-graph run.
         """
-        values = self._stored_values(existing_child)
-        values.update(child_item)
-        outputs: dict[str, Any] = {}
-        provenances: dict[str, str] = {}
-        for node in self._nodes_in_dependency_order(child_spec):
-            prov = self._node_provenance(node, values)
-            if prov is None:
-                return None
-            if self._node_is_fresh(node, prov, existing_child, child_spec):
-                node_outputs = {c.name: _normalize_value(existing_child[c.name]) for c in self._node_columns(node, child_spec)}
-            else:
-                node_outputs = self._run_column_node(node, values)
-            for c in self._node_columns(node, child_spec):
-                if c.name in node_outputs:
-                    outputs[c.name] = node_outputs[c.name]
-                    values[c.name] = node_outputs[c.name]
-                provenances[c.name] = prov
+        reconciled = self._reconcile_columns(child_item, existing_child, child_spec)
+        if reconciled is None:
+            return None
         child_identity = child_item.get(child_spec.identity, "")
         return self._child_row(
             child_spec,
@@ -1756,8 +1377,8 @@ class HyperTable:
             write_gen,
             status="complete",
             error=None,
-            outputs=outputs,
-            provenances=provenances,
+            outputs=reconciled.output_values(),
+            provenances=reconciled.provenance_values(),
         )
 
     async def _reconcile_child_row_async(
@@ -1770,23 +1391,9 @@ class HyperTable:
         write_gen: int,
     ) -> dict[str, Any] | None:
         """Async twin of ``_reconcile_child_row`` — identical except the awaited node runs."""
-        values = self._stored_values(existing_child)
-        values.update(child_item)
-        outputs: dict[str, Any] = {}
-        provenances: dict[str, str] = {}
-        for node in self._nodes_in_dependency_order(child_spec):
-            prov = self._node_provenance(node, values)
-            if prov is None:
-                return None
-            if self._node_is_fresh(node, prov, existing_child, child_spec):
-                node_outputs = {c.name: _normalize_value(existing_child[c.name]) for c in self._node_columns(node, child_spec)}
-            else:
-                node_outputs = await self._run_column_node_async(node, values)
-            for c in self._node_columns(node, child_spec):
-                if c.name in node_outputs:
-                    outputs[c.name] = node_outputs[c.name]
-                    values[c.name] = node_outputs[c.name]
-                provenances[c.name] = prov
+        reconciled = await self._reconcile_columns_async(child_item, existing_child, child_spec)
+        if reconciled is None:
+            return None
         child_identity = child_item.get(child_spec.identity, "")
         return self._child_row(
             child_spec,
@@ -1797,8 +1404,8 @@ class HyperTable:
             write_gen,
             status="complete",
             error=None,
-            outputs=outputs,
-            provenances=provenances,
+            outputs=reconciled.output_values(),
+            provenances=reconciled.provenance_values(),
         )
 
     def _insert_children(self, parent_id: str, outputs: dict, child_spec: TableSpec, write_gen: int) -> None:
@@ -2067,7 +1674,7 @@ class HyperTable:
         return {str(row[self._identity]): row for row in rows if row.get(self._identity) is not None}
 
     def _row_unchanged(self, item: dict[str, Any], existing: dict[str, Any]) -> bool:
-        return existing.get("_row_fingerprint") == self._compute_row_fingerprint(self._extract_graph_inputs(item))
+        return existing.get("_row_fingerprint") == self._provenance_policy.root_fingerprint(self._extract_graph_inputs(item))
 
     def _error_row_for(self, id_val: str) -> ErrorRow | None:
         """Build an ErrorRow from the persisted error row for a failed identity."""
@@ -2101,7 +1708,7 @@ class HyperTable:
                 else:
                     inserted += 1
             elif self._row_unchanged(item, existing):
-                if self._row_missing_stamp(existing):
+                if self._provenance_policy.row_missing_stamp(existing, RECIPE_COLUMN):
                     # A pre-stamp row the fingerprint match just proved current:
                     # stamp it (and its provable children) — no derive.
                     self._refresh_missing_stamps(existing)
@@ -2138,7 +1745,7 @@ class HyperTable:
                 else:
                     inserted += 1
             elif self._row_unchanged(item, existing):
-                if self._row_missing_stamp(existing):
+                if self._provenance_policy.row_missing_stamp(existing, RECIPE_COLUMN):
                     self._refresh_missing_stamps(existing)
                 skipped += 1
             else:
@@ -2167,16 +1774,16 @@ class HyperTable:
         stale so the pending cascade stays visible.
         """
         new_row = {k: _normalize_value(v) for k, v in existing.items()}
-        for c in self._node_columns(node):
+        for c in self._provenance_policy.node_columns(node):
             if c.name in node_outputs:
                 new_row[c.name] = node_outputs[c.name]
-        prov = self._node_provenance(node, self._stored_values(new_row))
-        for c in self._node_columns(node):
+        prov = self._provenance_policy.node_provenance(node, self._provenance_policy.stored_values(new_row))
+        for c in self._provenance_policy.node_columns(node):
             new_row[f"_provenance_{c.name}"] = prov
         self._record_node_recipe(node)
         new_row["_write_gen"] = write_gen
-        if self._row_converged(new_row):
-            new_row["_row_fingerprint"] = self._compute_row_fingerprint(self._source_inputs_from_row(new_row))
+        if self._provenance_policy.row_converged(new_row):
+            new_row["_row_fingerprint"] = self._provenance_policy.root_fingerprint(self._source_inputs_from_row(new_row))
             # Same convergence rule for the recipe stamp: a partially-current
             # row keeps its OLD stamp so recipe_drift keeps reporting it.
             self._stamp_recipe(new_row, self._spec.name)
@@ -2200,10 +1807,6 @@ class HyperTable:
                 {column: python_type_to_arrow(col_type), f"_provenance_{column}": python_type_to_arrow(str)},
             )
 
-    @staticmethod
-    def _column_is_null(value: Any) -> bool:
-        return value is None or (isinstance(value, float) and math.isnan(value))
-
     def recompute(self, column: str) -> Any:
         """Re-derive one column for all rows using current bound components."""
         self._require_runner()
@@ -2213,17 +1816,29 @@ class HyperTable:
         return self._recompute_sync(column)
 
     def _recompute_sync(self, column: str) -> None:
-        node = self._producing_node(column)
+        node = self._provenance_policy.producing_node(column)
         write_gen = self._store.max_write_gen(self._spec.name) + 1
         for existing in _dedup_rows(self._store.read_rows(self._spec.name), self._identity):
-            node_outputs = self._run_column_node(node, self._stored_values(existing))
+            values = self._provenance_policy.stored_values(existing)
+            node_outputs = self._extract_outputs(
+                self._runner.run(
+                    self._provenance_policy.column_graph(node),
+                    **self._provenance_policy.node_inputs(node, values),
+                )
+            )
             self._persist_node_outputs(existing, node, node_outputs, write_gen)
 
     async def _recompute_async(self, column: str) -> None:
-        node = self._producing_node(column)
+        node = self._provenance_policy.producing_node(column)
         write_gen = self._store.max_write_gen(self._spec.name) + 1
         for existing in _dedup_rows(self._store.read_rows(self._spec.name), self._identity):
-            node_outputs = await self._run_column_node_async(node, self._stored_values(existing))
+            values = self._provenance_policy.stored_values(existing)
+            node_outputs = self._extract_outputs(
+                await self._runner.run(
+                    self._provenance_policy.column_graph(node),
+                    **self._provenance_policy.node_inputs(node, values),
+                )
+            )
             self._persist_node_outputs(existing, node, node_outputs, write_gen)
 
     def backfill(self, column: str) -> Any:
@@ -2236,28 +1851,32 @@ class HyperTable:
 
     def _backfill_sync(self, column: str) -> None:
         self._evolve_for_backfill_column(column)
-        node = self._producing_node(column)
+        node = self._provenance_policy.producing_node(column)
         write_gen = self._store.max_write_gen(self._spec.name) + 1
         for existing in _dedup_rows(self._store.read_rows(self._spec.name), self._identity):
-            if not self._column_is_null(existing.get(column)):
+            if not self._provenance_policy.column_is_null(existing.get(column)):
                 continue
-            node_outputs = self._run_column_node(node, self._stored_values(existing))
+            values = self._provenance_policy.stored_values(existing)
+            node_outputs = self._extract_outputs(
+                self._runner.run(
+                    self._provenance_policy.column_graph(node),
+                    **self._provenance_policy.node_inputs(node, values),
+                )
+            )
             self._persist_node_outputs(existing, node, node_outputs, write_gen)
 
     async def _backfill_async(self, column: str) -> None:
         self._evolve_for_backfill_column(column)
-        node = self._producing_node(column)
+        node = self._provenance_policy.producing_node(column)
         write_gen = self._store.max_write_gen(self._spec.name) + 1
         for existing in _dedup_rows(self._store.read_rows(self._spec.name), self._identity):
-            if not self._column_is_null(existing.get(column)):
+            if not self._provenance_policy.column_is_null(existing.get(column)):
                 continue
-            node_outputs = await self._run_column_node_async(node, self._stored_values(existing))
+            values = self._provenance_policy.stored_values(existing)
+            node_outputs = self._extract_outputs(
+                await self._runner.run(
+                    self._provenance_policy.column_graph(node),
+                    **self._provenance_policy.node_inputs(node, values),
+                )
+            )
             self._persist_node_outputs(existing, node, node_outputs, write_gen)
-
-    # --- Fingerprint and provenance ---
-
-    def _compute_row_fingerprint(self, graph_inputs: dict) -> str:
-        return compute_row_fingerprint(self._graph, self._components, graph_inputs)
-
-    def _compute_child_fingerprint(self, child_inputs: dict, child_spec: TableSpec) -> str:
-        return compute_child_fingerprint(child_spec.child_graph, self._components, child_inputs)

--- a/src/hypergraph/materialization/_hypertable.py
+++ b/src/hypergraph/materialization/_hypertable.py
@@ -10,72 +10,30 @@ from hypergraph.materialization._hypertable_viz import render_hypertable
 from hypergraph.materialization._indexes import IndexPolicy
 from hypergraph.materialization._provenance import (
     Provenance,
-    RebuildChildren,
-    ReconcileComplete,
-    ReconcileResult,
-    ReconcileUnavailable,
 )
-from hypergraph.materialization._recipe_journal import RecipeJournal
 from hypergraph.materialization._schema import (
     RECIPE_COLUMN,
     STATUS_COLUMNS,
     TableSpec,
     analyze_table,
-    input_names,
     is_internal_column,
     node_func,
-    python_type_to_arrow,
-    return_type,
 )
-from hypergraph.materialization._types import ErrorRow, RecipeDrift, SyncResult, TableStatus
-
-
-def _normalize_to_dict(item: Any) -> dict[str, Any]:
-    """Convert a mapped child item to a plain dict if it isn't one already."""
-    if isinstance(item, dict):
-        return item
-    if hasattr(item, "model_dump"):
-        return item.model_dump(mode="python")
-    if hasattr(item, "__dataclass_fields__"):
-        from dataclasses import asdict
-
-        return asdict(item)
-    return dict(item)
-
-
-def _normalize_value(v: Any) -> Any:
-    """Convert numpy/arrow types back to Python-native for the public API."""
-    import numpy as np
-
-    if isinstance(v, np.ndarray):
-        return v.tolist()
-    if isinstance(v, (np.floating, np.integer)):
-        return v.item()
-    return v
-
-
-def _dedup_rows(rows: list[dict[str, Any]], identity: str) -> list[dict[str, Any]]:
-    """Keep only the highest _write_gen per identity (crash-leftover dedup)."""
-    best: dict[str, dict[str, Any]] = {}
-    for row in rows:
-        id_val = str(row.get(identity, ""))
-        existing = best.get(id_val)
-        if existing is None or row.get("_write_gen", 0) > existing.get("_write_gen", 0):
-            best[id_val] = row
-    return list(best.values())
-
-
-def _dedup_child_rows(rows: list[dict[str, Any]], identity: str) -> list[dict[str, Any]]:
-    """Keep only the highest _write_gen per parent+child identity."""
-    best: dict[tuple[str, str], dict[str, Any]] = {}
-    for row in rows:
-        id_val = str(row.get(identity, ""))
-        parent_val = str(row.get("_parent_id", ""))
-        key = (parent_val, id_val)
-        existing = best.get(key)
-        if existing is None or row.get("_write_gen", 0) > existing.get("_write_gen", 0):
-            best[key] = row
-    return list(best.values())
+from hypergraph.materialization._types import RecipeDrift, TableStatus
+from hypergraph.materialization._writes import (
+    RunGraph,
+    WriteOperation,
+    Writes,
+)
+from hypergraph.materialization._writes import (
+    dedup_child_rows as _dedup_child_rows,
+)
+from hypergraph.materialization._writes import (
+    dedup_rows as _dedup_rows,
+)
+from hypergraph.materialization._writes import (
+    normalize_value as _normalize_value,
+)
 
 
 def _public_row(row: dict[str, Any], *, include_status: bool = False) -> dict[str, Any]:
@@ -141,10 +99,7 @@ class HyperTable:
         self._column_graphs: dict[int, Any] = {}
         self._provenance_obj: Provenance | None = None
         self._indexes_obj: IndexPolicy | None = None
-        self._journal_obj: RecipeJournal | None = None
-        # Tables whose physical schema is known to hold the recipe-stamp column
-        # (memoized so the additive evolution runs at most once per table).
-        self._recipe_column_ready: set[str] = set()
+        self._writes_obj: Writes | None = None
 
     def bind(self, **components: Any) -> HyperTable:
         merged = {**self._components, **components}
@@ -205,6 +160,15 @@ class HyperTable:
             self._column_graphs,
         )
         self._indexes_obj = IndexPolicy(self._store, self._spec, self._provenance_obj)
+        self._writes_obj = Writes(
+            self._graph,
+            self._spec,
+            self._identity,
+            self._store,
+            self._components,
+            self._on_error,
+            self._provenance_obj,
+        )
 
     @property
     def _provenance_policy(self) -> Provenance:
@@ -217,6 +181,12 @@ class HyperTable:
         if self._indexes_obj is None:
             raise RuntimeError("HyperTable indexes requested before graph analysis")
         return self._indexes_obj
+
+    @property
+    def _writes(self) -> Writes:
+        if self._writes_obj is None:
+            raise RuntimeError("HyperTable writes requested before graph analysis")
+        return self._writes_obj
 
     def _resolve_store(self):
         from hypergraph.materialization._table_store import TableStore
@@ -237,13 +207,6 @@ class HyperTable:
 
     # --- Shared helpers ---
 
-    def _graph_required_inputs(self) -> set[str]:
-        return input_names(self._graph.inputs.required)
-
-    def _extract_graph_inputs(self, item: dict[str, Any]) -> dict[str, Any]:
-        required = self._graph_required_inputs()
-        return {k: v for k, v in item.items() if k != self._identity and k in required}
-
     def _extract_outputs(self, result: Any) -> dict[str, Any]:
         if hasattr(result, "values") and isinstance(result.values, dict):
             return result.values
@@ -251,196 +214,51 @@ class HyperTable:
             return result
         return {}
 
-    def _build_row(
-        self,
-        item: dict[str, Any],
-        graph_inputs: dict[str, Any],
-        outputs: dict[str, Any],
-        write_gen: int,
-        provenances: dict[str, str] | None = None,
-    ) -> dict[str, Any]:
-        identity_value = item[self._identity]
-        row: dict[str, Any] = {self._identity: identity_value}
-        row.update({k: v for k, v in item.items() if k != self._identity})
-
-        derived_cols = [c for c in self._spec.columns if c.role == "derived"]
-        for col in derived_cols:
-            if col.name in outputs:
-                row[col.name] = outputs[col.name]
-
-        row["_row_fingerprint"] = self._provenance_policy.root_fingerprint(graph_inputs)
-        row["_write_gen"] = write_gen
-        self._stamp_recipe(row, self._spec.name)
-
-        if provenances is None:
-            values = {**{k: v for k, v in item.items() if k != self._identity}, **outputs}
-            provenances = {c.name: self._provenance_policy.node_provenance(c.produced_by, values) for c in derived_cols}
-            for child_spec in self._spec.children:
-                bnode = self._provenance_policy.boundary_node(child_spec)
-                if bnode is None:
+    def _drive_sync(self, operation: WriteOperation) -> Any:
+        """Execute one shared write plan with a synchronous runner."""
+        try:
+            action = next(operation)
+        except StopIteration as complete:
+            return complete.value
+        while True:
+            if isinstance(action, RunGraph):
+                try:
+                    response = self._extract_outputs(self._runner.run(action.graph, **action.input_values()))
+                except Exception as error:
+                    try:
+                        action = operation.throw(error)
+                    except StopIteration as complete:
+                        return complete.value
                     continue
-                prov = self._provenance_policy.node_provenance(bnode, values)
-                if prov is not None:
-                    provenances[child_spec.map_input] = self._provenance_policy.boundary_provenance_value(prov, outputs.get(child_spec.map_input))
-        for name, prov in provenances.items():
-            row[f"_provenance_{name}"] = prov
-            node = self._provenance_node(name)
-            if node is not None:
-                self._record_node_recipe(node)
+            else:
+                response = self._writes.executor.apply(action)
+            try:
+                action = operation.send(response)
+            except StopIteration as complete:
+                return complete.value
 
-        return row
-
-    def _provenance_node(self, name: str) -> Any:
-        """The node behind a root provenance column: a derived node, or a boundary node."""
-        for c in self._spec.columns:
-            if c.role == "derived" and c.name == name:
-                return c.produced_by
-        for child_spec in self._spec.children:
-            if child_spec.map_input == name:
-                return self._provenance_policy.boundary_node(child_spec)
-        return None
-
-    def _write_error_row(
-        self,
-        item: dict[str, Any],
-        graph_inputs: dict[str, Any],
-        write_gen: int,
-        error: Exception,
-        existing: dict[str, Any] | None,
-    ) -> None:
-        identity_value = item[self._identity]
-        self._evolve_for_metadata(item)
-
-        row: dict[str, Any] = {self._identity: identity_value}
-        row.update({k: v for k, v in item.items() if k != self._identity})
-
-        derived_cols = [c for c in self._spec.columns if c.role == "derived"]
-        for col in derived_cols:
-            row[col.name] = None
-
-        row["_row_fingerprint"] = self._provenance_policy.root_fingerprint(graph_inputs)
-        row["_write_gen"] = write_gen
-        # An error row stamps the recipe it was ATTEMPTED under, so a recipe
-        # change after a failure still reads as drift.
-        self._stamp_recipe(row, self._spec.name)
-        row["_status"] = "error"
-        row["_error"] = f"{type(error).__name__}: {error}"
-
-        self._store.write_rows(self._spec.name, [row])
-
-        if existing is not None:
-            self._store.delete_rows(
-                self._spec.name,
-                [
-                    (self._identity, "eq", identity_value),
-                    ("_write_gen", "lt", write_gen),
-                ],
-            )
-
-    def _evolve_for_metadata(self, item: dict[str, Any], *, table_name: str | None = None, identity: str | None = None) -> None:
-        """Add schema columns for metadata keys the store hasn't seen."""
-        store = self._store
-        target = table_name or self._spec.name
-        id_col = identity or self._identity
-        # Consult the physical schema, not a sampled row. Sampling returns nothing
-        # exactly when the table has been emptied (every row deleted), and the
-        # spec-only fallback omits metadata columns added earlier via update — so a
-        # re-inserted row would re-evolve a column the schema already holds. The
-        # store reports its real columns; only when it cannot introspect (default
-        # ``[]``) do we fall back to sampling, and evolve_schema idempotence guards
-        # that case.
-        known_cols = set(store.column_names(target))
-        if not known_cols:
-            sample = store.read_rows(target, limit=1)
-            known_cols = set(sample[0].keys()) if sample else {c.name for c in self._spec.columns}
-        new_meta = {k: python_type_to_arrow(type(v) if v is not None else str) for k, v in item.items() if k not in known_cols and k != id_col}
-        if new_meta:
-            store.evolve_schema(target, new_meta)
-
-    def _get_derived_column_type(self, column_name: str) -> type:
-        for c in self._spec.columns:
-            if c.name == column_name and c.role == "derived" and c.produced_by:
-                return return_type(c.produced_by)
-        return str
-
-    # --- Per-row recipe stamp (PRD 0027: drift = a stored-column comparison) ---
-
-    def _ensure_recipe_column(self, table_name: str) -> None:
-        """Additively evolve the stamp column onto a pre-stamp physical table, once.
-
-        Write-lane only (called from the stamping helper, never from a read
-        path), so a pre-wave store that is only ever READ keeps its schema
-        byte-identical. Idempotent through evolve_schema; memoized so the
-        schema consultation happens at most once per table per instance.
-        """
-        if table_name in self._recipe_column_ready:
-            return
-        physical = self._store.column_names(table_name)
-        if physical and RECIPE_COLUMN not in physical:
-            self._store.evolve_schema(table_name, {RECIPE_COLUMN: python_type_to_arrow(str)})
-        self._recipe_column_ready.add(table_name)
-
-    def _stamp_recipe(self, row: dict[str, Any], table_name: str, *, child_spec: TableSpec | None = None) -> None:
-        """Stamp the recipe-only fingerprint onto a row being assembled for write."""
-        if not self._provenance_policy.table_stamps_recipe():
-            return
-        if child_spec is not None:
-            if child_spec.child_graph is None:
-                return
-            fingerprint = self._provenance_policy.current_child_recipe_fingerprint(child_spec)
-        else:
-            fingerprint = self._provenance_policy.current_recipe_fingerprint()
-        self._ensure_recipe_column(table_name)
-        row[RECIPE_COLUMN] = fingerprint
-
-    def _refresh_missing_stamps(self, existing: dict[str, Any]) -> None:
-        """Stamp a fingerprint-proven-current row (and its provable children) without deriving.
-
-        A pre-stamp row whose FULL fingerprint matches today's computation was
-        provably derived under today's recipe — the fingerprint embeds the
-        recipe (node code + component hashes) alongside the inputs — so the
-        recipe-only stamp can be written truthfully with zero node runs.
-        Without this repair, a store written before stamping existed reads
-        "N rows derived under an older recipe" forever and Sync is a visible
-        no-op. A child row whose own fingerprint does NOT match stays honestly
-        unstamped (unknown) — repair never invents currency.
-        """
-        identity_value = existing[self._identity]
-        write_gen = self._store.max_write_gen(self._spec.name) + 1
-        new_row = {k: _normalize_value(v) for k, v in existing.items()}
-        self._stamp_recipe(new_row, self._spec.name)
-        new_row["_write_gen"] = write_gen
-        self._store.write_rows(self._spec.name, [new_row])
-        self._cleanup_old_parent_gens(identity_value, write_gen)
-        for child_spec in self._spec.children:
-            if child_spec.child_graph is None:
-                continue
-            child_gen = self._store.max_write_gen(child_spec.name) + 1
-            rows = _dedup_child_rows(
-                self._store.read_rows(child_spec.name, [("_parent_id", "eq", identity_value)]),
-                child_spec.identity,
-            )
-            for row in rows:
-                stamp = row.get(RECIPE_COLUMN)
-                if isinstance(stamp, str) and stamp:
+    async def _drive_async(self, operation: WriteOperation) -> Any:
+        """Execute the same write plan; only the runner action is awaited."""
+        try:
+            action = next(operation)
+        except StopIteration as complete:
+            return complete.value
+        while True:
+            if isinstance(action, RunGraph):
+                try:
+                    response = self._extract_outputs(await self._runner.run(action.graph, **action.input_values()))
+                except Exception as error:
+                    try:
+                        action = operation.throw(error)
+                    except StopIteration as complete:
+                        return complete.value
                     continue
-                proven = row.get("_row_fingerprint") == self._provenance_policy.child_fingerprint(
-                    self._provenance_policy.child_source_inputs(row, child_spec), child_spec
-                )
-                if not proven:
-                    continue
-                new_child = {k: _normalize_value(v) for k, v in row.items()}
-                self._stamp_recipe(new_child, child_spec.name, child_spec=child_spec)
-                new_child["_write_gen"] = child_gen
-                self._store.write_rows(child_spec.name, [new_child])
-                self._store.delete_rows(
-                    child_spec.name,
-                    [
-                        (child_spec.identity, "eq", row[child_spec.identity]),
-                        ("_parent_id", "eq", identity_value),
-                        ("_write_gen", "lt", child_gen),
-                    ],
-                )
+            else:
+                response = self._writes.executor.apply(action)
+            try:
+                action = operation.send(response)
+            except StopIteration as complete:
+                return complete.value
 
     def recipe_drift(self) -> RecipeDrift:
         """Which stored rows were derived under something other than today's recipe.
@@ -501,75 +319,6 @@ class HyperTable:
             else:
                 drifted += 1
         return RecipeDrift(table=table_name, total=len(rows), current=current, drifted=drifted, unknown=unknown)
-
-    # --- Recipe journal (hash -> readable recipe text) ---
-
-    @property
-    def _journal(self) -> RecipeJournal:
-        if self._journal_obj is None:
-            self._journal_obj = RecipeJournal(self._store)
-        return self._journal_obj
-
-    def _record_node_recipe(self, node: Any) -> str:
-        """Journal a node's recipe text on first sight; return its definition hash.
-
-        Called only from the WRITE assembly (``_build_row`` / ``_child_row`` /
-        ``_persist_node_outputs``) — never from ``status()`` or any read path, so
-        the read-only guarantee holds. Journals the node source under its own
-        DEFINITION hash (stable across rows — value-chained provenance is NOT
-        journaled, which is why the journal stays tiny: one payload per recipe,
-        not one per row) plus every consumed component config / bound plain value
-        under its payload hash. The returned definition hash is the key
-        ``explain`` hands a reader to resolve the source.
-        """
-        entries = self._provenance_policy.recipe_entries(node)
-        for entry in entries:
-            self._journal.record(entry.hash, entry.kind, entry.payload)
-        return entries[0].hash
-
-    def _stored_child_count(self, child_spec: TableSpec, parent_id: Any) -> int:
-        rows = self._store.read_rows(child_spec.name, [("_parent_id", "eq", parent_id)])
-        return len(_dedup_child_rows(rows, child_spec.identity))
-
-    def _start_reconcile(self, item: dict[str, Any], existing: dict[str, Any], spec: TableSpec | None = None):
-        target = spec or self._spec
-        boundary_counts = {child_spec.name: self._stored_child_count(child_spec, item[target.identity]) for child_spec in target.children}
-        incoming = {key: value for key, value in item.items() if key != target.identity}
-        return self._provenance_policy.start_reconcile(target, existing, incoming, boundary_counts)
-
-    def _reconcile_columns(self, item: dict[str, Any], existing: dict[str, Any], spec: TableSpec | None = None) -> ReconcileResult | None:
-        """Execute only runner calls requested by the shared pure reconcile plan."""
-        state = self._start_reconcile(item, existing, spec)
-        while True:
-            state, step = self._provenance_policy.next_reconcile_step(state)
-            if isinstance(step, ReconcileUnavailable):
-                return None
-            if isinstance(step, ReconcileComplete):
-                return step.result
-            node_outputs = self._extract_outputs(
-                self._runner.run(
-                    self._provenance_policy.column_graph(step.node),
-                    **step.input_values(),
-                )
-            )
-            state = self._provenance_policy.apply_reconcile_result(state, step, node_outputs)
-
-    async def _reconcile_columns_async(self, item: dict[str, Any], existing: dict[str, Any], spec: TableSpec | None = None) -> ReconcileResult | None:
-        """Async color of the same plan; only the requested runner call is awaited."""
-        state = self._start_reconcile(item, existing, spec)
-        while True:
-            state, step = self._provenance_policy.next_reconcile_step(state)
-            if isinstance(step, ReconcileUnavailable):
-                return None
-            if isinstance(step, ReconcileComplete):
-                return step.result
-            node_outputs = self._extract_outputs(
-                await self._runner.run(
-                    self._provenance_policy.column_graph(step.node),
-                    **step.input_values(),
-                )
-            )
-            state = self._provenance_policy.apply_reconcile_result(state, step, node_outputs)
 
     # --- Public API ---
 
@@ -641,7 +390,7 @@ class HyperTable:
         root = self._classify_rows(
             rows,
             identity=self._identity,
-            fingerprint_of=lambda row: self._provenance_policy.root_fingerprint(self._source_inputs_from_row(row)),
+            fingerprint_of=lambda row: self._provenance_policy.root_fingerprint(self._provenance_policy.source_inputs(row)),
             on_stale=lambda row: self._count_stale_columns(row, stale_column_counts),
         )
         children = tuple(self._child_status(child_spec) for child_spec in self._spec.children)
@@ -700,10 +449,6 @@ class HyperTable:
             "errored_ids": tuple(sorted(errored_ids)),
         }
 
-    def _child_source_inputs_from_row(self, row: dict[str, Any], child_spec: TableSpec) -> dict[str, Any]:
-        """Reconstruct a child's content-key inputs from its stored row (mirrors _plan_child)."""
-        return {c.name: _normalize_value(row[c.name]) for c in child_spec.columns if c.role == "source" and c.content_key and c.name in row}
-
     def get(self, identity_value: str, *, include_status: bool = False) -> dict[str, Any] | None:
         self._ensure_analyzed()
         row = self._store.read_one(self._spec.name, self._identity, identity_value)
@@ -740,7 +485,10 @@ class HyperTable:
             if c.produced_by is None:
                 continue
             def_hash = compute_definition_hash(node_func(c.produced_by))
-            explained[c.name] = {"provenance": def_hash, "source": self._journal.resolve(def_hash)}
+            explained[c.name] = {
+                "provenance": def_hash,
+                "source": self._writes.journal.resolve(def_hash),
+            }
         return explained
 
     def resolve_provenance(self, stamp: str) -> str | None:
@@ -751,12 +499,12 @@ class HyperTable:
         config/bound-value payload hash) and get the readable payload back.
         """
         self._ensure_analyzed()
-        return self._journal.resolve(stamp)
+        return self._writes.journal.resolve(stamp)
 
     def journal_rows(self) -> list[dict[str, Any]]:
         """Every journaled ``(hash, kind, payload, first_seen_at)`` row — the raw recipe journal."""
         self._ensure_analyzed()
-        return self._journal.rows()
+        return self._writes.journal.rows()
 
     def children(self, parent_id: str, *, include_status: bool = False) -> list[dict[str, Any]]:
         self._ensure_analyzed()
@@ -851,962 +599,73 @@ class HyperTable:
     def set_children(self, where: Any = None, **fields: Any) -> int:
         """Bulk metadata update for child rows matching a predicate."""
         self._ensure_analyzed()
-        if not self._spec.children:
-            return 0
-        child_spec = self._spec.children[0]
-        table_name = child_spec.name
-        identity = child_spec.identity
-        rows = _dedup_child_rows(
-            self._store.read_rows(table_name, _where_predicate(where)),
-            identity,
-        )
-        if not rows:
-            return 0
-        self._evolve_for_metadata(
-            {identity: rows[0][identity], **fields},
-            table_name=table_name,
-            identity=identity,
-        )
-        write_gen = self._store.max_write_gen(table_name) + 1
-        updated: list[dict[str, Any]] = []
-        for row in rows:
-            new_row = {k: _normalize_value(v) for k, v in row.items()}
-            new_row.update(fields)
-            new_row["_write_gen"] = write_gen
-            updated.append(new_row)
-        self._store.write_rows(table_name, updated)
-        for row in rows:
-            self._store.delete_rows(
-                table_name,
-                [
-                    (identity, "eq", row[identity]),
-                    ("_parent_id", "eq", row["_parent_id"]),
-                    ("_write_gen", "lt", write_gen),
-                ],
-            )
-        return len(updated)
+        operation = self._writes.plans.set_children(tuple(_where_predicate(where)), fields)
+        return self._drive_sync(operation)
 
     def set(self, where: Any, **fields: Any) -> Any:
         """Bulk metadata update for all rows matching a predicate."""
         self._ensure_analyzed()
+        operation = self._writes.plans.set_rows(tuple(_where_predicate(where)), fields)
         if self._is_async_runner():
-            return self._set_async(where, **fields)
-        return self._set_sync(where, **fields)
+            return self._drive_async(operation)
+        return self._drive_sync(operation)
 
-    def _set_sync(self, where: Any, **fields: Any) -> int:
-        content_key_fields = {c.name for c in self._spec.columns if c.content_key}
-        blocked = sorted(content_key_fields.intersection(fields))
-        if blocked:
-            raise ValueError(f"set() cannot update content-key fields: {', '.join(blocked)}")
-
-        rows = _dedup_rows(self._store.read_rows(self._spec.name, _where_predicate(where)), self._identity)
-        if not rows:
-            return 0
-
-        self._evolve_for_metadata({self._identity: rows[0][self._identity], **fields})
-        write_gen = self._store.max_write_gen(self._spec.name) + 1
-        updated_rows: list[dict[str, Any]] = []
-        for row in rows:
-            new_row = {k: _normalize_value(v) for k, v in row.items()}
-            new_row.update(fields)
-            new_row["_write_gen"] = write_gen
-            updated_rows.append(new_row)
-
-        self._store.write_rows(self._spec.name, updated_rows)
-        for row in rows:
-            self._store.delete_rows(
-                self._spec.name,
-                [
-                    (self._identity, "eq", row[self._identity]),
-                    ("_write_gen", "lt", write_gen),
-                ],
-            )
-        return len(updated_rows)
-
-    async def _set_async(self, where: Any, **fields: Any) -> int:
-        return self._set_sync(where, **fields)
-
-    def _insert_items(self, *args, **kwargs) -> list[dict[str, Any]]:
+    @staticmethod
+    def _insert_items(*args: Any, **kwargs: Any) -> list[dict[str, Any]]:
         if args and isinstance(args[0], list):
             return args[0]
         if kwargs:
             return [kwargs]
         raise ValueError("insert() requires kwargs or a list of dicts")
 
-    def insert(self, *args, **kwargs) -> Any:
+    def insert(self, *args: Any, **kwargs: Any) -> Any:
         self._require_runner()
         self._ensure_analyzed()
-        items = self._insert_items(*args, **kwargs)
+        operation = self._writes.plans.insert(self._insert_items(*args, **kwargs))
         if self._is_async_runner():
-            return self._insert_async(items)
-        return self._insert_sync(items)
-
-    def _insert_sync(self, items: list[dict[str, Any]]) -> None:
-        write_gen = self._store.max_write_gen(self._spec.name) + 1
-
-        for item in items:
-            self._insert_one(item, write_gen)
-
-    async def _insert_async(self, items: list[dict[str, Any]]) -> None:
-        write_gen = self._store.max_write_gen(self._spec.name) + 1
-
-        for item in items:
-            await self._insert_one_async(item, write_gen)
-
-    def _plan_insert(self, item: dict[str, Any], graph_inputs: dict[str, Any]) -> tuple[dict[str, Any] | None, bool]:
-        """Read the current row and decide whether the parent can be skipped.
-
-        A parent is skippable when its fingerprint is unchanged and its last write
-        completed. Returns ``(existing_row, parent_skipped)``.
-        """
-        existing = self._store.read_one(self._spec.name, self._identity, item[self._identity])
-        parent_skipped = False
-        if existing is not None and existing.get("_row_fingerprint") == self._provenance_policy.root_fingerprint(graph_inputs):
-            status = existing.get("_status")
-            parent_skipped = status is None or status == "complete"
-        return existing, parent_skipped
-
-    def _write_parent_row(self, item: dict[str, Any], graph_inputs: dict[str, Any], outputs: dict[str, Any], write_gen: int) -> None:
-        """Persist the parent row for a completed derivation."""
-        self._evolve_for_metadata(item)
-        row = self._build_row(item, graph_inputs, outputs, write_gen)
-        row["_status"] = "complete"
-        row["_error"] = None
-        self._store.write_rows(self._spec.name, [row])
-
-    def _cleanup_old_parent_gens(self, identity_value: Any, write_gen: int) -> None:
-        self._store.delete_rows(
-            self._spec.name,
-            [(self._identity, "eq", identity_value), ("_write_gen", "lt", write_gen)],
-        )
-
-    def _cleanup_old_child_gens(self, identity_value: Any, write_gen: int) -> None:
-        for child_spec in self._spec.children:
-            self._store.delete_rows(
-                child_spec.name,
-                [("_parent_id", "eq", identity_value), ("_write_gen", "lt", write_gen)],
-            )
-
-    def _can_reconcile(self, existing: dict[str, Any] | None) -> bool:
-        """Column-scoped reconcile applies to any complete (non-error) prior row."""
-        return existing is not None and existing.get("_status") != "error"
-
-    def _apply_reconciled(
-        self,
-        item: dict[str, Any],
-        graph_inputs: dict[str, Any],
-        existing: dict[str, Any],
-        reconciled: ReconcileResult,
-        parent_skipped: bool,
-        write_gen: int,
-    ) -> str:
-        """Persist a reconciled row: children first, then the parent row that vouches for them.
-
-        The parent row is rewritten only when it changed (or when a provenance
-        column must be persisted for a pre-provenance row); a skipped parent's
-        stored row is left untouched so its old generation is never cleaned away.
-        """
-        outputs = reconciled.output_values()
-        provenances = reconciled.provenance_values()
-        identity_value = item[self._identity]
-        for child_selection in reconciled.children:
-            child_spec = child_selection.spec
-            items = (
-                self._rebuild_child_items(child_spec, identity_value) if isinstance(child_selection, RebuildChildren) else list(child_selection.items)
-            )
-            self._insert_children_items(identity_value, items, child_spec, write_gen)
-        prov_changed = any(existing.get(f"_provenance_{name}") != prov for name, prov in provenances.items())
-        # A pre-stamp parent row that reconciled clean is provably current:
-        # rewrite it so the recipe stamp lands (same rule as provenance repair).
-        if not parent_skipped or prov_changed or self._provenance_policy.row_missing_stamp(existing, RECIPE_COLUMN):
-            self._evolve_for_metadata(item)
-            row = self._build_row(item, graph_inputs, outputs, write_gen, provenances=provenances)
-            row["_status"] = "complete"
-            row["_error"] = None
-            self._store.write_rows(self._spec.name, [row])
-            self._cleanup_old_parent_gens(identity_value, write_gen)
-        self._cleanup_old_child_gens(identity_value, write_gen)
-        return "skipped" if parent_skipped else "updated"
-
-    async def _apply_reconciled_async(
-        self,
-        item: dict[str, Any],
-        graph_inputs: dict[str, Any],
-        existing: dict[str, Any],
-        reconciled: ReconcileResult,
-        parent_skipped: bool,
-        write_gen: int,
-    ) -> str:
-        """Async twin of ``_apply_reconciled`` — identical except the awaited child runs."""
-        outputs = reconciled.output_values()
-        provenances = reconciled.provenance_values()
-        identity_value = item[self._identity]
-        for child_selection in reconciled.children:
-            child_spec = child_selection.spec
-            items = (
-                self._rebuild_child_items(child_spec, identity_value) if isinstance(child_selection, RebuildChildren) else list(child_selection.items)
-            )
-            await self._insert_children_items_async(identity_value, items, child_spec, write_gen)
-        prov_changed = any(existing.get(f"_provenance_{name}") != prov for name, prov in provenances.items())
-        # A pre-stamp parent row that reconciled clean is provably current:
-        # rewrite it so the recipe stamp lands (same rule as provenance repair).
-        if not parent_skipped or prov_changed or self._provenance_policy.row_missing_stamp(existing, RECIPE_COLUMN):
-            self._evolve_for_metadata(item)
-            row = self._build_row(item, graph_inputs, outputs, write_gen, provenances=provenances)
-            row["_status"] = "complete"
-            row["_error"] = None
-            self._store.write_rows(self._spec.name, [row])
-            self._cleanup_old_parent_gens(identity_value, write_gen)
-        self._cleanup_old_child_gens(identity_value, write_gen)
-        return "skipped" if parent_skipped else "updated"
-
-    def _insert_one(self, item: dict[str, Any], write_gen: int) -> str:
-        """Insert or upsert a single row. Returns 'inserted', 'updated', 'skipped', or 'errored'."""
-        identity_value = item[self._identity]
-        graph_inputs = self._extract_graph_inputs(item)
-        existing, parent_skipped = self._plan_insert(item, graph_inputs)
-        if parent_skipped and not self._spec.children:
-            if self._provenance_policy.row_missing_stamp(existing, RECIPE_COLUMN):
-                self._refresh_missing_stamps(existing)
-            return "skipped"
-
-        if self._can_reconcile(existing):
-            try:
-                reconciled = self._reconcile_columns(item, existing)
-            except Exception as e:
-                if self._on_error == "raise":
-                    raise
-                if parent_skipped:
-                    # Parent is complete and unchanged; a transient failure while
-                    # reconciling solely for the children must not downgrade the
-                    # stored-complete parent to an error row.
-                    return "skipped"
-                self._write_error_row(item, graph_inputs, write_gen, e, existing)
-                return "errored"
-            if reconciled is not None:
-                return self._apply_reconciled(item, graph_inputs, existing, reconciled, parent_skipped, write_gen)
-
-        try:
-            outputs = self._extract_outputs(self._runner.run(self._graph, **graph_inputs))
-        except Exception as e:
-            if self._on_error == "raise":
-                raise
-            if parent_skipped:
-                # Parent is complete and unchanged; a transient failure while
-                # re-deriving solely to reconcile children must not downgrade the
-                # stored-complete parent to an error row.
-                return "skipped"
-            self._write_error_row(item, graph_inputs, write_gen, e, existing)
-            return "errored"
-
-        if parent_skipped:
-            # Parent unchanged — reconcile children only (don't rewrite parent).
-            for child_spec in self._spec.children:
-                self._insert_children(identity_value, outputs, child_spec, write_gen)
-            self._cleanup_old_child_gens(identity_value, write_gen)
-            return "skipped"
-
-        # Children before the parent row: the parent row carries the boundary
-        # provenance that vouches for the stored child set, so it must land last.
-        for child_spec in self._spec.children:
-            self._insert_children(identity_value, outputs, child_spec, write_gen)
-        self._write_parent_row(item, graph_inputs, outputs, write_gen)
-        if existing is not None:
-            self._cleanup_old_parent_gens(identity_value, write_gen)
-            self._cleanup_old_child_gens(identity_value, write_gen)
-        return "updated" if existing is not None else "inserted"
-
-    async def _insert_one_async(self, item: dict[str, Any], write_gen: int) -> str:
-        """Async twin of ``_insert_one`` — identical except the awaited graph run."""
-        identity_value = item[self._identity]
-        graph_inputs = self._extract_graph_inputs(item)
-        existing, parent_skipped = self._plan_insert(item, graph_inputs)
-        if parent_skipped and not self._spec.children:
-            if self._provenance_policy.row_missing_stamp(existing, RECIPE_COLUMN):
-                self._refresh_missing_stamps(existing)
-            return "skipped"
-
-        if self._can_reconcile(existing):
-            try:
-                reconciled = await self._reconcile_columns_async(item, existing)
-            except Exception as e:
-                if self._on_error == "raise":
-                    raise
-                if parent_skipped:
-                    # Parent is complete and unchanged; a transient failure while
-                    # reconciling solely for the children must not downgrade the
-                    # stored-complete parent to an error row.
-                    return "skipped"
-                self._write_error_row(item, graph_inputs, write_gen, e, existing)
-                return "errored"
-            if reconciled is not None:
-                return await self._apply_reconciled_async(item, graph_inputs, existing, reconciled, parent_skipped, write_gen)
-
-        try:
-            outputs = self._extract_outputs(await self._runner.run(self._graph, **graph_inputs))
-        except Exception as e:
-            if self._on_error == "raise":
-                raise
-            if parent_skipped:
-                # Parent is complete and unchanged; a transient failure while
-                # re-deriving solely to reconcile children must not downgrade the
-                # stored-complete parent to an error row.
-                return "skipped"
-            self._write_error_row(item, graph_inputs, write_gen, e, existing)
-            return "errored"
-
-        if parent_skipped:
-            for child_spec in self._spec.children:
-                await self._insert_children_async(identity_value, outputs, child_spec, write_gen)
-            self._cleanup_old_child_gens(identity_value, write_gen)
-            return "skipped"
-
-        # Children before the parent row: the parent row carries the boundary
-        # provenance that vouches for the stored child set, so it must land last.
-        for child_spec in self._spec.children:
-            await self._insert_children_async(identity_value, outputs, child_spec, write_gen)
-        self._write_parent_row(item, graph_inputs, outputs, write_gen)
-        if existing is not None:
-            self._cleanup_old_parent_gens(identity_value, write_gen)
-            self._cleanup_old_child_gens(identity_value, write_gen)
-        return "updated" if existing is not None else "inserted"
-
-    def _bind_child_components(self, child_graph: Any) -> Any:
-        if not self._components:
-            return child_graph
-        valid_inputs = set(child_graph.inputs.all)
-        binds = {key: value for key, value in self._components.items() if key in valid_inputs}
-        return child_graph.bind(**binds) if binds else child_graph
-
-    def _child_items(self, outputs: dict, child_spec: TableSpec) -> list | None:
-        """The mapped child items for a child table, or None if there's nothing to process."""
-        if not child_spec.child_graph:
-            return None
-        child_items = outputs.get(child_spec.map_input)
-        if not child_items or not isinstance(child_items, list):
-            return None
-        return child_items
-
-    def _plan_child(
-        self, child_spec: TableSpec, child_item: dict[str, Any], parent_id: str, write_gen: int
-    ) -> tuple[str, dict[str, Any], str, dict[str, Any] | None] | None:
-        """Compute ``(child_identity, child_inputs, fingerprint, existing_child)`` for a child item.
-
-        If the child is unchanged and complete, bump its ``_write_gen`` so it
-        survives cleanup and return None to signal a skip.
-        """
-        child_identity = child_item.get(child_spec.identity, "")
-        child_inputs = {
-            col.name: child_item[col.name] for col in child_spec.columns if col.role == "source" and col.content_key and col.name in child_item
-        }
-        new_fingerprint = self._provenance_policy.child_fingerprint(child_inputs, child_spec)
-
-        existing_children = self._store.read_rows(
-            child_spec.name,
-            [("_parent_id", "eq", parent_id), (child_spec.identity, "eq", child_identity)],
-        )
-        existing_child = max(existing_children, key=lambda r: r.get("_write_gen", 0)) if existing_children else None
-        if existing_child is not None and existing_child.get("_row_fingerprint") == new_fingerprint:
-            status = existing_child.get("_status")
-            if status is None or status == "complete":
-                bumped = dict(existing_child)
-                bumped["_write_gen"] = write_gen
-                if self._provenance_policy.row_missing_stamp(bumped, RECIPE_COLUMN):
-                    # The unchanged fingerprint proves this child current under
-                    # today's child recipe — stamp the rewrite (pre-stamp store).
-                    self._stamp_recipe(bumped, child_spec.name, child_spec=child_spec)
-                self._store.write_rows(child_spec.name, [bumped])
-                return None
-        return child_identity, child_inputs, new_fingerprint, existing_child
-
-    def _child_row(
-        self,
-        child_spec: TableSpec,
-        child_item: dict[str, Any],
-        child_identity: str,
-        parent_id: str,
-        new_fingerprint: str,
-        write_gen: int,
-        *,
-        status: str,
-        error: str | None,
-        outputs: dict[str, Any] | None = None,
-        provenances: dict[str, str] | None = None,
-    ) -> dict[str, Any]:
-        """Assemble a child row from its source item plus (on success) its derived outputs."""
-        row = {
-            child_spec.identity: child_identity,
-            "_parent_id": parent_id,
-            "_write_gen": write_gen,
-            "_row_fingerprint": new_fingerprint,
-            "_status": status,
-            "_error": error,
-        }
-        self._stamp_recipe(row, child_spec.name, child_spec=child_spec)
-        for k, v in child_item.items():
-            if k != child_spec.identity and k != "_parent_id":
-                row[k] = v
-        for k, v in (outputs or {}).items():
-            row[k] = v
-        for name, prov in (provenances or {}).items():
-            row[f"_provenance_{name}"] = prov
-            for c in child_spec.columns:
-                if c.role == "derived" and c.name == name:
-                    self._record_node_recipe(c.produced_by)
-                    break
-        return row
-
-    def _child_provenances(self, child_spec: TableSpec, values: dict[str, Any]) -> dict[str, str]:
-        """Per-column provenance for a child row, from the inner graph's nodes."""
-        provenances: dict[str, str] = {}
-        for node in self._provenance_policy.nodes_in_dependency_order(child_spec):
-            prov = self._provenance_policy.node_provenance(node, values)
-            for c in self._provenance_policy.node_columns(node, child_spec):
-                provenances[c.name] = prov
-        return provenances
-
-    def _rebuild_child_items(self, child_spec: TableSpec, parent_id: str) -> list[dict[str, Any]]:
-        """Reconstruct the mapped items from stored child rows (source + metadata columns).
-
-        Error child rows are included — their source columns are preserved — so
-        they naturally retry.
-        """
-        rows = _dedup_child_rows(
-            self._store.read_rows(child_spec.name, [("_parent_id", "eq", parent_id)]),
-            child_spec.identity,
-        )
-        derived = {c.name for c in child_spec.columns if c.role == "derived"}
-        return [
-            {k: _normalize_value(v) for k, v in row.items() if k not in derived and k != "_parent_id" and not is_internal_column(k)} for row in rows
-        ]
-
-    def _reconcile_child_row(
-        self,
-        child_spec: TableSpec,
-        child_item: dict[str, Any],
-        existing_child: dict[str, Any],
-        parent_id: str,
-        new_fingerprint: str,
-        write_gen: int,
-    ) -> dict[str, Any] | None:
-        """Column-scoped child upsert: reuse fresh columns, re-derive stale ones.
-
-        Returns the new child row, or None when a required input is unavailable —
-        the caller falls back to a full child-graph run.
-        """
-        reconciled = self._reconcile_columns(child_item, existing_child, child_spec)
-        if reconciled is None:
-            return None
-        child_identity = child_item.get(child_spec.identity, "")
-        return self._child_row(
-            child_spec,
-            child_item,
-            child_identity,
-            parent_id,
-            new_fingerprint,
-            write_gen,
-            status="complete",
-            error=None,
-            outputs=reconciled.output_values(),
-            provenances=reconciled.provenance_values(),
-        )
-
-    async def _reconcile_child_row_async(
-        self,
-        child_spec: TableSpec,
-        child_item: dict[str, Any],
-        existing_child: dict[str, Any],
-        parent_id: str,
-        new_fingerprint: str,
-        write_gen: int,
-    ) -> dict[str, Any] | None:
-        """Async twin of ``_reconcile_child_row`` — identical except the awaited node runs."""
-        reconciled = await self._reconcile_columns_async(child_item, existing_child, child_spec)
-        if reconciled is None:
-            return None
-        child_identity = child_item.get(child_spec.identity, "")
-        return self._child_row(
-            child_spec,
-            child_item,
-            child_identity,
-            parent_id,
-            new_fingerprint,
-            write_gen,
-            status="complete",
-            error=None,
-            outputs=reconciled.output_values(),
-            provenances=reconciled.provenance_values(),
-        )
-
-    def _insert_children(self, parent_id: str, outputs: dict, child_spec: TableSpec, write_gen: int) -> None:
-        child_items = self._child_items(outputs, child_spec)
-        if child_items is None:
-            return
-        self._insert_children_items(parent_id, child_items, child_spec, write_gen)
-
-    def _insert_children_items(self, parent_id: str, child_items: list, child_spec: TableSpec, write_gen: int) -> None:
-        if child_spec.child_graph is None:
-            return
-        bound_graph = self._bind_child_components(child_spec.child_graph)
-        for raw_item in child_items:
-            child_item = _normalize_to_dict(raw_item)
-            plan = self._plan_child(child_spec, child_item, parent_id, write_gen)
-            if plan is None:
-                continue
-            child_identity, child_inputs, new_fingerprint, existing_child = plan
-            row = None
-            if existing_child is not None and existing_child.get("_status") in (None, "complete"):
-                try:
-                    row = self._reconcile_child_row(child_spec, child_item, existing_child, parent_id, new_fingerprint, write_gen)
-                except Exception as e:
-                    if self._on_error == "raise":
-                        raise
-                    row = self._child_row(
-                        child_spec,
-                        child_item,
-                        child_identity,
-                        parent_id,
-                        new_fingerprint,
-                        write_gen,
-                        status="error",
-                        error=f"{type(e).__name__}: {e}",
-                    )
-                    self._store.write_rows(child_spec.name, [row])
-                    continue
-            if row is None:
-                try:
-                    child_outputs = self._extract_outputs(self._runner.run(bound_graph, **child_inputs))
-                except Exception as e:
-                    if self._on_error == "raise":
-                        raise
-                    row = self._child_row(
-                        child_spec,
-                        child_item,
-                        child_identity,
-                        parent_id,
-                        new_fingerprint,
-                        write_gen,
-                        status="error",
-                        error=f"{type(e).__name__}: {e}",
-                    )
-                    self._store.write_rows(child_spec.name, [row])
-                    continue
-                child_values = {**child_item, **child_outputs}
-                row = self._child_row(
-                    child_spec,
-                    child_item,
-                    child_identity,
-                    parent_id,
-                    new_fingerprint,
-                    write_gen,
-                    status="complete",
-                    error=None,
-                    outputs=child_outputs,
-                    provenances=self._child_provenances(child_spec, child_values),
-                )
-            self._store.write_rows(child_spec.name, [row])
-
-    async def _insert_children_async(self, parent_id: str, outputs: dict, child_spec: TableSpec, write_gen: int) -> None:
-        child_items = self._child_items(outputs, child_spec)
-        if child_items is None:
-            return
-        await self._insert_children_items_async(parent_id, child_items, child_spec, write_gen)
-
-    async def _insert_children_items_async(self, parent_id: str, child_items: list, child_spec: TableSpec, write_gen: int) -> None:
-        if child_spec.child_graph is None:
-            return
-        bound_graph = self._bind_child_components(child_spec.child_graph)
-        for raw_item in child_items:
-            child_item = _normalize_to_dict(raw_item)
-            plan = self._plan_child(child_spec, child_item, parent_id, write_gen)
-            if plan is None:
-                continue
-            child_identity, child_inputs, new_fingerprint, existing_child = plan
-            row = None
-            if existing_child is not None and existing_child.get("_status") in (None, "complete"):
-                try:
-                    row = await self._reconcile_child_row_async(child_spec, child_item, existing_child, parent_id, new_fingerprint, write_gen)
-                except Exception as e:
-                    if self._on_error == "raise":
-                        raise
-                    row = self._child_row(
-                        child_spec,
-                        child_item,
-                        child_identity,
-                        parent_id,
-                        new_fingerprint,
-                        write_gen,
-                        status="error",
-                        error=f"{type(e).__name__}: {e}",
-                    )
-                    self._store.write_rows(child_spec.name, [row])
-                    continue
-            if row is None:
-                try:
-                    child_outputs = self._extract_outputs(await self._runner.run(bound_graph, **child_inputs))
-                except Exception as e:
-                    if self._on_error == "raise":
-                        raise
-                    row = self._child_row(
-                        child_spec,
-                        child_item,
-                        child_identity,
-                        parent_id,
-                        new_fingerprint,
-                        write_gen,
-                        status="error",
-                        error=f"{type(e).__name__}: {e}",
-                    )
-                    self._store.write_rows(child_spec.name, [row])
-                    continue
-                child_values = {**child_item, **child_outputs}
-                row = self._child_row(
-                    child_spec,
-                    child_item,
-                    child_identity,
-                    parent_id,
-                    new_fingerprint,
-                    write_gen,
-                    status="complete",
-                    error=None,
-                    outputs=child_outputs,
-                    provenances=self._child_provenances(child_spec, child_values),
-                )
-            self._store.write_rows(child_spec.name, [row])
+            return self._drive_async(operation)
+        return self._drive_sync(operation)
 
     def update(self, identity_value: str, **changes: Any) -> Any:
         """Update a row. Re-derives downstream if source columns changed."""
         self._require_runner()
         self._ensure_analyzed()
+        operation = self._writes.plans.update(identity_value, changes)
         if self._is_async_runner():
-            return self._update_async(identity_value, **changes)
-        return self._update_sync(identity_value, **changes)
-
-    def _prepare_update(self, identity_value: str, changes: dict[str, Any]) -> tuple[dict[str, Any], bool, int]:
-        existing = self._store.read_one(self._spec.name, self._identity, identity_value)
-        if existing is None:
-            raise KeyError(identity_value)
-
-        item: dict[str, Any] = {self._identity: identity_value}
-        for c in self._spec.columns:
-            if c.role == "source" and c.name in existing:
-                item[c.name] = _normalize_value(existing[c.name])
-        spec_col_names = {c.name for c in self._spec.columns}
-        for k, v in existing.items():
-            if k not in spec_col_names and not is_internal_column(k):
-                item[k] = _normalize_value(v)
-        item.update(changes)
-
-        source_names = {c.name for c in self._spec.columns if c.role == "source"}
-        needs_rederive = any(k in source_names for k in changes)
-
-        write_gen = self._store.max_write_gen(self._spec.name) + 1
-        return item, needs_rederive, write_gen
-
-    def _row_with_changes(self, identity_value: str, changes: dict[str, Any], write_gen: int) -> dict[str, Any]:
-        """Next generation of a row with metadata changes applied (no re-derivation)."""
-        existing = self._store.read_one(self._spec.name, self._identity, identity_value)
-        # A metadata-only update may introduce a brand-new column (a curated key
-        # the schema has never seen); evolve for it first, or the write would
-        # silently drop the unknown key.
-        self._evolve_for_metadata({self._identity: identity_value, **changes})
-        row = {k: _normalize_value(v) for k, v in existing.items()}
-        row.update(changes)
-        row["_write_gen"] = write_gen
-        return row
-
-    def _update_sync(self, identity_value: str, **changes: Any) -> None:
-        item, needs_rederive, write_gen = self._prepare_update(identity_value, changes)
-        if not needs_rederive:
-            row = self._row_with_changes(identity_value, changes, write_gen)
-            self._store.write_rows(self._spec.name, [row])
-            self._cleanup_old_parent_gens(identity_value, write_gen)
-            return
-
-        graph_inputs = self._extract_graph_inputs(item)
-        existing = self._store.read_one(self._spec.name, self._identity, identity_value)
-        if self._can_reconcile(existing):
-            reconciled = self._reconcile_columns(item, existing)
-            if reconciled is not None:
-                self._apply_reconciled(item, graph_inputs, existing, reconciled, parent_skipped=False, write_gen=write_gen)
-                return
-
-        outputs = self._extract_outputs(self._runner.run(self._graph, **graph_inputs))
-        self._evolve_for_metadata(item)
-        row = self._build_row(item, graph_inputs, outputs, write_gen)
-        # Write new children BEFORE the parent row and old-gen cleanup — crash-safe
-        # ordering: the parent row carries the boundary provenance that vouches
-        # for the stored child set.
-        for child_spec in self._spec.children:
-            self._insert_children(identity_value, outputs, child_spec, write_gen)
-        self._store.write_rows(self._spec.name, [row])
-        self._cleanup_old_child_gens(identity_value, write_gen)
-        self._cleanup_old_parent_gens(identity_value, write_gen)
-
-    async def _update_async(self, identity_value: str, **changes: Any) -> None:
-        item, needs_rederive, write_gen = self._prepare_update(identity_value, changes)
-        if not needs_rederive:
-            row = self._row_with_changes(identity_value, changes, write_gen)
-            self._store.write_rows(self._spec.name, [row])
-            self._cleanup_old_parent_gens(identity_value, write_gen)
-            return
-
-        graph_inputs = self._extract_graph_inputs(item)
-        existing = self._store.read_one(self._spec.name, self._identity, identity_value)
-        if self._can_reconcile(existing):
-            reconciled = await self._reconcile_columns_async(item, existing)
-            if reconciled is not None:
-                await self._apply_reconciled_async(item, graph_inputs, existing, reconciled, parent_skipped=False, write_gen=write_gen)
-                return
-
-        outputs = self._extract_outputs(await self._runner.run(self._graph, **graph_inputs))
-        self._evolve_for_metadata(item)
-        row = self._build_row(item, graph_inputs, outputs, write_gen)
-        # Write new children BEFORE the parent row and old-gen cleanup — crash-safe
-        # ordering: the parent row carries the boundary provenance that vouches
-        # for the stored child set.
-        for child_spec in self._spec.children:
-            await self._insert_children_async(identity_value, outputs, child_spec, write_gen)
-        self._store.write_rows(self._spec.name, [row])
-        self._cleanup_old_child_gens(identity_value, write_gen)
-        self._cleanup_old_parent_gens(identity_value, write_gen)
+            return self._drive_async(operation)
+        return self._drive_sync(operation)
 
     def delete(self, identity_value: str) -> Any:
         """Delete a row and cascade-delete its children."""
         self._ensure_analyzed()
+        operation = self._writes.plans.delete(identity_value)
         if self._is_async_runner():
-            return self._delete_async(identity_value)
-        return self._delete_sync(identity_value)
-
-    def _delete_sync(self, identity_value: str) -> None:
-        existing = self._store.read_one(self._spec.name, self._identity, identity_value)
-        if existing is None:
-            return
-
-        for child_spec in self._spec.children:
-            self._store.delete_rows(child_spec.name, [("_parent_id", "eq", identity_value)])
-        self._store.delete_rows(self._spec.name, [(self._identity, "eq", identity_value)])
-
-    async def _delete_async(self, identity_value: str) -> None:
-        self._delete_sync(identity_value)
+            return self._drive_async(operation)
+        return self._drive_sync(operation)
 
     def sync(self, items: list[dict[str, Any]]) -> Any:
         """Reconcile: insert new, update changed, delete missing, skip unchanged."""
         self._require_runner()
         self._ensure_analyzed()
+        operation = self._writes.plans.sync(items)
         if self._is_async_runner():
-            return self._sync_async(items)
-        return self._sync_sync(items)
-
-    def _sync_existing_index(self) -> dict[str, dict[str, Any]]:
-        """Map identity -> newest stored row, for reconciliation."""
-        rows = _dedup_rows(self._store.read_rows(self._spec.name), self._identity)
-        return {str(row[self._identity]): row for row in rows if row.get(self._identity) is not None}
-
-    def _row_unchanged(self, item: dict[str, Any], existing: dict[str, Any]) -> bool:
-        return existing.get("_row_fingerprint") == self._provenance_policy.root_fingerprint(self._extract_graph_inputs(item))
-
-    def _error_row_for(self, id_val: str) -> ErrorRow | None:
-        """Build an ErrorRow from the persisted error row for a failed identity."""
-        row = self._store.read_one(self._spec.name, self._identity, id_val)
-        if not row:
-            return None
-        err = row.get("_error", "")
-        return ErrorRow(
-            identity={self._identity: id_val},
-            error_type=err.split(":")[0] if err else "Unknown",
-            error_msg=err,
-        )
-
-    def _sync_sync(self, items: list[dict[str, Any]]) -> Any:
-        existing_by_id = self._sync_existing_index()
-        incoming_ids: set[str] = set()
-        inserted = updated = skipped = errored = 0
-        errors: list[ErrorRow] = []
-        write_gen = self._store.max_write_gen(self._spec.name) + 1
-
-        for item in items:
-            id_val = str(item[self._identity])
-            incoming_ids.add(id_val)
-            existing = existing_by_id.get(id_val)
-            if existing is None:
-                if self._insert_one(item, write_gen) == "errored":
-                    errored += 1
-                    err = self._error_row_for(id_val)
-                    if err is not None:
-                        errors.append(err)
-                else:
-                    inserted += 1
-            elif self._row_unchanged(item, existing):
-                if self._provenance_policy.row_missing_stamp(existing, RECIPE_COLUMN):
-                    # A pre-stamp row the fingerprint match just proved current:
-                    # stamp it (and its provable children) — no derive.
-                    self._refresh_missing_stamps(existing)
-                skipped += 1
-            else:
-                self.update(id_val, **{k: v for k, v in item.items() if k != self._identity})
-                updated += 1
-
-        deleted = 0
-        for id_val in existing_by_id:
-            if id_val not in incoming_ids:
-                self.delete(id_val)
-                deleted += 1
-
-        return SyncResult(inserted=inserted, updated=updated, deleted=deleted, skipped=skipped, errored=errored, errors=tuple(errors))
-
-    async def _sync_async(self, items: list[dict[str, Any]]) -> Any:
-        existing_by_id = self._sync_existing_index()
-        incoming_ids: set[str] = set()
-        inserted = updated = skipped = errored = 0
-        errors: list[ErrorRow] = []
-        write_gen = self._store.max_write_gen(self._spec.name) + 1
-
-        for item in items:
-            id_val = str(item[self._identity])
-            incoming_ids.add(id_val)
-            existing = existing_by_id.get(id_val)
-            if existing is None:
-                if await self._insert_one_async(item, write_gen) == "errored":
-                    errored += 1
-                    err = self._error_row_for(id_val)
-                    if err is not None:
-                        errors.append(err)
-                else:
-                    inserted += 1
-            elif self._row_unchanged(item, existing):
-                if self._provenance_policy.row_missing_stamp(existing, RECIPE_COLUMN):
-                    self._refresh_missing_stamps(existing)
-                skipped += 1
-            else:
-                await self._update_async(id_val, **{k: v for k, v in item.items() if k != self._identity})
-                updated += 1
-
-        deleted = 0
-        for id_val in existing_by_id:
-            if id_val not in incoming_ids:
-                await self._delete_async(id_val)
-                deleted += 1
-
-        return SyncResult(inserted=inserted, updated=updated, deleted=deleted, skipped=skipped, errored=errored, errors=tuple(errors))
-
-    # --- Column re-derivation (recompute / backfill) ---
-
-    def _source_inputs_from_row(self, existing: dict[str, Any]) -> dict[str, Any]:
-        """Reconstruct graph inputs from a stored row's source columns."""
-        return {c.name: _normalize_value(existing[c.name]) for c in self._spec.columns if c.role == "source" and c.name in existing}
-
-    def _persist_node_outputs(self, existing: dict[str, Any], node: Any, node_outputs: dict[str, Any], write_gen: int) -> None:
-        """Write a new generation of one row with the node's columns re-derived, then drop the old one.
-
-        The row fingerprint is refreshed only when every derived column now
-        matches the current recipe — a partially-current row must keep reporting
-        stale so the pending cascade stays visible.
-        """
-        new_row = {k: _normalize_value(v) for k, v in existing.items()}
-        for c in self._provenance_policy.node_columns(node):
-            if c.name in node_outputs:
-                new_row[c.name] = node_outputs[c.name]
-        prov = self._provenance_policy.node_provenance(node, self._provenance_policy.stored_values(new_row))
-        for c in self._provenance_policy.node_columns(node):
-            new_row[f"_provenance_{c.name}"] = prov
-        self._record_node_recipe(node)
-        new_row["_write_gen"] = write_gen
-        if self._provenance_policy.row_converged(new_row):
-            new_row["_row_fingerprint"] = self._provenance_policy.root_fingerprint(self._source_inputs_from_row(new_row))
-            # Same convergence rule for the recipe stamp: a partially-current
-            # row keeps its OLD stamp so recipe_drift keeps reporting it.
-            self._stamp_recipe(new_row, self._spec.name)
-
-        self._store.write_rows(self._spec.name, [new_row])
-        self._store.delete_rows(
-            self._spec.name,
-            [
-                (self._identity, "eq", existing[self._identity]),
-                ("_write_gen", "lt", write_gen),
-            ],
-        )
-
-    def _evolve_for_backfill_column(self, column: str) -> None:
-        """Add `column` (and its provenance) to the schema if it doesn't exist yet."""
-        sample = self._store.read_rows(self._spec.name, limit=1)
-        if sample and column not in sample[0]:
-            col_type = self._get_derived_column_type(column)
-            self._store.evolve_schema(
-                self._spec.name,
-                {column: python_type_to_arrow(col_type), f"_provenance_{column}": python_type_to_arrow(str)},
-            )
+            return self._drive_async(operation)
+        return self._drive_sync(operation)
 
     def recompute(self, column: str) -> Any:
         """Re-derive one column for all rows using current bound components."""
         self._require_runner()
         self._ensure_analyzed()
+        operation = self._writes.plans.derive_column(column, backfill=False)
         if self._is_async_runner():
-            return self._recompute_async(column)
-        return self._recompute_sync(column)
-
-    def _recompute_sync(self, column: str) -> None:
-        node = self._provenance_policy.producing_node(column)
-        write_gen = self._store.max_write_gen(self._spec.name) + 1
-        for existing in _dedup_rows(self._store.read_rows(self._spec.name), self._identity):
-            values = self._provenance_policy.stored_values(existing)
-            node_outputs = self._extract_outputs(
-                self._runner.run(
-                    self._provenance_policy.column_graph(node),
-                    **self._provenance_policy.node_inputs(node, values),
-                )
-            )
-            self._persist_node_outputs(existing, node, node_outputs, write_gen)
-
-    async def _recompute_async(self, column: str) -> None:
-        node = self._provenance_policy.producing_node(column)
-        write_gen = self._store.max_write_gen(self._spec.name) + 1
-        for existing in _dedup_rows(self._store.read_rows(self._spec.name), self._identity):
-            values = self._provenance_policy.stored_values(existing)
-            node_outputs = self._extract_outputs(
-                await self._runner.run(
-                    self._provenance_policy.column_graph(node),
-                    **self._provenance_policy.node_inputs(node, values),
-                )
-            )
-            self._persist_node_outputs(existing, node, node_outputs, write_gen)
+            return self._drive_async(operation)
+        return self._drive_sync(operation)
 
     def backfill(self, column: str) -> Any:
         """Derive a new column for existing rows that have NULL."""
         self._require_runner()
         self._ensure_analyzed()
+        operation = self._writes.plans.derive_column(column, backfill=True)
         if self._is_async_runner():
-            return self._backfill_async(column)
-        return self._backfill_sync(column)
-
-    def _backfill_sync(self, column: str) -> None:
-        self._evolve_for_backfill_column(column)
-        node = self._provenance_policy.producing_node(column)
-        write_gen = self._store.max_write_gen(self._spec.name) + 1
-        for existing in _dedup_rows(self._store.read_rows(self._spec.name), self._identity):
-            if not self._provenance_policy.column_is_null(existing.get(column)):
-                continue
-            values = self._provenance_policy.stored_values(existing)
-            node_outputs = self._extract_outputs(
-                self._runner.run(
-                    self._provenance_policy.column_graph(node),
-                    **self._provenance_policy.node_inputs(node, values),
-                )
-            )
-            self._persist_node_outputs(existing, node, node_outputs, write_gen)
-
-    async def _backfill_async(self, column: str) -> None:
-        self._evolve_for_backfill_column(column)
-        node = self._provenance_policy.producing_node(column)
-        write_gen = self._store.max_write_gen(self._spec.name) + 1
-        for existing in _dedup_rows(self._store.read_rows(self._spec.name), self._identity):
-            if not self._provenance_policy.column_is_null(existing.get(column)):
-                continue
-            values = self._provenance_policy.stored_values(existing)
-            node_outputs = self._extract_outputs(
-                await self._runner.run(
-                    self._provenance_policy.column_graph(node),
-                    **self._provenance_policy.node_inputs(node, values),
-                )
-            )
-            self._persist_node_outputs(existing, node, node_outputs, write_gen)
+            return self._drive_async(operation)
+        return self._drive_sync(operation)

--- a/src/hypergraph/materialization/_hypertable.py
+++ b/src/hypergraph/materialization/_hypertable.py
@@ -8,9 +8,8 @@ from hypergraph import Graph
 from hypergraph.materialization._fingerprint import compute_definition_hash
 from hypergraph.materialization._hypertable_viz import render_hypertable
 from hypergraph.materialization._indexes import IndexPolicy
-from hypergraph.materialization._provenance import (
-    Provenance,
-)
+from hypergraph.materialization._provenance import Provenance
+from hypergraph.materialization._provenance import normalize_value as _normalize_value
 from hypergraph.materialization._schema import (
     RECIPE_COLUMN,
     STATUS_COLUMNS,
@@ -30,9 +29,6 @@ from hypergraph.materialization._writes import (
 )
 from hypergraph.materialization._writes import (
     dedup_rows as _dedup_rows,
-)
-from hypergraph.materialization._writes import (
-    normalize_value as _normalize_value,
 )
 
 
@@ -618,7 +614,7 @@ class HyperTable:
             return [kwargs]
         raise ValueError("insert() requires kwargs or a list of dicts")
 
-    def insert(self, *args: Any, **kwargs: Any) -> Any:
+    def insert(self, *args, **kwargs) -> Any:
         self._require_runner()
         self._ensure_analyzed()
         operation = self._writes.plans.insert(self._insert_items(*args, **kwargs))

--- a/src/hypergraph/materialization/_hypertable_viz.py
+++ b/src/hypergraph/materialization/_hypertable_viz.py
@@ -1,0 +1,111 @@
+"""HyperTable-specific graph visualization ownership."""
+
+from __future__ import annotations
+
+import warnings
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from hypergraph.graph import Graph
+from hypergraph.materialization._provenance import find_boundary_node
+from hypergraph.materialization._schema import TableSpec, item_schema_fields, return_type
+
+
+def fanout_viz_edges(
+    graph: Any,
+    spec: TableSpec,
+    map_over_nodes: Sequence[Any],
+) -> list[tuple[str, str, tuple[str, ...]]]:
+    """Viz-only producer-to-mapped-node edges, paired by declaration order."""
+    edges: list[tuple[str, str, tuple[str, ...]]] = []
+    for child_spec, map_node in zip(spec.children, map_over_nodes, strict=True):
+        column = child_spec.map_input
+        if not column:
+            continue
+        producer = find_boundary_node(graph, child_spec)
+        if producer is None:
+            continue
+        edges.append((producer.name, map_node.name, (column,)))
+    return edges
+
+
+def fanout_map_fields(
+    graph: Any,
+    spec: TableSpec,
+    map_over_nodes: Sequence[Any],
+) -> dict[tuple[str, str], tuple[str, ...]]:
+    """Map each injected fan-out edge to fields exposed by one mapped item."""
+    fields: dict[tuple[str, str], tuple[str, ...]] = {}
+    for child_spec, map_node in zip(spec.children, map_over_nodes, strict=True):
+        if not child_spec.map_input:
+            continue
+        producer = find_boundary_node(graph, child_spec)
+        if producer is None:
+            continue
+        config = getattr(map_node, "_map_config", None) or {}
+        schema = config.get("schema")
+        if schema is None:
+            try:
+                schema = return_type(producer)
+            except Exception:
+                schema = None
+        fields[(producer.name, map_node.name)] = item_schema_fields(schema)
+    return fields
+
+
+def render_hypertable(
+    graph: Any,
+    spec: TableSpec,
+    map_over_nodes: Sequence[Any],
+    components: Mapping[str, Any],
+    *,
+    include_children: bool,
+    options: dict[str, Any],
+) -> Any:
+    """Render the compute graph plus its storage-aware mapped-child fan-outs."""
+    if not include_children or not spec.children:
+        return graph.visualize(**options)
+
+    from hypergraph.viz.widget import render_flat_graph
+
+    all_nodes = list(graph.nodes.values()) if isinstance(graph.nodes, dict) else []
+    all_nodes.extend(map_over_nodes)
+    combined = Graph(all_nodes, name=spec.name)
+    if components:
+        valid_inputs = set(combined.inputs.all)
+        binds = {name: value for name, value in components.items() if name in valid_inputs}
+        if binds:
+            combined = combined.bind(**binds)
+
+    extra_edges = fanout_viz_edges(graph, spec, map_over_nodes)
+    for source_id, target_id, value_names in extra_edges:
+        if source_id in combined.nx_graph.nodes and target_id in combined.nx_graph.nodes and not combined.nx_graph.has_edge(source_id, target_id):
+            combined.nx_graph.add_edge(
+                source_id,
+                target_id,
+                edge_type="data",
+                value_names=list(value_names),
+                is_map=True,
+            )
+
+    show_external_inputs = options.pop("show_external_inputs", None)
+    show_inputs = options.pop("show_inputs", None)
+    if show_external_inputs is not None:
+        if show_inputs is not None and show_inputs != show_external_inputs:
+            raise TypeError("Pass either show_inputs or show_external_inputs, not both.")
+        warnings.warn(
+            "show_external_inputs is deprecated; use show_inputs instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        show_inputs = show_external_inputs
+    if show_inputs is None:
+        show_inputs = True
+    options.setdefault("depth", 1)
+
+    flat_graph = combined.to_flat_graph(extra_edges=extra_edges)
+    for (source_id, target_id), field_names in fanout_map_fields(graph, spec, map_over_nodes).items():
+        if flat_graph.has_edge(source_id, target_id):
+            flat_graph[source_id][target_id]["map_fields"] = list(field_names)
+
+    return render_flat_graph(flat_graph, combined, show_inputs=show_inputs, **options)

--- a/src/hypergraph/materialization/_indexes.py
+++ b/src/hypergraph/materialization/_indexes.py
@@ -1,0 +1,129 @@
+"""Named-index policy for HyperTable materializations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hypergraph.materialization._provenance import Provenance
+from hypergraph.materialization._schema import TableSpec, is_internal_column
+
+
+def _where_predicate(where: Any) -> list[tuple[str, str, Any]]:
+    if where is None:
+        return []
+    if isinstance(where, dict):
+        return [(key, "eq", value) for key, value in where.items()]
+    return list(where)
+
+
+class IndexPolicy:
+    """Own persisted named-index validation, freshness, and query policy."""
+
+    def __init__(self, store: Any, spec: TableSpec, provenance: Provenance):
+        self._store = store
+        self._spec = spec
+        self._provenance = provenance
+
+    def _resolve_table(self, on: str | None) -> TableSpec:
+        if on is None or on == self._spec.name:
+            return self._spec
+        for child_spec in self._spec.children:
+            if child_spec.name == on:
+                return child_spec
+        known = [self._spec.name, *(child_spec.name for child_spec in self._spec.children)]
+        raise ValueError(f"unknown table {on!r} for index; expected one of {known}")
+
+    def _recipe_fingerprint(self, spec: TableSpec, vector: str) -> str | None:
+        for column in self._provenance.derived_columns(spec):
+            if column.name == vector and column.produced_by is not None:
+                return self._provenance.node_recipe(column.produced_by)
+        return None
+
+    def _queryable_columns(self, spec: TableSpec) -> set[str]:
+        columns = {column.name for column in spec.columns if column.role != "internal"}
+        physical = self._store.open(self._spec, self._spec.children).get(spec.name, [])
+        columns.update(name for name in physical if not is_internal_column(name))
+        return columns
+
+    def _load(self) -> dict[str, dict[str, Any]]:
+        manifest = self._store.load_manifest(self._spec.name) or {}
+        return dict(manifest.get("indexes", {}))
+
+    def _save(self, indexes: dict[str, dict[str, Any]]) -> None:
+        manifest = self._store.load_manifest(self._spec.name) or {}
+        manifest["indexes"] = indexes
+        self._store.save_manifest(self._spec.name, manifest)
+
+    def create(
+        self,
+        name: str,
+        *,
+        on: str | None,
+        rows: Any,
+        text: str | None,
+        vector: str | None,
+    ) -> dict[str, Any]:
+        if not self._store.supports_manifests():
+            raise NotImplementedError(
+                f"{type(self._store).__name__} does not implement save_manifest/load_manifest, "
+                "so it cannot persist named indexes. Implement both manifest hooks to support "
+                "create_index, or use a store that does (e.g. LanceDBStore)."
+            )
+        spec = self._resolve_table(on)
+        if vector is None:
+            raise ValueError("create_index requires vector=<column>: v1 indexes are vector-search specs")
+        columns = self._queryable_columns(spec)
+        for label, column in (("vector", vector), ("text", text)):
+            if column is not None and column not in columns:
+                raise ValueError(f"{label} column {column!r} does not exist on table {spec.name!r}; known columns: {sorted(columns)}")
+        for column, _operator, _value in _where_predicate(rows):
+            if column not in columns:
+                raise ValueError(f"rows filter column {column!r} does not exist on table {spec.name!r}; known columns: {sorted(columns)}")
+        index_spec = {
+            "name": name,
+            "on": spec.name,
+            "rows": rows,
+            "text": text,
+            "vector": vector,
+            "recipe_fingerprint": self._recipe_fingerprint(spec, vector),
+        }
+        indexes = self._load()
+        indexes[name] = index_spec
+        self._save(indexes)
+        return dict(index_spec)
+
+    def list(self) -> list[dict[str, Any]]:
+        specs = []
+        for index_spec in self._load().values():
+            spec = self._resolve_table(index_spec.get("on"))
+            current = self._recipe_fingerprint(spec, index_spec["vector"])
+            specs.append({**index_spec, "current": current == index_spec.get("recipe_fingerprint")})
+        return specs
+
+    def drop(self, name: str) -> None:
+        indexes = self._load()
+        if name not in indexes:
+            raise KeyError(f"no index named {name!r}")
+        del indexes[name]
+        self._save(indexes)
+
+    def search(
+        self,
+        query_vector: list[float],
+        *,
+        index: str,
+        limit: int,
+        where: Any,
+    ) -> list[dict[str, Any]]:
+        indexes = self._load()
+        if index not in indexes:
+            raise KeyError(f"no index named {index!r}; known indexes: {sorted(indexes)}")
+        index_spec = indexes[index]
+        combined_where = [*_where_predicate(index_spec.get("rows")), *_where_predicate(where)]
+        return self._store.search(
+            index_spec["on"],
+            query_vector=list(query_vector),
+            vector_column=index_spec["vector"],
+            where=combined_where or None,
+            limit=limit,
+        )

--- a/src/hypergraph/materialization/_lancedb_store.py
+++ b/src/hypergraph/materialization/_lancedb_store.py
@@ -199,26 +199,18 @@ class LanceDBStore(TableStore):
                 if field_obj.name not in row:
                     row[field_obj.name] = None
 
-            arrays = []
-            for field_obj in schema:
-                val = row.get(field_obj.name)
-                if val is None:
-                    arrays.append(pa.array([None], type=field_obj.type))
-                elif pa.types.is_list(field_obj.type) and isinstance(val, list):
-                    inner_type = field_obj.type.value_type
-                    inner_arr = pa.array(val, type=inner_type)
-                    arrays.append(pa.array([inner_arr], type=field_obj.type))
-                else:
-                    arrays.append(pa.array([val], type=field_obj.type))
-
-            record_batch = pa.record_batch(arrays, schema=schema)
-            tbl.add(record_batch)
+        batch = pa.Table.from_pylist(rows, schema=schema)
+        tbl.add(batch)
 
     def delete_rows(self, table_name: str, where: RowPredicate) -> int:
         tbl = self._readable(table_name)
         if tbl is None:
             return 0
-        at = tbl.to_arrow()
+        predicate_columns = list(dict.fromkeys(self._predicate_columns(where)))
+        available = {field.name for field in tbl.schema}
+        if any(column not in available for column in predicate_columns):
+            return 0
+        at = self._read_arrow(tbl, predicate_columns, extra=[])
         matching = len(_apply_arrow_predicate(at, where))
         if matching == 0:
             return 0
@@ -230,7 +222,7 @@ class LanceDBStore(TableStore):
         tbl = self._readable(table_name)
         if tbl is None:
             return 0
-        at = tbl.to_arrow()
+        at = self._read_arrow(tbl, ["_write_gen"], extra=[])
         if len(at) == 0:
             return 0
         return pc.max(at.column("_write_gen")).as_py()
@@ -305,17 +297,10 @@ class LanceDBStore(TableStore):
         new_columns = {name: arrow_type for name, arrow_type in new_columns.items() if name not in existing}
         if not new_columns:
             return [f.name for f in tbl.schema]
-        existing_data = tbl.to_arrow()
-        new_fields = list(tbl.schema) + [pa.field(name, arrow_type) for name, arrow_type in new_columns.items()]
-        new_schema = pa.schema(new_fields)
-        self._db.drop_table(table_name)
-        tbl = self._db.create_table(table_name, schema=new_schema)
-        if len(existing_data) > 0:
-            for name, arrow_type in new_columns.items():
-                existing_data = existing_data.append_column(name, pa.array([None] * len(existing_data), type=arrow_type))
-            tbl.add(existing_data)
-        self._tables[table_name] = tbl
-        return [f.name for f in new_schema]
+        new_fields = [pa.field(name, arrow_type, nullable=True) for name, arrow_type in new_columns.items()]
+        tbl.add_columns(pa.schema(new_fields))
+        tbl.checkout_latest()
+        return [f.name for f in tbl.schema]
 
     # --- Internal ---
 

--- a/src/hypergraph/materialization/_lancedb_store.py
+++ b/src/hypergraph/materialization/_lancedb_store.py
@@ -194,13 +194,26 @@ class LanceDBStore(TableStore):
             tbl = self._tables[table_name]
             schema = tbl.schema
 
+        record_batches: list[pa.RecordBatch] = []
         for row in rows:
             for field_obj in schema:
                 if field_obj.name not in row:
                     row[field_obj.name] = None
 
-        batch = pa.Table.from_pylist(rows, schema=schema)
-        tbl.add(batch)
+            arrays = []
+            for field_obj in schema:
+                val = row.get(field_obj.name)
+                if val is None:
+                    arrays.append(pa.array([None], type=field_obj.type))
+                elif pa.types.is_list(field_obj.type) and isinstance(val, list):
+                    inner_type = field_obj.type.value_type
+                    inner_arr = pa.array(val, type=inner_type)
+                    arrays.append(pa.array([inner_arr], type=field_obj.type))
+                else:
+                    arrays.append(pa.array([val], type=field_obj.type))
+            record_batches.append(pa.record_batch(arrays, schema=schema))
+
+        tbl.add(pa.Table.from_batches(record_batches, schema=schema))
 
     def delete_rows(self, table_name: str, where: RowPredicate) -> int:
         tbl = self._readable(table_name)

--- a/src/hypergraph/materialization/_provenance.py
+++ b/src/hypergraph/materialization/_provenance.py
@@ -170,13 +170,11 @@ class Provenance:
         graph: Any,
         spec: TableSpec,
         components: Mapping[str, Any],
-        nodes: tuple[Any, ...],
         column_graphs: dict[int, Any],
     ) -> None:
         self.graph = graph
         self.spec = spec
         self.components = components
-        self.nodes = nodes
         self._column_graphs = column_graphs
 
     def derived_columns(self, spec: TableSpec | None = None) -> list[Any]:

--- a/src/hypergraph/materialization/_provenance.py
+++ b/src/hypergraph/materialization/_provenance.py
@@ -337,6 +337,10 @@ class Provenance:
             if column.role == "source" and column.content_key and column.name in row
         }
 
+    def source_inputs(self, row: Mapping[str, Any]) -> dict[str, Any]:
+        """Reconstruct root graph inputs from stored source columns."""
+        return {column.name: _normalize_value(row[column.name]) for column in self.spec.columns if column.role == "source" and column.name in row}
+
     @staticmethod
     def column_is_null(value: Any) -> bool:
         import math

--- a/src/hypergraph/materialization/_provenance.py
+++ b/src/hypergraph/materialization/_provenance.py
@@ -1,0 +1,494 @@
+"""HyperTable provenance policy and pure reconcile planning.
+
+This module owns the recipe/value-chain decisions that decide which stored
+columns can be reused and which graph node must run next.  It deliberately has
+no store or runner dependency: callers capture physical state, feed runner
+results back into the immutable reconcile state, and apply writes elsewhere.
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from hypergraph import Graph
+from hypergraph.materialization._fingerprint import (
+    _component_config_hashes,
+    _plain_value_payload,
+    compute_child_fingerprint,
+    compute_column_provenance,
+    compute_definition_hash,
+    compute_recipe_fingerprint,
+    compute_row_fingerprint,
+    compute_table_recipe_fingerprint,
+)
+from hypergraph.materialization._recipe_journal import (
+    KIND_BOUND_VALUE,
+    KIND_COMPONENT_CONFIG,
+    KIND_NODE_SOURCE,
+)
+from hypergraph.materialization._schema import TableSpec, is_internal_column, node_func
+
+_Items = tuple[tuple[str, Any], ...]
+
+
+def _freeze(values: Mapping[str, Any]) -> _Items:
+    return tuple(values.items())
+
+
+def _thaw(values: _Items) -> dict[str, Any]:
+    return dict(values)
+
+
+def _normalize_value(value: Any) -> Any:
+    """Convert numpy/arrow scalars into the public Python representation."""
+    import numpy as np
+
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, (np.floating, np.integer)):
+        return value.item()
+    return value
+
+
+def split_boundary_provenance(value: Any) -> tuple[str | None, int | None]:
+    """Parse ``<provenance>#<item-count>`` stored at a fan-out boundary."""
+    if not isinstance(value, str) or "#" not in value:
+        return None, None
+    provenance, _, count = value.rpartition("#")
+    try:
+        return provenance, int(count)
+    except ValueError:
+        return None, None
+
+
+def find_boundary_node(graph: Any, child_spec: TableSpec) -> Any:
+    """Find the root node that produces a child's mapped-items column."""
+    if not child_spec.map_input:
+        return None
+    nodes = graph.nodes if isinstance(graph.nodes, dict) else {}
+    for node in nodes.values():
+        if child_spec.map_input in (node.data_outputs if hasattr(node, "data_outputs") else ()):
+            return node
+    return None
+
+
+@dataclass(frozen=True, slots=True)
+class RecipeEntry:
+    """One durable recipe-journal entry planned without touching the journal."""
+
+    hash: str
+    kind: str
+    payload: str
+
+
+@dataclass(frozen=True, slots=True)
+class RebuildChildren:
+    """Reuse child source rows because their fan-out boundary is fresh."""
+
+    spec: TableSpec
+
+
+@dataclass(frozen=True, slots=True)
+class DerivedChildren:
+    """Use the item list returned by a newly executed fan-out boundary."""
+
+    spec: TableSpec
+    items: tuple[Any, ...]
+
+
+ChildSelection = RebuildChildren | DerivedChildren
+
+
+@dataclass(frozen=True, slots=True)
+class ReconcileResult:
+    """The complete, runner-neutral outcome of column reconciliation."""
+
+    outputs: _Items
+    provenances: tuple[tuple[str, str], ...]
+    children: tuple[ChildSelection, ...]
+
+    def output_values(self) -> dict[str, Any]:
+        return _thaw(self.outputs)
+
+    def provenance_values(self) -> dict[str, str]:
+        return dict(self.provenances)
+
+
+@dataclass(frozen=True, slots=True)
+class ReconcileState:
+    """Immutable progress through derived nodes and child boundaries."""
+
+    spec: TableSpec
+    existing: _Items
+    values: _Items
+    outputs: _Items
+    provenances: tuple[tuple[str, str], ...]
+    nodes: tuple[Any, ...]
+    node_index: int
+    boundary_counts: tuple[tuple[str, int], ...]
+    boundary_index: int
+    children: tuple[ChildSelection, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class RunNode:
+    """A single unavoidable runner call requested by the pure planner."""
+
+    node: Any
+    inputs: _Items
+    provenance: str
+    kind: Literal["column", "boundary"]
+    child_spec: TableSpec | None = None
+
+    def input_values(self) -> dict[str, Any]:
+        return _thaw(self.inputs)
+
+
+@dataclass(frozen=True, slots=True)
+class ReconcileUnavailable:
+    """Stored values cannot support column-scoped reconciliation."""
+
+
+@dataclass(frozen=True, slots=True)
+class ReconcileComplete:
+    """The planner needs no further runner calls."""
+
+    result: ReconcileResult
+
+
+ReconcileStep = RunNode | ReconcileUnavailable | ReconcileComplete
+
+
+class Provenance:
+    """Cohesive recipe and value-chain policy for one analyzed HyperTable."""
+
+    def __init__(
+        self,
+        graph: Any,
+        spec: TableSpec,
+        components: Mapping[str, Any],
+        nodes: tuple[Any, ...],
+        column_graphs: dict[int, Any],
+    ) -> None:
+        self.graph = graph
+        self.spec = spec
+        self.components = components
+        self.nodes = nodes
+        self._column_graphs = column_graphs
+
+    def derived_columns(self, spec: TableSpec | None = None) -> list[Any]:
+        target = spec or self.spec
+        return [column for column in target.columns if column.role == "derived"]
+
+    @staticmethod
+    def node_params(node: Any) -> Mapping[str, inspect.Parameter]:
+        func = node_func(node)
+        if func is not None:
+            return inspect.signature(func).parameters
+        params: dict[str, inspect.Parameter] = {}
+        for name in getattr(node, "inputs", ()):
+            default = inspect.Parameter.empty
+            if hasattr(node, "has_default_for") and node.has_default_for(name):
+                default = node.get_default_for(name)
+            params[name] = inspect.Parameter(name, inspect.Parameter.KEYWORD_ONLY, default=default)
+        return params
+
+    def node_columns(self, node: Any, spec: TableSpec | None = None) -> list[Any]:
+        return [column for column in self.derived_columns(spec) if column.produced_by is node]
+
+    def producing_node(self, column: str) -> Any:
+        for column_spec in self.derived_columns():
+            if column_spec.name == column:
+                return column_spec.produced_by
+        raise KeyError(f"{column!r} is not a derived column")
+
+    def nodes_in_dependency_order(self, spec: TableSpec | None = None) -> tuple[Any, ...]:
+        derived = self.derived_columns(spec)
+        nodes: list[Any] = []
+        seen: set[int] = set()
+        for column in derived:
+            if id(column.produced_by) not in seen:
+                seen.add(id(column.produced_by))
+                nodes.append(column.produced_by)
+        derived_names = {column.name for column in derived}
+        placed: set[str] = set()
+        ordered: list[Any] = []
+        remaining = list(nodes)
+        while remaining:
+            progressed = False
+            for node in list(remaining):
+                dependencies = {name for name in self.node_params(node) if name in derived_names}
+                if dependencies <= placed:
+                    ordered.append(node)
+                    placed.update(column.name for column in self.node_columns(node, spec))
+                    remaining.remove(node)
+                    progressed = True
+            if not progressed:
+                ordered.extend(remaining)
+                break
+        return tuple(ordered)
+
+    def node_provenance(self, node: Any, values: Mapping[str, Any]) -> str | None:
+        params = self.node_params(node)
+        components = {name: value for name, value in self.components.items() if name in params}
+        inputs: dict[str, Any] = {}
+        for name, parameter in params.items():
+            if name in components:
+                continue
+            if name in values:
+                inputs[name] = values[name]
+            elif parameter.default is inspect.Parameter.empty:
+                return None
+        return compute_column_provenance(node_func(node) or node, inputs, _component_config_hashes(components))
+
+    def node_recipe(self, node: Any) -> str:
+        params = self.node_params(node)
+        components = {name: value for name, value in self.components.items() if name in params}
+        return compute_recipe_fingerprint(node_func(node) or node, _component_config_hashes(components))
+
+    def root_fingerprint(self, graph_inputs: Mapping[str, Any]) -> str:
+        return compute_row_fingerprint(self.graph, dict(self.components), dict(graph_inputs))
+
+    def child_fingerprint(self, child_inputs: Mapping[str, Any], child_spec: TableSpec) -> str:
+        return compute_child_fingerprint(child_spec.child_graph, dict(self.components), dict(child_inputs))
+
+    def table_stamps_recipe(self) -> bool:
+        return bool(self.derived_columns() or self.spec.children)
+
+    def current_recipe_fingerprint(self) -> str:
+        return compute_table_recipe_fingerprint(self.graph, dict(self.components))
+
+    def current_child_recipe_fingerprint(self, child_spec: TableSpec) -> str:
+        child_graph = child_spec.child_graph
+        valid_inputs = set(child_graph.inputs.all) if child_graph is not None and hasattr(child_graph.inputs, "all") else set()
+        return compute_table_recipe_fingerprint(child_graph, dict(self.components), valid_inputs)
+
+    def row_missing_stamp(self, row: Mapping[str, Any], recipe_column: str) -> bool:
+        stamp = row.get(recipe_column)
+        return self.table_stamps_recipe() and (not isinstance(stamp, str) or not stamp)
+
+    def recipe_entries(self, node: Any) -> tuple[RecipeEntry, ...]:
+        func = node_func(node)
+        entries = [RecipeEntry(compute_definition_hash(func), KIND_NODE_SOURCE, self.node_source(func))]
+        params = self.node_params(node)
+        for name, component in self.components.items():
+            if name not in params:
+                continue
+            payload, kind = self.component_payload(component)
+            if payload is not None:
+                entries.append(RecipeEntry(compute_definition_hash(payload), kind, payload))
+        return tuple(entries)
+
+    @staticmethod
+    def node_source(func: Any) -> str:
+        try:
+            return inspect.getsource(func)
+        except (OSError, TypeError):
+            return repr(func)
+
+    @staticmethod
+    def component_payload(component: Any) -> tuple[str | None, str]:
+        config = getattr(component, "__component_config__", None) or (component._config() if hasattr(component, "_config") else None)
+        if config is not None:
+            return str(config), KIND_COMPONENT_CONFIG
+        plain = _plain_value_payload(component)
+        if plain is not None:
+            return plain, KIND_BOUND_VALUE
+        return None, KIND_BOUND_VALUE
+
+    def column_graph(self, node: Any) -> Any:
+        graph = self._column_graphs.get(id(node))
+        if graph is None:
+            label = getattr(node_func(node), "__name__", None) or getattr(node, "name", "column")
+            graph = Graph([node], name=f"{self.spec.name}__{label}")
+            binds = {name: value for name, value in self.components.items() if name in set(graph.inputs.all)}
+            if binds:
+                graph = graph.bind(**binds)
+            self._column_graphs[id(node)] = graph
+        return graph
+
+    def node_inputs(self, node: Any, values: Mapping[str, Any]) -> dict[str, Any]:
+        return {name: values[name] for name in self.node_params(node) if name not in self.components and name in values}
+
+    @staticmethod
+    def stored_values(row: Mapping[str, Any]) -> dict[str, Any]:
+        return {name: _normalize_value(value) for name, value in row.items() if not is_internal_column(name)}
+
+    def node_is_fresh(self, node: Any, provenance: str, existing: Mapping[str, Any], spec: TableSpec | None = None) -> bool:
+        return all(
+            existing.get(f"_provenance_{column.name}") == provenance and not self.column_is_null(existing.get(column.name))
+            for column in self.node_columns(node, spec)
+        )
+
+    def boundary_node(self, child_spec: TableSpec) -> Any:
+        return find_boundary_node(self.graph, child_spec)
+
+    def boundary_provenance_value(self, provenance: str, items: Any) -> str:
+        count = len(items) if isinstance(items, list) else 0
+        return f"{provenance}#{count}"
+
+    def child_source_inputs(self, row: Mapping[str, Any], child_spec: TableSpec) -> dict[str, Any]:
+        return {
+            column.name: _normalize_value(row[column.name])
+            for column in child_spec.columns
+            if column.role == "source" and column.content_key and column.name in row
+        }
+
+    @staticmethod
+    def column_is_null(value: Any) -> bool:
+        import math
+
+        return value is None or (isinstance(value, float) and math.isnan(value))
+
+    def row_converged(self, row: Mapping[str, Any]) -> bool:
+        values = self.stored_values(row)
+        for node in self.nodes_in_dependency_order():
+            provenance = self.node_provenance(node, values)
+            for column in self.node_columns(node):
+                if provenance is None or self.column_is_null(row.get(column.name)) or row.get(f"_provenance_{column.name}") != provenance:
+                    return False
+        return True
+
+    def start_reconcile(
+        self,
+        spec: TableSpec,
+        existing: Mapping[str, Any],
+        incoming_values: Mapping[str, Any],
+        boundary_counts: Mapping[str, int] | None = None,
+    ) -> ReconcileState:
+        values = self.stored_values(existing)
+        values.update(incoming_values)
+        return ReconcileState(
+            spec=spec,
+            existing=_freeze(existing),
+            values=_freeze(values),
+            outputs=(),
+            provenances=(),
+            nodes=self.nodes_in_dependency_order(spec),
+            node_index=0,
+            boundary_counts=tuple((boundary_counts or {}).items()),
+            boundary_index=0,
+            children=(),
+        )
+
+    def next_reconcile_step(self, state: ReconcileState) -> tuple[ReconcileState, ReconcileStep]:
+        current = state
+        while current.node_index < len(current.nodes):
+            node = current.nodes[current.node_index]
+            values = _thaw(current.values)
+            existing = _thaw(current.existing)
+            provenance = self.node_provenance(node, values)
+            if provenance is None:
+                return current, ReconcileUnavailable()
+            if not self.node_is_fresh(node, provenance, existing, current.spec):
+                return current, RunNode(
+                    node=node,
+                    inputs=_freeze(self.node_inputs(node, values)),
+                    provenance=provenance,
+                    kind="column",
+                )
+            node_outputs = {column.name: _normalize_value(existing[column.name]) for column in self.node_columns(node, current.spec)}
+            current = self._advance_column(current, node, provenance, node_outputs)
+
+        while current.boundary_index < len(current.spec.children):
+            child_spec = current.spec.children[current.boundary_index]
+            boundary = self.boundary_node(child_spec)
+            if boundary is None or any(column.produced_by is boundary for column in self.derived_columns()):
+                return current, ReconcileUnavailable()
+            values = _thaw(current.values)
+            provenance = self.node_provenance(boundary, values)
+            if provenance is None:
+                return current, ReconcileUnavailable()
+            existing = _thaw(current.existing)
+            stored = existing.get(f"_provenance_{child_spec.map_input}")
+            stored_provenance, stored_count = split_boundary_provenance(stored)
+            counts = dict(current.boundary_counts)
+            if stored_provenance == provenance and stored_count == counts.get(child_spec.name, 0):
+                current = ReconcileState(
+                    spec=current.spec,
+                    existing=current.existing,
+                    values=current.values,
+                    outputs=current.outputs,
+                    provenances=(*current.provenances, (child_spec.map_input, stored)),
+                    nodes=current.nodes,
+                    node_index=current.node_index,
+                    boundary_counts=current.boundary_counts,
+                    boundary_index=current.boundary_index + 1,
+                    children=(*current.children, RebuildChildren(child_spec)),
+                )
+                continue
+            return current, RunNode(
+                node=boundary,
+                inputs=_freeze(self.node_inputs(boundary, values)),
+                provenance=provenance,
+                kind="boundary",
+                child_spec=child_spec,
+            )
+
+        return current, ReconcileComplete(
+            ReconcileResult(
+                outputs=current.outputs,
+                provenances=current.provenances,
+                children=current.children,
+            )
+        )
+
+    def apply_reconcile_result(
+        self,
+        state: ReconcileState,
+        request: RunNode,
+        node_outputs: Mapping[str, Any],
+    ) -> ReconcileState:
+        if request.kind == "column":
+            return self._advance_column(state, request.node, request.provenance, node_outputs)
+        child_spec = request.child_spec
+        if child_spec is None:
+            raise RuntimeError("boundary reconcile request is missing its child table spec")
+        raw_items = node_outputs.get(child_spec.map_input)
+        items = raw_items if isinstance(raw_items, list) else []
+        return ReconcileState(
+            spec=state.spec,
+            existing=state.existing,
+            values=state.values,
+            outputs=state.outputs,
+            provenances=(
+                *state.provenances,
+                (child_spec.map_input, self.boundary_provenance_value(request.provenance, items)),
+            ),
+            nodes=state.nodes,
+            node_index=state.node_index,
+            boundary_counts=state.boundary_counts,
+            boundary_index=state.boundary_index + 1,
+            children=(*state.children, DerivedChildren(child_spec, tuple(items))),
+        )
+
+    def _advance_column(
+        self,
+        state: ReconcileState,
+        node: Any,
+        provenance: str,
+        node_outputs: Mapping[str, Any],
+    ) -> ReconcileState:
+        values = _thaw(state.values)
+        outputs = _thaw(state.outputs)
+        provenances = dict(state.provenances)
+        for column in self.node_columns(node, state.spec):
+            if column.name in node_outputs:
+                outputs[column.name] = node_outputs[column.name]
+                values[column.name] = node_outputs[column.name]
+            provenances[column.name] = provenance
+        return ReconcileState(
+            spec=state.spec,
+            existing=state.existing,
+            values=_freeze(values),
+            outputs=_freeze(outputs),
+            provenances=tuple(provenances.items()),
+            nodes=state.nodes,
+            node_index=state.node_index + 1,
+            boundary_counts=state.boundary_counts,
+            boundary_index=state.boundary_index,
+            children=state.children,
+        )

--- a/src/hypergraph/materialization/_provenance.py
+++ b/src/hypergraph/materialization/_provenance.py
@@ -42,7 +42,7 @@ def _thaw(values: _Items) -> dict[str, Any]:
     return dict(values)
 
 
-def _normalize_value(value: Any) -> Any:
+def normalize_value(value: Any) -> Any:
     """Convert numpy/arrow scalars into the public Python representation."""
     import numpy as np
 
@@ -315,7 +315,7 @@ class Provenance:
 
     @staticmethod
     def stored_values(row: Mapping[str, Any]) -> dict[str, Any]:
-        return {name: _normalize_value(value) for name, value in row.items() if not is_internal_column(name)}
+        return {name: normalize_value(value) for name, value in row.items() if not is_internal_column(name)}
 
     def node_is_fresh(self, node: Any, provenance: str, existing: Mapping[str, Any], spec: TableSpec | None = None) -> bool:
         return all(
@@ -332,14 +332,14 @@ class Provenance:
 
     def child_source_inputs(self, row: Mapping[str, Any], child_spec: TableSpec) -> dict[str, Any]:
         return {
-            column.name: _normalize_value(row[column.name])
+            column.name: normalize_value(row[column.name])
             for column in child_spec.columns
             if column.role == "source" and column.content_key and column.name in row
         }
 
     def source_inputs(self, row: Mapping[str, Any]) -> dict[str, Any]:
         """Reconstruct root graph inputs from stored source columns."""
-        return {column.name: _normalize_value(row[column.name]) for column in self.spec.columns if column.role == "source" and column.name in row}
+        return {column.name: normalize_value(row[column.name]) for column in self.spec.columns if column.role == "source" and column.name in row}
 
     @staticmethod
     def column_is_null(value: Any) -> bool:
@@ -394,7 +394,7 @@ class Provenance:
                     provenance=provenance,
                     kind="column",
                 )
-            node_outputs = {column.name: _normalize_value(existing[column.name]) for column in self.node_columns(node, current.spec)}
+            node_outputs = {column.name: normalize_value(existing[column.name]) for column in self.node_columns(node, current.spec)}
             current = self._advance_column(current, node, provenance, node_outputs)
 
         while current.boundary_index < len(current.spec.children):

--- a/src/hypergraph/materialization/_write_actions.py
+++ b/src/hypergraph/materialization/_write_actions.py
@@ -29,41 +29,6 @@ def _thaw_rows(rows: _Rows) -> list[dict[str, Any]]:
     return [_thaw(row) for row in rows]
 
 
-def normalize_to_dict(item: Any) -> dict[str, Any]:
-    """Convert a mapped child item to a plain dict if it is not one already."""
-    if isinstance(item, dict):
-        return item
-    if hasattr(item, "model_dump"):
-        return item.model_dump(mode="python")
-    if hasattr(item, "__dataclass_fields__"):
-        from dataclasses import asdict
-
-        return asdict(item)
-    return dict(item)
-
-
-def dedup_rows(rows: list[dict[str, Any]], identity: str) -> list[dict[str, Any]]:
-    """Keep only the highest write generation for each root identity."""
-    best: dict[str, dict[str, Any]] = {}
-    for row in rows:
-        identity_value = str(row.get(identity, ""))
-        existing = best.get(identity_value)
-        if existing is None or row.get("_write_gen", 0) > existing.get("_write_gen", 0):
-            best[identity_value] = row
-    return list(best.values())
-
-
-def dedup_child_rows(rows: list[dict[str, Any]], identity: str) -> list[dict[str, Any]]:
-    """Keep only the highest write generation for each parent/child identity."""
-    best: dict[tuple[str, str], dict[str, Any]] = {}
-    for row in rows:
-        key = (str(row.get("_parent_id", "")), str(row.get(identity, "")))
-        existing = best.get(key)
-        if existing is None or row.get("_write_gen", 0) > existing.get("_write_gen", 0):
-            best[key] = row
-    return list(best.values())
-
-
 @dataclass(frozen=True, slots=True)
 class RunGraph:
     """The only colored action: execute this graph with these inputs."""

--- a/src/hypergraph/materialization/_write_actions.py
+++ b/src/hypergraph/materialization/_write_actions.py
@@ -1,0 +1,182 @@
+"""Immutable action algebra shared by HyperTable write planning and apply."""
+
+from __future__ import annotations
+
+from collections.abc import Generator, Mapping
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from hypergraph.materialization._schema import TableSpec
+
+_Items = tuple[tuple[str, Any], ...]
+_Rows = tuple[_Items, ...]
+_Predicate = tuple[tuple[str, str, Any], ...]
+
+
+def _freeze(values: Mapping[str, Any]) -> _Items:
+    return tuple(values.items())
+
+
+def _thaw(values: _Items) -> dict[str, Any]:
+    return dict(values)
+
+
+def _freeze_rows(rows: list[dict[str, Any]]) -> _Rows:
+    return tuple(_freeze(row) for row in rows)
+
+
+def _thaw_rows(rows: _Rows) -> list[dict[str, Any]]:
+    return [_thaw(row) for row in rows]
+
+
+def normalize_to_dict(item: Any) -> dict[str, Any]:
+    """Convert a mapped child item to a plain dict if it is not one already."""
+    if isinstance(item, dict):
+        return item
+    if hasattr(item, "model_dump"):
+        return item.model_dump(mode="python")
+    if hasattr(item, "__dataclass_fields__"):
+        from dataclasses import asdict
+
+        return asdict(item)
+    return dict(item)
+
+
+def dedup_rows(rows: list[dict[str, Any]], identity: str) -> list[dict[str, Any]]:
+    """Keep only the highest write generation for each root identity."""
+    best: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        identity_value = str(row.get(identity, ""))
+        existing = best.get(identity_value)
+        if existing is None or row.get("_write_gen", 0) > existing.get("_write_gen", 0):
+            best[identity_value] = row
+    return list(best.values())
+
+
+def dedup_child_rows(rows: list[dict[str, Any]], identity: str) -> list[dict[str, Any]]:
+    """Keep only the highest write generation for each parent/child identity."""
+    best: dict[tuple[str, str], dict[str, Any]] = {}
+    for row in rows:
+        key = (str(row.get("_parent_id", "")), str(row.get(identity, "")))
+        existing = best.get(key)
+        if existing is None or row.get("_write_gen", 0) > existing.get("_write_gen", 0):
+            best[key] = row
+    return list(best.values())
+
+
+@dataclass(frozen=True, slots=True)
+class RunGraph:
+    """The only colored action: execute this graph with these inputs."""
+
+    graph: Any
+    inputs: _Items
+
+    def input_values(self) -> dict[str, Any]:
+        return _thaw(self.inputs)
+
+
+@dataclass(frozen=True, slots=True)
+class ReadOne:
+    table: str
+    identity: str
+    value: Any
+
+
+@dataclass(frozen=True, slots=True)
+class ReadRows:
+    table: str
+    where: _Predicate | None = None
+    limit: int | None = None
+    columns: tuple[str, ...] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class MaxWriteGen:
+    table: str
+
+
+@dataclass(frozen=True, slots=True)
+class WriteRows:
+    table: str
+    rows: _Rows
+
+    @classmethod
+    def from_rows(cls, table: str, rows: list[dict[str, Any]]) -> WriteRows:
+        return cls(table, _freeze_rows(rows))
+
+
+@dataclass(frozen=True, slots=True)
+class DeleteRows:
+    table: str
+    where: _Predicate
+
+
+@dataclass(frozen=True, slots=True)
+class EvolveMetadata:
+    item: _Items
+    table: str | None = None
+    identity: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class BuildParentRow:
+    item: _Items
+    graph_inputs: _Items
+    outputs: _Items
+    write_gen: int
+    mode: Literal["complete", "update", "error"]
+    provenances: _Items | None = None
+    error: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class BuildChildRow:
+    spec: TableSpec
+    item: _Items
+    identity: Any
+    parent_id: Any
+    fingerprint: str
+    write_gen: int
+    status: Literal["complete", "error"]
+    error: str | None
+    outputs: _Items = ()
+    provenances: _Items = ()
+
+
+@dataclass(frozen=True, slots=True)
+class StampExistingRow:
+    table: str
+    row: _Items
+    write_gen: int
+    child_spec: TableSpec | None = None
+    normalize_values: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class BuildNodeRow:
+    existing: _Items
+    node: Any
+    outputs: _Items
+    write_gen: int
+
+
+@dataclass(frozen=True, slots=True)
+class EvolveBackfillColumn:
+    column: str
+
+
+WriteAction = (
+    RunGraph
+    | ReadOne
+    | ReadRows
+    | MaxWriteGen
+    | WriteRows
+    | DeleteRows
+    | EvolveMetadata
+    | BuildParentRow
+    | BuildChildRow
+    | StampExistingRow
+    | BuildNodeRow
+    | EvolveBackfillColumn
+)
+WriteOperation = Generator[WriteAction, Any, Any]

--- a/src/hypergraph/materialization/_write_executor.py
+++ b/src/hypergraph/materialization/_write_executor.py
@@ -1,0 +1,256 @@
+"""Physical apply owner for HyperTable write actions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hypergraph.materialization._provenance import Provenance, normalize_value
+from hypergraph.materialization._recipe_journal import RecipeJournal
+from hypergraph.materialization._schema import (
+    RECIPE_COLUMN,
+    TableSpec,
+    python_type_to_arrow,
+    return_type,
+)
+from hypergraph.materialization._write_actions import (
+    BuildChildRow,
+    BuildNodeRow,
+    BuildParentRow,
+    DeleteRows,
+    EvolveBackfillColumn,
+    EvolveMetadata,
+    MaxWriteGen,
+    ReadOne,
+    ReadRows,
+    RunGraph,
+    StampExistingRow,
+    WriteAction,
+    WriteRows,
+    _thaw,
+    _thaw_rows,
+)
+
+
+class WriteExecutor:
+    """Apply store, schema, recipe-journal, and row-assembly actions once."""
+
+    def __init__(self, store: Any, spec: TableSpec, identity: str, provenance: Provenance):
+        self._store = store
+        self._spec = spec
+        self._identity = identity
+        self._provenance = provenance
+        self._recipe_column_ready: set[str] = set()
+        self._journal_obj: RecipeJournal | None = None
+
+    @property
+    def journal(self) -> RecipeJournal:
+        if self._journal_obj is None:
+            self._journal_obj = RecipeJournal(self._store)
+        return self._journal_obj
+
+    def apply(self, action: WriteAction) -> Any:
+        """Apply one non-runner action; runner actions are owned by the color driver."""
+        if isinstance(action, RunGraph):
+            raise TypeError("RunGraph must be executed by the sync/async color driver")
+        if isinstance(action, ReadOne):
+            return self._store.read_one(action.table, action.identity, action.value)
+        if isinstance(action, ReadRows):
+            where = list(action.where) if action.where is not None else None
+            columns = list(action.columns) if action.columns is not None else None
+            if columns is None or not self._store.supports_column_projection():
+                rows = self._store.read_rows(action.table, where, limit=action.limit)
+                return self._store._project_rows(rows, columns)
+            return self._store.read_rows(
+                action.table,
+                where,
+                limit=action.limit,
+                columns=columns,
+            )
+        if isinstance(action, MaxWriteGen):
+            return self._store.max_write_gen(action.table)
+        if isinstance(action, WriteRows):
+            return self._store.write_rows(action.table, _thaw_rows(action.rows))
+        if isinstance(action, DeleteRows):
+            return self._store.delete_rows(action.table, list(action.where))
+        if isinstance(action, EvolveMetadata):
+            return self._evolve_for_metadata(_thaw(action.item), table_name=action.table, identity=action.identity)
+        if isinstance(action, BuildParentRow):
+            return self._build_parent_row(action)
+        if isinstance(action, BuildChildRow):
+            return self._build_child_row(action)
+        if isinstance(action, StampExistingRow):
+            return self._stamp_existing_row(action)
+        if isinstance(action, BuildNodeRow):
+            return self._build_node_row(action)
+        if isinstance(action, EvolveBackfillColumn):
+            return self._evolve_for_backfill_column(action.column)
+        raise TypeError(f"unsupported write action: {type(action).__name__}")
+
+    def _evolve_for_metadata(
+        self,
+        item: dict[str, Any],
+        *,
+        table_name: str | None = None,
+        identity: str | None = None,
+    ) -> None:
+        target = table_name or self._spec.name
+        identity_column = identity or self._identity
+        known_columns = set(self._store.column_names(target))
+        if not known_columns:
+            sample = self._store.read_rows(target, limit=1)
+            known_columns = set(sample[0]) if sample else {column.name for column in self._spec.columns}
+        new_metadata = {
+            key: python_type_to_arrow(type(value) if value is not None else str)
+            for key, value in item.items()
+            if key not in known_columns and key != identity_column
+        }
+        if new_metadata:
+            self._store.evolve_schema(target, new_metadata)
+
+    def _ensure_recipe_column(self, table_name: str) -> None:
+        if table_name in self._recipe_column_ready:
+            return
+        physical = self._store.column_names(table_name)
+        if physical and RECIPE_COLUMN not in physical:
+            self._store.evolve_schema(table_name, {RECIPE_COLUMN: python_type_to_arrow(str)})
+        self._recipe_column_ready.add(table_name)
+
+    def _stamp_recipe(self, row: dict[str, Any], table_name: str, child_spec: TableSpec | None = None) -> None:
+        if not self._provenance.table_stamps_recipe():
+            return
+        if child_spec is not None:
+            if child_spec.child_graph is None:
+                return
+            fingerprint = self._provenance.current_child_recipe_fingerprint(child_spec)
+        else:
+            fingerprint = self._provenance.current_recipe_fingerprint()
+        self._ensure_recipe_column(table_name)
+        row[RECIPE_COLUMN] = fingerprint
+
+    def _record_node_recipe(self, node: Any) -> str:
+        entries = self._provenance.recipe_entries(node)
+        for entry in entries:
+            self.journal.record(entry.hash, entry.kind, entry.payload)
+        return entries[0].hash
+
+    def _provenance_node(self, name: str) -> Any:
+        for column in self._spec.columns:
+            if column.role == "derived" and column.name == name:
+                return column.produced_by
+        for child_spec in self._spec.children:
+            if child_spec.map_input == name:
+                return self._provenance.boundary_node(child_spec)
+        return None
+
+    def _build_parent_row(self, action: BuildParentRow) -> dict[str, Any]:
+        item = _thaw(action.item)
+        graph_inputs = _thaw(action.graph_inputs)
+        outputs = _thaw(action.outputs)
+        identity_value = item[self._identity]
+        row: dict[str, Any] = {self._identity: identity_value}
+        row.update({key: value for key, value in item.items() if key != self._identity})
+
+        derived_columns = self._provenance.derived_columns()
+        if action.mode == "error":
+            for column in derived_columns:
+                row[column.name] = None
+        else:
+            for column in derived_columns:
+                if column.name in outputs:
+                    row[column.name] = outputs[column.name]
+
+        row["_row_fingerprint"] = self._provenance.root_fingerprint(graph_inputs)
+        row["_write_gen"] = action.write_gen
+        self._stamp_recipe(row, self._spec.name)
+
+        if action.mode != "error":
+            provenances = _thaw(action.provenances) if action.provenances is not None else None
+            if provenances is None:
+                values = {**{key: value for key, value in item.items() if key != self._identity}, **outputs}
+                provenances = {column.name: self._provenance.node_provenance(column.produced_by, values) for column in derived_columns}
+                for child_spec in self._spec.children:
+                    boundary = self._provenance.boundary_node(child_spec)
+                    if boundary is None:
+                        continue
+                    provenance = self._provenance.node_provenance(boundary, values)
+                    if provenance is not None:
+                        provenances[child_spec.map_input] = self._provenance.boundary_provenance_value(
+                            provenance,
+                            outputs.get(child_spec.map_input),
+                        )
+            for name, provenance in provenances.items():
+                row[f"_provenance_{name}"] = provenance
+                node = self._provenance_node(name)
+                if node is not None:
+                    self._record_node_recipe(node)
+
+        if action.mode == "complete":
+            row["_status"] = "complete"
+            row["_error"] = None
+        elif action.mode == "error":
+            row["_status"] = "error"
+            row["_error"] = action.error
+        return row
+
+    def _build_child_row(self, action: BuildChildRow) -> dict[str, Any]:
+        item = _thaw(action.item)
+        row = {
+            action.spec.identity: action.identity,
+            "_parent_id": action.parent_id,
+            "_write_gen": action.write_gen,
+            "_row_fingerprint": action.fingerprint,
+            "_status": action.status,
+            "_error": action.error,
+        }
+        self._stamp_recipe(row, action.spec.name, action.spec)
+        for key, value in item.items():
+            if key != action.spec.identity and key != "_parent_id":
+                row[key] = value
+        row.update(_thaw(action.outputs))
+        for name, provenance in _thaw(action.provenances).items():
+            row[f"_provenance_{name}"] = provenance
+            for column in action.spec.columns:
+                if column.role == "derived" and column.name == name:
+                    self._record_node_recipe(column.produced_by)
+                    break
+        return row
+
+    def _stamp_existing_row(self, action: StampExistingRow) -> dict[str, Any]:
+        existing = _thaw(action.row)
+        row = {key: normalize_value(value) for key, value in existing.items()} if action.normalize_values else dict(existing)
+        self._stamp_recipe(row, action.table, action.child_spec)
+        row["_write_gen"] = action.write_gen
+        return row
+
+    def _build_node_row(self, action: BuildNodeRow) -> dict[str, Any]:
+        existing = _thaw(action.existing)
+        outputs = _thaw(action.outputs)
+        new_row = {key: normalize_value(value) for key, value in existing.items()}
+        for column in self._provenance.node_columns(action.node):
+            if column.name in outputs:
+                new_row[column.name] = outputs[column.name]
+        provenance = self._provenance.node_provenance(action.node, self._provenance.stored_values(new_row))
+        for column in self._provenance.node_columns(action.node):
+            new_row[f"_provenance_{column.name}"] = provenance
+        self._record_node_recipe(action.node)
+        new_row["_write_gen"] = action.write_gen
+        if self._provenance.row_converged(new_row):
+            new_row["_row_fingerprint"] = self._provenance.root_fingerprint(self._provenance.source_inputs(new_row))
+            self._stamp_recipe(new_row, self._spec.name)
+        return new_row
+
+    def _evolve_for_backfill_column(self, column: str) -> None:
+        sample = self._store.read_rows(self._spec.name, limit=1)
+        if sample and column not in sample[0]:
+            column_type = str
+            for spec_column in self._spec.columns:
+                if spec_column.name == column and spec_column.role == "derived" and spec_column.produced_by:
+                    column_type = return_type(spec_column.produced_by)
+                    break
+            self._store.evolve_schema(
+                self._spec.name,
+                {
+                    column: python_type_to_arrow(column_type),
+                    f"_provenance_{column}": python_type_to_arrow(str),
+                },
+            )

--- a/src/hypergraph/materialization/_writes.py
+++ b/src/hypergraph/materialization/_writes.py
@@ -1,9 +1,8 @@
-"""Pure write plans and the single physical apply owner for HyperTable."""
+"""Pure write plans and row normalization for HyperTable."""
 
 from __future__ import annotations
 
 from collections.abc import Generator, Mapping
-from dataclasses import dataclass
 from typing import Any, Literal
 
 from hypergraph.materialization._provenance import (
@@ -15,36 +14,31 @@ from hypergraph.materialization._provenance import (
     ReconcileUnavailable,
     normalize_value,
 )
-from hypergraph.materialization._recipe_journal import RecipeJournal
 from hypergraph.materialization._schema import (
     RECIPE_COLUMN,
     TableSpec,
     input_names,
     is_internal_column,
-    python_type_to_arrow,
-    return_type,
 )
 from hypergraph.materialization._types import ErrorRow, SyncResult
-
-_Items = tuple[tuple[str, Any], ...]
-_Rows = tuple[_Items, ...]
-_Predicate = tuple[tuple[str, str, Any], ...]
-
-
-def _freeze(values: Mapping[str, Any]) -> _Items:
-    return tuple(values.items())
-
-
-def _thaw(values: _Items) -> dict[str, Any]:
-    return dict(values)
-
-
-def _freeze_rows(rows: list[dict[str, Any]]) -> _Rows:
-    return tuple(_freeze(row) for row in rows)
-
-
-def _thaw_rows(rows: _Rows) -> list[dict[str, Any]]:
-    return [_thaw(row) for row in rows]
+from hypergraph.materialization._write_actions import (
+    BuildChildRow,
+    BuildNodeRow,
+    BuildParentRow,
+    DeleteRows,
+    EvolveBackfillColumn,
+    EvolveMetadata,
+    MaxWriteGen,
+    ReadOne,
+    ReadRows,
+    RunGraph,
+    StampExistingRow,
+    WriteAction,
+    WriteOperation,
+    WriteRows,
+    _freeze,
+    _Predicate,
+)
 
 
 def normalize_to_dict(item: Any) -> dict[str, Any]:
@@ -80,349 +74,6 @@ def dedup_child_rows(rows: list[dict[str, Any]], identity: str) -> list[dict[str
         if existing is None or row.get("_write_gen", 0) > existing.get("_write_gen", 0):
             best[key] = row
     return list(best.values())
-
-
-@dataclass(frozen=True, slots=True)
-class RunGraph:
-    """The only colored action: execute this graph with these inputs."""
-
-    graph: Any
-    inputs: _Items
-
-    def input_values(self) -> dict[str, Any]:
-        return _thaw(self.inputs)
-
-
-@dataclass(frozen=True, slots=True)
-class ReadOne:
-    table: str
-    identity: str
-    value: Any
-
-
-@dataclass(frozen=True, slots=True)
-class ReadRows:
-    table: str
-    where: _Predicate | None = None
-    limit: int | None = None
-    columns: tuple[str, ...] | None = None
-
-
-@dataclass(frozen=True, slots=True)
-class MaxWriteGen:
-    table: str
-
-
-@dataclass(frozen=True, slots=True)
-class WriteRows:
-    table: str
-    rows: _Rows
-
-    @classmethod
-    def from_rows(cls, table: str, rows: list[dict[str, Any]]) -> WriteRows:
-        return cls(table, _freeze_rows(rows))
-
-
-@dataclass(frozen=True, slots=True)
-class DeleteRows:
-    table: str
-    where: _Predicate
-
-
-@dataclass(frozen=True, slots=True)
-class EvolveMetadata:
-    item: _Items
-    table: str | None = None
-    identity: str | None = None
-
-
-@dataclass(frozen=True, slots=True)
-class BuildParentRow:
-    item: _Items
-    graph_inputs: _Items
-    outputs: _Items
-    write_gen: int
-    mode: Literal["complete", "update", "error"]
-    provenances: _Items | None = None
-    error: str | None = None
-
-
-@dataclass(frozen=True, slots=True)
-class BuildChildRow:
-    spec: TableSpec
-    item: _Items
-    identity: Any
-    parent_id: Any
-    fingerprint: str
-    write_gen: int
-    status: Literal["complete", "error"]
-    error: str | None
-    outputs: _Items = ()
-    provenances: _Items = ()
-
-
-@dataclass(frozen=True, slots=True)
-class StampExistingRow:
-    table: str
-    row: _Items
-    write_gen: int
-    child_spec: TableSpec | None = None
-    normalize_values: bool = True
-
-
-@dataclass(frozen=True, slots=True)
-class BuildNodeRow:
-    existing: _Items
-    node: Any
-    outputs: _Items
-    write_gen: int
-
-
-@dataclass(frozen=True, slots=True)
-class EvolveBackfillColumn:
-    column: str
-
-
-WriteAction = (
-    RunGraph
-    | ReadOne
-    | ReadRows
-    | MaxWriteGen
-    | WriteRows
-    | DeleteRows
-    | EvolveMetadata
-    | BuildParentRow
-    | BuildChildRow
-    | StampExistingRow
-    | BuildNodeRow
-    | EvolveBackfillColumn
-)
-WriteOperation = Generator[WriteAction, Any, Any]
-
-
-class WriteExecutor:
-    """Apply store, schema, recipe-journal, and row-assembly actions once."""
-
-    def __init__(self, store: Any, spec: TableSpec, identity: str, provenance: Provenance):
-        self._store = store
-        self._spec = spec
-        self._identity = identity
-        self._provenance = provenance
-        self._recipe_column_ready: set[str] = set()
-        self._journal_obj: RecipeJournal | None = None
-
-    @property
-    def journal(self) -> RecipeJournal:
-        if self._journal_obj is None:
-            self._journal_obj = RecipeJournal(self._store)
-        return self._journal_obj
-
-    def apply(self, action: WriteAction) -> Any:
-        """Apply one non-runner action; runner actions are owned by the color driver."""
-        if isinstance(action, RunGraph):
-            raise TypeError("RunGraph must be executed by the sync/async color driver")
-        if isinstance(action, ReadOne):
-            return self._store.read_one(action.table, action.identity, action.value)
-        if isinstance(action, ReadRows):
-            where = list(action.where) if action.where is not None else None
-            columns = list(action.columns) if action.columns is not None else None
-            if columns is None or not self._store.supports_column_projection():
-                rows = self._store.read_rows(action.table, where, limit=action.limit)
-                return self._store._project_rows(rows, columns)
-            return self._store.read_rows(
-                action.table,
-                where,
-                limit=action.limit,
-                columns=columns,
-            )
-        if isinstance(action, MaxWriteGen):
-            return self._store.max_write_gen(action.table)
-        if isinstance(action, WriteRows):
-            return self._store.write_rows(action.table, _thaw_rows(action.rows))
-        if isinstance(action, DeleteRows):
-            return self._store.delete_rows(action.table, list(action.where))
-        if isinstance(action, EvolveMetadata):
-            return self._evolve_for_metadata(_thaw(action.item), table_name=action.table, identity=action.identity)
-        if isinstance(action, BuildParentRow):
-            return self._build_parent_row(action)
-        if isinstance(action, BuildChildRow):
-            return self._build_child_row(action)
-        if isinstance(action, StampExistingRow):
-            return self._stamp_existing_row(action)
-        if isinstance(action, BuildNodeRow):
-            return self._build_node_row(action)
-        if isinstance(action, EvolveBackfillColumn):
-            return self._evolve_for_backfill_column(action.column)
-        raise TypeError(f"unsupported write action: {type(action).__name__}")
-
-    def _evolve_for_metadata(
-        self,
-        item: dict[str, Any],
-        *,
-        table_name: str | None = None,
-        identity: str | None = None,
-    ) -> None:
-        target = table_name or self._spec.name
-        identity_column = identity or self._identity
-        known_columns = set(self._store.column_names(target))
-        if not known_columns:
-            sample = self._store.read_rows(target, limit=1)
-            known_columns = set(sample[0]) if sample else {column.name for column in self._spec.columns}
-        new_metadata = {
-            key: python_type_to_arrow(type(value) if value is not None else str)
-            for key, value in item.items()
-            if key not in known_columns and key != identity_column
-        }
-        if new_metadata:
-            self._store.evolve_schema(target, new_metadata)
-
-    def _ensure_recipe_column(self, table_name: str) -> None:
-        if table_name in self._recipe_column_ready:
-            return
-        physical = self._store.column_names(table_name)
-        if physical and RECIPE_COLUMN not in physical:
-            self._store.evolve_schema(table_name, {RECIPE_COLUMN: python_type_to_arrow(str)})
-        self._recipe_column_ready.add(table_name)
-
-    def _stamp_recipe(self, row: dict[str, Any], table_name: str, child_spec: TableSpec | None = None) -> None:
-        if not self._provenance.table_stamps_recipe():
-            return
-        if child_spec is not None:
-            if child_spec.child_graph is None:
-                return
-            fingerprint = self._provenance.current_child_recipe_fingerprint(child_spec)
-        else:
-            fingerprint = self._provenance.current_recipe_fingerprint()
-        self._ensure_recipe_column(table_name)
-        row[RECIPE_COLUMN] = fingerprint
-
-    def _record_node_recipe(self, node: Any) -> str:
-        entries = self._provenance.recipe_entries(node)
-        for entry in entries:
-            self.journal.record(entry.hash, entry.kind, entry.payload)
-        return entries[0].hash
-
-    def _provenance_node(self, name: str) -> Any:
-        for column in self._spec.columns:
-            if column.role == "derived" and column.name == name:
-                return column.produced_by
-        for child_spec in self._spec.children:
-            if child_spec.map_input == name:
-                return self._provenance.boundary_node(child_spec)
-        return None
-
-    def _build_parent_row(self, action: BuildParentRow) -> dict[str, Any]:
-        item = _thaw(action.item)
-        graph_inputs = _thaw(action.graph_inputs)
-        outputs = _thaw(action.outputs)
-        identity_value = item[self._identity]
-        row: dict[str, Any] = {self._identity: identity_value}
-        row.update({key: value for key, value in item.items() if key != self._identity})
-
-        derived_columns = self._provenance.derived_columns()
-        if action.mode == "error":
-            for column in derived_columns:
-                row[column.name] = None
-        else:
-            for column in derived_columns:
-                if column.name in outputs:
-                    row[column.name] = outputs[column.name]
-
-        row["_row_fingerprint"] = self._provenance.root_fingerprint(graph_inputs)
-        row["_write_gen"] = action.write_gen
-        self._stamp_recipe(row, self._spec.name)
-
-        if action.mode != "error":
-            provenances = _thaw(action.provenances) if action.provenances is not None else None
-            if provenances is None:
-                values = {**{key: value for key, value in item.items() if key != self._identity}, **outputs}
-                provenances = {column.name: self._provenance.node_provenance(column.produced_by, values) for column in derived_columns}
-                for child_spec in self._spec.children:
-                    boundary = self._provenance.boundary_node(child_spec)
-                    if boundary is None:
-                        continue
-                    provenance = self._provenance.node_provenance(boundary, values)
-                    if provenance is not None:
-                        provenances[child_spec.map_input] = self._provenance.boundary_provenance_value(
-                            provenance,
-                            outputs.get(child_spec.map_input),
-                        )
-            for name, provenance in provenances.items():
-                row[f"_provenance_{name}"] = provenance
-                node = self._provenance_node(name)
-                if node is not None:
-                    self._record_node_recipe(node)
-
-        if action.mode == "complete":
-            row["_status"] = "complete"
-            row["_error"] = None
-        elif action.mode == "error":
-            row["_status"] = "error"
-            row["_error"] = action.error
-        return row
-
-    def _build_child_row(self, action: BuildChildRow) -> dict[str, Any]:
-        item = _thaw(action.item)
-        row = {
-            action.spec.identity: action.identity,
-            "_parent_id": action.parent_id,
-            "_write_gen": action.write_gen,
-            "_row_fingerprint": action.fingerprint,
-            "_status": action.status,
-            "_error": action.error,
-        }
-        self._stamp_recipe(row, action.spec.name, action.spec)
-        for key, value in item.items():
-            if key != action.spec.identity and key != "_parent_id":
-                row[key] = value
-        row.update(_thaw(action.outputs))
-        for name, provenance in _thaw(action.provenances).items():
-            row[f"_provenance_{name}"] = provenance
-            for column in action.spec.columns:
-                if column.role == "derived" and column.name == name:
-                    self._record_node_recipe(column.produced_by)
-                    break
-        return row
-
-    def _stamp_existing_row(self, action: StampExistingRow) -> dict[str, Any]:
-        existing = _thaw(action.row)
-        row = {key: normalize_value(value) for key, value in existing.items()} if action.normalize_values else dict(existing)
-        self._stamp_recipe(row, action.table, action.child_spec)
-        row["_write_gen"] = action.write_gen
-        return row
-
-    def _build_node_row(self, action: BuildNodeRow) -> dict[str, Any]:
-        existing = _thaw(action.existing)
-        outputs = _thaw(action.outputs)
-        new_row = {key: normalize_value(value) for key, value in existing.items()}
-        for column in self._provenance.node_columns(action.node):
-            if column.name in outputs:
-                new_row[column.name] = outputs[column.name]
-        provenance = self._provenance.node_provenance(action.node, self._provenance.stored_values(new_row))
-        for column in self._provenance.node_columns(action.node):
-            new_row[f"_provenance_{column.name}"] = provenance
-        self._record_node_recipe(action.node)
-        new_row["_write_gen"] = action.write_gen
-        if self._provenance.row_converged(new_row):
-            new_row["_row_fingerprint"] = self._provenance.root_fingerprint(self._provenance.source_inputs(new_row))
-            self._stamp_recipe(new_row, self._spec.name)
-        return new_row
-
-    def _evolve_for_backfill_column(self, column: str) -> None:
-        sample = self._store.read_rows(self._spec.name, limit=1)
-        if sample and column not in sample[0]:
-            column_type = str
-            for spec_column in self._spec.columns:
-                if spec_column.name == column and spec_column.role == "derived" and spec_column.produced_by:
-                    column_type = return_type(spec_column.produced_by)
-                    break
-            self._store.evolve_schema(
-                self._spec.name,
-                {
-                    column: python_type_to_arrow(column_type),
-                    f"_provenance_{column}": python_type_to_arrow(str),
-                },
-            )
 
 
 class WritePlanner:
@@ -1054,24 +705,3 @@ class WritePlanner:
                     ("_write_gen", "lt", write_gen),
                 ),
             )
-
-
-class Writes:
-    """Cohesive write subsystem: pure plans plus one physical action executor."""
-
-    def __init__(
-        self,
-        graph: Any,
-        spec: TableSpec,
-        identity: str,
-        store: Any,
-        components: Mapping[str, Any],
-        on_error: Literal["raise", "store"],
-        provenance: Provenance,
-    ):
-        self.plans = WritePlanner(graph, spec, identity, components, on_error, provenance)
-        self.executor = WriteExecutor(store, spec, identity, provenance)
-
-    @property
-    def journal(self) -> RecipeJournal:
-        return self.executor.journal

--- a/src/hypergraph/materialization/_writes.py
+++ b/src/hypergraph/materialization/_writes.py
@@ -1,0 +1,1093 @@
+"""Pure write plans and the single physical apply owner for HyperTable."""
+
+from __future__ import annotations
+
+from collections.abc import Generator, Mapping
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from hypergraph.materialization._provenance import (
+    DerivedChildren,
+    Provenance,
+    RebuildChildren,
+    ReconcileComplete,
+    ReconcileResult,
+    ReconcileUnavailable,
+)
+from hypergraph.materialization._recipe_journal import RecipeJournal
+from hypergraph.materialization._schema import (
+    RECIPE_COLUMN,
+    TableSpec,
+    input_names,
+    is_internal_column,
+    python_type_to_arrow,
+    return_type,
+)
+from hypergraph.materialization._types import ErrorRow, SyncResult
+
+_Items = tuple[tuple[str, Any], ...]
+_Rows = tuple[_Items, ...]
+_Predicate = tuple[tuple[str, str, Any], ...]
+
+
+def _freeze(values: Mapping[str, Any]) -> _Items:
+    return tuple(values.items())
+
+
+def _thaw(values: _Items) -> dict[str, Any]:
+    return dict(values)
+
+
+def _freeze_rows(rows: list[dict[str, Any]]) -> _Rows:
+    return tuple(_freeze(row) for row in rows)
+
+
+def _thaw_rows(rows: _Rows) -> list[dict[str, Any]]:
+    return [_thaw(row) for row in rows]
+
+
+def normalize_to_dict(item: Any) -> dict[str, Any]:
+    """Convert a mapped child item to a plain dict if it is not one already."""
+    if isinstance(item, dict):
+        return item
+    if hasattr(item, "model_dump"):
+        return item.model_dump(mode="python")
+    if hasattr(item, "__dataclass_fields__"):
+        from dataclasses import asdict
+
+        return asdict(item)
+    return dict(item)
+
+
+def normalize_value(value: Any) -> Any:
+    """Convert numpy/Arrow scalar values back to native Python values."""
+    import numpy as np
+
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, (np.floating, np.integer)):
+        return value.item()
+    return value
+
+
+def dedup_rows(rows: list[dict[str, Any]], identity: str) -> list[dict[str, Any]]:
+    """Keep only the highest write generation for each root identity."""
+    best: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        identity_value = str(row.get(identity, ""))
+        existing = best.get(identity_value)
+        if existing is None or row.get("_write_gen", 0) > existing.get("_write_gen", 0):
+            best[identity_value] = row
+    return list(best.values())
+
+
+def dedup_child_rows(rows: list[dict[str, Any]], identity: str) -> list[dict[str, Any]]:
+    """Keep only the highest write generation for each parent/child identity."""
+    best: dict[tuple[str, str], dict[str, Any]] = {}
+    for row in rows:
+        key = (str(row.get("_parent_id", "")), str(row.get(identity, "")))
+        existing = best.get(key)
+        if existing is None or row.get("_write_gen", 0) > existing.get("_write_gen", 0):
+            best[key] = row
+    return list(best.values())
+
+
+@dataclass(frozen=True, slots=True)
+class RunGraph:
+    """The only colored action: execute this graph with these inputs."""
+
+    graph: Any
+    inputs: _Items
+
+    def input_values(self) -> dict[str, Any]:
+        return _thaw(self.inputs)
+
+
+@dataclass(frozen=True, slots=True)
+class ReadOne:
+    table: str
+    identity: str
+    value: Any
+
+
+@dataclass(frozen=True, slots=True)
+class ReadRows:
+    table: str
+    where: _Predicate | None = None
+    limit: int | None = None
+    columns: tuple[str, ...] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class MaxWriteGen:
+    table: str
+
+
+@dataclass(frozen=True, slots=True)
+class WriteRows:
+    table: str
+    rows: _Rows
+
+    @classmethod
+    def from_rows(cls, table: str, rows: list[dict[str, Any]]) -> WriteRows:
+        return cls(table, _freeze_rows(rows))
+
+
+@dataclass(frozen=True, slots=True)
+class DeleteRows:
+    table: str
+    where: _Predicate
+
+
+@dataclass(frozen=True, slots=True)
+class EvolveMetadata:
+    item: _Items
+    table: str | None = None
+    identity: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class BuildParentRow:
+    item: _Items
+    graph_inputs: _Items
+    outputs: _Items
+    write_gen: int
+    mode: Literal["complete", "update", "error"]
+    provenances: _Items | None = None
+    error: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class BuildChildRow:
+    spec: TableSpec
+    item: _Items
+    identity: Any
+    parent_id: Any
+    fingerprint: str
+    write_gen: int
+    status: Literal["complete", "error"]
+    error: str | None
+    outputs: _Items = ()
+    provenances: _Items = ()
+
+
+@dataclass(frozen=True, slots=True)
+class StampExistingRow:
+    table: str
+    row: _Items
+    write_gen: int
+    child_spec: TableSpec | None = None
+    normalize_values: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class BuildNodeRow:
+    existing: _Items
+    node: Any
+    outputs: _Items
+    write_gen: int
+
+
+@dataclass(frozen=True, slots=True)
+class EvolveBackfillColumn:
+    column: str
+
+
+WriteAction = (
+    RunGraph
+    | ReadOne
+    | ReadRows
+    | MaxWriteGen
+    | WriteRows
+    | DeleteRows
+    | EvolveMetadata
+    | BuildParentRow
+    | BuildChildRow
+    | StampExistingRow
+    | BuildNodeRow
+    | EvolveBackfillColumn
+)
+WriteOperation = Generator[WriteAction, Any, Any]
+
+
+class WriteExecutor:
+    """Apply store, schema, recipe-journal, and row-assembly actions once."""
+
+    def __init__(self, store: Any, spec: TableSpec, identity: str, provenance: Provenance):
+        self._store = store
+        self._spec = spec
+        self._identity = identity
+        self._provenance = provenance
+        self._recipe_column_ready: set[str] = set()
+        self._journal_obj: RecipeJournal | None = None
+
+    @property
+    def journal(self) -> RecipeJournal:
+        if self._journal_obj is None:
+            self._journal_obj = RecipeJournal(self._store)
+        return self._journal_obj
+
+    def apply(self, action: WriteAction) -> Any:
+        """Apply one non-runner action; runner actions are owned by the color driver."""
+        if isinstance(action, RunGraph):
+            raise TypeError("RunGraph must be executed by the sync/async color driver")
+        if isinstance(action, ReadOne):
+            return self._store.read_one(action.table, action.identity, action.value)
+        if isinstance(action, ReadRows):
+            where = list(action.where) if action.where is not None else None
+            columns = list(action.columns) if action.columns is not None else None
+            if columns is None or not self._store.supports_column_projection():
+                rows = self._store.read_rows(action.table, where, limit=action.limit)
+                return self._store._project_rows(rows, columns)
+            return self._store.read_rows(
+                action.table,
+                where,
+                limit=action.limit,
+                columns=columns,
+            )
+        if isinstance(action, MaxWriteGen):
+            return self._store.max_write_gen(action.table)
+        if isinstance(action, WriteRows):
+            return self._store.write_rows(action.table, _thaw_rows(action.rows))
+        if isinstance(action, DeleteRows):
+            return self._store.delete_rows(action.table, list(action.where))
+        if isinstance(action, EvolveMetadata):
+            return self._evolve_for_metadata(_thaw(action.item), table_name=action.table, identity=action.identity)
+        if isinstance(action, BuildParentRow):
+            return self._build_parent_row(action)
+        if isinstance(action, BuildChildRow):
+            return self._build_child_row(action)
+        if isinstance(action, StampExistingRow):
+            return self._stamp_existing_row(action)
+        if isinstance(action, BuildNodeRow):
+            return self._build_node_row(action)
+        if isinstance(action, EvolveBackfillColumn):
+            return self._evolve_for_backfill_column(action.column)
+        raise TypeError(f"unsupported write action: {type(action).__name__}")
+
+    def _evolve_for_metadata(
+        self,
+        item: dict[str, Any],
+        *,
+        table_name: str | None = None,
+        identity: str | None = None,
+    ) -> None:
+        target = table_name or self._spec.name
+        identity_column = identity or self._identity
+        known_columns = set(self._store.column_names(target))
+        if not known_columns:
+            sample = self._store.read_rows(target, limit=1)
+            known_columns = set(sample[0]) if sample else {column.name for column in self._spec.columns}
+        new_metadata = {
+            key: python_type_to_arrow(type(value) if value is not None else str)
+            for key, value in item.items()
+            if key not in known_columns and key != identity_column
+        }
+        if new_metadata:
+            self._store.evolve_schema(target, new_metadata)
+
+    def _ensure_recipe_column(self, table_name: str) -> None:
+        if table_name in self._recipe_column_ready:
+            return
+        physical = self._store.column_names(table_name)
+        if physical and RECIPE_COLUMN not in physical:
+            self._store.evolve_schema(table_name, {RECIPE_COLUMN: python_type_to_arrow(str)})
+        self._recipe_column_ready.add(table_name)
+
+    def _stamp_recipe(self, row: dict[str, Any], table_name: str, child_spec: TableSpec | None = None) -> None:
+        if not self._provenance.table_stamps_recipe():
+            return
+        if child_spec is not None:
+            if child_spec.child_graph is None:
+                return
+            fingerprint = self._provenance.current_child_recipe_fingerprint(child_spec)
+        else:
+            fingerprint = self._provenance.current_recipe_fingerprint()
+        self._ensure_recipe_column(table_name)
+        row[RECIPE_COLUMN] = fingerprint
+
+    def _record_node_recipe(self, node: Any) -> str:
+        entries = self._provenance.recipe_entries(node)
+        for entry in entries:
+            self.journal.record(entry.hash, entry.kind, entry.payload)
+        return entries[0].hash
+
+    def _provenance_node(self, name: str) -> Any:
+        for column in self._spec.columns:
+            if column.role == "derived" and column.name == name:
+                return column.produced_by
+        for child_spec in self._spec.children:
+            if child_spec.map_input == name:
+                return self._provenance.boundary_node(child_spec)
+        return None
+
+    def _build_parent_row(self, action: BuildParentRow) -> dict[str, Any]:
+        item = _thaw(action.item)
+        graph_inputs = _thaw(action.graph_inputs)
+        outputs = _thaw(action.outputs)
+        identity_value = item[self._identity]
+        row: dict[str, Any] = {self._identity: identity_value}
+        row.update({key: value for key, value in item.items() if key != self._identity})
+
+        derived_columns = self._provenance.derived_columns()
+        if action.mode == "error":
+            for column in derived_columns:
+                row[column.name] = None
+        else:
+            for column in derived_columns:
+                if column.name in outputs:
+                    row[column.name] = outputs[column.name]
+
+        row["_row_fingerprint"] = self._provenance.root_fingerprint(graph_inputs)
+        row["_write_gen"] = action.write_gen
+        self._stamp_recipe(row, self._spec.name)
+
+        if action.mode != "error":
+            provenances = _thaw(action.provenances) if action.provenances is not None else None
+            if provenances is None:
+                values = {**{key: value for key, value in item.items() if key != self._identity}, **outputs}
+                provenances = {column.name: self._provenance.node_provenance(column.produced_by, values) for column in derived_columns}
+                for child_spec in self._spec.children:
+                    boundary = self._provenance.boundary_node(child_spec)
+                    if boundary is None:
+                        continue
+                    provenance = self._provenance.node_provenance(boundary, values)
+                    if provenance is not None:
+                        provenances[child_spec.map_input] = self._provenance.boundary_provenance_value(
+                            provenance,
+                            outputs.get(child_spec.map_input),
+                        )
+            for name, provenance in provenances.items():
+                row[f"_provenance_{name}"] = provenance
+                node = self._provenance_node(name)
+                if node is not None:
+                    self._record_node_recipe(node)
+
+        if action.mode == "complete":
+            row["_status"] = "complete"
+            row["_error"] = None
+        elif action.mode == "error":
+            row["_status"] = "error"
+            row["_error"] = action.error
+        return row
+
+    def _build_child_row(self, action: BuildChildRow) -> dict[str, Any]:
+        item = _thaw(action.item)
+        row = {
+            action.spec.identity: action.identity,
+            "_parent_id": action.parent_id,
+            "_write_gen": action.write_gen,
+            "_row_fingerprint": action.fingerprint,
+            "_status": action.status,
+            "_error": action.error,
+        }
+        self._stamp_recipe(row, action.spec.name, action.spec)
+        for key, value in item.items():
+            if key != action.spec.identity and key != "_parent_id":
+                row[key] = value
+        row.update(_thaw(action.outputs))
+        for name, provenance in _thaw(action.provenances).items():
+            row[f"_provenance_{name}"] = provenance
+            for column in action.spec.columns:
+                if column.role == "derived" and column.name == name:
+                    self._record_node_recipe(column.produced_by)
+                    break
+        return row
+
+    def _stamp_existing_row(self, action: StampExistingRow) -> dict[str, Any]:
+        existing = _thaw(action.row)
+        row = {key: normalize_value(value) for key, value in existing.items()} if action.normalize_values else dict(existing)
+        self._stamp_recipe(row, action.table, action.child_spec)
+        row["_write_gen"] = action.write_gen
+        return row
+
+    def _source_inputs(self, row: dict[str, Any]) -> dict[str, Any]:
+        return {column.name: normalize_value(row[column.name]) for column in self._spec.columns if column.role == "source" and column.name in row}
+
+    def _build_node_row(self, action: BuildNodeRow) -> dict[str, Any]:
+        existing = _thaw(action.existing)
+        outputs = _thaw(action.outputs)
+        new_row = {key: normalize_value(value) for key, value in existing.items()}
+        for column in self._provenance.node_columns(action.node):
+            if column.name in outputs:
+                new_row[column.name] = outputs[column.name]
+        provenance = self._provenance.node_provenance(action.node, self._provenance.stored_values(new_row))
+        for column in self._provenance.node_columns(action.node):
+            new_row[f"_provenance_{column.name}"] = provenance
+        self._record_node_recipe(action.node)
+        new_row["_write_gen"] = action.write_gen
+        if self._provenance.row_converged(new_row):
+            new_row["_row_fingerprint"] = self._provenance.root_fingerprint(self._source_inputs(new_row))
+            self._stamp_recipe(new_row, self._spec.name)
+        return new_row
+
+    def _evolve_for_backfill_column(self, column: str) -> None:
+        sample = self._store.read_rows(self._spec.name, limit=1)
+        if sample and column not in sample[0]:
+            column_type = str
+            for spec_column in self._spec.columns:
+                if spec_column.name == column and spec_column.role == "derived" and spec_column.produced_by:
+                    column_type = return_type(spec_column.produced_by)
+                    break
+            self._store.evolve_schema(
+                self._spec.name,
+                {
+                    column: python_type_to_arrow(column_type),
+                    f"_provenance_{column}": python_type_to_arrow(str),
+                },
+            )
+
+
+class WritePlanner:
+    """Emit immutable actions for every mutating HyperTable operation."""
+
+    def __init__(
+        self,
+        graph: Any,
+        spec: TableSpec,
+        identity: str,
+        components: Mapping[str, Any],
+        on_error: Literal["raise", "store"],
+        provenance: Provenance,
+    ):
+        self._graph = graph
+        self._spec = spec
+        self._identity = identity
+        self._components = dict(components)
+        self._on_error = on_error
+        self._provenance = provenance
+
+    def _graph_inputs(self, item: Mapping[str, Any]) -> dict[str, Any]:
+        required = input_names(self._graph.inputs.required)
+        return {key: value for key, value in item.items() if key != self._identity and key in required}
+
+    @staticmethod
+    def _parent_skipped(existing: dict[str, Any] | None, fingerprint: str) -> bool:
+        if existing is None or existing.get("_row_fingerprint") != fingerprint:
+            return False
+        return existing.get("_status") in (None, "complete")
+
+    @staticmethod
+    def _can_reconcile(existing: dict[str, Any] | None) -> bool:
+        return existing is not None and existing.get("_status") != "error"
+
+    def _reconcile(
+        self,
+        item: dict[str, Any],
+        existing: dict[str, Any],
+        spec: TableSpec | None = None,
+    ) -> Generator[WriteAction, Any, ReconcileResult | None]:
+        target = spec or self._spec
+        boundary_counts: dict[str, int] = {}
+        for child_spec in target.children:
+            rows = yield ReadRows(
+                child_spec.name,
+                (("_parent_id", "eq", item[target.identity]),),
+            )
+            boundary_counts[child_spec.name] = len(dedup_child_rows(rows, child_spec.identity))
+        incoming = {key: value for key, value in item.items() if key != target.identity}
+        state = self._provenance.start_reconcile(target, existing, incoming, boundary_counts)
+        while True:
+            state, step = self._provenance.next_reconcile_step(state)
+            if isinstance(step, ReconcileUnavailable):
+                return None
+            if isinstance(step, ReconcileComplete):
+                return step.result
+            outputs = yield RunGraph(
+                self._provenance.column_graph(step.node),
+                _freeze(step.input_values()),
+            )
+            state = self._provenance.apply_reconcile_result(state, step, outputs)
+
+    def _cleanup_parent(self, identity_value: Any, write_gen: int) -> DeleteRows:
+        return DeleteRows(
+            self._spec.name,
+            ((self._identity, "eq", identity_value), ("_write_gen", "lt", write_gen)),
+        )
+
+    def _cleanup_children(self, identity_value: Any, write_gen: int) -> Generator[WriteAction, Any, None]:
+        for child_spec in self._spec.children:
+            yield DeleteRows(
+                child_spec.name,
+                (("_parent_id", "eq", identity_value), ("_write_gen", "lt", write_gen)),
+            )
+
+    def _refresh_missing_stamps(
+        self,
+        existing: dict[str, Any],
+    ) -> Generator[WriteAction, Any, None]:
+        identity_value = existing[self._identity]
+        write_gen = (yield MaxWriteGen(self._spec.name)) + 1
+        new_row = yield StampExistingRow(self._spec.name, _freeze(existing), write_gen)
+        yield WriteRows.from_rows(self._spec.name, [new_row])
+        yield self._cleanup_parent(identity_value, write_gen)
+        for child_spec in self._spec.children:
+            if child_spec.child_graph is None:
+                continue
+            child_gen = (yield MaxWriteGen(child_spec.name)) + 1
+            rows = yield ReadRows(child_spec.name, (("_parent_id", "eq", identity_value),))
+            for row in dedup_child_rows(rows, child_spec.identity):
+                stamp = row.get(RECIPE_COLUMN)
+                if isinstance(stamp, str) and stamp:
+                    continue
+                inputs = self._provenance.child_source_inputs(row, child_spec)
+                if row.get("_row_fingerprint") != self._provenance.child_fingerprint(inputs, child_spec):
+                    continue
+                new_child = yield StampExistingRow(
+                    child_spec.name,
+                    _freeze(row),
+                    child_gen,
+                    child_spec,
+                )
+                yield WriteRows.from_rows(child_spec.name, [new_child])
+                yield DeleteRows(
+                    child_spec.name,
+                    (
+                        (child_spec.identity, "eq", row[child_spec.identity]),
+                        ("_parent_id", "eq", identity_value),
+                        ("_write_gen", "lt", child_gen),
+                    ),
+                )
+
+    def _bind_child_components(self, child_graph: Any) -> Any:
+        if not self._components:
+            return child_graph
+        valid_inputs = set(child_graph.inputs.all)
+        bindings = {key: value for key, value in self._components.items() if key in valid_inputs}
+        return child_graph.bind(**bindings) if bindings else child_graph
+
+    @staticmethod
+    def _child_items(outputs: Mapping[str, Any], child_spec: TableSpec) -> list[Any] | None:
+        if not child_spec.child_graph:
+            return None
+        child_items = outputs.get(child_spec.map_input)
+        if not child_items or not isinstance(child_items, list):
+            return None
+        return child_items
+
+    def _child_provenances(self, child_spec: TableSpec, values: dict[str, Any]) -> dict[str, str]:
+        provenances: dict[str, str] = {}
+        for node in self._provenance.nodes_in_dependency_order(child_spec):
+            provenance = self._provenance.node_provenance(node, values)
+            for column in self._provenance.node_columns(node, child_spec):
+                provenances[column.name] = provenance
+        return provenances
+
+    @staticmethod
+    def _rebuild_child_items(rows: list[dict[str, Any]], child_spec: TableSpec) -> list[dict[str, Any]]:
+        derived = {column.name for column in child_spec.columns if column.role == "derived"}
+        return [
+            {key: normalize_value(value) for key, value in row.items() if key not in derived and key != "_parent_id" and not is_internal_column(key)}
+            for row in dedup_child_rows(rows, child_spec.identity)
+        ]
+
+    def _build_child_action(
+        self,
+        child_spec: TableSpec,
+        child_item: dict[str, Any],
+        child_identity: Any,
+        parent_id: Any,
+        fingerprint: str,
+        write_gen: int,
+        *,
+        status: Literal["complete", "error"],
+        error: str | None,
+        outputs: Mapping[str, Any] | None = None,
+        provenances: Mapping[str, Any] | None = None,
+    ) -> BuildChildRow:
+        return BuildChildRow(
+            child_spec,
+            _freeze(child_item),
+            child_identity,
+            parent_id,
+            fingerprint,
+            write_gen,
+            status,
+            error,
+            _freeze(outputs or {}),
+            _freeze(provenances or {}),
+        )
+
+    def _insert_children_items(
+        self,
+        parent_id: Any,
+        child_items: list[Any],
+        child_spec: TableSpec,
+        write_gen: int,
+    ) -> Generator[WriteAction, Any, None]:
+        if child_spec.child_graph is None:
+            return
+        bound_graph = self._bind_child_components(child_spec.child_graph)
+        for raw_item in child_items:
+            child_item = normalize_to_dict(raw_item)
+            child_identity = child_item.get(child_spec.identity, "")
+            child_inputs = {
+                column.name: child_item[column.name]
+                for column in child_spec.columns
+                if column.role == "source" and column.content_key and column.name in child_item
+            }
+            fingerprint = self._provenance.child_fingerprint(child_inputs, child_spec)
+            existing_rows = yield ReadRows(
+                child_spec.name,
+                (
+                    ("_parent_id", "eq", parent_id),
+                    (child_spec.identity, "eq", child_identity),
+                ),
+            )
+            existing = max(existing_rows, key=lambda row: row.get("_write_gen", 0)) if existing_rows else None
+            if existing is not None and existing.get("_row_fingerprint") == fingerprint and existing.get("_status") in (None, "complete"):
+                if self._provenance.row_missing_stamp(existing, RECIPE_COLUMN):
+                    bumped = yield StampExistingRow(
+                        child_spec.name,
+                        _freeze(existing),
+                        write_gen,
+                        child_spec,
+                        False,
+                    )
+                else:
+                    bumped = dict(existing)
+                    bumped["_write_gen"] = write_gen
+                yield WriteRows.from_rows(child_spec.name, [bumped])
+                continue
+
+            row: dict[str, Any] | None = None
+            if existing is not None and existing.get("_status") in (None, "complete"):
+                try:
+                    reconciled = yield from self._reconcile(child_item, existing, child_spec)
+                except Exception as error:
+                    if self._on_error == "raise":
+                        raise
+                    row = yield self._build_child_action(
+                        child_spec,
+                        child_item,
+                        child_identity,
+                        parent_id,
+                        fingerprint,
+                        write_gen,
+                        status="error",
+                        error=f"{type(error).__name__}: {error}",
+                    )
+                    yield WriteRows.from_rows(child_spec.name, [row])
+                    continue
+                if reconciled is not None:
+                    row = yield self._build_child_action(
+                        child_spec,
+                        child_item,
+                        child_identity,
+                        parent_id,
+                        fingerprint,
+                        write_gen,
+                        status="complete",
+                        error=None,
+                        outputs=reconciled.output_values(),
+                        provenances=reconciled.provenance_values(),
+                    )
+
+            if row is None:
+                try:
+                    child_outputs = yield RunGraph(bound_graph, _freeze(child_inputs))
+                except Exception as error:
+                    if self._on_error == "raise":
+                        raise
+                    row = yield self._build_child_action(
+                        child_spec,
+                        child_item,
+                        child_identity,
+                        parent_id,
+                        fingerprint,
+                        write_gen,
+                        status="error",
+                        error=f"{type(error).__name__}: {error}",
+                    )
+                    yield WriteRows.from_rows(child_spec.name, [row])
+                    continue
+                row = yield self._build_child_action(
+                    child_spec,
+                    child_item,
+                    child_identity,
+                    parent_id,
+                    fingerprint,
+                    write_gen,
+                    status="complete",
+                    error=None,
+                    outputs=child_outputs,
+                    provenances=self._child_provenances(child_spec, {**child_item, **child_outputs}),
+                )
+            yield WriteRows.from_rows(child_spec.name, [row])
+
+    def _insert_children(
+        self,
+        parent_id: Any,
+        outputs: Mapping[str, Any],
+        child_spec: TableSpec,
+        write_gen: int,
+    ) -> Generator[WriteAction, Any, None]:
+        child_items = self._child_items(outputs, child_spec)
+        if child_items is not None:
+            yield from self._insert_children_items(parent_id, child_items, child_spec, write_gen)
+
+    def _apply_reconciled(
+        self,
+        item: dict[str, Any],
+        graph_inputs: dict[str, Any],
+        existing: dict[str, Any],
+        reconciled: ReconcileResult,
+        parent_skipped: bool,
+        write_gen: int,
+    ) -> Generator[WriteAction, Any, str]:
+        outputs = reconciled.output_values()
+        provenances = reconciled.provenance_values()
+        identity_value = item[self._identity]
+        for selection in reconciled.children:
+            if isinstance(selection, RebuildChildren):
+                rows = yield ReadRows(selection.spec.name, (("_parent_id", "eq", identity_value),))
+                child_items = self._rebuild_child_items(rows, selection.spec)
+            elif isinstance(selection, DerivedChildren):
+                child_items = list(selection.items)
+            else:
+                raise TypeError(f"unsupported child selection: {type(selection).__name__}")
+            yield from self._insert_children_items(
+                identity_value,
+                child_items,
+                selection.spec,
+                write_gen,
+            )
+        provenance_changed = any(existing.get(f"_provenance_{name}") != provenance for name, provenance in provenances.items())
+        rewrite_parent = not parent_skipped or provenance_changed or self._provenance.row_missing_stamp(existing, RECIPE_COLUMN)
+        if rewrite_parent:
+            yield EvolveMetadata(_freeze(item))
+            row = yield BuildParentRow(
+                _freeze(item),
+                _freeze(graph_inputs),
+                _freeze(outputs),
+                write_gen,
+                "complete",
+                _freeze(provenances),
+            )
+            yield WriteRows.from_rows(self._spec.name, [row])
+            yield self._cleanup_parent(identity_value, write_gen)
+        yield from self._cleanup_children(identity_value, write_gen)
+        return "skipped" if parent_skipped else "updated"
+
+    def _error_parent(
+        self,
+        item: dict[str, Any],
+        graph_inputs: dict[str, Any],
+        write_gen: int,
+        error: Exception,
+        existing: dict[str, Any] | None,
+    ) -> Generator[WriteAction, Any, None]:
+        yield EvolveMetadata(_freeze(item))
+        row = yield BuildParentRow(
+            _freeze(item),
+            _freeze(graph_inputs),
+            (),
+            write_gen,
+            "error",
+            error=f"{type(error).__name__}: {error}",
+        )
+        yield WriteRows.from_rows(self._spec.name, [row])
+        if existing is not None:
+            yield self._cleanup_parent(item[self._identity], write_gen)
+
+    def _insert_one(
+        self,
+        item: dict[str, Any],
+        write_gen: int,
+    ) -> Generator[WriteAction, Any, str]:
+        identity_value = item[self._identity]
+        graph_inputs = self._graph_inputs(item)
+        existing = yield ReadOne(self._spec.name, self._identity, identity_value)
+        parent_skipped = self._parent_skipped(existing, self._provenance.root_fingerprint(graph_inputs))
+        if parent_skipped and not self._spec.children:
+            if self._provenance.row_missing_stamp(existing, RECIPE_COLUMN):
+                yield from self._refresh_missing_stamps(existing)
+            return "skipped"
+
+        if self._can_reconcile(existing):
+            try:
+                reconciled = yield from self._reconcile(item, existing)
+            except Exception as error:
+                if self._on_error == "raise":
+                    raise
+                if parent_skipped:
+                    return "skipped"
+                yield from self._error_parent(item, graph_inputs, write_gen, error, existing)
+                return "errored"
+            if reconciled is not None:
+                return (
+                    yield from self._apply_reconciled(
+                        item,
+                        graph_inputs,
+                        existing,
+                        reconciled,
+                        parent_skipped,
+                        write_gen,
+                    )
+                )
+
+        try:
+            outputs = yield RunGraph(self._graph, _freeze(graph_inputs))
+        except Exception as error:
+            if self._on_error == "raise":
+                raise
+            if parent_skipped:
+                return "skipped"
+            yield from self._error_parent(item, graph_inputs, write_gen, error, existing)
+            return "errored"
+
+        if parent_skipped:
+            for child_spec in self._spec.children:
+                yield from self._insert_children(identity_value, outputs, child_spec, write_gen)
+            yield from self._cleanup_children(identity_value, write_gen)
+            return "skipped"
+
+        for child_spec in self._spec.children:
+            yield from self._insert_children(identity_value, outputs, child_spec, write_gen)
+        yield EvolveMetadata(_freeze(item))
+        row = yield BuildParentRow(
+            _freeze(item),
+            _freeze(graph_inputs),
+            _freeze(outputs),
+            write_gen,
+            "complete",
+        )
+        yield WriteRows.from_rows(self._spec.name, [row])
+        if existing is not None:
+            yield self._cleanup_parent(identity_value, write_gen)
+            yield from self._cleanup_children(identity_value, write_gen)
+        return "updated" if existing is not None else "inserted"
+
+    def insert(self, items: list[dict[str, Any]]) -> WriteOperation:
+        write_gen = (yield MaxWriteGen(self._spec.name)) + 1
+        for item in items:
+            yield from self._insert_one(item, write_gen)
+
+    def _prepare_update(
+        self,
+        identity_value: str,
+        changes: dict[str, Any],
+    ) -> Generator[WriteAction, Any, tuple[dict[str, Any], bool, int]]:
+        existing = yield ReadOne(self._spec.name, self._identity, identity_value)
+        if existing is None:
+            raise KeyError(identity_value)
+        item: dict[str, Any] = {self._identity: identity_value}
+        for column in self._spec.columns:
+            if column.role == "source" and column.name in existing:
+                item[column.name] = normalize_value(existing[column.name])
+        spec_columns = {column.name for column in self._spec.columns}
+        for key, value in existing.items():
+            if key not in spec_columns and not is_internal_column(key):
+                item[key] = normalize_value(value)
+        item.update(changes)
+        source_names = {column.name for column in self._spec.columns if column.role == "source"}
+        needs_rederive = any(key in source_names for key in changes)
+        write_gen = (yield MaxWriteGen(self._spec.name)) + 1
+        return item, needs_rederive, write_gen
+
+    def update(self, identity_value: str, changes: dict[str, Any]) -> WriteOperation:
+        item, needs_rederive, write_gen = yield from self._prepare_update(identity_value, changes)
+        existing = yield ReadOne(self._spec.name, self._identity, identity_value)
+        if not needs_rederive:
+            yield EvolveMetadata(_freeze({self._identity: identity_value, **changes}))
+            row = {key: normalize_value(value) for key, value in existing.items()}
+            row.update(changes)
+            row["_write_gen"] = write_gen
+            yield WriteRows.from_rows(self._spec.name, [row])
+            yield self._cleanup_parent(identity_value, write_gen)
+            return
+
+        graph_inputs = self._graph_inputs(item)
+        if self._can_reconcile(existing):
+            reconciled = yield from self._reconcile(item, existing)
+            if reconciled is not None:
+                yield from self._apply_reconciled(
+                    item,
+                    graph_inputs,
+                    existing,
+                    reconciled,
+                    False,
+                    write_gen,
+                )
+                return
+
+        outputs = yield RunGraph(self._graph, _freeze(graph_inputs))
+        yield EvolveMetadata(_freeze(item))
+        row = yield BuildParentRow(
+            _freeze(item),
+            _freeze(graph_inputs),
+            _freeze(outputs),
+            write_gen,
+            "update",
+        )
+        for child_spec in self._spec.children:
+            yield from self._insert_children(identity_value, outputs, child_spec, write_gen)
+        yield WriteRows.from_rows(self._spec.name, [row])
+        yield from self._cleanup_children(identity_value, write_gen)
+        yield self._cleanup_parent(identity_value, write_gen)
+
+    def delete(self, identity_value: str) -> WriteOperation:
+        existing = yield ReadOne(self._spec.name, self._identity, identity_value)
+        if existing is None:
+            return
+        for child_spec in self._spec.children:
+            yield DeleteRows(child_spec.name, (("_parent_id", "eq", identity_value),))
+        yield DeleteRows(self._spec.name, ((self._identity, "eq", identity_value),))
+
+    def _row_unchanged(self, item: dict[str, Any], existing: dict[str, Any]) -> bool:
+        inputs = self._graph_inputs(item)
+        return existing.get("_row_fingerprint") == self._provenance.root_fingerprint(inputs)
+
+    def _error_row(self, identity_value: str) -> Generator[WriteAction, Any, ErrorRow | None]:
+        row = yield ReadOne(self._spec.name, self._identity, identity_value)
+        if not row:
+            return None
+        error = row.get("_error", "")
+        return ErrorRow(
+            identity={self._identity: identity_value},
+            error_type=error.split(":")[0] if error else "Unknown",
+            error_msg=error,
+        )
+
+    def sync(self, items: list[dict[str, Any]]) -> WriteOperation:
+        rows = yield ReadRows(self._spec.name)
+        existing_by_id = {str(row[self._identity]): row for row in dedup_rows(rows, self._identity) if row.get(self._identity) is not None}
+        incoming_ids: set[str] = set()
+        inserted = updated = skipped = errored = 0
+        errors: list[ErrorRow] = []
+        write_gen = (yield MaxWriteGen(self._spec.name)) + 1
+
+        for item in items:
+            identity_value = str(item[self._identity])
+            incoming_ids.add(identity_value)
+            existing = existing_by_id.get(identity_value)
+            if existing is None:
+                result = yield from self._insert_one(item, write_gen)
+                if result == "errored":
+                    errored += 1
+                    error = yield from self._error_row(identity_value)
+                    if error is not None:
+                        errors.append(error)
+                else:
+                    inserted += 1
+            elif self._row_unchanged(item, existing):
+                if self._provenance.row_missing_stamp(existing, RECIPE_COLUMN):
+                    yield from self._refresh_missing_stamps(existing)
+                skipped += 1
+            else:
+                changes = {key: value for key, value in item.items() if key != self._identity}
+                yield from self.update(identity_value, changes)
+                updated += 1
+
+        deleted = 0
+        for identity_value in existing_by_id:
+            if identity_value not in incoming_ids:
+                yield from self.delete(identity_value)
+                deleted += 1
+        return SyncResult(inserted, updated, deleted, skipped, errored, tuple(errors))
+
+    def set_rows(self, where: _Predicate, fields: dict[str, Any]) -> WriteOperation:
+        content_keys = {column.name for column in self._spec.columns if column.content_key}
+        blocked = sorted(content_keys.intersection(fields))
+        if blocked:
+            raise ValueError(f"set() cannot update content-key fields: {', '.join(blocked)}")
+        rows = dedup_rows((yield ReadRows(self._spec.name, where)), self._identity)
+        if not rows:
+            return 0
+        yield EvolveMetadata(_freeze({self._identity: rows[0][self._identity], **fields}))
+        write_gen = (yield MaxWriteGen(self._spec.name)) + 1
+        updated = []
+        for row in rows:
+            new_row = {key: normalize_value(value) for key, value in row.items()}
+            new_row.update(fields)
+            new_row["_write_gen"] = write_gen
+            updated.append(new_row)
+        yield WriteRows.from_rows(self._spec.name, updated)
+        for row in rows:
+            yield DeleteRows(
+                self._spec.name,
+                ((self._identity, "eq", row[self._identity]), ("_write_gen", "lt", write_gen)),
+            )
+        return len(updated)
+
+    def set_children(self, where: _Predicate, fields: dict[str, Any]) -> WriteOperation:
+        if not self._spec.children:
+            return 0
+        child_spec = self._spec.children[0]
+        rows = dedup_child_rows(
+            (yield ReadRows(child_spec.name, where)),
+            child_spec.identity,
+        )
+        if not rows:
+            return 0
+        yield EvolveMetadata(
+            _freeze({child_spec.identity: rows[0][child_spec.identity], **fields}),
+            child_spec.name,
+            child_spec.identity,
+        )
+        write_gen = (yield MaxWriteGen(child_spec.name)) + 1
+        updated = []
+        for row in rows:
+            new_row = {key: normalize_value(value) for key, value in row.items()}
+            new_row.update(fields)
+            new_row["_write_gen"] = write_gen
+            updated.append(new_row)
+        yield WriteRows.from_rows(child_spec.name, updated)
+        for row in rows:
+            yield DeleteRows(
+                child_spec.name,
+                (
+                    (child_spec.identity, "eq", row[child_spec.identity]),
+                    ("_parent_id", "eq", row["_parent_id"]),
+                    ("_write_gen", "lt", write_gen),
+                ),
+            )
+        return len(updated)
+
+    def _source_inputs(self, row: dict[str, Any]) -> dict[str, Any]:
+        return {column.name: normalize_value(row[column.name]) for column in self._spec.columns if column.role == "source" and column.name in row}
+
+    def derive_column(self, column: str, *, backfill: bool) -> WriteOperation:
+        if backfill:
+            yield EvolveBackfillColumn(column)
+        node = self._provenance.producing_node(column)
+        write_gen = (yield MaxWriteGen(self._spec.name)) + 1
+        rows = dedup_rows((yield ReadRows(self._spec.name)), self._identity)
+        for existing in rows:
+            if backfill and not self._provenance.column_is_null(existing.get(column)):
+                continue
+            values = self._provenance.stored_values(existing)
+            outputs = yield RunGraph(
+                self._provenance.column_graph(node),
+                _freeze(self._provenance.node_inputs(node, values)),
+            )
+            new_row = yield BuildNodeRow(_freeze(existing), node, _freeze(outputs), write_gen)
+            yield WriteRows.from_rows(self._spec.name, [new_row])
+            yield DeleteRows(
+                self._spec.name,
+                (
+                    (self._identity, "eq", existing[self._identity]),
+                    ("_write_gen", "lt", write_gen),
+                ),
+            )
+
+
+class Writes:
+    """Cohesive write subsystem: pure plans plus one physical action executor."""
+
+    def __init__(
+        self,
+        graph: Any,
+        spec: TableSpec,
+        identity: str,
+        store: Any,
+        components: Mapping[str, Any],
+        on_error: Literal["raise", "store"],
+        provenance: Provenance,
+    ):
+        self.plans = WritePlanner(graph, spec, identity, components, on_error, provenance)
+        self.executor = WriteExecutor(store, spec, identity, provenance)
+
+    @property
+    def journal(self) -> RecipeJournal:
+        return self.executor.journal

--- a/src/hypergraph/materialization/_writes.py
+++ b/src/hypergraph/materialization/_writes.py
@@ -13,6 +13,7 @@ from hypergraph.materialization._provenance import (
     ReconcileComplete,
     ReconcileResult,
     ReconcileUnavailable,
+    normalize_value,
 )
 from hypergraph.materialization._recipe_journal import RecipeJournal
 from hypergraph.materialization._schema import (
@@ -57,17 +58,6 @@ def normalize_to_dict(item: Any) -> dict[str, Any]:
 
         return asdict(item)
     return dict(item)
-
-
-def normalize_value(value: Any) -> Any:
-    """Convert numpy/Arrow scalar values back to native Python values."""
-    import numpy as np
-
-    if isinstance(value, np.ndarray):
-        return value.tolist()
-    if isinstance(value, (np.floating, np.integer)):
-        return value.item()
-    return value
 
 
 def dedup_rows(rows: list[dict[str, Any]], identity: str) -> list[dict[str, Any]]:
@@ -401,9 +391,6 @@ class WriteExecutor:
         row["_write_gen"] = action.write_gen
         return row
 
-    def _source_inputs(self, row: dict[str, Any]) -> dict[str, Any]:
-        return {column.name: normalize_value(row[column.name]) for column in self._spec.columns if column.role == "source" and column.name in row}
-
     def _build_node_row(self, action: BuildNodeRow) -> dict[str, Any]:
         existing = _thaw(action.existing)
         outputs = _thaw(action.outputs)
@@ -417,7 +404,7 @@ class WriteExecutor:
         self._record_node_recipe(action.node)
         new_row["_write_gen"] = action.write_gen
         if self._provenance.row_converged(new_row):
-            new_row["_row_fingerprint"] = self._provenance.root_fingerprint(self._source_inputs(new_row))
+            new_row["_row_fingerprint"] = self._provenance.root_fingerprint(self._provenance.source_inputs(new_row))
             self._stamp_recipe(new_row, self._spec.name)
         return new_row
 
@@ -1043,9 +1030,6 @@ class WritePlanner:
                 ),
             )
         return len(updated)
-
-    def _source_inputs(self, row: dict[str, Any]) -> dict[str, Any]:
-        return {column.name: normalize_value(row[column.name]) for column in self._spec.columns if column.role == "source" and column.name in row}
 
     def derive_column(self, column: str, *, backfill: bool) -> WriteOperation:
         if backfill:

--- a/tests/events/test_nontty_progress.py
+++ b/tests/events/test_nontty_progress.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 from unittest.mock import patch
 
+from hypergraph.events._progress_renderers import _LogRenderer, _NotebookRenderer, _RichTTYRenderer
 from hypergraph.events.rich_progress import RichProgressProcessor
 from hypergraph.events.types import (
     NodeEndEvent,
@@ -164,7 +165,7 @@ class TestNonTTYMapMilestones:
             proc.on_run_start(_run_start("item1", parent="map1", graph="process"))
             proc.on_run_end(_run_end("item1", parent="map1", graph="process", status=RunStatus.PARTIAL))
 
-            map_info = proc._spans["map1"]
+            map_info = proc._tracker.spans["map1"]
             assert map_info.failures == 1
             assert map_info.succeeded == 0
         finally:
@@ -177,22 +178,21 @@ class TestNonTTYAutoDetect:
     def test_auto_detects_nontty(self):
         with patch("hypergraph.events.rich_progress._detect_mode", return_value="non-tty"):
             proc = RichProgressProcessor(force_mode="auto")
-            assert proc._tty_mode is False
+            assert isinstance(proc._renderer, _LogRenderer)
 
     def test_auto_detects_tty(self):
         with patch("hypergraph.events.rich_progress._detect_mode", return_value="tty"):
             proc = RichProgressProcessor(force_mode="auto")
-            assert proc._tty_mode is True
+            assert isinstance(proc._renderer, _RichTTYRenderer)
 
     def test_auto_detects_notebook(self):
         with patch("hypergraph.events.rich_progress._detect_mode", return_value="notebook"):
             proc = RichProgressProcessor(force_mode="auto")
-            assert proc._tty_mode is True
-            assert proc._notebook is True
+            assert isinstance(proc._renderer, _NotebookRenderer)
 
     def test_force_nontty(self):
         proc = RichProgressProcessor(force_mode="non-tty")
-        assert proc._tty_mode is False
+        assert isinstance(proc._renderer, _LogRenderer)
 
     def test_shutdown_nontty_no_error(self):
         proc = _make_processor()

--- a/tests/events/test_rich_progress.py
+++ b/tests/events/test_rich_progress.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from hypergraph.events._progress_renderers import (
+    _NotebookRenderer,
+    _require_rich,
+    _RichTTYRenderer,
+)
 from hypergraph.events.rich_progress import RichProgressProcessor
 from hypergraph.events.types import (
     InnerCacheEvent,
@@ -25,21 +31,17 @@ def _make_processor() -> tuple[RichProgressProcessor, MagicMock]:
     """Create a RichProgressProcessor with a mocked Progress object."""
     proc = RichProgressProcessor(transient=True, force_mode="tty")
     mock_progress = MagicMock()
-    # Mock tasks list for description updates
-    mock_progress.tasks = {}
-    # add_task returns incrementing task IDs
+    renderer = proc._renderer
+    assert isinstance(renderer, _RichTTYRenderer)
     task_counter = [0]
 
     def _add_task(desc, **kwargs):
         tid = task_counter[0]
         task_counter[0] += 1
-        mock_task = MagicMock()
-        mock_task.description = desc
-        mock_progress.tasks[tid] = mock_task
         return tid
 
     mock_progress.add_task.side_effect = _add_task
-    proc._progress = mock_progress
+    renderer._progress = mock_progress
     proc._started = True
     return proc, mock_progress
 
@@ -153,7 +155,8 @@ class TestSingleRun:
         proc.on_node_start(_node_start(node_name="load"))
         proc.on_node_end(_node_end(node_name="load"))
 
-        mock.advance.assert_called_once_with(0, 1)
+        completed = [call.kwargs["completed"] for call in mock.update.call_args_list if "completed" in call.kwargs]
+        assert completed == [1]
 
     def test_total_is_1_for_single_run(self):
         proc, mock = _make_processor()
@@ -210,8 +213,8 @@ class TestSingleRun:
 
         proc.on_inner_cache(_inner_cache(parent_span_id="inner_node", node_name="shared", hit=True))
 
-        outer_bar = proc._node_bars[proc._spans["outer_node"].node_bar_key]
-        inner_bar = proc._node_bars[proc._spans["inner_node"].node_bar_key]
+        outer_bar = proc._tracker.node_bars[proc._tracker.spans["outer_node"].node_bar_key]
+        inner_bar = proc._tracker.node_bars[proc._tracker.spans["inner_node"].node_bar_key]
 
         assert outer_bar.inner_cache_hits == 0
         assert inner_bar.inner_cache_hits == 1
@@ -257,8 +260,8 @@ class TestMapOperation:
         proc.on_run_start(_run_start(run_id="r2", span_id="item1", parent_span_id="map1"))
         proc.on_run_end(_run_end(run_id="r2", span_id="item1", parent_span_id="map1"))
 
-        # advance called on map task (task_id=0)
-        mock.advance.assert_called_with(0, 1)
+        completed = [call.kwargs["completed"] for call in mock.update.call_args_list if "completed" in call.kwargs]
+        assert completed[-1] == 1
 
     def test_node_bars_reused_across_items(self):
         proc, mock = _make_processor()
@@ -304,8 +307,9 @@ class TestMapOperation:
 
         # add_task: 1 for map bar + 1 for "load" node (reused)
         assert mock.add_task.call_count == 2
-        # advance called twice for node bar
-        assert mock.advance.call_count == 2
+        # The reused logical task receives exact completed snapshots.
+        completed = [call.kwargs["completed"] for call in mock.update.call_args_list if "completed" in call.kwargs]
+        assert completed == [1, 2]
 
     def test_child_nodes_have_tree_characters(self):
         proc, mock = _make_processor()
@@ -473,7 +477,7 @@ class TestNodeError:
             )
         )
 
-        mock.advance.assert_called()
+        assert any(call.kwargs.get("completed") == 1 for call in mock.update.call_args_list)
         stats_calls = [c for c in mock.update.call_args_list if "stats" in c.kwargs]
         assert "1✗" in stats_calls[-1].kwargs["stats"]
 
@@ -504,19 +508,22 @@ class TestLifecycle:
 class TestNotebookRefresh:
     def test_notebook_uses_manual_refresh(self):
         proc = RichProgressProcessor(force_mode="notebook")
-        live = getattr(proc._progress, "live", None)
-        assert proc._manual_notebook_refresh is True
-        assert bool(getattr(live, "auto_refresh", False)) is False
+        renderer = proc._renderer
+        assert isinstance(renderer, _NotebookRenderer)
+        assert not hasattr(renderer._progress, "live")
 
-    def test_refresh_skips_when_manual_refresh_disabled(self):
+    def test_refresh_throttles_inside_interval(self):
         proc = RichProgressProcessor(force_mode="notebook")
+        renderer = proc._renderer
+        assert isinstance(renderer, _NotebookRenderer)
         mock_progress = MagicMock()
-        proc._progress = mock_progress
-        proc._manual_notebook_refresh = False
+        renderer._progress = mock_progress
+        renderer._last_refresh = time.monotonic()
 
-        proc._refresh()
+        renderer._refresh()
 
         mock_progress.refresh.assert_not_called()
+        assert renderer._refresh_dirty is True
 
 
 # ---------------------------------------------------------------------------
@@ -527,6 +534,4 @@ class TestNotebookRefresh:
 class TestImportGuard:
     def test_raises_without_rich(self):
         with patch.dict("sys.modules", {"rich": None}), pytest.raises(ImportError, match="rich"):
-            from hypergraph.events.rich_progress import _require_rich
-
             _require_rich()

--- a/tests/events/test_ticket185_progress_modes.py
+++ b/tests/events/test_ticket185_progress_modes.py
@@ -234,3 +234,49 @@ def test_notebook_stopped_completion_keeps_paused_foreground() -> None:
     completion_html = display.call_args.args[0].data
     assert f"color:{STATUS_COLORS['paused']}" in completion_html
     assert "◼ pipeline stopped" in completion_html
+
+
+def test_unknown_size_map_never_materializes_a_late_progress_task() -> None:
+    tty = RichProgressProcessor(force_mode="tty")
+    tty_renderer = tty._renderer
+    assert isinstance(tty_renderer, _RichTTYRenderer)
+    tty_progress = _mock_rich_progress()
+    tty_renderer._progress = tty_progress
+
+    with patch("IPython.display.display", return_value=MagicMock()):
+        notebook = RichProgressProcessor(force_mode="notebook")
+        notebook_renderer = notebook._renderer
+        assert isinstance(notebook_renderer, _NotebookRenderer)
+
+        for processor in (tty, notebook):
+            processor.on_run_start(RunStartEvent(run_id="root", span_id="root", graph_name="pipeline"))
+            processor.on_run_start(
+                RunStartEvent(
+                    run_id="map",
+                    span_id="map",
+                    parent_span_id="root",
+                    graph_name="inner",
+                    is_map=True,
+                    map_size=None,
+                )
+            )
+            processor.on_run_start(
+                RunStartEvent(
+                    run_id="child",
+                    span_id="child",
+                    parent_span_id="map",
+                    graph_name="inner",
+                )
+            )
+            processor.on_run_end(
+                RunEndEvent(
+                    run_id="child",
+                    span_id="child",
+                    parent_span_id="map",
+                    graph_name="inner",
+                    status=RunStatus.COMPLETED,
+                )
+            )
+
+    assert tty_progress.add_task.call_args_list == []
+    assert notebook_renderer._progress._tasks == {}

--- a/tests/events/test_ticket185_progress_modes.py
+++ b/tests/events/test_ticket185_progress_modes.py
@@ -1,0 +1,236 @@
+"""Ticket #185 transcript parity for progress renderers."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from hypergraph._repr import STATUS_COLORS
+from hypergraph.events._progress_renderers import (
+    _LogRenderer,
+    _NotebookRenderer,
+    _RichTTYRenderer,
+)
+from hypergraph.events.rich_progress import RichProgressProcessor
+from hypergraph.events.types import (
+    InnerCacheEvent,
+    NodeEndEvent,
+    NodeErrorEvent,
+    NodeStartEvent,
+    RunEndEvent,
+    RunStartEvent,
+    RunStatus,
+)
+
+
+def _event_transcript() -> list[object]:
+    events: list[object] = [
+        RunStartEvent(run_id="root", span_id="root", graph_name="pipeline"),
+        NodeStartEvent(
+            run_id="root",
+            span_id="load-span",
+            parent_span_id="root",
+            node_name="load",
+            graph_name="pipeline",
+        ),
+        NodeEndEvent(
+            run_id="root",
+            span_id="load-span",
+            parent_span_id="root",
+            node_name="load",
+            graph_name="pipeline",
+            duration_ms=8.0,
+        ),
+        NodeStartEvent(
+            run_id="root",
+            span_id="map-node",
+            parent_span_id="root",
+            node_name="fanout",
+            graph_name="pipeline",
+        ),
+        RunStartEvent(
+            run_id="map-run",
+            span_id="map",
+            parent_span_id="map-node",
+            graph_name="inner",
+            is_map=True,
+            map_size=5,
+        ),
+    ]
+
+    statuses = (
+        RunStatus.COMPLETED,
+        RunStatus.FAILED,
+        RunStatus.PARTIAL,
+        RunStatus.PAUSED,
+        RunStatus.STOPPED,
+    )
+    for index, status in enumerate(statuses):
+        item_span = f"item-{index}"
+        node_span = f"work-{index}"
+        events.extend(
+            [
+                RunStartEvent(
+                    run_id=f"item-run-{index}",
+                    span_id=item_span,
+                    parent_span_id="map",
+                    graph_name="inner",
+                ),
+                NodeStartEvent(
+                    run_id=f"item-run-{index}",
+                    span_id=node_span,
+                    parent_span_id=item_span,
+                    node_name="work<unsafe>",
+                    graph_name="inner",
+                ),
+            ]
+        )
+        if index == 0:
+            events.append(
+                InnerCacheEvent(
+                    run_id=f"item-run-{index}",
+                    parent_span_id=node_span,
+                    node_name="work<unsafe>",
+                    graph_name="inner",
+                    hit=True,
+                    refreshing=True,
+                )
+            )
+        if status in (RunStatus.FAILED, RunStatus.PARTIAL):
+            events.append(
+                NodeErrorEvent(
+                    run_id=f"item-run-{index}",
+                    span_id=node_span,
+                    parent_span_id=item_span,
+                    node_name="work<unsafe>",
+                    graph_name="inner",
+                    error="boom",
+                    error_type="ValueError",
+                )
+            )
+        else:
+            events.append(
+                NodeEndEvent(
+                    run_id=f"item-run-{index}",
+                    span_id=node_span,
+                    parent_span_id=item_span,
+                    node_name="work<unsafe>",
+                    graph_name="inner",
+                    duration_ms=10.0,
+                )
+            )
+        events.append(
+            RunEndEvent(
+                run_id=f"item-run-{index}",
+                span_id=item_span,
+                parent_span_id="map",
+                graph_name="inner",
+                status=status,
+            )
+        )
+
+    events.append(
+        RunEndEvent(
+            run_id="root",
+            span_id="root",
+            graph_name="pipeline",
+            status=RunStatus.COMPLETED,
+        )
+    )
+    return events
+
+
+def _drive(processor: RichProgressProcessor) -> None:
+    for event in _event_transcript():
+        processor.on_event(event)
+
+
+def _mock_rich_progress() -> MagicMock:
+    progress = MagicMock()
+    counter = iter(range(100))
+    progress.add_task.side_effect = lambda *_args, **_kwargs: next(counter)
+    return progress
+
+
+def test_one_transcript_preserves_tty_tasks_stats_and_completion() -> None:
+    processor = RichProgressProcessor(transient=True, force_mode="tty")
+    renderer = processor._renderer
+    assert isinstance(renderer, _RichTTYRenderer)
+    progress = _mock_rich_progress()
+    renderer._progress = progress
+
+    _drive(processor)
+
+    descriptions = [call.args[0] for call in progress.add_task.call_args_list]
+    assert descriptions == ["load", "fanout", "◈ fanout", "  └─ work<unsafe>"]
+    assert any(call.kwargs.get("visible") is False for call in progress.update.call_args_list)
+    stats = [call.kwargs["stats"] for call in progress.update.call_args_list if "stats" in call.kwargs]
+    assert "3✓ 2✗ ~6ms 1↩ 1↻" in stats
+    assert stats[-1] == "1✓ 2✗"
+    progress.console.print.assert_called_once_with("[bold green]✓ pipeline completed![/bold green]")
+
+
+def test_one_transcript_preserves_notebook_html_refresh_and_completion() -> None:
+    display_handle = MagicMock()
+    with patch("IPython.display.display", return_value=display_handle) as display:
+        processor = RichProgressProcessor(transient=True, force_mode="notebook")
+        renderer = processor._renderer
+        assert isinstance(renderer, _NotebookRenderer)
+
+        _drive(processor)
+
+        rendered = renderer._progress._render_html()
+        assert "◈ fanout" in rendered
+        assert "└─ work&lt;unsafe&gt;" in rendered
+        assert "3✓" in rendered and "2✗" in rendered
+        assert "1↩" in rendered and "1↻" in rendered
+        completion_html = display.call_args.args[0].data
+        assert "✓ pipeline completed!" in completion_html
+        assert display_handle.update.called
+        assert renderer.take_async_flush() is True
+        assert renderer.take_async_flush() is False
+
+
+def test_one_transcript_preserves_exact_non_tty_text_and_map_milestones(
+    capsys,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr("hypergraph.events._progress_renderers._timestamp", lambda: "[12:34:56]")
+    processor = RichProgressProcessor(force_mode="non-tty")
+    assert isinstance(processor._renderer, _LogRenderer)
+
+    _drive(processor)
+
+    assert capsys.readouterr().out.splitlines() == [
+        "[12:34:56] ▶ load started",
+        "[12:34:56] ✓ load completed",
+        "[12:34:56] ▶ fanout started",
+        "[12:34:56] ◈ inner: 10% (1/5)",
+        "[12:34:56] ◈ inner: 25% (2/5)",
+        "[12:34:56] ◈ inner: 50% (3/5)",
+        "[12:34:56] ◈ inner: 75% (4/5)",
+        "[12:34:56] ◈ inner: 100% (5/5)",
+        "[12:34:56] ✓ pipeline completed!",
+    ]
+
+
+def test_invalid_force_mode_still_falls_through_to_non_tty() -> None:
+    processor = RichProgressProcessor(force_mode="not-a-mode")  # type: ignore[arg-type]
+    assert isinstance(processor._renderer, _LogRenderer)
+
+
+def test_notebook_stopped_completion_keeps_paused_foreground() -> None:
+    with patch("IPython.display.display") as display:
+        processor = RichProgressProcessor(force_mode="notebook")
+        processor.on_run_start(RunStartEvent(run_id="root", span_id="root", graph_name="pipeline"))
+        processor.on_run_end(
+            RunEndEvent(
+                run_id="root",
+                span_id="root",
+                graph_name="pipeline",
+                status=RunStatus.STOPPED,
+            )
+        )
+
+    completion_html = display.call_args.args[0].data
+    assert f"color:{STATUS_COLORS['paused']}" in completion_html
+    assert "◼ pipeline stopped" in completion_html

--- a/tests/test_checkpointer/test_sqlite.py
+++ b/tests/test_checkpointer/test_sqlite.py
@@ -1,8 +1,9 @@
 """Tests for SqliteCheckpointer."""
 
 import asyncio
-from datetime import timedelta, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import Any
 
 import pytest
 import pytest_asyncio
@@ -14,6 +15,7 @@ from hypergraph.checkpointers import (
     StepStatus,
     WorkflowStatus,
 )
+from hypergraph.checkpointers.serializers import JsonSerializer, Serializer
 
 # Skip all tests if aiosqlite is not installed
 aiosqlite = pytest.importorskip("aiosqlite")
@@ -43,6 +45,20 @@ def _make_step(run_id="wf-1", superstep=0, node_name="embed", index=0, **kwargs)
         index=index,
         **defaults,
     )
+
+
+class _FailOnDemandSerializer(Serializer):
+    def __init__(self) -> None:
+        self.fail = False
+        self._json = JsonSerializer()
+
+    def serialize(self, value: Any) -> bytes:
+        if self.fail:
+            raise RuntimeError("baseline serialization failed")
+        return self._json.serialize(value)
+
+    def deserialize(self, data: bytes) -> Any:
+        return self._json.deserialize(data)
 
 
 class TestRunLifecycle:
@@ -230,6 +246,43 @@ class TestStepPersistence:
         steps = checkpointer.steps("wf-1")
         assert len(steps) == 1
         assert steps[0].values == {"v": 2}
+
+    async def test_upsert_preserves_fields_outside_the_update_policy(self, checkpointer):
+        await checkpointer.create_run("wf-1")
+        original_created_at = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        replacement_created_at = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        await checkpointer.save_step(
+            _make_step(
+                index=7,
+                input_versions={"source": 1},
+                values={"v": 1},
+                created_at=original_created_at,
+                child_run_id="child-original",
+            )
+        )
+
+        await checkpointer.save_step(
+            _make_step(
+                index=99,
+                input_versions={"source": 2},
+                values={"v": 2},
+                status=StepStatus.FAILED,
+                error="replacement",
+                created_at=replacement_created_at,
+                child_run_id="child-replacement",
+                partial=True,
+            )
+        )
+
+        [step] = checkpointer.steps("wf-1")
+        assert step.index == 7
+        assert step.input_versions == {"source": 1}
+        assert step.created_at == original_created_at
+        assert step.child_run_id == "child-original"
+        assert step.values == {"v": 2}
+        assert step.status is StepStatus.FAILED
+        assert step.error == "replacement"
+        assert step.partial is True
 
     async def test_get_steps_by_superstep(self, checkpointer):
         await checkpointer.create_run("wf-1")
@@ -652,6 +705,57 @@ class TestRetentionPolicyBehavior:
 
         assert checkpointer.state("wf-latest-state") == {"x": 1}
         assert checkpointer.checkpoint("wf-latest-state").values == {"x": 1}
+
+    async def test_baseline_serialization_finishes_before_delete_and_failure_rolls_back(self, tmp_path, monkeypatch):
+        path = tmp_path / "retention-serialization.db"
+        serializer = _FailOnDemandSerializer()
+        checkpointer = SqliteCheckpointer(path, serializer=serializer)
+        await checkpointer.create_run("wf-serialize")
+        await checkpointer.save_step(
+            _make_step(
+                run_id="wf-serialize",
+                superstep=0,
+                node_name="a",
+                index=0,
+                values={"x": 1},
+            )
+        )
+        checkpointer.policy = CheckpointPolicy(durability="sync", retention="latest")
+
+        connection_type = type(checkpointer._db)
+        original_execute = connection_type.execute
+        delete_statements: list[str] = []
+
+        async def track_execute(connection, sql, parameters=None):
+            if sql.lstrip().startswith("DELETE FROM steps"):
+                delete_statements.append(sql)
+            return await original_execute(connection, sql, parameters)
+
+        monkeypatch.setattr(connection_type, "execute", track_execute)
+        serializer.fail = True
+        with pytest.raises(RuntimeError, match="baseline serialization failed"):
+            await checkpointer.save_step(
+                _make_step(
+                    run_id="wf-serialize",
+                    superstep=1,
+                    node_name="a",
+                    index=1,
+                    status=StepStatus.FAILED,
+                    values=None,
+                    error="boom",
+                )
+            )
+
+        assert delete_statements == []
+        await checkpointer.close()
+
+        reopened = SqliteCheckpointer(path)
+        try:
+            steps = reopened.steps("wf-serialize")
+            assert [(step.superstep, step.node_name, step.values) for step in steps] == [(0, "a", {"x": 1})]
+            assert reopened.state("wf-serialize") == {"x": 1}
+        finally:
+            await reopened.close()
 
     async def test_windowed_retention_keeps_recent_supersteps(self, checkpointer):
         """windowed retention should compact values before the latest N supersteps."""

--- a/tests/test_checkpointer/test_ticket185_presenters.py
+++ b/tests/test_checkpointer/test_ticket185_presenters.py
@@ -92,6 +92,14 @@ def test_missing_and_corrupt_explorer_assets_fail_loudly(monkeypatch) -> None:
     with pytest.raises(RuntimeError, match="corrupt"):
         presenters._read_explorer_asset()
 
+    class _TruncatedResource(_MissingResource):
+        def read_text(self, *, encoding: str) -> str:
+            return "/* hypergraph-checkpointer-explorer */"
+
+    monkeypatch.setattr(presenters, "files", lambda _package: _TruncatedResource())
+    with pytest.raises(RuntimeError, match="corrupt"):
+        presenters._read_explorer_asset()
+
 
 def _explorer_html(path: str, dangerous: str) -> str:
     created = datetime(2026, 7, 12, tzinfo=timezone.utc)
@@ -134,6 +142,39 @@ def _explorer_html(path: str, dangerous: str) -> str:
         state_key=f"state-{path}",
         runs=[root, child],
         steps_by_run={root.id: steps, child.id: []},
+    )
+
+
+def _reserved_id_explorer_html() -> str:
+    created = datetime(2026, 7, 12, tzinfo=timezone.utc)
+    root = Run(
+        id="constructor",
+        status=WorkflowStatus.COMPLETED,
+        graph_name="pipeline",
+        created_at=created,
+    )
+    children = [
+        Run(
+            id="__proto__",
+            status=WorkflowStatus.COMPLETED,
+            graph_name="pipeline",
+            parent_run_id=root.id,
+            created_at=created,
+        ),
+        Run(
+            id="toString",
+            status=WorkflowStatus.STOPPED,
+            graph_name="pipeline",
+            parent_run_id=root.id,
+            created_at=created,
+        ),
+    ]
+    return render_checkpointer_explorer_html(
+        title="Reserved IDs",
+        path="reserved-ids",
+        state_key="state-reserved-ids",
+        runs=[root, *children],
+        steps_by_run={},
     )
 
 
@@ -191,6 +232,27 @@ def test_real_dom_proves_navigation_safety_bind_once_and_isolation() -> None:
         )
         assert rebound == 0
         assert first.evaluate("root => root.__hgExplorerBound") is True
+        browser.close()
+
+
+def test_real_dom_accepts_workflow_ids_that_are_object_prototype_names() -> None:
+    playwright = pytest.importorskip("playwright.sync_api")
+    page_errors: list[Exception] = []
+
+    with playwright.sync_playwright() as runtime:
+        browser = runtime.chromium.launch(headless=True)
+        page = browser.new_page()
+        page.on("pageerror", lambda error: page_errors.append(error))
+        page.set_content(f"<!doctype html><html><body>{_reserved_id_explorer_html()}</body></html>")
+        root = page.locator('[data-hg-explorer="checkpointer"]')
+
+        assert page_errors == []
+        assert root.locator("[data-run-target]").count() >= 3
+        assert "constructor" in root.locator("[data-hg-explorer-header]").inner_text()
+        for run_id in ("__proto__", "toString"):
+            root.get_by_role("button", name=run_id, exact=True).first.click()
+            assert run_id in root.locator("[data-hg-explorer-header]").inner_text()
+        assert root.evaluate("node => node.__hgExplorerBound") is True
         browser.close()
 
 

--- a/tests/test_checkpointer/test_ticket185_presenters.py
+++ b/tests/test_checkpointer/test_ticket185_presenters.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from datetime import datetime, timezone
 from importlib.resources import files
 
@@ -73,9 +74,16 @@ def test_explorer_asset_is_a_real_package_resource() -> None:
 def test_missing_and_corrupt_explorer_assets_fail_loudly(monkeypatch) -> None:
     import hypergraph.checkpointers.presenters as presenters
 
+    canonical_resource = files("hypergraph.checkpointers._assets").joinpath("explorer.js")
+    canonical_source = canonical_resource.read_text(encoding="utf-8")
+    canonical_bytes = canonical_resource.read_bytes()
+
     class _MissingResource:
         def joinpath(self, _name: str) -> _MissingResource:
             return self
+
+        def read_bytes(self) -> bytes:
+            raise FileNotFoundError("explorer.js missing")
 
         def read_text(self, *, encoding: str) -> str:
             raise FileNotFoundError("explorer.js missing")
@@ -85,6 +93,9 @@ def test_missing_and_corrupt_explorer_assets_fail_loudly(monkeypatch) -> None:
         presenters._read_explorer_asset()
 
     class _CorruptResource(_MissingResource):
+        def read_bytes(self) -> bytes:
+            return b"not the explorer"
+
         def read_text(self, *, encoding: str) -> str:
             return "not the explorer"
 
@@ -93,10 +104,25 @@ def test_missing_and_corrupt_explorer_assets_fail_loudly(monkeypatch) -> None:
         presenters._read_explorer_asset()
 
     class _TruncatedResource(_MissingResource):
+        def read_bytes(self) -> bytes:
+            return b"/* hypergraph-checkpointer-explorer */"
+
         def read_text(self, *, encoding: str) -> str:
             return "/* hypergraph-checkpointer-explorer */"
 
     monkeypatch.setattr(presenters, "files", lambda _package: _TruncatedResource())
+    with pytest.raises(RuntimeError, match="corrupt"):
+        presenters._read_explorer_asset()
+
+    class _ChangedPhysicalBytesResource(_MissingResource):
+        def read_bytes(self) -> bytes:
+            return canonical_bytes.replace(b"\n", b"\r\n")
+
+        def read_text(self, *, encoding: str) -> str:
+            # Text-mode universal-newline decoding hides the physical mutation.
+            return canonical_source
+
+    monkeypatch.setattr(presenters, "files", lambda _package: _ChangedPhysicalBytesResource())
     with pytest.raises(RuntimeError, match="corrupt"):
         presenters._read_explorer_asset()
 
@@ -249,8 +275,16 @@ def test_real_dom_accepts_workflow_ids_that_are_object_prototype_names() -> None
         assert page_errors == []
         assert root.locator("[data-run-target]").count() >= 3
         assert "constructor" in root.locator("[data-hg-explorer-header]").inner_text()
-        for run_id in ("__proto__", "toString"):
-            root.get_by_role("button", name=run_id, exact=True).first.click()
+        statuses = {
+            "__proto__": "completed",
+            "toString": "stopped",
+        }
+        for run_id, status in statuses.items():
+            button = root.get_by_role(
+                "button",
+                name=re.compile(rf"^{re.escape(run_id)}\s+{status}\s+pipeline\b", re.IGNORECASE),
+            ).first
+            button.click()
             assert run_id in root.locator("[data-hg-explorer-header]").inner_text()
         assert root.evaluate("node => node.__hgExplorerBound") is True
         browser.close()

--- a/tests/test_checkpointer/test_ticket185_presenters.py
+++ b/tests/test_checkpointer/test_ticket185_presenters.py
@@ -1,0 +1,203 @@
+"""Ticket #185 policy, resource, and browser falsifiers for presenters."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from importlib.resources import files
+
+import pytest
+
+from hypergraph._repr import STATUS_COLORS, STATUS_PALETTE, status_badge
+from hypergraph.checkpointers.presenters import (
+    _aggregate_workflow_status,
+    _read_explorer_asset,
+    render_checkpointer_explorer_html,
+)
+from hypergraph.checkpointers.types import Run, RunTable, StepRecord, StepStatus, WorkflowStatus
+
+
+@pytest.mark.parametrize(
+    ("statuses", "expected"),
+    [
+        ([], WorkflowStatus.COMPLETED),
+        ([WorkflowStatus.COMPLETED], WorkflowStatus.COMPLETED),
+        ([WorkflowStatus.STOPPED, WorkflowStatus.COMPLETED], WorkflowStatus.STOPPED),
+        ([WorkflowStatus.FAILED], WorkflowStatus.FAILED),
+        ([WorkflowStatus.FAILED, WorkflowStatus.COMPLETED], WorkflowStatus.PARTIAL),
+        ([WorkflowStatus.PARTIAL, WorkflowStatus.STOPPED], WorkflowStatus.PARTIAL),
+        ([WorkflowStatus.PAUSED, WorkflowStatus.FAILED], WorkflowStatus.PAUSED),
+        ([WorkflowStatus.ACTIVE, WorkflowStatus.PAUSED], WorkflowStatus.ACTIVE),
+    ],
+)
+def test_aggregate_workflow_status_has_one_explicit_precedence(
+    statuses: list[WorkflowStatus],
+    expected: WorkflowStatus,
+) -> None:
+    assert _aggregate_workflow_status(statuses) is expected
+
+
+def test_run_table_synthetic_parent_consumes_canonical_aggregate_policy() -> None:
+    table = RunTable(
+        [
+            Run(id="batch/0", status=WorkflowStatus.FAILED),
+            Run(id="batch/1", status=WorkflowStatus.COMPLETED),
+        ]
+    )
+
+    html = table._repr_html_()
+
+    assert html is not None
+    assert 'data-id="batch" data-status="partial"' in html
+
+
+def test_status_palette_is_the_badge_and_explorer_color_owner() -> None:
+    assert STATUS_PALETTE["stopped"] == ("#92400e", "#fff7ed")
+    assert {status: pair[0] for status, pair in STATUS_PALETTE.items()} == STATUS_COLORS
+    foreground, background = STATUS_PALETTE["stopped"]
+    assert f"color:{foreground}" in status_badge("stopped")
+    assert f"background:{background}" in status_badge("stopped")
+
+    html = _explorer_html("palette", "safe")
+    assert foreground in html and background in html
+    asset = _read_explorer_asset()
+    assert "#92400e" not in asset
+    assert "#fff7ed" not in asset
+
+
+def test_explorer_asset_is_a_real_package_resource() -> None:
+    resource = files("hypergraph.checkpointers._assets").joinpath("explorer.js")
+    assert resource.is_file()
+    assert resource.read_text(encoding="utf-8") == _read_explorer_asset()
+
+
+def test_missing_and_corrupt_explorer_assets_fail_loudly(monkeypatch) -> None:
+    import hypergraph.checkpointers.presenters as presenters
+
+    class _MissingResource:
+        def joinpath(self, _name: str) -> _MissingResource:
+            return self
+
+        def read_text(self, *, encoding: str) -> str:
+            raise FileNotFoundError("explorer.js missing")
+
+    monkeypatch.setattr(presenters, "files", lambda _package: _MissingResource())
+    with pytest.raises(FileNotFoundError, match="explorer.js missing"):
+        presenters._read_explorer_asset()
+
+    class _CorruptResource(_MissingResource):
+        def read_text(self, *, encoding: str) -> str:
+            return "not the explorer"
+
+    monkeypatch.setattr(presenters, "files", lambda _package: _CorruptResource())
+    with pytest.raises(RuntimeError, match="corrupt"):
+        presenters._read_explorer_asset()
+
+
+def _explorer_html(path: str, dangerous: str) -> str:
+    created = datetime(2026, 7, 12, tzinfo=timezone.utc)
+    root = Run(
+        id=f"{path}-root",
+        status=WorkflowStatus.COMPLETED,
+        graph_name="pipeline",
+        created_at=created,
+    )
+    child = Run(
+        id=f"{path}-child",
+        status=WorkflowStatus.STOPPED,
+        graph_name="pipeline",
+        forked_from=root.id,
+        created_at=created,
+    )
+    steps = [
+        StepRecord(
+            run_id=root.id,
+            superstep=0,
+            node_name="first",
+            index=0,
+            status=StepStatus.COMPLETED,
+            input_versions={},
+            values={"safe": True},
+        ),
+        StepRecord(
+            run_id=root.id,
+            superstep=1,
+            node_name="second",
+            index=1,
+            status=StepStatus.COMPLETED,
+            input_versions={},
+            values={"dangerous": dangerous},
+        ),
+    ]
+    return render_checkpointer_explorer_html(
+        title=f"Explorer {path}",
+        path=path,
+        state_key=f"state-{path}",
+        runs=[root, child],
+        steps_by_run={root.id: steps, child.id: []},
+    )
+
+
+def test_real_dom_proves_navigation_safety_bind_once_and_isolation() -> None:
+    playwright = pytest.importorskip("playwright.sync_api")
+    dangerous = "</script><img id='owned' src=x onerror='document.body.dataset.pwned=1'>"
+    html_a = _explorer_html("alpha", dangerous)
+    html_b = _explorer_html("beta", "other")
+
+    with playwright.sync_playwright() as runtime:
+        browser = runtime.chromium.launch(headless=True)
+        page = browser.new_page()
+        page.set_content(f"<!doctype html><html><body>{html_a}{html_b}</body></html>")
+        roots = page.locator('[data-hg-explorer="checkpointer"]')
+        assert roots.count() == 2
+        first = roots.nth(0)
+        second = roots.nth(1)
+
+        assert "alpha-root" in first.locator("[data-hg-explorer-header]").inner_text()
+        assert "beta-root" in second.locator("[data-hg-explorer-header]").inner_text()
+        assert "Recent Steps" in first.locator("[data-hg-explorer-body]").inner_text()
+
+        first.get_by_role("button", name="Steps", exact=True).click()
+        first.locator('tr[data-step-index="1"]').click()
+        detail = first.locator("[data-hg-explorer-body]").inner_text()
+        assert "Step Detail" in detail and "second" in detail
+        assert dangerous in detail
+        assert page.locator("#owned").count() == 0
+        assert page.locator("body").get_attribute("data-pwned") is None
+
+        first.get_by_role("button", name="Lineage", exact=True).click()
+        lineage = first.locator("[data-hg-explorer-body]").inner_text()
+        assert "Ancestry" in lineage and "Descendants" in lineage
+
+        first.get_by_role("button", name="alpha-child", exact=True).first.click()
+        assert "alpha-child" in first.locator("[data-hg-explorer-header]").inner_text()
+        assert "beta-root" in second.locator("[data-hg-explorer-header]").inner_text()
+
+        asset = _read_explorer_asset()
+        rebound = first.evaluate(
+            """(root, source) => {
+              let additions = 0;
+              const original = root.addEventListener;
+              root.addEventListener = function() {
+                additions += 1;
+                return original.apply(this, arguments);
+              };
+              const script = document.createElement('script');
+              script.textContent = source;
+              root.appendChild(script);
+              root.addEventListener = original;
+              return additions;
+            }""",
+            asset,
+        )
+        assert rebound == 0
+        assert first.evaluate("root => root.__hgExplorerBound") is True
+        browser.close()
+
+
+def test_explorer_payload_and_config_are_script_safe_without_generated_ids() -> None:
+    dangerous = "</script><script>globalThis.owned=true</script>"
+    html = _explorer_html("safe", dangerous)
+    assert dangerous not in html
+    assert "\\u003c/script\\u003e" in html
+    assert "data-hg-explorer-config" in html
+    assert "document.getElementById" not in _read_explorer_asset()

--- a/tests/test_hypertable_mutations.py
+++ b/tests/test_hypertable_mutations.py
@@ -644,7 +644,6 @@ class TestFingerprintCorrectness:
     def test_fingerprint_detects_component_config_change(self, store):
         """Changing a component's config produces a different fingerprint."""
         from hypergraph.materialization import HyperTable
-        from hypergraph.materialization._fingerprint import compute_row_fingerprint
 
         emb_a = Embedder(model_name="model-a", dim=3)
         table_a = (
@@ -659,7 +658,7 @@ class TestFingerprintCorrectness:
 
         table_a._ensure_analyzed()
         graph_inputs = {"text": "hello"}
-        fp_a = compute_row_fingerprint(table_a._graph, table_a._components, graph_inputs)
+        fp_a = table_a._provenance_policy.root_fingerprint(graph_inputs)
 
         emb_b = Embedder(model_name="model-b", dim=3)
         table_b = (
@@ -673,7 +672,7 @@ class TestFingerprintCorrectness:
         )
 
         table_b._ensure_analyzed()
-        fp_b = compute_row_fingerprint(table_b._graph, table_b._components, graph_inputs)
+        fp_b = table_b._provenance_policy.root_fingerprint(graph_inputs)
         assert fp_a != fp_b
 
 

--- a/tests/test_hypertable_mutations.py
+++ b/tests/test_hypertable_mutations.py
@@ -644,6 +644,7 @@ class TestFingerprintCorrectness:
     def test_fingerprint_detects_component_config_change(self, store):
         """Changing a component's config produces a different fingerprint."""
         from hypergraph.materialization import HyperTable
+        from hypergraph.materialization._fingerprint import compute_row_fingerprint
 
         emb_a = Embedder(model_name="model-a", dim=3)
         table_a = (
@@ -658,7 +659,7 @@ class TestFingerprintCorrectness:
 
         table_a._ensure_analyzed()
         graph_inputs = {"text": "hello"}
-        fp_a = table_a._compute_row_fingerprint(graph_inputs)
+        fp_a = compute_row_fingerprint(table_a._graph, table_a._components, graph_inputs)
 
         emb_b = Embedder(model_name="model-b", dim=3)
         table_b = (
@@ -672,7 +673,7 @@ class TestFingerprintCorrectness:
         )
 
         table_b._ensure_analyzed()
-        fp_b = table_b._compute_row_fingerprint(graph_inputs)
+        fp_b = compute_row_fingerprint(table_b._graph, table_b._components, graph_inputs)
         assert fp_a != fp_b
 
 

--- a/tests/test_ticket185_hypertable_contracts.py
+++ b/tests/test_ticket185_hypertable_contracts.py
@@ -1,0 +1,16 @@
+"""Foreman-owned structural contracts for ticket #185 HyperTable extraction."""
+
+from __future__ import annotations
+
+import inspect
+
+from hypergraph.materialization import HyperTable
+
+
+def test_insert_keeps_its_existing_public_signature_annotations() -> None:
+    parameters = inspect.signature(HyperTable.insert).parameters
+
+    assert parameters["args"].kind is inspect.Parameter.VAR_POSITIONAL
+    assert parameters["args"].annotation is inspect.Parameter.empty
+    assert parameters["kwargs"].kind is inspect.Parameter.VAR_KEYWORD
+    assert parameters["kwargs"].annotation is inspect.Parameter.empty

--- a/tests/test_ticket185_persistence_safety.py
+++ b/tests/test_ticket185_persistence_safety.py
@@ -1,0 +1,169 @@
+"""Foreman-owned falsifiers for ticket #185 persistence hardening."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pyarrow as pa
+import pytest
+
+from hypergraph import node
+from hypergraph.materialization import HyperTable
+from hypergraph.materialization._lancedb_store import LanceDBStore
+from hypergraph.materialization._schema import ColumnSpec, TableSpec
+from hypergraph.runners import SyncRunner
+
+
+def _store_spec() -> TableSpec:
+    return TableSpec(
+        name="t",
+        identity="cid",
+        columns=[
+            ColumnSpec("cid", role="identity", arrow_type=pa.utf8()),
+            ColumnSpec("n", role="source", arrow_type=pa.int64()),
+            ColumnSpec("content", role="source", content_key=True, arrow_type=pa.large_binary()),
+            ColumnSpec("_write_gen", role="internal", arrow_type=pa.int64()),
+            ColumnSpec("_status", role="internal", arrow_type=pa.utf8()),
+            ColumnSpec("_row_fingerprint", role="internal", arrow_type=pa.utf8()),
+            ColumnSpec("_error", role="internal", arrow_type=pa.utf8()),
+        ],
+    )
+
+
+def _row(cid: str, n: Any, *, write_gen: int = 1, content: bytes = b"blob") -> dict[str, Any]:
+    return {
+        "cid": cid,
+        "n": n,
+        "content": content,
+        "_write_gen": write_gen,
+        "_status": "complete",
+        "_row_fingerprint": "fp",
+        "_error": None,
+    }
+
+
+class _TableProxy:
+    def __init__(self, table: Any) -> None:
+        self._table = table
+        self.add_calls = 0
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._table, name)
+
+    def add(self, data: Any) -> Any:
+        self.add_calls += 1
+        return self._table.add(data)
+
+
+class _DatasetProjectionProxy:
+    def __init__(self, dataset: Any, projections: list[tuple[str, ...]]) -> None:
+        self._dataset = dataset
+        self._projections = projections
+
+    def to_table(self, *, columns: list[str]) -> pa.Table:
+        self._projections.append(tuple(columns))
+        return self._dataset.to_table(columns=columns)
+
+
+class _ProjectionOnlyTable:
+    def __init__(self, table: Any) -> None:
+        self._table = table
+        self.projections: list[tuple[str, ...]] = []
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._table, name)
+
+    def to_arrow(self) -> pa.Table:
+        raise AssertionError("metadata-only operations must not materialize full rows")
+
+    def to_lance(self) -> _DatasetProjectionProxy:
+        return _DatasetProjectionProxy(self._table.to_lance(), self.projections)
+
+
+def test_write_rows_uses_one_lancedb_add_for_the_whole_batch(tmp_path) -> None:
+    store = LanceDBStore(str(tmp_path / "one-add"))
+    store.open(_store_spec(), [])
+    proxy = _TableProxy(store._tables["t"])
+    store._tables["t"] = proxy
+
+    store.write_rows("t", [_row("a", 1), _row("b", 2)])
+
+    assert proxy.add_calls == 1
+    assert store.count("t") == 2
+
+
+def test_invalid_lancedb_batch_leaves_no_committed_prefix(tmp_path) -> None:
+    path = str(tmp_path / "atomic-batch")
+    store = LanceDBStore(path)
+    spec = _store_spec()
+    store.open(spec, [])
+
+    with pytest.raises((pa.ArrowInvalid, pa.ArrowTypeError)):
+        store.write_rows("t", [_row("good", 1), _row("bad", "not-an-int")])
+
+    fresh = LanceDBStore(path)
+    fresh.open(spec, [])
+    assert fresh.read_rows("t") == []
+
+
+def test_write_rows_preserves_missing_field_null_fill_on_input_rows(tmp_path) -> None:
+    store = LanceDBStore(str(tmp_path / "null-fill"))
+    store.open(_store_spec(), [])
+    row = _row("a", 1)
+    del row["content"]
+
+    store.write_rows("t", [row])
+
+    assert row["content"] is None
+
+
+def test_metadata_operations_physically_project_only_consumed_columns(tmp_path) -> None:
+    store = LanceDBStore(str(tmp_path / "projection"))
+    store.open(_store_spec(), [])
+    store.write_rows("t", [_row("a", 1, content=b"large" * 1000), _row("b", 2, write_gen=4)])
+    proxy = _ProjectionOnlyTable(store._tables["t"])
+    store._tables["t"] = proxy
+
+    assert store.max_write_gen("t") == 4
+    assert store.delete_rows("t", [("cid", "eq", "a")]) == 1
+    assert proxy.projections == [("_write_gen",), ("cid",)]
+    assert store.read_rows("t", columns=["cid"]) == [{"cid": "b"}]
+
+
+def test_evolve_schema_never_enters_a_drop_table_data_loss_window(tmp_path, monkeypatch) -> None:
+    path = str(tmp_path / "drop-free-evolve")
+    store = LanceDBStore(path)
+    spec = _store_spec()
+    store.open(spec, [])
+    original = _row("a", 1, content=b"irreplaceable")
+    store.write_rows("t", [original])
+
+    connection_type = type(store._db)
+    original_drop = connection_type.drop_table
+
+    def destructive_drop_then_fail(connection, table_name, *args, **kwargs):
+        original_drop(connection, table_name, *args, **kwargs)
+        raise RuntimeError("simulated crash after destructive drop")
+
+    monkeypatch.setattr(connection_type, "drop_table", destructive_drop_then_fail)
+
+    columns = store.evolve_schema("t", {"tag": pa.utf8()})
+
+    assert "tag" in columns
+    fresh = LanceDBStore(path)
+    fresh.open(spec, [])
+    assert fresh.read_rows("t", columns=["cid", "content", "tag"]) == [{"cid": "a", "content": b"irreplaceable", "tag": None}]
+    assert "tag" in fresh.evolve_schema("t", {"tag": pa.utf8()})
+
+
+@node(output_name="derived")
+def _derive(source: str) -> str:
+    return source.upper()
+
+
+def test_hypertable_owns_map_over_state_before_lazy_analysis(tmp_path) -> None:
+    table = HyperTable([_derive], identity="cid", store=LanceDBStore(str(tmp_path / "constructor-state")))
+
+    assert table._map_over_nodes == []
+    assert table.bind(unused="value")._map_over_nodes == []
+    assert table.with_runner(SyncRunner())._map_over_nodes == []

--- a/tests/test_ticket185_persistence_safety.py
+++ b/tests/test_ticket185_persistence_safety.py
@@ -97,13 +97,17 @@ def test_invalid_lancedb_batch_leaves_no_committed_prefix(tmp_path) -> None:
     store = LanceDBStore(path)
     spec = _store_spec()
     store.open(spec, [])
+    rows = [_row("good", 1), _row("bad", "not-an-int"), _row("later", 3)]
+    for row in rows:
+        del row["content"]
 
     with pytest.raises((pa.ArrowInvalid, pa.ArrowTypeError)):
-        store.write_rows("t", [_row("good", 1), _row("bad", "not-an-int")])
+        store.write_rows("t", rows)
 
     fresh = LanceDBStore(path)
     fresh.open(spec, [])
     assert fresh.read_rows("t") == []
+    assert ["content" in row for row in rows] == [True, True, False]
 
 
 def test_failed_lancedb_add_leaves_no_committed_rows(tmp_path, monkeypatch) -> None:

--- a/tests/test_ticket185_persistence_safety.py
+++ b/tests/test_ticket185_persistence_safety.py
@@ -106,6 +106,26 @@ def test_invalid_lancedb_batch_leaves_no_committed_prefix(tmp_path) -> None:
     assert fresh.read_rows("t") == []
 
 
+def test_failed_lancedb_add_leaves_no_committed_rows(tmp_path, monkeypatch) -> None:
+    path = str(tmp_path / "failed-add")
+    store = LanceDBStore(path)
+    spec = _store_spec()
+    store.open(spec, [])
+
+    table_type = type(store._tables["t"])
+
+    def fail_add(table, data, *args, **kwargs):
+        raise RuntimeError("simulated add failure")
+
+    monkeypatch.setattr(table_type, "add", fail_add)
+    with pytest.raises(RuntimeError, match="simulated add failure"):
+        store.write_rows("t", [_row("a", 1), _row("b", 2)])
+
+    fresh = LanceDBStore(path)
+    fresh.open(spec, [])
+    assert fresh.read_rows("t") == []
+
+
 def test_write_rows_preserves_missing_field_null_fill_on_input_rows(tmp_path) -> None:
     store = LanceDBStore(str(tmp_path / "null-fill"))
     store.open(_store_spec(), [])
@@ -137,6 +157,7 @@ def test_evolve_schema_never_enters_a_drop_table_data_loss_window(tmp_path, monk
     store.open(spec, [])
     original = _row("a", 1, content=b"irreplaceable")
     store.write_rows("t", [original])
+    before_version = store._tables["t"].version
 
     connection_type = type(store._db)
     original_drop = connection_type.drop_table
@@ -150,10 +171,13 @@ def test_evolve_schema_never_enters_a_drop_table_data_loss_window(tmp_path, monk
     columns = store.evolve_schema("t", {"tag": pa.utf8()})
 
     assert "tag" in columns
+    assert store._tables["t"].version == before_version + 1
     fresh = LanceDBStore(path)
     fresh.open(spec, [])
     assert fresh.read_rows("t", columns=["cid", "content", "tag"]) == [{"cid": "a", "content": b"irreplaceable", "tag": None}]
+    fresh_version = fresh._tables["t"].version
     assert "tag" in fresh.evolve_schema("t", {"tag": pa.utf8()})
+    assert fresh._tables["t"].version == fresh_version
 
 
 @node(output_name="derived")

--- a/tests/viz/test_hypertable_fanout_edge.py
+++ b/tests/viz/test_hypertable_fanout_edge.py
@@ -17,6 +17,7 @@ import pytest
 
 from hypergraph import Graph, node
 from hypergraph.materialization import HyperTable
+from hypergraph.materialization._hypertable_viz import fanout_map_fields, fanout_viz_edges
 from hypergraph.materialization._lancedb_store import LanceDBStore
 
 
@@ -53,8 +54,8 @@ def _combined_flat_graph(table: HyperTable):
     nodes = list(table._graph.nodes.values())
     nodes.extend(table._map_over_nodes)
     combined = _Graph(nodes, name=table._spec.name)
-    flat = combined.to_flat_graph(extra_edges=table._fanout_viz_edges())
-    for (src, tgt), fields in table._fanout_map_fields().items():
+    flat = combined.to_flat_graph(extra_edges=fanout_viz_edges(table._graph, table._spec, table._map_over_nodes))
+    for (src, tgt), fields in fanout_map_fields(table._graph, table._spec, table._map_over_nodes).items():
         if flat.has_edge(src, tgt):
             flat[src][tgt]["map_fields"] = list(fields)
     return flat
@@ -162,7 +163,7 @@ def test_two_children_each_get_their_own_fanout_edge(store):
     )
     table._ensure_analyzed()
 
-    edges = table._fanout_viz_edges()
+    edges = fanout_viz_edges(table._graph, table._spec, table._map_over_nodes)
 
     assert ("produce_a", "a_node", ("items_a",)) in edges
     assert ("produce_b", "b_node", ("items_b",)) in edges
@@ -192,12 +193,7 @@ def test_fanout_pairing_is_positional_not_name_matched():
     spec = analyze_table(root_graph, "doc_id", {}, map_over_nodes)
     assert [c.map_input for c in spec.children] == ["items", "items"]
 
-    table = HyperTable.__new__(HyperTable)
-    table._spec = spec
-    table._map_over_nodes = map_over_nodes
-    table._boundary_node = lambda child_spec: root_graph.nodes.get("produce_items")
-
-    edges = table._fanout_viz_edges()
+    edges = fanout_viz_edges(root_graph, spec, map_over_nodes)
 
     assert ("produce_items", "clean_node", ("items",)) in edges
     assert ("produce_items", "shout_node", ("items",)) in edges
@@ -448,22 +444,19 @@ def test_unresolvable_schema_yields_no_fields_not_a_raise():
     class _ChildSpec:
         map_input = "items"
 
-    table = HyperTable.__new__(HyperTable)
-
     class _Spec:
         children = [_ChildSpec()]
 
-    table._spec = _Spec()
-    table._map_over_nodes = [_MapNode()]
-    table._boundary_node = lambda child_spec: _RaisingProducer()
+    class _Graph:
+        nodes = {"producer": _RaisingProducer()}
 
     # Patch return_type to raise, simulating an annotation that resolves at
     # analysis time but not here.
-    import hypergraph.materialization._hypertable as ht
+    import hypergraph.materialization._hypertable_viz as hypertable_viz
 
-    original = ht.return_type
-    ht.return_type = lambda node: (_ for _ in ()).throw(NameError("Unresolved"))
+    original = hypertable_viz.return_type
+    hypertable_viz.return_type = lambda node: (_ for _ in ()).throw(NameError("Unresolved"))
     try:
-        assert table._fanout_map_fields() == {("producer", "items_node"): ()}
+        assert fanout_map_fields(_Graph(), _Spec(), [_MapNode()]) == {("producer", "items_node"): ()}
     finally:
-        ht.return_type = original
+        hypertable_viz.return_type = original

--- a/tests/viz/test_parity.py
+++ b/tests/viz/test_parity.py
@@ -268,6 +268,7 @@ def _fanout_ir(inner_inputs: tuple[str, ...]):
     from hypergraph import Graph
     from hypergraph.graph import Graph as _Graph
     from hypergraph.materialization import HyperTable
+    from hypergraph.materialization._hypertable_viz import fanout_map_fields, fanout_viz_edges
     from hypergraph.materialization._lancedb_store import LanceDBStore
 
     store = LanceDBStore(tempfile.mkdtemp() + "/store")
@@ -277,9 +278,9 @@ def _fanout_ir(inner_inputs: tuple[str, ...]):
     nodes = list(table._graph.nodes.values())
     nodes.extend(table._map_over_nodes)
     combined = _Graph(nodes, name=table._spec.name)
-    extra = table._fanout_viz_edges()
+    extra = fanout_viz_edges(table._graph, table._spec, table._map_over_nodes)
     flat = combined.to_flat_graph(extra_edges=extra)
-    for (src, tgt), fields in table._fanout_map_fields().items():
+    for (src, tgt), fields in fanout_map_fields(table._graph, table._spec, table._map_over_nodes).items():
         if flat.has_edge(src, tgt):
             flat[src][tgt]["map_fields"] = list(fields)
     return build_graph_ir(flat)


### PR DESCRIPTION
## Problem / Bug / Challenge

Refs #185 and the production-readiness map #180.

HyperTable persistence decisions were interleaved across sync/async paths in a 2,262-line facade. SQLite retention repeated raw tuple indexing and step-upsert SQL. Rich progress mixed tracking with three presentation modes. LanceDB performed whole-row metadata reads, appended one row at a time, and used a destructive drop/recreate window for additive schema evolution. Checkpointer status colors and explorer behavior also had multiple owners.

Public imports, signatures, stored keys, return/exception behavior, and user-facing transcripts remain compatible. The intentionally changed physical guarantees are the ticket's explicit safety requirements: one atomic LanceDB add per call and drop-free additive schema evolution.

## Before / After

**Before:** decisions and physical I/O were intertwined and duplicated.

```python
# Persistence policy lived in separate sync/async flows.
outputs = runner.run(graph, **inputs)
outputs = await runner.run(graph, **inputs)

# LanceDB committed each row separately.
for row in rows:
    tbl.add(record_batch_for(row))

# Explorer behavior was generated as a ~299-line Python string.
```

```text
_hypertable.py      2,262 lines
rich_progress.py      893 lines
presenters.py          772 lines
```

**After:** one typed plan owns decisions; tiny color drivers own only call versus await; one executor owns ordered physical mutation.

```python
operation = self._write_planner.sync(items)
if self._is_async_runner():
    return self._drive_async(operation)
return self._drive_sync(operation)

# Convert every row before one physical commit.
tbl.add(pa.Table.from_batches(record_batches, schema=schema))

# Additive evolution is LanceDB-versioned and drop-free.
tbl.add_columns(pa.schema(new_fields))
```

```text
_hypertable.py        676 lines
_writes.py            707 lines  # shared write planner
_write_actions.py     147 lines  # frozen typed actions
_write_executor.py    256 lines  # ordered physical apply
rich_progress.py      124 lines  # public processor entry point
presenters.py          502 lines
explorer.js            306 lines  # packaged, hash-validated, inlined offline
```

SQLite now decodes retention rows once into frozen typed records, plans every policy through one pure function, serializes baselines before deletion, and uses one exact `_STEP_UPSERT_SQL`. Progress tracking emits renderer-neutral updates consumed by Rich TTY, notebook, and log renderers. One Python status palette feeds both Python badges and the explorer.

## Test Plan

- [x] `uv sync --frozen --group dev --extra daft --extra materialization`
- [x] CI-equivalent suite on post-#201 master: `3160 passed in 17.53s`
- [x] Focused Wave 3b battery: `424 passed in 5.05s`
- [x] `uv run pre-commit run --all-files`
- [x] `uv run ruff check src/ tests/`
- [x] `uv run ruff format --check src/ tests/`
- [x] Exact sync/async/store behavior witness unchanged: `09aee88694297a6601767c5f9412cf879413efb8c3b25f2d26bbc87d62e78de9`
- [x] Wheel contains the exact 17,046-byte explorer asset: `9909428d38a1ec32738c16eb54d8a72f1f4bb6a38b03858709b86286c35b413d`
- [x] Direct zipped-wheel resource import and Python 3.10 optional-Rich behavior passed
- [x] Real LanceDB projection/add/evolution and SQLite serialization/rollback witnesses passed
- [x] Real DOM checks passed: dangerous payload inert, prototype-name IDs safe, two explorers isolated, bind-once lifecycle, accessible run context
- [x] Independent native-Codex Standards review: APPROVE, zero P0–P3 findings, all eight smell passes clean
- [x] Independent native-Codex Spec review: APPROVE, V01–V30 satisfied
- [x] Rebase audit after PRs #198/#201: identical stable patch ID and all 26 Wave 3b blobs byte-identical; both final-tip reviewers re-approved

Final-tip review also exposed a duplicate-progress bug in newly merged graph-carried processors plus `show_progress=True`. The exact sync/async reproducer emits 6 lines on both base `0247e0e` and this branch versus the expected 3, so it is not introduced by this PR and will be tracked separately on the production-readiness map.
