### PR TITLE
ci(security): enable Dependabot and CodeQL configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+# Dependabot version-update configuration.
+#
+# Docs:
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Dependency-vulnerability alerts and security updates are enabled/managed
+# via repository settings, not this file.
+version: 2
+
+updates:
+  # Python dependencies, resolved via uv.lock at the repo root.
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      # NOTE: the "uv" ecosystem does not support the `dependency-type`
+      # groups filter (development vs. production) as of this writing —
+      # see https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#dependency-type-groups
+      # ("Supported by: bundler, composer, mix, maven, npm, and pip.").
+      # All minor/patch updates are grouped together regardless of
+      # dependency type; major updates are left out of the group so each
+      # opens its own pull request for individual review.
+      python-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions referenced from workflow files under .github/workflows/.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,9 +23,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: python
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,31 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    # Weekly, Monday 06:00 UTC.
+    - cron: "0 6 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze (python)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
Part of #222 (file portion; repo settings toggles follow post-merge).

## Problem statement
Dependabot has no update configuration and GitHub reports no CodeQL analysis — dependency and Python security coverage are blind spots while secret scanning/push protection are already on.

## Before / after
```text
Before: no dependabot.yml; code scanning reports 'no analysis found'
After:  weekly grouped uv + github-actions update PRs (bounded at 5 each);
        CodeQL python analysis on push/PR to master + weekly cron
```

Notes:
- The uv ecosystem does not support dependency-type group splits (GitHub platform limitation, doc-cited in the file) — minor/patch grouped together, majors individual.
- codeql-action pinned @v4 (v3 deprecates December 2026).
- No secrets introduced; existing workflows untouched.

## Test plan
YAML parse validation both files; CI-equivalent suite green (no Python changes; 3493 passed). CodeQL's first real run happens on merge — will verify the check appears and code-scanning stops reporting 'no analysis found'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)