### PR TITLE
chore(repo): stop specs/* from silently hiding new spec files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,11 +20,9 @@ wheels/
 AGENTS.md.bak
 CLAUDE.md.bak
 # END Ruler Generated Files
-specs/tmp/*
 docs/plans/*
 # Continuous Claude cache (local only)
 thoughts/*
-specs/deprecated/*
 .claude/*
 !.claude/skills/
 !.claude/skills/**
@@ -36,7 +34,6 @@ specs/deprecated/*
 !.doc-manager/cache/.gitkeep
 .DS_Store
 tmp/*
-specs/*
 deprecated/*
 .doc-manager/*
 

--- a/tests/test_gitignore_specs.py
+++ b/tests/test_gitignore_specs.py
@@ -1,0 +1,47 @@
+"""Regression check for issue #214: `specs/*` must not silently hide new spec files.
+
+`.gitignore` previously had a broad `specs/*` rule that hid any newly created
+file under `specs/` (e.g. `specs/reviewed/new-contract.md`) from `git status`,
+so it could be silently omitted from a PR. This test pins the fix by asserting
+representative, non-existent spec paths are NOT ignored, and that an unrelated
+generated-artifact path (`.venv/`) still is — so the check can't silently pass
+because git itself is misbehaving.
+
+Uses `git check-ignore` via subprocess against paths that do not exist on disk;
+`check-ignore` evaluates purely by pattern matching, so this makes no repo
+mutations and does no network access.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _is_ignored(relative_path: str) -> bool:
+    """Return whether `relative_path` (need not exist) is git-ignored under ROOT."""
+    result = subprocess.run(
+        ["git", "check-ignore", "--quiet", relative_path],
+        cwd=ROOT,
+        capture_output=True,
+    )
+    # git check-ignore exit codes: 0 = ignored, 1 = not ignored, >1 = fatal error.
+    assert result.returncode in (0, 1), f"git check-ignore failed unexpectedly for {relative_path!r}: rc={result.returncode} stderr={result.stderr!r}"
+    return result.returncode == 0
+
+
+def test_new_reviewed_spec_is_not_ignored():
+    assert not _is_ignored("specs/reviewed/_x.md")
+
+
+def test_new_not_reviewed_spec_is_not_ignored():
+    assert not _is_ignored("specs/not_reviewed/_x.md")
+
+
+def test_unrelated_generated_artifact_is_still_ignored():
+    # Control assertion: if this ever flips, `git check-ignore` itself is
+    # broken (e.g. run outside a git checkout) and the two checks above
+    # would be false negatives rather than a real fix.
+    assert _is_ignored(".venv/_x")


### PR DESCRIPTION
Closes #214.

## Problem statement
`.gitignore` line 39 (`specs/*`) silently hid any newly created specification file from git status, so new specs could be omitted from PRs unnoticed. Two narrower rules (`specs/tmp/*`, `specs/deprecated/*`) were fully shadowed by it — removing only the broad rule would have reactivated them as the same bug at smaller scope.

## Before / after
```text
Before: git check-ignore specs/reviewed/new-contract.md → .gitignore:39:specs/*  (hidden)
After:  git check-ignore specs/reviewed/new-contract.md → exit 1                (visible)
```
Nothing under specs/ is generated/cache content (verified: no file ever existed at specs/tmp/ in history; specs/deprecated/ holds 9 tracked authored files). No previously-ignored file is added by this PR.

## Test plan
- New `tests/test_gitignore_specs.py` (subprocess `git check-ignore`, no repo mutation): fails on the old .gitignore, passes on the new, with a .venv control assertion.
- Full CI-equivalent: 3496 passed, 15 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)