### PR TITLE
docs(adr): lock background map failure policy

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -95,6 +95,18 @@ _Avoid_: Start node, root node
 - `link_inputs` was considered for shared input fan-out, but the MVP keeps **Exposed port** as the single boundary-flattening concept; `link_inputs` may be added later as direct-child input-only sugar.
 - Direction-specific expose was considered, but the MVP keeps **Exposed port** name-based across matching input and output directions.
 
+## Background execution
+
+Vocabulary for background execution. The durable collection and retrieval decision is recorded in [ADR 0003](docs/adr/0003-background-maps-collect-before-result-retrieval.md).
+
+**Retrieval policy**:
+The caller's choice when retrieving a stored execution result: return the result or raise a captured failure. A retrieval policy does not control which work is scheduled.
+_Avoid_: Presentation policy, execution policy
+
+**Settled background batch**:
+A background batch that is no longer executing. Settled does not mean successful; the batch may contain completed, failed, paused, or stopped item outcomes.
+_Avoid_: Complete batch, successful batch
+
 ## Materialization
 
 Vocabulary for `hypergraph.materialization` — incremental, declarative tables derived from a source. See [ADR 0001](docs/adr/0001-sync-and-async-derived-table-classes.md) and [ADR 0002](docs/adr/0002-stream-materialization-through-runner-with-sinks.md).

--- a/docs/adr/0003-background-maps-collect-before-result-retrieval.md
+++ b/docs/adr/0003-background-maps-collect-before-result-retrieval.md
@@ -1,0 +1,51 @@
+# Background maps collect item failures before result retrieval
+
+**Status:** Accepted on 2026-07-13; implementation is tracked by [issue #155](https://github.com/gilad-rubin/hypergraph/issues/155). `start_map()` is not a shipped API until that implementation merges.
+
+Background execution must let a caller regain control immediately and inspect the eventual batch without losing later item outcomes. Reusing blocking `map(error_handling="raise")` would not provide one scheduling contract: sync mapping stops at the first failed item, bounded async mapping stops claiming new items after a failure is observed, and unbounded async mapping may already have started every item.
+
+We therefore separate collection from retrieval.
+
+## Decision
+
+- `start_map()` does not accept `error_handling`. A mapped-item failure does not stop sibling items from being scheduled.
+- Background mapping captures every requested item outcome unless the caller explicitly stops the handle or a batch-level failure prevents construction of a `MapResult`.
+- Sync and async handles follow the same collection contract, independent of async concurrency limits.
+- `handle.result(raise_on_failure=True)` waits for the batch to settle, then raises the original error from the first failed `RunResult` in input order. `True` is the default, and raising order does not depend on whether node-level evidence is available.
+- `handle.result(raise_on_failure=False)` returns the settled `MapResult`, including failed item results and their `FailureEvidence` when the failure is attributable to a node.
+- `handle.wait()` waits for settlement without turning captured item failures into retrieval exceptions.
+- A batch-level failure that prevents construction of a `MapResult` still propagates from `wait()` and `result()`. `raise_on_failure` governs captured mapped-item failures only.
+- Blocking `map()` keeps its existing `error_handling="raise" | "continue"` contract.
+
+The planned user-facing shape is:
+
+```python
+handle = runner.start_map(document_graph, {"document": documents}, map_over="document")
+
+# Exception-first code: raising happens after every item has settled.
+handle.result()
+
+# Diagnostic code: inspect every outcome, including failures with no node evidence.
+batch = handle.result(raise_on_failure=False)
+for item_index, item in enumerate(batch.results):
+    if not item.failed:
+        continue
+    if item.failure is None:
+        print(item_index, type(item.error).__name__)
+    else:
+        print(item.failure.item_index, item.failure.node_name)
+```
+
+The async runner exposes the same operations as awaitables.
+
+## Considered options
+
+- **Mirror blocking `map()`** — rejected because a non-raising retrieval cannot recover outcomes that were never scheduled, and scheduling already differs between sync, bounded async, and unbounded async runners.
+- **Accept both execution modes but default background mapping to continue** — rejected because `error_handling` and `raise_on_failure` become overlapping controls, including combinations that return an already-truncated batch without raising.
+- **Always collect mapped-item outcomes and raise only at retrieval (chosen)** — gives handles one stable purpose and preserves complete diagnostic evidence unless work is explicitly stopped.
+
+## Consequences
+
+- A failed background batch can continue consuming resources and producing item-level side effects. Callers use `handle.stop()` when they intend to curtail work.
+- `handle.result()` remains exception-first by default, matching blocking runner calls and Python future/task retrieval conventions, while diagnostic callers opt into `raise_on_failure=False`.
+- Implementing issue #155 must add the public API reference, practical how-to, runnable sync and async examples, and documentation contract tests in the same PR as the code.

--- a/docs/adr/0003-background-maps-collect-before-result-retrieval.md
+++ b/docs/adr/0003-background-maps-collect-before-result-retrieval.md
@@ -36,7 +36,7 @@ for item_index, item in enumerate(batch.results):
         print(item.failure.item_index, item.failure.node_name)
 ```
 
-The async runner exposes the same operations as awaitables.
+`AsyncRunner.start_map()` returns its handle immediately without `await`. The async handle's `wait()` and `result()` methods are awaitable; for example, use `batch = await handle.result(raise_on_failure=False)`.
 
 ## Considered options
 


### PR DESCRIPTION
## Problem / Bug / Challenge

Issue #188 needed one durable contract before background handles can be implemented in #155. Mirroring blocking `map(error_handling="raise")` would make background batch completeness depend on runner/concurrency, while documenting the planned API as already shipped would create code-doc drift.

This PR records the maintainer-approved decision and the canonical vocabulary. It explicitly marks `start_map()` as unshipped until #155 merges.

## Before / After

**Before:**

```python
# Two overlapping controls, with scheduling that can differ by runner.
handle = runner.start_map(graph, items, error_handling="continue")
batch = handle.result(raise_on_failure=False)
```

**After:**

```python
# Background execution always collects unless explicitly stopped.
handle = runner.start_map(graph, items)

handle.result()                         # raises after settlement by default
batch = handle.result(raise_on_failure=False)  # returns every item outcome
```

A failed item without node-level `FailureEvidence` remains valid: retrieval order follows failed `RunResult`s in input order, and diagnostic code falls back to `RunResult.error`.

## Test Plan

- [x] `uv run pytest tests/test_docs_contract.py -W error -W 'ignore::pytest.PytestUnraisableExceptionWarning'` — 5 passed
- [x] `uv run pre-commit run --all-files` — all hooks passed
- [x] `uv run pytest -W error -W 'ignore::pytest.PytestUnraisableExceptionWarning'` — 3,200 passed, 0 skipped
- [x] Two independent read-only reviews; fixed the finding that `FailureEvidence` is optional, then both reviewers re-approved

Issue: #188
Implementation follow-up: #155


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added terminology for background execution, including retrieval policies and settled background batches.
  * Documented the design for collecting all background map outcomes before retrieving results.
  * Clarified result retrieval, failure handling, waiting behavior, and diagnostic access for background map executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->