### PR TITLE
feat(runners): expose structured node failure evidence

### DIFF
--- a/docs/06-api-reference/runners.md
+++ b/docs/06-api-reference/runners.md
@@ -859,6 +859,7 @@ class RunResult:
     run_id: str                 # Unique identifier (auto-generated)
     workflow_id: str | None     # Optional workflow tracking
     error: BaseException | None # Exception if FAILED
+    node_failures: tuple[FailureEvidence, ...]  # Attributable leaf failures
     pause: PauseInfo | None     # Pause info if PAUSED (InterruptNode)
     log: RunLog | None          # Execution trace, if collected
     checkpoint_ok: bool         # False when a best-effort async step save failed
@@ -876,6 +877,7 @@ does not change the execution status. Check `checkpoint_ok` and
 result.completed  # True if status == COMPLETED
 result.paused     # True if status == PAUSED
 result.failed     # True if status == FAILED
+result.failure    # First FailureEvidence, or None
 ```
 
 ### Dict-like Access
@@ -907,6 +909,90 @@ if result.status == RunStatus.FAILED:
 ```
 
 This is useful for debugging — you can inspect which nodes completed successfully.
+
+### Structured Failure Evidence
+
+Use `result.failure` when you need to reproduce the exact leaf-node call that
+failed, rather than only reading its exception:
+
+```python
+@node(output_name="order")
+def parse_order(raw_order: str) -> dict:
+    raise ValueError(f"invalid order: {raw_order}")
+
+graph = Graph([parse_order], name="orders")
+result = SyncRunner().run(
+    graph,
+    {"raw_order": "missing-price"},
+    error_handling="continue",
+)
+
+failure = result.failure
+assert failure is not None
+failure.node_name       # "parse_order"
+failure.inputs          # {"raw_order": "missing-price"}
+failure.error is result.error  # True: the original exception object
+result.node_failures    # Deterministic tuple of every attributable failure
+```
+
+Default raise mode still raises the original exception type and object. Use
+`get_failure_evidence()` when you catch it:
+
+```python
+from hypergraph import get_failure_evidence
+
+try:
+    SyncRunner().run(graph, {"raw_order": "missing-price"})
+except ValueError as error:
+    failure = get_failure_evidence(error)[0]
+    assert failure.inputs == {"raw_order": "missing-price"}
+```
+
+Mapped failures retain their source item index. `MapResult.failures` remains a
+list of failed `RunResult` children:
+
+```python
+results = SyncRunner().map(
+    graph,
+    {"raw_order": ["missing-price", "missing-sku"]},
+    map_over="raw_order",
+    error_handling="continue",
+)
+
+[(item.failure.item_index, item.failure.inputs) for item in results.failures]
+# [(0, {"raw_order": "missing-price"}), (1, {"raw_order": "missing-sku"})]
+```
+
+Nested GraphNodes report the leaf once and prefix its path at each boundary:
+
+```python
+inner = Graph([parse_order], name="order-parser")
+middle = Graph([inner.as_node(name="parser")], name="order-worker")
+outer = Graph([middle.as_node(name="worker")], name="batch")
+
+result = SyncRunner().run(
+    outer,
+    {"raw_order": "missing-price"},
+    error_handling="continue",
+)
+result.failure.node_name   # "worker/parser/parse_order"
+result.failure.graph_name  # "order-parser" (the leaf graph)
+```
+
+`FailureEvidence.inputs` is deliberately ephemeral debugging state. It is a
+shallow copy of the resolved graph-input mapping; contained values retain their
+identity, and framework-injected `NodeContext` is excluded. Explicitly reading
+`.inputs` returns the raw objects, which may include large values or secrets.
+Those objects remain referenced until the `RunResult` or raised exception and
+its suppressed evidence context are collected.
+
+Raw inputs never appear in repr/HTML, `to_dict()`, run logs, events, checkpoints,
+or OpenTelemetry. Failed `RunResult.to_dict()` output includes safe
+`node_failures` metadata—node path, error text/type, timing, graph/workflow, and
+item index—but no `inputs` or exception objects. Infrastructure failures that
+cannot be attributed to a node executor use `node_failures == ()` and
+`failure is None`. Daft integrations may likewise return no evidence until
+they execute through the core node seam.
 
 ### Progressive Disclosure
 
@@ -1082,7 +1168,7 @@ except InfiniteLoopError as e:
 
 ### ExecutionError
 
-Wraps an exception raised inside a node during graph execution and carries the partial `GraphState` accumulated before the failure (`partial_state` attribute).
+Wraps an exception raised inside a node during graph execution and carries the partial `GraphState` accumulated before the failure (`partial_state` attribute). While this internal wrapper is in hand, `node_failures` exposes the same deterministic tuple as `RunResult`, and `failure` returns its first item or `None`.
 
 `runner.run()` with the default `error_handling="raise"` unwraps it and re-raises the original node exception, so application code normally catches the node's own exception type. `ExecutionError` is exported for advanced integrations (custom runners, executors, or superstep-level code) that need access to the partial state alongside the failure.
 
@@ -1094,6 +1180,7 @@ try:
 except ExecutionError as e:
     print(e.partial_state)   # state accumulated before the failure
     print(e.__cause__)       # the original node exception
+    print(e.node_failures)   # attributable leaf failures, if any
 ```
 
 ---

--- a/docs/06-api-reference/runners.md
+++ b/docs/06-api-reference/runners.md
@@ -859,12 +859,12 @@ class RunResult:
     run_id: str                 # Unique identifier (auto-generated)
     workflow_id: str | None     # Optional workflow tracking
     error: BaseException | None # Exception if FAILED
-    node_failures: tuple[FailureEvidence, ...]  # Attributable leaf failures
     pause: PauseInfo | None     # Pause info if PAUSED (InterruptNode)
     log: RunLog | None          # Execution trace, if collected
     checkpoint_ok: bool         # False when a best-effort async step save failed
     checkpoint_errors: tuple[str, ...]  # String-only checkpoint save errors
     restored: bool              # True only for a checkpoint-skipped map child
+    node_failures: tuple[FailureEvidence, ...]  # Attributable leaf failures
 ```
 
 With async checkpoint durability, step saves are best-effort: a persistence gap

--- a/src/hypergraph/__init__.py
+++ b/src/hypergraph/__init__.py
@@ -39,6 +39,7 @@ from hypergraph.exceptions import (
     WorkflowAlreadyRunningError,
     WorkflowForkError,
     WorkflowStoppedError,
+    get_failure_evidence,
 )
 from hypergraph.graph import Graph, GraphConfigError, InputSpec
 from hypergraph.nodes import (
@@ -62,6 +63,7 @@ from hypergraph.runners import (
     BaseRunner,
     DaftRunner,
     ErrorHandling,
+    FailureEvidence,
     MapLog,
     MapResult,
     NodeRecord,
@@ -99,6 +101,7 @@ __all__ = [
     "DaftRunner",
     "BaseRunner",
     "ErrorHandling",
+    "FailureEvidence",
     "PauseInfo",
     "RunResult",
     "MapResult",
@@ -110,6 +113,7 @@ __all__ = [
     "InfiniteLoopError",
     "IncompatibleRunnerError",
     "ExecutionError",
+    "get_failure_evidence",
     "WorkflowAlreadyCompletedError",
     "GraphChangedError",
     "WorkflowForkError",

--- a/src/hypergraph/exceptions.py
+++ b/src/hypergraph/exceptions.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from contextlib import contextmanager
+from contextvars import ContextVar
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -11,6 +12,13 @@ if TYPE_CHECKING:
 
     from hypergraph.runners._shared.results import FailureEvidence
     from hypergraph.runners._shared.state import GraphState
+
+
+_CURRENT_FAILURE_EVIDENCE_INVOCATION: ContextVar[object | None] = ContextVar(
+    "_CURRENT_FAILURE_EVIDENCE_INVOCATION",
+    default=None,
+)
+_ANY_FAILURE_EVIDENCE_INVOCATION = object()
 
 
 class MissingInputError(Exception):
@@ -135,15 +143,40 @@ class ExecutionError(Exception):
 
 
 class _NodeExecutionError(ExecutionError):
-    """Runner-owned wrapper proving failure arose at the executor boundary."""
+    """Runner-owned wrapper proving failure arose in the current invocation."""
+
+    def __init__(
+        self,
+        cause: BaseException,
+        partial_state: GraphState,
+        attempted_node_names: tuple[str, ...] = (),
+        node_errors: Mapping[str, BaseException] | None = None,
+        node_failures: tuple[FailureEvidence, ...] = (),
+        *,
+        invocation_token: object | None,
+    ) -> None:
+        self._invocation_token = invocation_token
+        super().__init__(
+            cause,
+            partial_state,
+            attempted_node_names,
+            node_errors,
+            node_failures,
+        )
 
 
 class _FailureEvidenceCarrier(Exception):
     """Typed suppressed context used when map re-raises a child error."""
 
-    def __init__(self, error: BaseException, node_failures: tuple[FailureEvidence, ...]) -> None:
+    def __init__(
+        self,
+        error: BaseException,
+        node_failures: tuple[FailureEvidence, ...],
+        invocation_token: object | None,
+    ) -> None:
         self.error = error
         self.node_failures = tuple(node_failures)
+        self._invocation_token = invocation_token
         super().__init__()
 
 
@@ -154,13 +187,38 @@ def _failure_evidence_context(
 ) -> Iterator[None]:
     """Install typed evidence as the standard context for a caller re-raise."""
     try:
-        raise _FailureEvidenceCarrier(error, node_failures)
+        raise _FailureEvidenceCarrier(
+            error,
+            node_failures,
+            _get_failure_evidence_invocation(),
+        )
     except _FailureEvidenceCarrier:
         yield
 
 
+def _get_failure_evidence_invocation() -> object | None:
+    """Return the nearest GraphNode invocation token in this execution context."""
+    return _CURRENT_FAILURE_EVIDENCE_INVOCATION.get()
+
+
+@contextmanager
+def _bind_failure_evidence_invocation(invocation_token: object | None) -> Iterator[None]:
+    """Bind a GraphNode invocation token for its delegated executor call."""
+    if invocation_token is None:
+        yield
+        return
+
+    reset_token = _CURRENT_FAILURE_EVIDENCE_INVOCATION.set(invocation_token)
+    try:
+        yield
+    finally:
+        _CURRENT_FAILURE_EVIDENCE_INVOCATION.reset(reset_token)
+
+
 def _get_failure_evidence_from_context(
     error: BaseException | None,
+    *,
+    invocation_token: object = _ANY_FAILURE_EVIDENCE_INVOCATION,
 ) -> tuple[FailureEvidence, ...] | None:
     """Return evidence from trusted context, or None when none is present."""
     if error is None:
@@ -170,12 +228,24 @@ def _get_failure_evidence_from_context(
     current = BaseException.__getattribute__(error, "__context__")
     while current is not None and id(current) not in seen:
         seen.add(id(current))
+        if type(current) is _NodeExecutionError:
+            if current.__cause__ is not error:
+                return ()
+            if invocation_token is not _ANY_FAILURE_EVIDENCE_INVOCATION and current._invocation_token is not invocation_token:
+                return ()
+            return current.node_failures
         if isinstance(current, _NodeExecutionError):
-            return current.node_failures if current.__cause__ is error else ()
+            return ()
         if isinstance(current, ExecutionError):
             return ()
+        if type(current) is _FailureEvidenceCarrier:
+            if current.error is not error:
+                return ()
+            if invocation_token is not _ANY_FAILURE_EVIDENCE_INVOCATION and current._invocation_token is not invocation_token:
+                return ()
+            return current.node_failures
         if isinstance(current, _FailureEvidenceCarrier):
-            return current.node_failures if current.error is error else ()
+            return ()
         current = BaseException.__getattribute__(current, "__context__")
     return None
 

--- a/src/hypergraph/exceptions.py
+++ b/src/hypergraph/exceptions.py
@@ -165,7 +165,7 @@ def get_failure_evidence(error: BaseException | None) -> tuple[FailureEvidence, 
         return ()
 
     seen = {id(error)}
-    current = error.__context__
+    current = BaseException.__getattribute__(error, "__context__")
     while current is not None and id(current) not in seen:
         seen.add(id(current))
         if isinstance(current, _NodeExecutionError):
@@ -174,7 +174,7 @@ def get_failure_evidence(error: BaseException | None) -> tuple[FailureEvidence, 
             return ()
         if isinstance(current, _FailureEvidenceCarrier):
             return current.node_failures if current.error is error else ()
-        current = current.__context__
+        current = BaseException.__getattribute__(current, "__context__")
     return error.node_failures if isinstance(error, ExecutionError) else ()
 
 

--- a/src/hypergraph/exceptions.py
+++ b/src/hypergraph/exceptions.py
@@ -159,10 +159,12 @@ def _failure_evidence_context(
         yield
 
 
-def get_failure_evidence(error: BaseException | None) -> tuple[FailureEvidence, ...]:
-    """Return node-failure evidence carried by a runner exception chain."""
+def _get_failure_evidence_from_context(
+    error: BaseException | None,
+) -> tuple[FailureEvidence, ...] | None:
+    """Return evidence from trusted context, or None when none is present."""
     if error is None:
-        return ()
+        return None
 
     seen = {id(error)}
     current = BaseException.__getattribute__(error, "__context__")
@@ -175,6 +177,16 @@ def get_failure_evidence(error: BaseException | None) -> tuple[FailureEvidence, 
         if isinstance(current, _FailureEvidenceCarrier):
             return current.node_failures if current.error is error else ()
         current = BaseException.__getattribute__(current, "__context__")
+    return None
+
+
+def get_failure_evidence(error: BaseException | None) -> tuple[FailureEvidence, ...]:
+    """Return node-failure evidence carried by a runner exception chain."""
+    contextual = _get_failure_evidence_from_context(error)
+    if contextual is not None:
+        return contextual
+    if error is None:
+        return ()
     return error.node_failures if isinstance(error, ExecutionError) else ()
 
 

--- a/src/hypergraph/exceptions.py
+++ b/src/hypergraph/exceptions.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
+    from hypergraph.runners._shared.results import FailureEvidence
     from hypergraph.runners._shared.state import GraphState
 
 
@@ -107,6 +110,7 @@ class ExecutionError(Exception):
             superstep. Empty when the failure cannot be attributed to
             specific nodes (e.g. a scheduler-level error).
         node_errors: Mapping of node name to the exception that node raised.
+        node_failures: Attributable leaf-node failures in deterministic order.
     """
 
     def __init__(
@@ -115,12 +119,63 @@ class ExecutionError(Exception):
         partial_state: GraphState,
         attempted_node_names: tuple[str, ...] = (),
         node_errors: Mapping[str, BaseException] | None = None,
+        node_failures: tuple[FailureEvidence, ...] = (),
     ) -> None:
         self.partial_state = partial_state
         self.attempted_node_names = tuple(attempted_node_names)
         self.node_errors: dict[str, BaseException] = dict(node_errors) if node_errors else {}
+        self.node_failures = tuple(node_failures)
         super().__init__(str(cause))
         self.__cause__ = cause
+
+    @property
+    def failure(self) -> FailureEvidence | None:
+        """First attributable node failure, if one exists."""
+        return self.node_failures[0] if self.node_failures else None
+
+
+class _NodeExecutionError(ExecutionError):
+    """Runner-owned wrapper proving failure arose at the executor boundary."""
+
+
+class _FailureEvidenceCarrier(Exception):
+    """Typed suppressed context used when map re-raises a child error."""
+
+    def __init__(self, error: BaseException, node_failures: tuple[FailureEvidence, ...]) -> None:
+        self.error = error
+        self.node_failures = tuple(node_failures)
+        super().__init__()
+
+
+@contextmanager
+def _failure_evidence_context(
+    error: BaseException,
+    node_failures: tuple[FailureEvidence, ...],
+) -> Iterator[None]:
+    """Install typed evidence as the standard context for a caller re-raise."""
+    try:
+        raise _FailureEvidenceCarrier(error, node_failures)
+    except _FailureEvidenceCarrier:
+        yield
+
+
+def get_failure_evidence(error: BaseException | None) -> tuple[FailureEvidence, ...]:
+    """Return node-failure evidence carried by a runner exception chain."""
+    if error is None:
+        return ()
+
+    seen = {id(error)}
+    current = error.__context__
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, _NodeExecutionError):
+            return current.node_failures if current.__cause__ is error else ()
+        if isinstance(current, ExecutionError):
+            return ()
+        if isinstance(current, _FailureEvidenceCarrier):
+            return current.node_failures if current.error is error else ()
+        current = current.__context__
+    return error.node_failures if isinstance(error, ExecutionError) else ()
 
 
 class WorkflowAlreadyCompletedError(Exception):

--- a/src/hypergraph/runners/__init__.py
+++ b/src/hypergraph/runners/__init__.py
@@ -2,6 +2,7 @@
 
 from hypergraph.runners._shared.results import (
     ErrorHandling,
+    FailureEvidence,
     MapLog,
     MapResult,
     NodeRecord,
@@ -25,6 +26,7 @@ from hypergraph.runners.sync import SyncRunner
 __all__ = [
     # Core types
     "ErrorHandling",
+    "FailureEvidence",
     "RunStatus",
     "PauseExecution",
     "PauseInfo",

--- a/src/hypergraph/runners/_shared/results.py
+++ b/src/hypergraph/runners/_shared/results.py
@@ -96,7 +96,6 @@ class RunResult:
         run_id: Unique identifier for this run
         workflow_id: Optional workflow identifier for tracking related runs
         error: Exception if status is FAILED, else None
-        node_failures: Attributable leaf-node failures in deterministic order
         pause: PauseInfo if status is PAUSED, else None
         log: RunLog with execution trace (timing, status, routing), or None
         checkpoint_ok: False when background checkpoint step-saves failed
@@ -107,6 +106,7 @@ class RunResult:
         restored: Whether this completed map child was skipped because its
             checkpoint was restored. Other resume/cache/missing-log paths are
             always False.
+        node_failures: Attributable leaf-node failures in deterministic order
     """
 
     values: dict[str, Any]
@@ -114,12 +114,12 @@ class RunResult:
     run_id: str = field(default_factory=generate_run_id)
     workflow_id: str | None = None
     error: BaseException | None = None
-    node_failures: tuple[FailureEvidence, ...] = ()
     pause: PauseInfo | None = None
     log: RunLog | None = None
     checkpoint_ok: bool = True
     checkpoint_errors: tuple[str, ...] = ()
     restored: bool = False
+    node_failures: tuple[FailureEvidence, ...] = ()
 
     @property
     def stopped(self) -> bool:

--- a/src/hypergraph/runners/_shared/results.py
+++ b/src/hypergraph/runners/_shared/results.py
@@ -15,6 +15,36 @@ ErrorHandling = Literal["raise", "continue"]
 DURATION_PRECISION = 3  # decimal places for duration_ms (microsecond precision)
 
 
+@dataclass(frozen=True)
+class FailureEvidence:
+    """Ephemeral evidence for an exception raised by a node executor.
+
+    ``inputs`` is a shallow snapshot of the resolved graph inputs. Contained
+    values retain identity and stay referenced until this evidence is
+    collected. Raw inputs are intentionally available only through explicit
+    attribute access; implicit representations and serialization omit them.
+    """
+
+    node_name: str
+    error: BaseException = field(repr=False)
+    inputs: dict[str, Any] = field(repr=False)
+    superstep: int
+    duration_ms: float
+    graph_name: str
+    workflow_id: str | None
+    item_index: int | None
+
+    def __post_init__(self) -> None:
+        """Own the input mapping without copying any contained value."""
+        object.__setattr__(self, "inputs", dict(self.inputs))
+
+    def __repr__(self) -> str:
+        """Return a safe summary that never renders raw inputs or the error."""
+        return (
+            f"FailureEvidence({self.node_name!r} | {type(self.error).__name__} | superstep {self.superstep} | {_format_duration(self.duration_ms)})"
+        )
+
+
 class RunStatus(Enum):
     """Status of a graph execution run.
 
@@ -66,6 +96,7 @@ class RunResult:
         run_id: Unique identifier for this run
         workflow_id: Optional workflow identifier for tracking related runs
         error: Exception if status is FAILED, else None
+        node_failures: Attributable leaf-node failures in deterministic order
         pause: PauseInfo if status is PAUSED, else None
         log: RunLog with execution trace (timing, status, routing), or None
         checkpoint_ok: False when background checkpoint step-saves failed
@@ -83,6 +114,7 @@ class RunResult:
     run_id: str = field(default_factory=generate_run_id)
     workflow_id: str | None = None
     error: BaseException | None = None
+    node_failures: tuple[FailureEvidence, ...] = ()
     pause: PauseInfo | None = None
     log: RunLog | None = None
     checkpoint_ok: bool = True
@@ -108,6 +140,11 @@ class RunResult:
     def failed(self) -> bool:
         """Whether execution failed."""
         return self.status == RunStatus.FAILED
+
+    @property
+    def failure(self) -> FailureEvidence | None:
+        """First attributable node failure, if one exists."""
+        return self.node_failures[0] if self.node_failures else None
 
     def summary(self) -> str:
         """One-line overview: 'completed | 3 nodes | 12ms' or 'failed: ValueError'."""
@@ -143,6 +180,19 @@ class RunResult:
             d["log"] = self.log.to_dict()
         if self.error:
             d["error"] = f"{type(self.error).__name__}: {self.error}"
+        if self.status == RunStatus.FAILED:
+            d["node_failures"] = [
+                {
+                    "node_name": failure.node_name,
+                    "error": f"{type(failure.error).__name__}: {failure.error}",
+                    "superstep": failure.superstep,
+                    "duration_ms": failure.duration_ms,
+                    "graph_name": failure.graph_name,
+                    "workflow_id": failure.workflow_id,
+                    "item_index": failure.item_index,
+                }
+                for failure in self.node_failures
+            ]
         return d
 
     def __getitem__(self, key: str) -> Any:
@@ -229,6 +279,7 @@ def build_failed_run_result(
     workflow_id: str | None,
     error: BaseException,
     log: RunLog,
+    node_failures: Sequence[FailureEvidence] = (),
     checkpoint_errors: Sequence[str] = (),
 ) -> RunResult:
     """Build a failed result with durability evidence."""
@@ -239,6 +290,7 @@ def build_failed_run_result(
         run_id=run_id,
         workflow_id=workflow_id,
         error=error,
+        node_failures=tuple(node_failures),
         log=log,
         checkpoint_ok=not errors,
         checkpoint_errors=errors,

--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -770,10 +770,8 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                         if result.status == RunStatus.FAILED:
                             error = result.error
                             assert error is not None, "FAILED status requires an error"
-                            if result.node_failures:
-                                with _failure_evidence_context(error, result.node_failures):
-                                    raise error from None
-                            raise error
+                            with _failure_evidence_context(error, result.node_failures):
+                                raise error from None
             else:
                 results_list: list[RunResult] = []
                 queue: asyncio.Queue[tuple[int, dict[str, Any]]] = asyncio.Queue()
@@ -809,10 +807,8 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                         if result.status == RunStatus.FAILED:
                             error = result.error
                             assert error is not None, "FAILED status requires an error"
-                            if result.node_failures:
-                                with _failure_evidence_context(error, result.node_failures):
-                                    raise error from None
-                            raise error
+                            with _failure_evidence_context(error, result.node_failures):
+                                raise error from None
 
             batch_summary = BatchSummary.from_results(results)
 
@@ -1006,10 +1002,8 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                 if error_handling == "raise" and result.status == RunStatus.FAILED:
                     error = result.error
                     assert error is not None, "FAILED status requires an error"
-                    if result.node_failures:
-                        with _failure_evidence_context(error, result.node_failures):
-                            raise error from None
-                    raise error
+                    with _failure_evidence_context(error, result.node_failures):
+                        raise error from None
                 yield i, result
         finally:
             for w in workers:

--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -12,6 +12,8 @@ from hypergraph.exceptions import (
     ExecutionError,
     MissingInputError,
     WorkflowAlreadyRunningError,
+    _failure_evidence_context,
+    _NodeExecutionError,
 )
 from hypergraph.runners._shared.event_metadata import (
     DEFAULT_RUN_CONTEXT,
@@ -533,9 +535,12 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
         except Exception as e:
             error = e
             partial_state = None
+            node_failures = ()
             if isinstance(e, ExecutionError):
                 error = e.__cause__ or e
                 partial_state = e.partial_state
+                if isinstance(e, _NodeExecutionError):
+                    node_failures = e.node_failures
 
             await self._emit_run_end_async(
                 dispatcher,
@@ -583,6 +588,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                 run_id=run_id,
                 workflow_id=workflow_id,
                 error=error,
+                node_failures=node_failures,
                 log=collector.build(graph.name, run_id, total_duration_ms),
                 checkpoint_errors=checkpoint_save_errors,
             )
@@ -762,7 +768,12 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                 if error_handling == "raise":
                     for result in results:
                         if result.status == RunStatus.FAILED:
-                            raise result.error  # type: ignore[misc]
+                            error = result.error
+                            assert error is not None, "FAILED status requires an error"
+                            if result.node_failures:
+                                with _failure_evidence_context(error, result.node_failures):
+                                    raise error from None
+                            raise error
             else:
                 results_list: list[RunResult] = []
                 queue: asyncio.Queue[tuple[int, dict[str, Any]]] = asyncio.Queue()
@@ -796,7 +807,12 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                 if error_handling == "raise":
                     for result in results:
                         if result.status == RunStatus.FAILED:
-                            raise result.error  # type: ignore[misc]
+                            error = result.error
+                            assert error is not None, "FAILED status requires an error"
+                            if result.node_failures:
+                                with _failure_evidence_context(error, result.node_failures):
+                                    raise error from None
+                            raise error
 
             batch_summary = BatchSummary.from_results(results)
 
@@ -961,6 +977,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                         error_handling="continue",
                         show_progress=False,
                         _validation_ctx=ctx,
+                        _item_index=i,
                     )
                 except Exception as e:  # node/validation error during a single run → failed row
                     result = build_pre_run_failed_result(e)
@@ -987,7 +1004,12 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                     break
                 i, result = item
                 if error_handling == "raise" and result.status == RunStatus.FAILED:
-                    raise result.error  # type: ignore[misc]
+                    error = result.error
+                    assert error is not None, "FAILED status requires an error"
+                    if result.node_failures:
+                        with _failure_evidence_context(error, result.node_failures):
+                            raise error from None
+                    raise error
                 yield i, result
         finally:
             for w in workers:

--- a/src/hypergraph/runners/_shared/template_sync.py
+++ b/src/hypergraph/runners/_shared/template_sync.py
@@ -11,6 +11,8 @@ from hypergraph.exceptions import (
     ExecutionError,
     MissingInputError,
     WorkflowAlreadyRunningError,
+    _failure_evidence_context,
+    _NodeExecutionError,
 )
 from hypergraph.runners._shared.event_metadata import (
     DEFAULT_RUN_CONTEXT,
@@ -511,9 +513,12 @@ class SyncRunnerTemplate(BaseRunner, ABC):
         except Exception as e:
             error = e
             partial_state = None
+            node_failures = ()
             if isinstance(e, ExecutionError):
                 error = e.__cause__ or e
                 partial_state = e.partial_state
+                if isinstance(e, _NodeExecutionError):
+                    node_failures = e.node_failures
 
             self._emit_run_end_sync(
                 dispatcher,
@@ -548,6 +553,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
                 run_id=run_id,
                 workflow_id=workflow_id,
                 error=error,
+                node_failures=node_failures,
                 log=collector.build(graph.name, run_id, total_duration_ms),
             )
         finally:
@@ -703,7 +709,12 @@ class SyncRunnerTemplate(BaseRunner, ABC):
                     result = build_pre_run_failed_result(e)
                 results.append(result)
                 if error_handling == "raise" and result.status == RunStatus.FAILED:
-                    raise result.error  # type: ignore[misc]
+                    error = result.error
+                    assert error is not None, "FAILED status requires an error"
+                    if result.node_failures:
+                        with _failure_evidence_context(error, result.node_failures):
+                            raise error from None
+                    raise error
 
             batch_summary = BatchSummary.from_results(results)
 
@@ -829,11 +840,17 @@ class SyncRunnerTemplate(BaseRunner, ABC):
                     error_handling="continue",
                     show_progress=False,
                     _validation_ctx=ctx,
+                    _item_index=idx,
                 )
             except Exception as e:  # per-item validation error (e.g. missing input) → failed row
                 result = build_pre_run_failed_result(e)
             if error_handling == "raise" and result.status == RunStatus.FAILED:
-                raise result.error  # type: ignore[misc]
+                error = result.error
+                assert error is not None, "FAILED status requires an error"
+                if result.node_failures:
+                    with _failure_evidence_context(error, result.node_failures):
+                        raise error from None
+                raise error
             yield idx, result
 
 

--- a/src/hypergraph/runners/_shared/template_sync.py
+++ b/src/hypergraph/runners/_shared/template_sync.py
@@ -711,10 +711,8 @@ class SyncRunnerTemplate(BaseRunner, ABC):
                 if error_handling == "raise" and result.status == RunStatus.FAILED:
                     error = result.error
                     assert error is not None, "FAILED status requires an error"
-                    if result.node_failures:
-                        with _failure_evidence_context(error, result.node_failures):
-                            raise error from None
-                    raise error
+                    with _failure_evidence_context(error, result.node_failures):
+                        raise error from None
 
             batch_summary = BatchSummary.from_results(results)
 
@@ -847,10 +845,8 @@ class SyncRunnerTemplate(BaseRunner, ABC):
             if error_handling == "raise" and result.status == RunStatus.FAILED:
                 error = result.error
                 assert error is not None, "FAILED status requires an error"
-                if result.node_failures:
-                    with _failure_evidence_context(error, result.node_failures):
-                        raise error from None
-                raise error
+                with _failure_evidence_context(error, result.node_failures):
+                    raise error from None
             yield idx, result
 
 

--- a/src/hypergraph/runners/_shared/types.py
+++ b/src/hypergraph/runners/_shared/types.py
@@ -9,6 +9,9 @@ from hypergraph.runners._shared.results import (
     ErrorHandling as ErrorHandling,
 )
 from hypergraph.runners._shared.results import (
+    FailureEvidence as FailureEvidence,
+)
+from hypergraph.runners._shared.results import (
     MapLog as MapLog,
 )
 from hypergraph.runners._shared.results import (

--- a/src/hypergraph/runners/async_/superstep.py
+++ b/src/hypergraph/runners/async_/superstep.py
@@ -8,7 +8,7 @@ from contextvars import ContextVar
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
-from hypergraph.exceptions import ExecutionError, _NodeExecutionError, get_failure_evidence
+from hypergraph.exceptions import ExecutionError, _get_failure_evidence_from_context, _NodeExecutionError
 from hypergraph.nodes.base import HyperNode
 from hypergraph.nodes.graph_node import GraphNode
 from hypergraph.runners._shared.caching import (
@@ -232,7 +232,7 @@ async def run_superstep_async(
                                 )
                             )
                         if isinstance(node, GraphNode):
-                            inner_failures = get_failure_evidence(executor_error)
+                            inner_failures = _get_failure_evidence_from_context(executor_error) or ()
                             node_failures = tuple(replace(failure, node_name=f"{node.name}/{failure.node_name}") for failure in inner_failures)
                         else:
                             node_failures = (

--- a/src/hypergraph/runners/async_/superstep.py
+++ b/src/hypergraph/runners/async_/superstep.py
@@ -8,7 +8,13 @@ from contextvars import ContextVar
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
-from hypergraph.exceptions import ExecutionError, _get_failure_evidence_from_context, _NodeExecutionError
+from hypergraph.exceptions import (
+    ExecutionError,
+    _bind_failure_evidence_invocation,
+    _get_failure_evidence_from_context,
+    _get_failure_evidence_invocation,
+    _NodeExecutionError,
+)
 from hypergraph.nodes.base import HyperNode
 from hypergraph.nodes.graph_node import GraphNode
 from hypergraph.runners._shared.caching import (
@@ -206,12 +212,15 @@ async def run_superstep_async(
             # can attribute itself to this exact span even under concurrency.
             span_token = set_current_node_span(NodeSpanRef(run_id=run_id, span_id=node_span_id, node_name=node.name, graph_name=graph.name))
             evidence_inputs = dict(inputs)
+            parent_invocation_token = _get_failure_evidence_invocation()
+            invocation_token = object() if isinstance(node, GraphNode) else None
             try:
                 try:
                     # Pass new_state so routing decisions are stored in the
                     # updated state. This exact executor boundary is the only
                     # place that creates FailureEvidence.
-                    outputs = await executor(node, new_state, inputs, ctx)
+                    with _bind_failure_evidence_invocation(invocation_token):
+                        outputs = await executor(node, new_state, inputs, ctx)
                 except BaseException as executor_error:
                     if isinstance(executor_error, PauseExecution):
                         raise
@@ -232,7 +241,14 @@ async def run_superstep_async(
                                 )
                             )
                         if isinstance(node, GraphNode):
-                            inner_failures = _get_failure_evidence_from_context(executor_error) or ()
+                            assert invocation_token is not None
+                            inner_failures = (
+                                _get_failure_evidence_from_context(
+                                    executor_error,
+                                    invocation_token=invocation_token,
+                                )
+                                or ()
+                            )
                             node_failures = tuple(replace(failure, node_name=f"{node.name}/{failure.node_name}") for failure in inner_failures)
                         else:
                             node_failures = (
@@ -253,6 +269,7 @@ async def run_superstep_async(
                             attempted_node_names=(node.name,),
                             node_errors={node.name: executor_error},
                             node_failures=node_failures,
+                            invocation_token=parent_invocation_token,
                         )
                         raise executor_failure from executor_error
                     raise
@@ -357,14 +374,22 @@ async def run_superstep_async(
 
     if first_error is not None:
         attempted = tuple(node.name for node in ready_nodes)
-        error_type = _NodeExecutionError if node_failures else ExecutionError
-        error = error_type(
-            first_error,
-            new_state,
-            attempted_node_names=attempted,
-            node_errors=node_errors,
-            node_failures=tuple(node_failures),
-        )
+        if node_failures:
+            error = _NodeExecutionError(
+                first_error,
+                new_state,
+                attempted_node_names=attempted,
+                node_errors=node_errors,
+                node_failures=tuple(node_failures),
+                invocation_token=_get_failure_evidence_invocation(),
+            )
+        else:
+            error = ExecutionError(
+                first_error,
+                new_state,
+                attempted_node_names=attempted,
+                node_errors=node_errors,
+            )
         raise error from first_error
 
     return new_state

--- a/src/hypergraph/runners/async_/superstep.py
+++ b/src/hypergraph/runners/async_/superstep.py
@@ -8,8 +8,9 @@ from contextvars import ContextVar
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
-from hypergraph.exceptions import ExecutionError
+from hypergraph.exceptions import ExecutionError, _NodeExecutionError, get_failure_evidence
 from hypergraph.nodes.base import HyperNode
+from hypergraph.nodes.graph_node import GraphNode
 from hypergraph.runners._shared.caching import (
     check_cache,
     restore_routing_decision,
@@ -28,6 +29,7 @@ from hypergraph.runners._shared.observability import (
     set_current_node_span,
 )
 from hypergraph.runners._shared.readiness import apply_node_result
+from hypergraph.runners._shared.results import FailureEvidence
 from hypergraph.runners._shared.state import ExecutionContext, GraphState, PauseExecution
 from hypergraph.runners._shared.value_resolution import address_for_node_input, collect_inputs_for_node
 
@@ -185,6 +187,7 @@ async def run_superstep_async(
             await dispatcher.emit_async(start_evt)
 
         node_start = time.time()
+        node_error_event_attempted = False
         try:
             executor = executors.get(type(node))
             if executor is None:
@@ -202,9 +205,57 @@ async def run_superstep_async(
             # Publish the node span so in-node telemetry (LLM clients, stores)
             # can attribute itself to this exact span even under concurrency.
             span_token = set_current_node_span(NodeSpanRef(run_id=run_id, span_id=node_span_id, node_name=node.name, graph_name=graph.name))
+            evidence_inputs = dict(inputs)
             try:
-                # Pass new_state so routing decisions are stored in the updated state
-                outputs = await executor(node, new_state, inputs, ctx)
+                try:
+                    # Pass new_state so routing decisions are stored in the
+                    # updated state. This exact executor boundary is the only
+                    # place that creates FailureEvidence.
+                    outputs = await executor(node, new_state, inputs, ctx)
+                except BaseException as executor_error:
+                    if isinstance(executor_error, PauseExecution):
+                        raise
+                    if isinstance(executor_error, Exception):
+                        duration_ms = (time.time() - node_start) * 1000
+                        if active:
+                            node_error_event_attempted = True
+                            await dispatcher.emit_async(
+                                build_node_error_event(
+                                    run_id,
+                                    node_span_id,
+                                    run_span_id,
+                                    node,
+                                    graph,
+                                    workflow_id=ctx_base.workflow_id,
+                                    item_index=ctx_base.item_index,
+                                    superstep=superstep_idx,
+                                )
+                            )
+                        if isinstance(node, GraphNode):
+                            inner_failures = get_failure_evidence(executor_error)
+                            node_failures = tuple(replace(failure, node_name=f"{node.name}/{failure.node_name}") for failure in inner_failures)
+                        else:
+                            node_failures = (
+                                FailureEvidence(
+                                    node_name=node.name,
+                                    error=executor_error,
+                                    inputs=evidence_inputs,
+                                    superstep=superstep_idx if superstep_idx is not None else 0,
+                                    duration_ms=duration_ms,
+                                    graph_name=graph.name or "",
+                                    workflow_id=ctx_base.workflow_id,
+                                    item_index=ctx_base.item_index,
+                                ),
+                            )
+                        executor_failure = _NodeExecutionError(
+                            executor_error,
+                            new_state,
+                            attempted_node_names=(node.name,),
+                            node_errors={node.name: executor_error},
+                            node_failures=node_failures,
+                        )
+                        raise executor_failure from executor_error
+                    raise
             finally:
                 reset_current_node_span(span_token)
 
@@ -247,8 +298,8 @@ async def run_superstep_async(
         except PauseExecution as exc:
             exc.span_id = node_span_id
             raise
-        except Exception:
-            if active:
+        except Exception as exc:
+            if active and not node_error_event_attempted and not isinstance(exc, _NodeExecutionError):
                 await dispatcher.emit_async(
                     build_node_error_event(
                         run_id,
@@ -272,13 +323,18 @@ async def run_superstep_async(
     first_error: BaseException | None = None
     control_flow_error: BaseException | None = None
     node_errors: dict[str, BaseException] = {}
+    node_failures: list[FailureEvidence] = []
     for node, result in zip(ready_nodes, results, strict=True):
         if isinstance(result, BaseException):
             if first_error is None:
-                first_error = result
+                first_error = (result.__cause__ or result) if isinstance(result, _NodeExecutionError) else result
             if control_flow_error is None and not isinstance(result, Exception):
                 control_flow_error = result
-            node_errors[node.name] = result
+            if isinstance(result, _NodeExecutionError):
+                node_errors[node.name] = result.__cause__ or result
+                node_failures.extend(result.node_failures)
+            else:
+                node_errors[node.name] = result
             continue
         node, outputs, input_versions, wait_for_versions, duration_ms, cached = result
         apply_node_result(
@@ -301,11 +357,13 @@ async def run_superstep_async(
 
     if first_error is not None:
         attempted = tuple(node.name for node in ready_nodes)
-        error = ExecutionError(
+        error_type = _NodeExecutionError if node_failures else ExecutionError
+        error = error_type(
             first_error,
             new_state,
             attempted_node_names=attempted,
             node_errors=node_errors,
+            node_failures=tuple(node_failures),
         )
         raise error from first_error
 

--- a/src/hypergraph/runners/sync/superstep.py
+++ b/src/hypergraph/runners/sync/superstep.py
@@ -102,16 +102,7 @@ def run_superstep_sync(
         # Check cache before execution
         cache_key, cached_outputs = ("", None)
         if cache is not None:
-            try:
-                cache_key, cached_outputs = check_cache(node, inputs, cache)
-            except ExecutionError as e:
-                error = ExecutionError(
-                    e,
-                    e.partial_state,
-                    attempted_node_names=e.attempted_node_names,
-                    node_errors=e.node_errors,
-                )
-                raise error from e
+            cache_key, cached_outputs = check_cache(node, inputs, cache)
 
         if cached_outputs is not None:
             outputs = cached_outputs

--- a/src/hypergraph/runners/sync/superstep.py
+++ b/src/hypergraph/runners/sync/superstep.py
@@ -6,7 +6,7 @@ import time
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
-from hypergraph.exceptions import ExecutionError, _NodeExecutionError, get_failure_evidence
+from hypergraph.exceptions import ExecutionError, _get_failure_evidence_from_context, _NodeExecutionError
 from hypergraph.nodes.base import HyperNode
 from hypergraph.nodes.graph_node import GraphNode
 from hypergraph.runners._shared.caching import (
@@ -221,7 +221,7 @@ def run_superstep_sync(
                                     )
                                 )
                             if isinstance(node, GraphNode):
-                                inner_failures = get_failure_evidence(executor_error)
+                                inner_failures = _get_failure_evidence_from_context(executor_error) or ()
                                 node_failures = tuple(replace(failure, node_name=f"{node.name}/{failure.node_name}") for failure in inner_failures)
                             else:
                                 node_failures = (

--- a/src/hypergraph/runners/sync/superstep.py
+++ b/src/hypergraph/runners/sync/superstep.py
@@ -6,8 +6,9 @@ import time
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
-from hypergraph.exceptions import ExecutionError
+from hypergraph.exceptions import ExecutionError, _NodeExecutionError, get_failure_evidence
 from hypergraph.nodes.base import HyperNode
+from hypergraph.nodes.graph_node import GraphNode
 from hypergraph.runners._shared.caching import (
     check_cache,
     restore_routing_decision,
@@ -26,6 +27,7 @@ from hypergraph.runners._shared.observability import (
     set_current_node_span,
 )
 from hypergraph.runners._shared.readiness import apply_node_result
+from hypergraph.runners._shared.results import FailureEvidence
 from hypergraph.runners._shared.state import ExecutionContext, GraphState, PauseExecution
 from hypergraph.runners._shared.value_resolution import address_for_node_input, collect_inputs_for_node
 
@@ -94,7 +96,16 @@ def run_superstep_sync(
         # Check cache before execution
         cache_key, cached_outputs = ("", None)
         if cache is not None:
-            cache_key, cached_outputs = check_cache(node, inputs, cache)
+            try:
+                cache_key, cached_outputs = check_cache(node, inputs, cache)
+            except ExecutionError as e:
+                error = ExecutionError(
+                    e,
+                    e.partial_state,
+                    attempted_node_names=e.attempted_node_names,
+                    node_errors=e.node_errors,
+                )
+                raise error from e
 
         if cached_outputs is not None:
             outputs = cached_outputs
@@ -166,6 +177,7 @@ def run_superstep_sync(
                 dispatcher.emit(start_evt)
 
             node_start = time.time()
+            node_error_event_attempted = False
             try:
                 executor = executors.get(type(node))
                 if executor is None:
@@ -183,9 +195,56 @@ def run_superstep_sync(
                 # Publish the node span so in-node telemetry (LLM clients, stores)
                 # can attribute itself to this exact span.
                 span_token = set_current_node_span(NodeSpanRef(run_id=run_id, span_id=node_span_id, node_name=node.name, graph_name=graph.name))
+                evidence_inputs = dict(inputs)
                 try:
-                    # Execute node
-                    outputs = executor(node, new_state, inputs, ctx)
+                    try:
+                        # Execute node. This is the only boundary that creates
+                        # FailureEvidence; surrounding work is infrastructure.
+                        outputs = executor(node, new_state, inputs, ctx)
+                    except BaseException as executor_error:
+                        if isinstance(executor_error, PauseExecution):
+                            raise
+                        if isinstance(executor_error, Exception):
+                            duration_ms = (time.time() - node_start) * 1000
+                            if active:
+                                node_error_event_attempted = True
+                                dispatcher.emit(
+                                    build_node_error_event(
+                                        run_id,
+                                        node_span_id,
+                                        run_span_id,
+                                        node,
+                                        graph,
+                                        workflow_id=ctx_base.workflow_id,
+                                        item_index=ctx_base.item_index,
+                                        superstep=superstep_idx,
+                                    )
+                                )
+                            if isinstance(node, GraphNode):
+                                inner_failures = get_failure_evidence(executor_error)
+                                node_failures = tuple(replace(failure, node_name=f"{node.name}/{failure.node_name}") for failure in inner_failures)
+                            else:
+                                node_failures = (
+                                    FailureEvidence(
+                                        node_name=node.name,
+                                        error=executor_error,
+                                        inputs=evidence_inputs,
+                                        superstep=superstep_idx if superstep_idx is not None else 0,
+                                        duration_ms=duration_ms,
+                                        graph_name=graph.name or "",
+                                        workflow_id=ctx_base.workflow_id,
+                                        item_index=ctx_base.item_index,
+                                    ),
+                                )
+                            executor_failure = _NodeExecutionError(
+                                executor_error,
+                                new_state,
+                                attempted_node_names=tuple(attempted_node_names),
+                                node_errors={node.name: executor_error},
+                                node_failures=node_failures,
+                            )
+                            raise executor_failure from executor_error
+                        raise
                 finally:
                     reset_current_node_span(span_token)
 
@@ -226,7 +285,7 @@ def run_superstep_sync(
 
             except BaseException as e:
                 duration_ms = (time.time() - node_start) * 1000
-                if active:
+                if active and not node_error_event_attempted and not isinstance(e, _NodeExecutionError):
                     dispatcher.emit(
                         build_node_error_event(
                             run_id,
@@ -243,8 +302,18 @@ def run_superstep_sync(
                 if isinstance(e, PauseExecution):
                     e.span_id = node_span_id
                     raise
+                if isinstance(e, _NodeExecutionError):
+                    raise
                 # Wrap only Exception subclasses
                 if isinstance(e, Exception):
+                    if isinstance(e, ExecutionError):
+                        error = ExecutionError(
+                            e,
+                            e.partial_state,
+                            attempted_node_names=e.attempted_node_names,
+                            node_errors=e.node_errors,
+                        )
+                        raise error from e
                     error = ExecutionError(
                         e,
                         new_state,

--- a/src/hypergraph/runners/sync/superstep.py
+++ b/src/hypergraph/runners/sync/superstep.py
@@ -6,7 +6,13 @@ import time
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
-from hypergraph.exceptions import ExecutionError, _get_failure_evidence_from_context, _NodeExecutionError
+from hypergraph.exceptions import (
+    ExecutionError,
+    _bind_failure_evidence_invocation,
+    _get_failure_evidence_from_context,
+    _get_failure_evidence_invocation,
+    _NodeExecutionError,
+)
 from hypergraph.nodes.base import HyperNode
 from hypergraph.nodes.graph_node import GraphNode
 from hypergraph.runners._shared.caching import (
@@ -196,11 +202,14 @@ def run_superstep_sync(
                 # can attribute itself to this exact span.
                 span_token = set_current_node_span(NodeSpanRef(run_id=run_id, span_id=node_span_id, node_name=node.name, graph_name=graph.name))
                 evidence_inputs = dict(inputs)
+                parent_invocation_token = _get_failure_evidence_invocation()
+                invocation_token = object() if isinstance(node, GraphNode) else None
                 try:
                     try:
                         # Execute node. This is the only boundary that creates
                         # FailureEvidence; surrounding work is infrastructure.
-                        outputs = executor(node, new_state, inputs, ctx)
+                        with _bind_failure_evidence_invocation(invocation_token):
+                            outputs = executor(node, new_state, inputs, ctx)
                     except BaseException as executor_error:
                         if isinstance(executor_error, PauseExecution):
                             raise
@@ -221,7 +230,14 @@ def run_superstep_sync(
                                     )
                                 )
                             if isinstance(node, GraphNode):
-                                inner_failures = _get_failure_evidence_from_context(executor_error) or ()
+                                assert invocation_token is not None
+                                inner_failures = (
+                                    _get_failure_evidence_from_context(
+                                        executor_error,
+                                        invocation_token=invocation_token,
+                                    )
+                                    or ()
+                                )
                                 node_failures = tuple(replace(failure, node_name=f"{node.name}/{failure.node_name}") for failure in inner_failures)
                             else:
                                 node_failures = (
@@ -242,6 +258,7 @@ def run_superstep_sync(
                                 attempted_node_names=tuple(attempted_node_names),
                                 node_errors={node.name: executor_error},
                                 node_failures=node_failures,
+                                invocation_token=parent_invocation_token,
                             )
                             raise executor_failure from executor_error
                         raise

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -7,7 +7,7 @@ import inspect
 from pathlib import Path
 from typing import get_args, get_type_hints
 
-from hypergraph import Graph, MapResult, RunResult, WorkflowStoppedError
+from hypergraph import FailureEvidence, Graph, MapResult, RunResult, WorkflowStoppedError
 from hypergraph.checkpointers import Checkpointer, MemoryCheckpointer, SqliteCheckpointer, SqliteRunInspector
 from hypergraph.events import RunEndEvent
 from hypergraph.runners._shared.results import NodeRecord
@@ -138,7 +138,24 @@ def test_result_docs_mirror_checkpoint_evidence() -> None:
     assert "log: RunLog | None" in run_attributes
     assert "checkpoint_ok: bool" in run_attributes
     assert "checkpoint_errors: tuple[str, ...]" in run_attributes
+    assert "node_failures: tuple[FailureEvidence, ...]" in run_attributes
     assert "best-effort" in run_result
+    assert "get_failure_evidence" in run_result
+    assert "worker/parser/parse_order" in run_result
+    assert "large values or secrets" in run_result
+    assert "until the `RunResult` or raised exception" in run_result
+    assert tuple(FailureEvidence.__dataclass_fields__) == (
+        "node_name",
+        "error",
+        "inputs",
+        "superstep",
+        "duration_ms",
+        "graph_name",
+        "workflow_id",
+        "item_index",
+    )
+    assert "node_failures" in RunResult.__dataclass_fields__
+    assert isinstance(inspect.getattr_static(RunResult, "failure"), property)
     run_progressive_disclosure = _scoped_section(run_result, "### Progressive Disclosure")
     assert '"checkpoint_ok": True' in run_progressive_disclosure
     assert '"checkpoint_errors": []' in run_progressive_disclosure

--- a/tests/test_failure_evidence.py
+++ b/tests/test_failure_evidence.py
@@ -332,6 +332,43 @@ def test_sync_map_raise_masks_stale_infrastructure_execution_error() -> None:
     assert get_failure_evidence(exc_info.value) == ()
 
 
+def test_sync_graph_node_rejects_stale_map_carrier_from_previous_call() -> None:
+    reused_error = RuntimeError("reused after sync map")
+
+    @node(output_name="first_out")
+    def first_failure(secret: str) -> str:
+        raise reused_error
+
+    with pytest.raises(RuntimeError) as exc_info:
+        SyncRunner().map(
+            Graph([first_failure], name="first-map"),
+            {"secret": ["TOP-SECRET"]},
+            map_over="secret",
+        )
+
+    assert exc_info.value is reused_error
+    assert get_failure_evidence(reused_error)[0].inputs == {"secret": "TOP-SECRET"}
+
+    @node(output_name="child_out")
+    def child_node(x: int) -> int:
+        return x
+
+    graph_node = Graph([child_node], name="child").as_node(name="custom_graph_node")
+    runner = SyncRunner()
+
+    def raise_reused_error(node, state, inputs, ctx):
+        raise reused_error
+
+    runner._executors[type(graph_node)] = raise_reused_error
+    result = runner.run(Graph([graph_node], name="second"), {"x": 5}, error_handling="continue")
+
+    assert result.error is reused_error
+    assert result.node_failures == ()
+    assert result.failure is None
+    assert "TOP-SECRET" not in repr(result)
+    assert "TOP-SECRET" not in repr(result.to_dict())
+
+
 @pytest.mark.asyncio
 async def test_async_map_attaches_source_item_indexes() -> None:
     results = await AsyncRunner().map(
@@ -402,6 +439,44 @@ async def test_async_map_raise_accessor_retains_failing_item_index() -> None:
     assert len(failures) == 1
     assert failures[0].item_index == 1
     assert failures[0].inputs == {"x": 3}
+
+
+@pytest.mark.asyncio
+async def test_async_graph_node_rejects_stale_map_carrier_from_previous_call() -> None:
+    reused_error = RuntimeError("reused after async map")
+
+    @node(output_name="first_out")
+    async def first_failure(secret: str) -> str:
+        raise reused_error
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await AsyncRunner().map(
+            Graph([first_failure], name="first-map"),
+            {"secret": ["TOP-SECRET"]},
+            map_over="secret",
+        )
+
+    assert exc_info.value is reused_error
+    assert get_failure_evidence(reused_error)[0].inputs == {"secret": "TOP-SECRET"}
+
+    @node(output_name="child_out")
+    def child_node(x: int) -> int:
+        return x
+
+    graph_node = Graph([child_node], name="child").as_node(name="custom_graph_node")
+    runner = AsyncRunner()
+
+    async def raise_reused_error(node, state, inputs, ctx):
+        raise reused_error
+
+    runner._executors[type(graph_node)] = raise_reused_error
+    result = await runner.run(Graph([graph_node], name="second"), {"x": 5}, error_handling="continue")
+
+    assert result.error is reused_error
+    assert result.node_failures == ()
+    assert result.failure is None
+    assert "TOP-SECRET" not in repr(result)
+    assert "TOP-SECRET" not in repr(result.to_dict())
 
 
 def test_sync_nested_failure_is_qualified_once_per_boundary() -> None:

--- a/tests/test_failure_evidence.py
+++ b/tests/test_failure_evidence.py
@@ -1,0 +1,476 @@
+"""Public contract tests for structured node-failure evidence (issue #154)."""
+
+from __future__ import annotations
+
+import asyncio
+import traceback
+from typing import Any
+
+import pytest
+
+from hypergraph import (
+    AsyncRunner,
+    FailureEvidence,
+    Graph,
+    NodeContext,
+    RunResult,
+    RunStatus,
+    SyncRunner,
+    get_failure_evidence,
+    node,
+)
+
+
+class EvidenceError(Exception):
+    """Distinct leaf error used to prove original-exception propagation."""
+
+
+class CacheInfrastructureError(Exception):
+    """Cache failure that must remain unattributed to the node executor."""
+
+
+class ExplodingCache:
+    """Cache backend proving cache read failures are not node failures."""
+
+    def get(self, key: str) -> tuple[bool, Any]:
+        raise CacheInfrastructureError(f"cache unavailable:{key}")
+
+    def set(self, key: str, value: Any) -> None:
+        raise AssertionError("cache set must not run after a failed read")
+
+
+@node(output_name="failed")
+def fail_with_x(x: int) -> int:
+    raise EvidenceError(f"failed:{x}")
+
+
+@node(output_name="left")
+async def fail_left(x: int) -> int:
+    raise EvidenceError(f"left:{x}")
+
+
+@node(output_name="right")
+async def fail_right(x: int) -> int:
+    raise LookupError(f"right:{x}")
+
+
+@node(output_name="good")
+async def succeed_alongside_failures(x: int) -> int:
+    return x * 10
+
+
+@node(output_name="mapped")
+def fail_on_odd(x: int) -> int:
+    if x % 2:
+        raise EvidenceError(f"odd:{x}")
+    return x * 2
+
+
+@node(output_name="mapped_async")
+async def fail_on_odd_async(x: int) -> int:
+    if x % 2:
+        raise EvidenceError(f"odd-async:{x}")
+    return x * 2
+
+
+@node(output_name="leaf")
+def nested_leaf_failure(x: int) -> int:
+    raise EvidenceError(f"nested:{x}")
+
+
+@node(output_name="leaf_async")
+async def nested_leaf_failure_async(x: int) -> int:
+    raise EvidenceError(f"nested-async:{x}")
+
+
+class ExplosivePayload:
+    """Input that fails if evidence capture implicitly renders or copies it."""
+
+    def __repr__(self) -> str:
+        raise AssertionError("payload repr must not be called")
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> ExplosivePayload:
+        raise AssertionError("payload deepcopy must not be called")
+
+
+@node(output_name="payload_result")
+def fail_with_unrenderable_payload(payload: ExplosivePayload) -> str:
+    raise EvidenceError("payload failed")
+
+
+@node(output_name="context_failure")
+def fail_with_node_context(x: int, ctx: NodeContext) -> int:
+    assert ctx.workflow_id == "context-run"
+    raise EvidenceError(f"context:{x}")
+
+
+@node(output_name="cached_failure", cache=True)
+def cached_node_that_must_not_run(x: int) -> int:
+    raise AssertionError(f"executor must not run after cache read failure:{x}")
+
+
+def test_sync_continue_captures_real_inputs_and_falsifies_on_change() -> None:
+    graph = Graph([fail_with_x], name="sync-evidence")
+    runner = SyncRunner()
+
+    first = runner.run(graph, {"x": 7}, error_handling="continue", workflow_id="sync-7")
+    second = runner.run(graph, {"x": 11}, error_handling="continue", workflow_id="sync-11")
+
+    assert first.status == RunStatus.FAILED
+    assert second.status == RunStatus.FAILED
+    assert isinstance(first.failure, FailureEvidence)
+    assert first.failure.inputs == {"x": 7}
+    assert second.failure is not None
+    assert second.failure.inputs == {"x": 11}
+    assert str(first.failure.error) == "failed:7"
+    assert str(second.failure.error) == "failed:11"
+    assert first.failure.error is first.error
+    assert first.node_failures == (first.failure,)
+    assert first.failure.node_name == "fail_with_x"
+    assert first.failure.graph_name == "sync-evidence"
+    assert first.failure.workflow_id == "sync-7"
+    assert first.failure.item_index is None
+    assert first.failure.superstep >= 0
+    assert first.failure.duration_ms >= 0
+
+
+@pytest.mark.asyncio
+async def test_async_parallel_preserves_every_failure_in_ready_order() -> None:
+    first_started = asyncio.Event()
+    second_finished = asyncio.Event()
+
+    @node(output_name="slow_left")
+    async def slow_first_failure(x: int) -> int:
+        first_started.set()
+        await second_finished.wait()
+        raise EvidenceError(f"slow-left:{x}")
+
+    @node(output_name="fast_right")
+    async def fast_second_failure(x: int) -> int:
+        await first_started.wait()
+        second_finished.set()
+        raise LookupError(f"fast-right:{x}")
+
+    graph = Graph([slow_first_failure, fast_second_failure, succeed_alongside_failures], name="parallel-evidence")
+
+    result = await AsyncRunner().run(graph, {"x": 3}, error_handling="continue", workflow_id="parallel")
+
+    assert result.status == RunStatus.FAILED
+    assert result.values["good"] == 30
+    assert [failure.node_name for failure in result.node_failures] == ["slow_first_failure", "fast_second_failure"]
+    assert [failure.inputs for failure in result.node_failures] == [{"x": 3}, {"x": 3}]
+    assert [type(failure.error) for failure in result.node_failures] == [EvidenceError, LookupError]
+    assert result.error is result.failure.error
+
+
+def test_sync_raise_preserves_original_type_and_uses_public_accessor() -> None:
+    graph = Graph([fail_with_x], name="raise-evidence")
+
+    with pytest.raises(EvidenceError, match="failed:5") as exc_info:
+        SyncRunner().run(graph, {"x": 5}, workflow_id="raise-sync")
+
+    failures = get_failure_evidence(exc_info.value)
+    assert len(failures) == 1
+    assert failures[0].inputs == {"x": 5}
+    assert failures[0].error is exc_info.value
+    for forbidden in ("failure", "failure_case", "_failure_evidence"):
+        assert not hasattr(exc_info.value, forbidden)
+    assert exc_info.value.__dict__ == {}
+    formatted = "".join(traceback.format_exception(exc_info.value))
+    assert "ExecutionError" not in formatted
+    assert "FailureEvidenceCarrier" not in formatted
+    assert "FailureEvidenceContext" not in formatted
+
+
+def test_sync_raise_preserves_the_exact_original_exception_object() -> None:
+    original = EvidenceError("same-object")
+
+    @node(output_name="never")
+    def raise_existing_error(x: int) -> int:
+        raise original
+
+    with pytest.raises(EvidenceError) as exc_info:
+        SyncRunner().run(Graph([raise_existing_error]), {"x": 1})
+
+    assert exc_info.value is original
+    assert get_failure_evidence(exc_info.value)[0].error is original
+
+
+@pytest.mark.asyncio
+async def test_async_raise_preserves_original_type_and_all_parallel_evidence() -> None:
+    graph = Graph([fail_left, fail_right], name="raise-parallel")
+
+    with pytest.raises(EvidenceError, match="left:9") as exc_info:
+        await AsyncRunner().run(graph, {"x": 9}, workflow_id="raise-async")
+
+    failures = get_failure_evidence(exc_info.value)
+    assert [failure.node_name for failure in failures] == ["fail_left", "fail_right"]
+    assert [failure.inputs for failure in failures] == [{"x": 9}, {"x": 9}]
+
+
+def test_sync_map_attaches_source_item_indexes() -> None:
+    results = SyncRunner().map(
+        Graph([fail_on_odd], name="sync-map-evidence"),
+        {"x": [1, 2, 3]},
+        map_over="x",
+        error_handling="continue",
+        workflow_id="sync-map",
+    )
+
+    assert [result.failure.item_index if result.failure else None for result in results] == [0, None, 2]
+    assert results[0].failure is not None
+    assert results[0].failure.inputs == {"x": 1}
+    assert results[1].node_failures == ()
+    assert results[2].failure is not None
+    assert results[2].failure.inputs == {"x": 3}
+
+
+def test_sync_map_iter_attaches_source_item_indexes() -> None:
+    streamed = list(
+        SyncRunner().map_iter(
+            Graph([fail_on_odd], name="sync-map-iter-evidence"),
+            {"x": [1, 2, 3]},
+            map_over="x",
+            error_handling="continue",
+        )
+    )
+
+    assert [index for index, _ in streamed] == [0, 1, 2]
+    assert [result.failure.item_index if result.failure else None for _, result in streamed] == [0, None, 2]
+
+
+def test_sync_map_iter_raise_accessor_retains_failing_item_index() -> None:
+    with pytest.raises(EvidenceError, match="odd:3") as exc_info:
+        list(
+            SyncRunner().map_iter(
+                Graph([fail_on_odd], name="sync-map-iter-raise-evidence"),
+                {"x": [2, 3]},
+                map_over="x",
+                error_handling="raise",
+            )
+        )
+
+    failures = get_failure_evidence(exc_info.value)
+    assert len(failures) == 1
+    assert failures[0].item_index == 1
+
+
+def test_sync_map_raise_accessor_retains_failing_item_index() -> None:
+    with pytest.raises(EvidenceError, match="odd:3") as exc_info:
+        SyncRunner().map(
+            Graph([fail_on_odd], name="sync-map-raise-evidence"),
+            {"x": [2, 3]},
+            map_over="x",
+            error_handling="raise",
+        )
+
+    failures = get_failure_evidence(exc_info.value)
+    assert len(failures) == 1
+    assert failures[0].item_index == 1
+    assert failures[0].inputs == {"x": 3}
+    formatted = "".join(traceback.format_exception(exc_info.value))
+    assert "FailureEvidenceCarrier" not in formatted
+    assert "FailureEvidenceContext" not in formatted
+
+
+@pytest.mark.asyncio
+async def test_async_map_attaches_source_item_indexes() -> None:
+    results = await AsyncRunner().map(
+        Graph([fail_on_odd_async], name="async-map-evidence"),
+        {"x": [1, 2, 3]},
+        map_over="x",
+        error_handling="continue",
+        workflow_id="async-map",
+    )
+
+    assert [result.failure.item_index if result.failure else None for result in results] == [0, None, 2]
+    assert results[0].failure is not None
+    assert results[0].failure.inputs == {"x": 1}
+    assert results[2].failure is not None
+    assert results[2].failure.inputs == {"x": 3}
+
+
+@pytest.mark.asyncio
+async def test_async_map_iter_attaches_source_item_indexes() -> None:
+    streamed = [
+        item
+        async for item in AsyncRunner().map_iter(
+            Graph([fail_on_odd_async], name="async-map-iter-evidence"),
+            {"x": [1, 2, 3]},
+            map_over="x",
+            error_handling="continue",
+            max_concurrency=2,
+        )
+    ]
+    by_index = dict(streamed)
+
+    assert sorted(by_index) == [0, 1, 2]
+    assert by_index[0].failure is not None
+    assert by_index[0].failure.item_index == 0
+    assert by_index[1].failure is None
+    assert by_index[2].failure is not None
+    assert by_index[2].failure.item_index == 2
+
+
+@pytest.mark.asyncio
+async def test_async_map_iter_raise_accessor_retains_failing_item_index() -> None:
+    with pytest.raises(EvidenceError, match="odd-async:3") as exc_info:
+        async for _ in AsyncRunner().map_iter(
+            Graph([fail_on_odd_async], name="async-map-iter-raise-evidence"),
+            {"x": [2, 3]},
+            map_over="x",
+            error_handling="raise",
+            max_concurrency=1,
+        ):
+            pass
+
+    failures = get_failure_evidence(exc_info.value)
+    assert len(failures) == 1
+    assert failures[0].item_index == 1
+
+
+@pytest.mark.asyncio
+async def test_async_map_raise_accessor_retains_failing_item_index() -> None:
+    with pytest.raises(EvidenceError, match="odd-async:3") as exc_info:
+        await AsyncRunner().map(
+            Graph([fail_on_odd_async], name="async-map-raise-evidence"),
+            {"x": [2, 3]},
+            map_over="x",
+            error_handling="raise",
+        )
+
+    failures = get_failure_evidence(exc_info.value)
+    assert len(failures) == 1
+    assert failures[0].item_index == 1
+    assert failures[0].inputs == {"x": 3}
+
+
+def test_sync_nested_failure_is_qualified_once_per_boundary() -> None:
+    inner = Graph([nested_leaf_failure], name="inner")
+    middle = Graph([inner.as_node(name="inner_node")], name="middle")
+    outer = Graph([middle.as_node(name="middle_node")], name="outer")
+
+    result = SyncRunner().run(outer, {"x": 4}, error_handling="continue", workflow_id="nested-sync")
+
+    assert result.failure is not None
+    assert result.node_failures == (result.failure,)
+    assert result.failure.node_name == "middle_node/inner_node/nested_leaf_failure"
+    assert result.failure.graph_name == "inner"
+    assert result.failure.inputs == {"x": 4}
+
+
+def test_sync_nested_raise_accessor_reports_the_qualified_leaf() -> None:
+    inner = Graph([nested_leaf_failure], name="inner-raise")
+    outer = Graph([inner.as_node(name="inner_node")], name="outer-raise")
+
+    with pytest.raises(EvidenceError, match="nested:4") as exc_info:
+        SyncRunner().run(outer, {"x": 4})
+
+    failures = get_failure_evidence(exc_info.value)
+    assert len(failures) == 1
+    assert failures[0].node_name == "inner_node/nested_leaf_failure"
+
+
+@pytest.mark.asyncio
+async def test_async_nested_failure_is_qualified_once_per_boundary() -> None:
+    inner = Graph([nested_leaf_failure_async], name="inner-async")
+    outer = Graph([inner.as_node(name="inner_node")], name="outer-async")
+
+    result = await AsyncRunner().run(outer, {"x": 6}, error_handling="continue", workflow_id="nested-async")
+
+    assert result.failure is not None
+    assert result.node_failures == (result.failure,)
+    assert result.failure.node_name == "inner_node/nested_leaf_failure_async"
+    assert result.failure.graph_name == "inner-async"
+    assert result.failure.inputs == {"x": 6}
+
+
+def test_raw_input_is_ephemeral_and_never_implicitly_rendered_or_copied() -> None:
+    payload = ExplosivePayload()
+    provided = {"payload": payload}
+
+    result = SyncRunner().run(
+        Graph([fail_with_unrenderable_payload], name="private-evidence"),
+        provided,
+        error_handling="continue",
+    )
+
+    assert result.failure is not None
+    assert result.failure.inputs is not provided
+    assert result.failure.inputs["payload"] is payload
+    assert "inputs=" not in repr(result.failure)
+    repr(result)
+    result._repr_html_()
+    serialized = result.to_dict()
+    assert "inputs" not in serialized["node_failures"][0]
+    assert all(value is not payload for value in serialized.values())
+
+
+def test_injected_node_context_is_not_captured_as_a_graph_input() -> None:
+    result = SyncRunner().run(
+        Graph([fail_with_node_context], name="context-evidence"),
+        {"x": 8},
+        workflow_id="context-run",
+        error_handling="continue",
+    )
+
+    assert result.failure is not None
+    assert result.failure.inputs == {"x": 8}
+
+
+def test_cache_read_failure_remains_unattributable() -> None:
+    result = SyncRunner(cache=ExplodingCache()).run(
+        Graph([cached_node_that_must_not_run], name="cache-infrastructure"),
+        {"x": 2},
+        error_handling="continue",
+    )
+
+    assert isinstance(result.error, CacheInfrastructureError)
+    assert result.node_failures == ()
+    assert result.failure is None
+
+
+def test_failed_result_without_node_attribution_has_empty_evidence() -> None:
+    result = RunResult(values={}, status=RunStatus.FAILED, error=RuntimeError("pre-node"))
+
+    assert result.node_failures == ()
+    assert result.failure is None
+    assert get_failure_evidence(result.error) == ()
+
+
+def test_public_accessor_terminates_on_an_unrelated_context_cycle() -> None:
+    first = RuntimeError("first")
+    second = RuntimeError("second")
+    first.__context__ = second
+    second.__context__ = first
+
+    assert get_failure_evidence(first) == ()
+
+
+def test_to_dict_serializes_metadata_but_not_raw_inputs() -> None:
+    result = SyncRunner().run(
+        Graph([fail_with_x], name="serialized-evidence"),
+        {"x": 13},
+        error_handling="continue",
+        workflow_id="serialized-run",
+    )
+
+    serialized = result.to_dict()
+    assert serialized["error"] == "EvidenceError: failed:13"
+    assert serialized["node_failures"] == [
+        {
+            "node_name": "fail_with_x",
+            "error": "EvidenceError: failed:13",
+            "superstep": result.failure.superstep,
+            "duration_ms": result.failure.duration_ms,
+            "graph_name": "serialized-evidence",
+            "workflow_id": "serialized-run",
+            "item_index": None,
+        }
+    ]
+
+
+def test_public_exports_are_available_from_runners_namespace() -> None:
+    from hypergraph.runners import FailureEvidence as RunnerFailureEvidence
+
+    assert RunnerFailureEvidence is FailureEvidence

--- a/tests/test_failure_evidence.py
+++ b/tests/test_failure_evidence.py
@@ -10,9 +10,11 @@ import pytest
 
 from hypergraph import (
     AsyncRunner,
+    ExecutionError,
     FailureEvidence,
     Graph,
     NodeContext,
+    PauseInfo,
     RunResult,
     RunStatus,
     SyncRunner,
@@ -196,6 +198,28 @@ def test_sync_raise_preserves_the_exact_original_exception_object() -> None:
     assert get_failure_evidence(exc_info.value)[0].error is original
 
 
+def test_accessor_bypasses_custom_context_hiding() -> None:
+    class HidingContextError(Exception):
+        def __getattribute__(self, name: str) -> Any:
+            if name == "__context__":
+                return None
+            return super().__getattribute__(name)
+
+    original = HidingContextError("hidden-context")
+
+    @node(output_name="never")
+    def raise_hiding_error(x: int) -> int:
+        raise original
+
+    with pytest.raises(HidingContextError) as exc_info:
+        SyncRunner().run(Graph([raise_hiding_error]), {"x": 3})
+
+    failures = get_failure_evidence(exc_info.value)
+    assert len(failures) == 1
+    assert failures[0].error is original
+    assert failures[0].inputs == {"x": 3}
+
+
 @pytest.mark.asyncio
 async def test_async_raise_preserves_original_type_and_all_parallel_evidence() -> None:
     graph = Graph([fail_left, fail_right], name="raise-parallel")
@@ -271,6 +295,41 @@ def test_sync_map_raise_accessor_retains_failing_item_index() -> None:
     formatted = "".join(traceback.format_exception(exc_info.value))
     assert "FailureEvidenceCarrier" not in formatted
     assert "FailureEvidenceContext" not in formatted
+
+
+def test_sync_map_raise_masks_stale_infrastructure_execution_error() -> None:
+    from hypergraph.runners import GraphState
+
+    cause = RuntimeError("cache unavailable")
+    stale = FailureEvidence(
+        node_name="stale",
+        error=cause,
+        inputs={"secret": "old"},
+        superstep=9,
+        duration_ms=1.0,
+        graph_name="old",
+        workflow_id=None,
+        item_index=None,
+    )
+    cache_error = ExecutionError(cause, GraphState(), node_failures=(stale,))
+
+    class StaleEvidenceCache:
+        def get(self, key: str) -> tuple[bool, Any]:
+            raise cache_error
+
+        def set(self, key: str, value: Any) -> None:
+            raise AssertionError("cache set must not run")
+
+    with pytest.raises(ExecutionError) as exc_info:
+        SyncRunner(cache=StaleEvidenceCache()).map(
+            Graph([cached_node_that_must_not_run], name="stale-cache-map"),
+            {"x": [5]},
+            map_over="x",
+            error_handling="raise",
+        )
+
+    assert exc_info.value is cache_error
+    assert get_failure_evidence(exc_info.value) == ()
 
 
 @pytest.mark.asyncio
@@ -436,6 +495,15 @@ def test_failed_result_without_node_attribution_has_empty_evidence() -> None:
     assert result.node_failures == ()
     assert result.failure is None
     assert get_failure_evidence(result.error) == ()
+
+
+def test_run_result_keeps_preexisting_positional_field_order() -> None:
+    pause = PauseInfo(node_name="approval", output_param="answer", value="draft")
+
+    result = RunResult({}, RunStatus.PAUSED, "run-positional", None, None, pause)
+
+    assert result.pause is pause
+    assert result.node_failures == ()
 
 
 def test_public_accessor_terminates_on_an_unrelated_context_cycle() -> None:

--- a/tests/test_failure_evidence.py
+++ b/tests/test_failure_evidence.py
@@ -320,7 +320,7 @@ def test_sync_map_raise_masks_stale_infrastructure_execution_error() -> None:
         def set(self, key: str, value: Any) -> None:
             raise AssertionError("cache set must not run")
 
-    with pytest.raises(ExecutionError) as exc_info:
+    with pytest.raises(RuntimeError) as exc_info:
         SyncRunner(cache=StaleEvidenceCache()).map(
             Graph([cached_node_that_must_not_run], name="stale-cache-map"),
             {"x": [5]},
@@ -328,7 +328,7 @@ def test_sync_map_raise_masks_stale_infrastructure_execution_error() -> None:
             error_handling="raise",
         )
 
-    assert exc_info.value is cache_error
+    assert exc_info.value is cause
     assert get_failure_evidence(exc_info.value) == ()
 
 

--- a/tests/test_public_exports.py
+++ b/tests/test_public_exports.py
@@ -13,6 +13,16 @@ class TestExceptionExports:
         assert ExecutionError is hypergraph.exceptions.ExecutionError
         assert "ExecutionError" in hypergraph.__all__
 
+    def test_failure_evidence_api_exported(self):
+        """Structured failure evidence and its accessor are root exports."""
+        from hypergraph import FailureEvidence, get_failure_evidence
+        from hypergraph.runners._shared.results import FailureEvidence as CanonicalFailureEvidence
+
+        assert FailureEvidence is CanonicalFailureEvidence
+        assert get_failure_evidence is hypergraph.exceptions.get_failure_evidence
+        assert "FailureEvidence" in hypergraph.__all__
+        assert "get_failure_evidence" in hypergraph.__all__
+
     def test_all_names_resolve(self):
         """Every name in __all__ is an attribute of the package."""
         for name in hypergraph.__all__:

--- a/tests/test_runners/test_type_ownership.py
+++ b/tests/test_runners/test_type_ownership.py
@@ -33,6 +33,7 @@ ROOT_EXPORTS = (
     "DaftRunner",
     "BaseRunner",
     "ErrorHandling",
+    "FailureEvidence",
     "PauseInfo",
     "RunResult",
     "MapResult",
@@ -43,6 +44,7 @@ ROOT_EXPORTS = (
     "InfiniteLoopError",
     "IncompatibleRunnerError",
     "ExecutionError",
+    "get_failure_evidence",
     "WorkflowAlreadyCompletedError",
     "GraphChangedError",
     "WorkflowForkError",
@@ -87,6 +89,7 @@ ROOT_EXPORTS = (
 
 RUNNER_EXPORTS = (
     "ErrorHandling",
+    "FailureEvidence",
     "RunStatus",
     "PauseExecution",
     "PauseInfo",
@@ -107,6 +110,7 @@ RUNNER_EXPORTS = (
 
 RESULT_NAMES = (
     "ErrorHandling",
+    "FailureEvidence",
     "RunStatus",
     "aggregate_run_status",
     "RunResult",
@@ -168,12 +172,13 @@ def test_legacy_public_and_canonical_identities() -> None:
         assert getattr(legacy_types, name) is getattr(canonical_state, name)
     assert legacy_types._generate_run_id is canonical_results.generate_run_id
 
-    for name in RUNNER_EXPORTS[:13]:
+    for name in RUNNER_EXPORTS[:14]:
         owner = canonical_state if name in STATE_NAMES else canonical_results
         assert getattr(runners, name) is getattr(owner, name)
 
     for name in (
         "ErrorHandling",
+        "FailureEvidence",
         "PauseInfo",
         "RunResult",
         "MapResult",
@@ -195,6 +200,7 @@ def test_canonical_modules_and_legacy_pickle_lookups() -> None:
     canonical_results, canonical_state = _canonical_modules()
     result_classes = (
         "RunStatus",
+        "FailureEvidence",
         "RunResult",
         "MapResult",
         "PauseInfo",

--- a/tests/test_runners/test_typed_side_channels.py
+++ b/tests/test_runners/test_typed_side_channels.py
@@ -16,10 +16,12 @@ import asyncio
 
 import pytest
 
-from hypergraph import Graph, node
-from hypergraph.exceptions import ExecutionError
+from hypergraph import AsyncRunner, Graph, SyncRunner, node
+from hypergraph.events import EventDispatcher, EventProcessor
+from hypergraph.events.types import Event, NodeErrorEvent
+from hypergraph.exceptions import ExecutionError, get_failure_evidence
 from hypergraph.runners._shared.readiness import get_ready_nodes
-from hypergraph.runners._shared.results import PauseInfo
+from hypergraph.runners._shared.results import FailureEvidence, PauseInfo
 from hypergraph.runners._shared.state import (
     ExecutionContext,
     GraphState,
@@ -51,8 +53,11 @@ class TestExecutionErrorConstructor:
     def test_defaults_are_empty_and_fresh(self):
         cause = ValueError("boom")
         err = ExecutionError(cause, GraphState())
+        assert get_failure_evidence(None) == ()
         assert err.attempted_node_names == ()
         assert err.node_errors == {}
+        assert err.node_failures == ()
+        assert err.failure is None
         assert err.__cause__ is cause
 
     def test_constructor_params_are_stored(self):
@@ -63,10 +68,25 @@ class TestExecutionErrorConstructor:
             state,
             attempted_node_names=("a", "b"),
             node_errors={"b": cause},
+            node_failures=(
+                FailureEvidence(
+                    node_name="b",
+                    error=cause,
+                    inputs={"x": 1},
+                    superstep=2,
+                    duration_ms=3.0,
+                    graph_name="graph",
+                    workflow_id="workflow",
+                    item_index=None,
+                ),
+            ),
         )
         assert err.partial_state is state
         assert err.attempted_node_names == ("a", "b")
         assert err.node_errors == {"b": cause}
+        assert err.failure is err.node_failures[0]
+        assert err.failure.inputs == {"x": 1}
+        assert get_failure_evidence(err) == err.node_failures
 
     def test_node_errors_default_is_not_shared(self):
         first = ExecutionError(ValueError("x"), GraphState())
@@ -235,6 +255,272 @@ class TestAsyncSuperstepNestedExecutionError:
         assert inner_error.attempted_node_names == original_attempted
         assert inner_error.node_errors == original_node_errors
         assert inner_error.__cause__ is cause
+        assert outer_error.failure is not None
+        assert outer_error.failure.node_name == "nested_failure"
+        assert outer_error.failure.error is inner_error
+        assert outer_error.failure.inputs == {"x": 5}
+
+
+class TestFailureEvidenceAttributionBoundaries:
+    def test_sync_node_error_processor_failure_is_attempted_once(self):
+        class RaisingProcessor(EventProcessor):
+            def __init__(self) -> None:
+                self.attempts = 0
+
+            def on_event(self, event: Event) -> None:
+                if isinstance(event, NodeErrorEvent):
+                    self.attempts += 1
+                    raise RuntimeError("processor failed")
+
+        graph = Graph([bad_node])
+        state = initialize_state(graph, {"x": 5})
+        processor = RaisingProcessor()
+
+        with pytest.raises(ExecutionError) as exc_info:
+            run_superstep_sync(
+                graph,
+                state,
+                get_ready_nodes(graph, state),
+                {"x": 5},
+                {type(bad_node): SyncFunctionNodeExecutor()},
+                ExecutionContext(),
+                dispatcher=EventDispatcher([processor], strict=True),
+                run_id="run",
+                run_span_id="span",
+            )
+
+        assert processor.attempts == 1
+        assert isinstance(exc_info.value.__cause__, RuntimeError)
+        assert str(exc_info.value.__cause__) == "processor failed"
+        assert exc_info.value.node_failures == ()
+
+    async def test_async_node_error_processor_failure_is_attempted_once(self):
+        class RaisingProcessor(EventProcessor):
+            def __init__(self) -> None:
+                self.attempts = 0
+
+            def on_event(self, event: Event) -> None:
+                if isinstance(event, NodeErrorEvent):
+                    self.attempts += 1
+                    raise RuntimeError("processor failed")
+
+        graph = Graph([bad_node])
+        state = initialize_state(graph, {"x": 5})
+        processor = RaisingProcessor()
+
+        with pytest.raises(ExecutionError) as exc_info:
+            await run_superstep_async(
+                graph,
+                state,
+                get_ready_nodes(graph, state),
+                {"x": 5},
+                {type(bad_node): AsyncFunctionNodeExecutor()},
+                ExecutionContext(),
+                dispatcher=EventDispatcher([processor], strict=True),
+                run_id="run",
+                run_span_id="span",
+            )
+
+        assert processor.attempts == 1
+        assert isinstance(exc_info.value.__cause__, RuntimeError)
+        assert str(exc_info.value.__cause__) == "processor failed"
+        assert exc_info.value.node_failures == ()
+
+    def test_non_graph_node_ignores_stale_failure_context(self):
+        stale_cause = ValueError("stale")
+        stale_evidence = FailureEvidence(
+            node_name="stale_node",
+            error=stale_cause,
+            inputs={"x": -1},
+            superstep=9,
+            duration_ms=1.0,
+            graph_name="stale_graph",
+            workflow_id=None,
+            item_index=None,
+        )
+        stale_error = ExecutionError(
+            stale_cause,
+            GraphState(),
+            node_failures=(stale_evidence,),
+        )
+        current_error = ValueError("current")
+        current_error.__context__ = stale_error
+
+        @node(output_name="bad_out")
+        def current_failure(x: int) -> int:
+            raise current_error
+
+        result = SyncRunner().run(
+            Graph([current_failure], name="current_graph"),
+            {"x": 5},
+            error_handling="continue",
+        )
+
+        assert result.failure is not None
+        assert result.failure.node_name == "current_failure"
+        assert result.failure.error is current_error
+        assert result.failure.inputs == {"x": 5}
+
+    def test_graph_node_qualifies_child_that_raises_execution_error(self):
+        stale_cause = ValueError("stale")
+        user_error = ExecutionError(
+            stale_cause,
+            GraphState(),
+            node_failures=(
+                FailureEvidence(
+                    node_name="stale_node",
+                    error=stale_cause,
+                    inputs={"x": -1},
+                    superstep=9,
+                    duration_ms=1.0,
+                    graph_name="stale_graph",
+                    workflow_id=None,
+                    item_index=None,
+                ),
+            ),
+        )
+
+        @node(output_name="bad_out")
+        def current_failure(x: int) -> int:
+            raise user_error
+
+        child = Graph([current_failure], name="child")
+        outer = Graph([child.as_node(name="child_node")], name="outer")
+
+        result = SyncRunner().run(
+            outer,
+            {"x": 5},
+            error_handling="continue",
+        )
+
+        assert result.error is user_error
+        assert result.failure is not None
+        assert result.failure.node_name == "child_node/current_failure"
+        assert result.failure.error is user_error
+        assert result.failure.inputs == {"x": 5}
+        assert result.failure.graph_name == "child"
+
+    def test_graph_node_does_not_attribute_child_infrastructure_failure(self):
+        class CacheFailure(RuntimeError):
+            pass
+
+        class ExplodingCache:
+            def get(self, key: str) -> tuple[bool, object]:
+                raise CacheFailure(key)
+
+            def set(self, key: str, value: object) -> None:
+                raise AssertionError("cache set must not run")
+
+        @node(output_name="cached_out", cache=True)
+        def cached_child(x: int) -> int:
+            raise AssertionError("executor must not run")
+
+        child = Graph([cached_child], name="child")
+        outer = Graph([child.as_node(name="child_node")], name="outer")
+
+        result = SyncRunner(cache=ExplodingCache()).run(
+            outer,
+            {"x": 5},
+            error_handling="continue",
+        )
+
+        assert isinstance(result.error, CacheFailure)
+        assert result.node_failures == ()
+        assert result.failure is None
+
+    def test_cache_execution_error_cannot_smuggle_stale_evidence(self):
+        cache_cause = RuntimeError("cache unavailable")
+        stale_evidence = FailureEvidence(
+            node_name="stale_node",
+            error=cache_cause,
+            inputs={"secret": object()},
+            superstep=9,
+            duration_ms=1.0,
+            graph_name="stale_graph",
+            workflow_id=None,
+            item_index=None,
+        )
+        cache_error = ExecutionError(
+            cache_cause,
+            GraphState(),
+            node_failures=(stale_evidence,),
+        )
+
+        class ExplodingCache:
+            def get(self, key: str) -> tuple[bool, object]:
+                raise cache_error
+
+            def set(self, key: str, value: object) -> None:
+                raise AssertionError("cache set must not run")
+
+        @node(output_name="cached_out", cache=True)
+        def cached_node(x: int) -> int:
+            raise AssertionError("executor must not run")
+
+        result = SyncRunner(cache=ExplodingCache()).run(
+            Graph([cached_node], name="cache_graph"),
+            {"x": 5},
+            error_handling="continue",
+        )
+
+        assert result.error is cache_error
+        assert result.node_failures == ()
+        assert result.failure is None
+
+        with pytest.raises(ExecutionError) as exc_info:
+            SyncRunner(cache=ExplodingCache()).run(
+                Graph([cached_node], name="cache_graph"),
+                {"x": 5},
+            )
+
+        assert exc_info.value is cache_error
+        assert get_failure_evidence(exc_info.value) == ()
+
+    async def test_async_cache_execution_error_retains_identity_without_evidence(self):
+        cache_cause = RuntimeError("async cache unavailable")
+        stale_evidence = FailureEvidence(
+            node_name="stale_node",
+            error=cache_cause,
+            inputs={"secret": object()},
+            superstep=9,
+            duration_ms=1.0,
+            graph_name="stale_graph",
+            workflow_id=None,
+            item_index=None,
+        )
+        cache_error = ExecutionError(
+            cache_cause,
+            GraphState(),
+            node_failures=(stale_evidence,),
+        )
+
+        class ExplodingCache:
+            def get(self, key: str) -> tuple[bool, object]:
+                raise cache_error
+
+            def set(self, key: str, value: object) -> None:
+                raise AssertionError("cache set must not run")
+
+        @node(output_name="cached_out", cache=True)
+        async def cached_node(x: int) -> int:
+            raise AssertionError("executor must not run")
+
+        graph = Graph([cached_node], name="async_cache_graph")
+        result = await AsyncRunner(cache=ExplodingCache()).run(
+            graph,
+            {"x": 5},
+            error_handling="continue",
+        )
+
+        assert result.error is cache_error
+        assert result.node_failures == ()
+        assert result.failure is None
+
+        with pytest.raises(ExecutionError) as exc_info:
+            await AsyncRunner(cache=ExplodingCache()).run(graph, {"x": 5})
+
+        assert exc_info.value is cache_error
+        assert get_failure_evidence(exc_info.value) == ()
 
 
 # === GraphState stop fields (B1.1b) ===

--- a/tests/test_runners/test_typed_side_channels.py
+++ b/tests/test_runners/test_typed_side_channels.py
@@ -613,17 +613,17 @@ class TestFailureEvidenceAttributionBoundaries:
             error_handling="continue",
         )
 
-        assert result.error is cache_error
+        assert result.error is cache_cause
         assert result.node_failures == ()
         assert result.failure is None
 
-        with pytest.raises(ExecutionError) as exc_info:
+        with pytest.raises(RuntimeError) as exc_info:
             SyncRunner(cache=ExplodingCache()).run(
                 Graph([cached_node], name="cache_graph"),
                 {"x": 5},
             )
 
-        assert exc_info.value is cache_error
+        assert exc_info.value is cache_cause
         assert get_failure_evidence(exc_info.value) == ()
 
     async def test_async_cache_execution_error_retains_identity_without_evidence(self):

--- a/tests/test_runners/test_typed_side_channels.py
+++ b/tests/test_runners/test_typed_side_channels.py
@@ -443,6 +443,38 @@ class TestFailureEvidenceAttributionBoundaries:
         assert "TOP-SECRET" not in repr(result)
         assert "TOP-SECRET" not in repr(result.to_dict())
 
+    def test_sync_graph_node_does_not_replay_evidence_from_previous_run(self):
+        reused_error = RuntimeError("reused across runs")
+
+        @node(output_name="first_out")
+        def first_failure(secret: str) -> str:
+            raise reused_error
+
+        with pytest.raises(RuntimeError) as exc_info:
+            SyncRunner().run(Graph([first_failure], name="first"), {"secret": "TOP-SECRET"})
+
+        assert exc_info.value is reused_error
+        assert get_failure_evidence(reused_error)[0].inputs == {"secret": "TOP-SECRET"}
+
+        @node(output_name="child_out")
+        def child_node(x: int) -> int:
+            return x
+
+        graph_node = Graph([child_node], name="child").as_node(name="custom_graph_node")
+        runner = SyncRunner()
+
+        def raise_reused_error(node, state, inputs, ctx):
+            raise reused_error
+
+        runner._executors[type(graph_node)] = raise_reused_error
+        result = runner.run(Graph([graph_node], name="second"), {"x": 5}, error_handling="continue")
+
+        assert result.error is reused_error
+        assert result.node_failures == ()
+        assert result.failure is None
+        assert "TOP-SECRET" not in repr(result)
+        assert "TOP-SECRET" not in repr(result.to_dict())
+
     async def test_async_graph_node_does_not_copy_raw_execution_error_evidence(self):
         cause = RuntimeError("custom async graph executor failed")
         raw_error = ExecutionError(
@@ -481,6 +513,38 @@ class TestFailureEvidenceAttributionBoundaries:
         )
 
         assert result.error is raw_error
+        assert result.node_failures == ()
+        assert result.failure is None
+        assert "TOP-SECRET" not in repr(result)
+        assert "TOP-SECRET" not in repr(result.to_dict())
+
+    async def test_async_graph_node_does_not_replay_evidence_from_previous_run(self):
+        reused_error = RuntimeError("reused across async runs")
+
+        @node(output_name="first_out")
+        async def first_failure(secret: str) -> str:
+            raise reused_error
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await AsyncRunner().run(Graph([first_failure], name="first"), {"secret": "TOP-SECRET"})
+
+        assert exc_info.value is reused_error
+        assert get_failure_evidence(reused_error)[0].inputs == {"secret": "TOP-SECRET"}
+
+        @node(output_name="child_out")
+        def child_node(x: int) -> int:
+            return x
+
+        graph_node = Graph([child_node], name="child").as_node(name="custom_graph_node")
+        runner = AsyncRunner()
+
+        async def raise_reused_error(node, state, inputs, ctx):
+            raise reused_error
+
+        runner._executors[type(graph_node)] = raise_reused_error
+        result = await runner.run(Graph([graph_node], name="second"), {"x": 5}, error_handling="continue")
+
+        assert result.error is reused_error
         assert result.node_failures == ()
         assert result.failure is None
         assert "TOP-SECRET" not in repr(result)

--- a/tests/test_runners/test_typed_side_channels.py
+++ b/tests/test_runners/test_typed_side_channels.py
@@ -400,6 +400,92 @@ class TestFailureEvidenceAttributionBoundaries:
         assert result.failure.inputs == {"x": 5}
         assert result.failure.graph_name == "child"
 
+    def test_sync_graph_node_does_not_copy_raw_execution_error_evidence(self):
+        cause = RuntimeError("custom graph executor failed")
+        raw_error = ExecutionError(
+            cause,
+            GraphState(),
+            node_failures=(
+                FailureEvidence(
+                    node_name="stale_node",
+                    error=cause,
+                    inputs={"secret": "TOP-SECRET"},
+                    superstep=9,
+                    duration_ms=1.0,
+                    graph_name="stale_graph",
+                    workflow_id=None,
+                    item_index=None,
+                ),
+            ),
+        )
+
+        @node(output_name="child_out")
+        def child_node(x: int) -> int:
+            return x
+
+        child = Graph([child_node], name="child")
+        graph_node = child.as_node(name="custom_graph_node")
+        runner = SyncRunner()
+
+        def raise_raw_error(node, state, inputs, ctx):
+            raise raw_error
+
+        runner._executors[type(graph_node)] = raise_raw_error
+        result = runner.run(
+            Graph([graph_node], name="outer"),
+            {"x": 5},
+            error_handling="continue",
+        )
+
+        assert result.error is raw_error
+        assert result.node_failures == ()
+        assert result.failure is None
+        assert "TOP-SECRET" not in repr(result)
+        assert "TOP-SECRET" not in repr(result.to_dict())
+
+    async def test_async_graph_node_does_not_copy_raw_execution_error_evidence(self):
+        cause = RuntimeError("custom async graph executor failed")
+        raw_error = ExecutionError(
+            cause,
+            GraphState(),
+            node_failures=(
+                FailureEvidence(
+                    node_name="stale_node",
+                    error=cause,
+                    inputs={"secret": "TOP-SECRET"},
+                    superstep=9,
+                    duration_ms=1.0,
+                    graph_name="stale_graph",
+                    workflow_id=None,
+                    item_index=None,
+                ),
+            ),
+        )
+
+        @node(output_name="child_out")
+        def child_node(x: int) -> int:
+            return x
+
+        child = Graph([child_node], name="child")
+        graph_node = child.as_node(name="custom_graph_node")
+        runner = AsyncRunner()
+
+        async def raise_raw_error(node, state, inputs, ctx):
+            raise raw_error
+
+        runner._executors[type(graph_node)] = raise_raw_error
+        result = await runner.run(
+            Graph([graph_node], name="outer"),
+            {"x": 5},
+            error_handling="continue",
+        )
+
+        assert result.error is raw_error
+        assert result.node_failures == ()
+        assert result.failure is None
+        assert "TOP-SECRET" not in repr(result)
+        assert "TOP-SECRET" not in repr(result.to_dict())
+
     def test_graph_node_does_not_attribute_child_infrastructure_failure(self):
         class CacheFailure(RuntimeError):
             pass


### PR DESCRIPTION
## Problem / Bug / Challenge

A failed graph or mapped item preserves the underlying exception, but callers cannot reliably answer which leaf node failed, which resolved inputs reached it, or which map item owns the failure. Nested and parallel failures are especially hard to reproduce without reconstructing state by hand.

Closes #154.

## Before / After

**Before:**

```python
try:
    runner.run(graph, {"x": 13})
except EvidenceError as error:
    print(error)  # "failed:13", but no structured node/input/item evidence
```

**After:**

```python
from hypergraph import get_failure_evidence

try:
    runner.run(graph, {"x": 13})
except EvidenceError as error:
    failure = get_failure_evidence(error)[0]
    print(failure.node_name)   # "explode"
    print(failure.inputs)      # {"x": 13}
    print(failure.item_index)  # None, or the zero-based map item index
```

Continue mode exposes the same contract without exception handling:

```python
result = runner.run(graph, {"x": 13}, error_handling="continue")
result.failure         # first attributable FailureEvidence
result.node_failures   # every parallel failure in deterministic ready-node order
```

Nested map failures are qualified and item-aware:

```python
failure.node_name   # "child/explode"
failure.item_index  # 1
```

`FailureEvidence.inputs` is an explicit, shallow raw-input snapshot for debugging. Raw inputs are never included in repr, HTML, checkpoints, logs, or `RunResult.to_dict()`; callers who read `.inputs` opt into retaining those values for the lifetime of the result/exception.

The implementation also binds private exception transports to the current GraphNode invocation, preventing a reused exception object from replaying historical inputs from an earlier run or map call.

## Test Plan

- [x] RED proof: focused contract initially failed at import because the public API did not exist.
- [x] 28 focused failure-evidence contract tests.
- [x] 183 runner/error regression tests in the foreman battery.
- [x] Four adversarial sync/async stale-wrapper and stale-map-carrier replay tests.
- [x] Independent read-only Codex review: prior privacy finding resolved; safe to push.
- [x] `uv run pre-commit run --all-files`.
- [x] `uv run ruff check src/ tests/`.
- [x] `uv run ruff format --check src/ tests/` (304 files formatted).
- [x] CI-equivalent: `uv run pytest -W error -W 'ignore::pytest.PytestUnraisableExceptionWarning'` — 3,200 passed, 0 skipped, 0 failed.
- [x] Manual black-box walk: sync raise accessor, reverse-completing async failures, nested map indexes, and an input whose repr/deepcopy raises.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured failure evidence for failed runs, including affected node names, mapped item indexes, nested paths, timing, and execution context.
  * Added convenient access to the first failure through `result.failure` and `error.failure`.
  * Added `result.node_failures` for inspecting all attributable failures.
  * Exposed `FailureEvidence` and `get_failure_evidence` through the public package APIs.

* **Documentation**
  * Expanded failure-handling reference documentation with examples for synchronous, asynchronous, mapped, and nested executions.
  * Clarified safety, serialization, and display behavior for captured failure inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->