### PR TITLE
fix(materialization): make LanceDB vector specialization failure-safe

### DIFF
--- a/src/hypergraph/materialization/_lancedb_store.py
+++ b/src/hypergraph/materialization/_lancedb_store.py
@@ -371,6 +371,9 @@ class LanceDBStore(TableStore):
             # no drop/recreate window. A failure at ANY point before that commit
             # leaves the previous version live, so every committed row stays
             # readable (mirrors the drop-free additive path in ``evolve_schema``).
+            # Preservation is at the TABLE level: the directory may retain
+            # unreachable staged data files from an aborted rewrite, invisible
+            # to readers because no manifest references them.
             alterations = [{"path": name, "data_type": pa.list_(pa.float32(), dim)} for name, dim in sorted(upgrades.items())]
             try:
                 tbl.alter_columns(*alterations)

--- a/src/hypergraph/materialization/_lancedb_store.py
+++ b/src/hypergraph/materialization/_lancedb_store.py
@@ -351,30 +351,36 @@ class LanceDBStore(TableStore):
 
     def _detect_and_fix_vectors(self, table_name: str, row: dict[str, Any]) -> None:
         tbl = self._tables[table_name]
-        schema = tbl.schema
+        # Advance to the latest committed version first: another connection on
+        # the same folder may already have specialized the column. Detecting on
+        # a stale schema would re-run the cast over superseded data (mirrors
+        # ``evolve_schema`` / the read path).
+        tbl.checkout_latest()
         upgrades: dict[str, int] = {}
 
-        for field_obj in schema:
+        for field_obj in tbl.schema:
             if pa.types.is_list(field_obj.type) and not pa.types.is_fixed_size_list(field_obj.type):
                 val = row.get(field_obj.name)
                 if isinstance(val, list) and len(val) > 0 and isinstance(val[0], (int, float)):
                     upgrades[field_obj.name] = len(val)
 
         if upgrades:
-            existing_data = tbl.to_arrow()
-            new_fields = []
-            for field_obj in schema:
-                if field_obj.name in upgrades:
-                    dim = upgrades[field_obj.name]
-                    new_fields.append(pa.field(field_obj.name, pa.list_(pa.float32(), dim)))
-                else:
-                    new_fields.append(field_obj)
-
-            new_schema = pa.schema(new_fields)
-            self._db.drop_table(table_name)
-            tbl = self._db.create_table(table_name, schema=new_schema)
-            if len(existing_data) > 0:
-                tbl.add(existing_data)
-            self._tables[table_name] = tbl
+            # Specialize IN PLACE via LanceDB's native column cast. Lance stages
+            # the rewritten column as new data files and publishes them with a
+            # single atomic manifest commit (a new dataset version) — there is
+            # no drop/recreate window. A failure at ANY point before that commit
+            # leaves the previous version live, so every committed row stays
+            # readable (mirrors the drop-free additive path in ``evolve_schema``).
+            alterations = [{"path": name, "data_type": pa.list_(pa.float32(), dim)} for name, dim in sorted(upgrades.items())]
+            try:
+                tbl.alter_columns(*alterations)
+            except Exception as exc:
+                raise RuntimeError(
+                    f"vector-schema specialization of table {table_name!r} failed while casting "
+                    f"column(s) {sorted(upgrades)} to fixed_size_list<float32> with dims {upgrades}; "
+                    f"the table is preserved unchanged at its last committed version and every "
+                    f"committed row remains readable"
+                ) from exc
+            tbl.checkout_latest()
 
         self._vector_dims[table_name] = upgrades

--- a/tests/test_ticket206_vector_specialization_safety.py
+++ b/tests/test_ticket206_vector_specialization_safety.py
@@ -1,0 +1,348 @@
+"""Foreman-owned falsifiers for ticket #206: failure-safe vector-schema specialization.
+
+``LanceDBStore`` specializes a plain ``list`` vector column to
+``fixed_size_list<float32, dim>`` on the first write that carries a real vector.
+These tests pin the failure-safety contract of that specialization: no injected
+or real failure at any stage may destroy or hide previously committed rows, and
+every failure surfaces loudly while a FRESH store handle over the same directory
+still reads the committed table completely (row counts + blob byte equality).
+"""
+
+from __future__ import annotations
+
+import contextlib
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pytest
+
+from hypergraph.materialization._lancedb_store import LanceDBStore
+from hypergraph.materialization._schema import ColumnSpec, TableSpec
+
+_BLOB_A = bytes([0x00, 0x01, 0x02, 0x80, 0xFF, 0xFE]) + b"\x00PDF\x00" + bytes(range(256))
+_BLOB_B = _BLOB_A[::-1]
+
+
+def _vec_spec() -> TableSpec:
+    return TableSpec(
+        name="t",
+        identity="cid",
+        columns=[
+            ColumnSpec("cid", role="identity", arrow_type=pa.utf8()),
+            ColumnSpec("content", role="source", content_key=True, arrow_type=pa.large_binary()),
+            ColumnSpec("vec", role="derived", arrow_type=pa.list_(pa.float64())),
+            ColumnSpec("_row_fingerprint", role="internal", arrow_type=pa.utf8()),
+            ColumnSpec("_write_gen", role="internal", arrow_type=pa.int64()),
+            ColumnSpec("_status", role="internal", arrow_type=pa.utf8()),
+            ColumnSpec("_error", role="internal", arrow_type=pa.utf8()),
+        ],
+    )
+
+
+def _row(cid: str, *, vec: list[float] | None, content: bytes, write_gen: int = 1) -> dict[str, Any]:
+    return {
+        "cid": cid,
+        "content": content,
+        "vec": vec,
+        "_row_fingerprint": f"fp-{cid}",
+        "_write_gen": write_gen,
+        "_status": "complete",
+        "_error": None,
+    }
+
+
+def _seed_committed_rows(path: str, rows: list[dict[str, Any]]) -> None:
+    """Commit rows through their own handle, leaving the vector column un-specialized.
+
+    The first row must carry ``vec=None`` so dimension detection (which samples
+    the first row of the first write) finds nothing to specialize — the exact
+    state of a real store whose rows were written before any embedding existed.
+    """
+    assert rows[0]["vec"] is None
+    store = LanceDBStore(path)
+    store.open(_vec_spec(), [])
+    store.write_rows("t", rows)
+    assert store._tables["t"].schema.field("vec").type == pa.list_(pa.float64())
+
+
+def _fresh_committed_state(path: str) -> tuple[LanceDBStore, list[dict[str, Any]], pa.DataType]:
+    """What a brand-new handle over the directory observes: rows + vec column type."""
+    fresh = LanceDBStore(path)
+    fresh.open(_vec_spec(), [])
+    rows = sorted(fresh.read_rows("t"), key=lambda r: r["cid"])
+    vec_type = fresh._tables["t"].schema.field("vec").type
+    return fresh, rows, vec_type
+
+
+def _assert_rows_preserved(path: str, expected: list[dict[str, Any]]) -> None:
+    """A fresh handle must read exactly the committed rows, blob bytes included."""
+    _fresh, rows, _vec_type = _fresh_committed_state(path)
+    got = [(r["cid"], r["content"], r["vec"], r["_write_gen"]) for r in rows]
+    want = [(r["cid"], r["content"], r["vec"], r["_write_gen"]) for r in sorted(expected, key=lambda r: r["cid"])]
+    assert got == want, (
+        f"committed rows were destroyed or hidden: got {[(c, v) for c, _, v, _ in got]!r}, expected {[(c, v) for c, _, v, _ in want]!r}"
+    )
+
+
+def _assert_seed_rows_readable(path: str, expected: list[dict[str, Any]]) -> None:
+    """Every previously committed row must still be readable byte-identically.
+
+    Subset semantics: rows written AFTER the seed (a trigger row whose write
+    succeeded) are allowed — what may never happen is a seed row going missing
+    or changing bytes.
+    """
+    _fresh, rows, _vec_type = _fresh_committed_state(path)
+    by_cid = {r["cid"]: r for r in rows}
+    for exp in expected:
+        got = by_cid.get(exp["cid"])
+        assert got is not None, f"previously committed row {exp['cid']!r} was destroyed or hidden; readable rows: {sorted(by_cid)!r}"
+        assert got["content"] == exp["content"], f"blob bytes of committed row {exp['cid']!r} changed"
+        assert got["_write_gen"] == exp["_write_gen"], f"_write_gen of committed row {exp['cid']!r} changed"
+
+
+_SEED = [
+    _row("a", vec=None, content=_BLOB_A),
+    _row("b", vec=None, content=_BLOB_B, write_gen=2),
+]
+
+
+# --- H1 failpoint (a): failure before any specialization work ---
+
+
+def test_failure_before_specialization_work_preserves_committed_rows(tmp_path, monkeypatch) -> None:
+    path = str(tmp_path / "failpoint-before")
+    _seed_committed_rows(path, _SEED)
+
+    store = LanceDBStore(path)
+    store.open(_vec_spec(), [])
+    table_type = type(store._tables["t"])
+    fired = {"count": 0}
+
+    def refuse_alter(table, *alterations, **kwargs):
+        fired["count"] += 1
+        raise RuntimeError("simulated failure before specialization work")
+
+    monkeypatch.setattr(table_type, "alter_columns", refuse_alter)
+
+    with pytest.raises(RuntimeError, match="preserved"):
+        store.write_rows("t", [_row("c", vec=[0.1, 0.2, 0.3], content=b"new")])
+
+    assert fired["count"] == 1, "the failpoint must actually fire for this proof to mean anything"
+    _assert_rows_preserved(path, _SEED)
+    _fresh, _rows, vec_type = _fresh_committed_state(path)
+    assert vec_type == pa.list_(pa.float64()), "a failed specialization must leave the schema untouched"
+
+
+# --- H1 failpoint (b) + H4: crash mid-rewrite, replacement staged but never published ---
+
+
+def test_crash_mid_rewrite_before_publish_preserves_committed_rows(tmp_path, monkeypatch) -> None:
+    """Replacement column files physically staged in the dataset dir, crash before
+    the manifest commit: the staged artifact is on disk yet a fresh handle reads
+    only committed data — publication is Lance's atomic manifest commit, so an
+    incomplete replacement is never readable under the live table name."""
+    path = str(tmp_path / "failpoint-midswap")
+    _seed_committed_rows(path, _SEED)
+
+    store = LanceDBStore(path)
+    store.open(_vec_spec(), [])
+    table_type = type(store._tables["t"])
+    staged = Path(path) / "t.lance" / "data" / "zz-staged-replacement-not-committed.lance"
+
+    def crash_mid_rewrite(table, *alterations, **kwargs):
+        staged.parent.mkdir(parents=True, exist_ok=True)
+        staged.write_bytes(b"\x00partial-replacement-column-data\xff")
+        raise RuntimeError("simulated crash mid-rewrite, before manifest commit")
+
+    monkeypatch.setattr(table_type, "alter_columns", crash_mid_rewrite)
+
+    with pytest.raises(RuntimeError, match="preserved"):
+        store.write_rows("t", [_row("c", vec=[0.1, 0.2, 0.3], content=b"new")])
+
+    assert staged.exists(), "the staged replacement artifact must physically exist for this proof"
+    _assert_rows_preserved(path, _SEED)
+    _fresh, _rows, vec_type = _fresh_committed_state(path)
+    assert vec_type == pa.list_(pa.float64()), "an unpublished replacement must not change the live schema"
+
+
+# --- H1 failpoint (c): a REAL conversion failure during replacement, no mocks ---
+
+
+def test_real_cast_failure_raises_loudly_preserves_rows_and_retries_clean(tmp_path) -> None:
+    """A committed row whose list length differs from the detected dimension makes
+    the physical cast fail. That failure must raise loudly (naming the table and
+    the preserved state), leave every committed row readable, and a retry after
+    removing the offending row must converge with no duplicates."""
+    path = str(tmp_path / "failpoint-real-cast")
+    seed = [*_SEED, _row("bad", vec=[0.1, 0.2], content=b"short", write_gen=3)]
+    _seed_committed_rows(path, seed)
+
+    store = LanceDBStore(path)
+    store.open(_vec_spec(), [])
+    with pytest.raises(RuntimeError, match=r"(?s)'t'.*vec.*preserved"):
+        store.write_rows("t", [_row("c", vec=[0.1, 0.2, 0.3], content=b"new")])
+
+    _assert_rows_preserved(path, seed)
+    _fresh, _rows, vec_type = _fresh_committed_state(path)
+    assert vec_type == pa.list_(pa.float64())
+
+    # Crashed-then-retried (H3): drop the offending row, retry through a fresh
+    # handle — specialization converges, no duplicate rows, no leftover tables.
+    cleaner = LanceDBStore(path)
+    cleaner.open(_vec_spec(), [])
+    assert cleaner.delete_rows("t", [("cid", "eq", "bad")]) == 1
+
+    retry = LanceDBStore(path)
+    retry.open(_vec_spec(), [])
+    retry.write_rows("t", [_row("c", vec=[0.1, 0.2, 0.3], content=b"new", write_gen=4)])
+
+    _fresh, rows, vec_type = _fresh_committed_state(path)
+    assert [r["cid"] for r in rows] == ["a", "b", "c"], "retry must converge with no duplicates"
+    assert vec_type == pa.list_(pa.float32(), 3)
+    assert _fresh._db.list_tables().tables == ["t"], "no leftover temp table may be visible as live"
+
+
+# --- Sentinel: the live table is never dropped or recreated during specialization ---
+
+
+def test_specialization_never_drops_or_recreates_the_live_table(tmp_path, monkeypatch) -> None:
+    path = str(tmp_path / "no-drop")
+    _seed_committed_rows(path, _SEED)
+
+    store = LanceDBStore(path)
+    store.open(_vec_spec(), [])
+    connection_type = type(store._db)
+
+    def forbid_drop(connection, *args, **kwargs):
+        raise AssertionError("destructive drop_table attempted during specialization")
+
+    def forbid_create(connection, *args, **kwargs):
+        raise AssertionError("create_table attempted during specialization (drop/recreate window)")
+
+    monkeypatch.setattr(connection_type, "drop_table", forbid_drop)
+    monkeypatch.setattr(connection_type, "create_table", forbid_create)
+
+    store.write_rows("t", [_row("c", vec=[0.1, 0.2, 0.3], content=b"new")])
+
+    monkeypatch.undo()
+    _fresh, rows, vec_type = _fresh_committed_state(path)
+    assert [r["cid"] for r in rows] == ["a", "b", "c"]
+    assert vec_type == pa.list_(pa.float32(), 3)
+
+
+# --- H2: successful specialization preserves everything and stays searchable ---
+
+
+def test_successful_specialization_preserves_rows_and_searches_after_reopen(tmp_path) -> None:
+    path = str(tmp_path / "success")
+    _seed_committed_rows(path, _SEED)
+
+    writer = LanceDBStore(path)
+    writer.open(_vec_spec(), [])
+    trigger = _row("c", vec=[0.1, 0.2, 0.3], content=b"new", write_gen=3)
+    writer.write_rows("t", [trigger])
+
+    _fresh, rows, vec_type = _fresh_committed_state(path)
+    assert vec_type == pa.list_(pa.float32(), 3)
+    by_cid = {r["cid"]: r for r in rows}
+    assert by_cid["a"]["content"] == _BLOB_A and by_cid["a"]["vec"] is None
+    assert by_cid["b"]["content"] == _BLOB_B and by_cid["b"]["vec"] is None
+    assert by_cid["c"]["content"] == b"new"
+    assert by_cid["c"]["vec"] == pytest.approx([0.1, 0.2, 0.3])
+
+    searcher = LanceDBStore(path)
+    searcher.open(_vec_spec(), [])
+    hits = searcher.search("t", query_vector=[0.1, 0.2, 0.3], vector_column="vec", limit=1)
+    assert [h["cid"] for h in hits] == ["c"]
+    assert "_distance" in hits[0]
+
+
+# --- H3: repeating specialization across handles is a no-op, no temp tables ---
+
+
+def test_specialization_is_idempotent_across_handles(tmp_path) -> None:
+    path = str(tmp_path / "idempotent")
+    _seed_committed_rows(path, _SEED)
+
+    first = LanceDBStore(path)
+    first.open(_vec_spec(), [])
+    first.write_rows("t", [_row("c", vec=[0.1, 0.2, 0.3], content=b"new", write_gen=3)])
+
+    second = LanceDBStore(path)
+    second.open(_vec_spec(), [])
+    version_before = second._tables["t"].version
+    second.write_rows("t", [_row("d", vec=[0.4, 0.5, 0.6], content=b"newer", write_gen=4)])
+
+    assert second._tables["t"].version == version_before + 1, "an already-specialized table must see exactly the row append, no hidden rewrite"
+    _fresh, rows, vec_type = _fresh_committed_state(path)
+    assert [r["cid"] for r in rows] == ["a", "b", "c", "d"], "no duplicate rows after repeated specialization"
+    assert vec_type == pa.list_(pa.float32(), 3)
+    assert _fresh._db.list_tables().tables == ["t"], "no leftover temp table may be visible as live"
+
+
+# --- H5: fresh world — pristine directory created by the store itself ---
+
+
+def test_fresh_world_first_write_specializes_and_searches(tmp_path) -> None:
+    path = str(tmp_path / "pristine" / "kb")
+    assert not Path(path).exists()
+
+    store = LanceDBStore(path)
+    store.open(_vec_spec(), [])
+    store.write_rows("t", [_row("a", vec=[1.0, 0.0, 0.0], content=_BLOB_A)])
+
+    assert Path(path).exists(), "the store itself must have created the directory"
+    _fresh, rows, vec_type = _fresh_committed_state(path)
+    assert [r["cid"] for r in rows] == ["a"]
+    assert rows[0]["content"] == _BLOB_A
+    assert vec_type == pa.list_(pa.float32(), 3)
+    hits = _fresh.search("t", query_vector=[1.0, 0.0, 0.0], vector_column="vec", limit=1)
+    assert [h["cid"] for h in hits] == ["a"]
+
+
+# --- Historical drop/recreate seams (the #206 RED proofs) ----------------------
+# These two inject at the physical seams where the pre-#206 implementation lost
+# data: ``create_table`` (fired after the destructive drop — rows destroyed) and
+# ``Table.add`` (fired while re-adding data to the replacement — rows hidden).
+# Against that implementation both FAILED with "readable rows: []". They stay in
+# the suite as trip-wires: any regression toward a drop/recreate window loses
+# committed rows again and trips the subset-preservation assertion.
+
+
+def test_crash_at_historical_create_table_seam_leaves_rows_readable(tmp_path, monkeypatch) -> None:
+    path = str(tmp_path / "red-after-drop")
+    _seed_committed_rows(path, _SEED)
+
+    store = LanceDBStore(path)
+    store.open(_vec_spec(), [])
+    connection_type = type(store._db)
+
+    def crash_create(connection, *args, **kwargs):
+        raise RuntimeError("simulated crash during replacement construction")
+
+    monkeypatch.setattr(connection_type, "create_table", crash_create)
+    with contextlib.suppress(RuntimeError):
+        store.write_rows("t", [_row("c", vec=[0.1, 0.2, 0.3], content=b"new")])
+    monkeypatch.undo()
+
+    _assert_seed_rows_readable(path, _SEED)
+
+
+def test_crash_at_historical_readd_seam_leaves_rows_readable(tmp_path, monkeypatch) -> None:
+    path = str(tmp_path / "red-during-readd")
+    _seed_committed_rows(path, _SEED)
+
+    store = LanceDBStore(path)
+    store.open(_vec_spec(), [])
+    table_type = type(store._tables["t"])
+
+    def crash_add(table, *args, **kwargs):
+        raise RuntimeError("simulated crash while re-adding data to the replacement")
+
+    monkeypatch.setattr(table_type, "add", crash_add)
+    with contextlib.suppress(RuntimeError):
+        store.write_rows("t", [_row("c", vec=[0.1, 0.2, 0.3], content=b"new")])
+    monkeypatch.undo()
+
+    _assert_seed_rows_readable(path, _SEED)

--- a/tests/test_ticket206_vector_specialization_safety.py
+++ b/tests/test_ticket206_vector_specialization_safety.py
@@ -10,7 +10,6 @@ still reads the committed table completely (row counts + blob byte equality).
 
 from __future__ import annotations
 
-import contextlib
 from pathlib import Path
 from typing import Any
 
@@ -52,18 +51,53 @@ def _row(cid: str, *, vec: list[float] | None, content: bytes, write_gen: int = 
     }
 
 
-def _seed_committed_rows(path: str, rows: list[dict[str, Any]]) -> None:
-    """Commit rows through their own handle, leaving the vector column un-specialized.
+def _vec2_spec() -> TableSpec:
+    """Two independent vector columns — exercises multi-column alterations."""
+    return TableSpec(
+        name="t",
+        identity="cid",
+        columns=[
+            ColumnSpec("cid", role="identity", arrow_type=pa.utf8()),
+            ColumnSpec("content", role="source", content_key=True, arrow_type=pa.large_binary()),
+            ColumnSpec("vec_a", role="derived", arrow_type=pa.list_(pa.float64())),
+            ColumnSpec("vec_b", role="derived", arrow_type=pa.list_(pa.float64())),
+            ColumnSpec("_row_fingerprint", role="internal", arrow_type=pa.utf8()),
+            ColumnSpec("_write_gen", role="internal", arrow_type=pa.int64()),
+            ColumnSpec("_status", role="internal", arrow_type=pa.utf8()),
+            ColumnSpec("_error", role="internal", arrow_type=pa.utf8()),
+        ],
+    )
 
-    The first row must carry ``vec=None`` so dimension detection (which samples
-    the first row of the first write) finds nothing to specialize — the exact
-    state of a real store whose rows were written before any embedding existed.
+
+def _row2(cid: str, *, vec_a: list[float] | None, vec_b: list[float] | None, content: bytes, write_gen: int = 1) -> dict[str, Any]:
+    return {
+        "cid": cid,
+        "content": content,
+        "vec_a": vec_a,
+        "vec_b": vec_b,
+        "_row_fingerprint": f"fp-{cid}",
+        "_write_gen": write_gen,
+        "_status": "complete",
+        "_error": None,
+    }
+
+
+def _seed_committed_rows(path: str, rows: list[dict[str, Any]], spec: TableSpec | None = None) -> LanceDBStore:
+    """Commit rows through their own handle, leaving vector columns un-specialized.
+
+    The first row must carry ``None`` for every vector column so dimension
+    detection (which samples the first row of the first write) finds nothing to
+    specialize — the exact state of a real store whose rows were written before
+    any embedding existed. Returns the seeding handle so a test can commit a
+    further batch (a second physical fragment) through it.
     """
-    assert rows[0]["vec"] is None
+    assert not any(isinstance(v, list) for v in rows[0].values())
     store = LanceDBStore(path)
-    store.open(_vec_spec(), [])
+    store.open(spec or _vec_spec(), [])
     store.write_rows("t", rows)
-    assert store._tables["t"].schema.field("vec").type == pa.list_(pa.float64())
+    for field in store._tables["t"].schema:
+        assert not pa.types.is_fixed_size_list(field.type)
+    return store
 
 
 def _fresh_committed_state(path: str) -> tuple[LanceDBStore, list[dict[str, Any]], pa.DataType]:
@@ -75,30 +109,17 @@ def _fresh_committed_state(path: str) -> tuple[LanceDBStore, list[dict[str, Any]
     return fresh, rows, vec_type
 
 
-def _assert_rows_preserved(path: str, expected: list[dict[str, Any]]) -> None:
+def _assert_rows_preserved(path: str, expected: list[dict[str, Any]], spec: TableSpec | None = None) -> None:
     """A fresh handle must read exactly the committed rows, blob bytes included."""
-    _fresh, rows, _vec_type = _fresh_committed_state(path)
-    got = [(r["cid"], r["content"], r["vec"], r["_write_gen"]) for r in rows]
-    want = [(r["cid"], r["content"], r["vec"], r["_write_gen"]) for r in sorted(expected, key=lambda r: r["cid"])]
+    fresh = LanceDBStore(path)
+    fresh.open(spec or _vec_spec(), [])
+    rows = sorted(fresh.read_rows("t"), key=lambda r: r["cid"])
+    keys = sorted(expected[0].keys())
+    got = [tuple(r.get(k) for k in keys) for r in rows]
+    want = [tuple(r.get(k) for k in keys) for r in sorted(expected, key=lambda r: r["cid"])]
     assert got == want, (
-        f"committed rows were destroyed or hidden: got {[(c, v) for c, _, v, _ in got]!r}, expected {[(c, v) for c, _, v, _ in want]!r}"
+        f"committed rows were destroyed, hidden, or altered: got cids {[r['cid'] for r in rows]!r}, expected {[r['cid'] for r in expected]!r}"
     )
-
-
-def _assert_seed_rows_readable(path: str, expected: list[dict[str, Any]]) -> None:
-    """Every previously committed row must still be readable byte-identically.
-
-    Subset semantics: rows written AFTER the seed (a trigger row whose write
-    succeeded) are allowed — what may never happen is a seed row going missing
-    or changing bytes.
-    """
-    _fresh, rows, _vec_type = _fresh_committed_state(path)
-    by_cid = {r["cid"]: r for r in rows}
-    for exp in expected:
-        got = by_cid.get(exp["cid"])
-        assert got is not None, f"previously committed row {exp['cid']!r} was destroyed or hidden; readable rows: {sorted(by_cid)!r}"
-        assert got["content"] == exp["content"], f"blob bytes of committed row {exp['cid']!r} changed"
-        assert got["_write_gen"] == exp["_write_gen"], f"_write_gen of committed row {exp['cid']!r} changed"
 
 
 _SEED = [
@@ -134,36 +155,53 @@ def test_failure_before_specialization_work_preserves_committed_rows(tmp_path, m
     assert vec_type == pa.list_(pa.float64()), "a failed specialization must leave the schema untouched"
 
 
-# --- H1 failpoint (b) + H4: crash mid-rewrite, replacement staged but never published ---
+# --- H1 failpoint (b) + H4: REAL mid-rewrite crash, replacement staged but never published ---
 
 
-def test_crash_mid_rewrite_before_publish_preserves_committed_rows(tmp_path, monkeypatch) -> None:
-    """Replacement column files physically staged in the dataset dir, crash before
-    the manifest commit: the staged artifact is on disk yet a fresh handle reads
-    only committed data — publication is Lance's atomic manifest commit, so an
-    incomplete replacement is never readable under the live table name."""
-    path = str(tmp_path / "failpoint-midswap")
-    _seed_committed_rows(path, _SEED)
+def test_real_mid_rewrite_failure_stages_files_but_never_publishes(tmp_path) -> None:
+    """H4 mid-swap proof on Lance's REAL rewrite path, no mocks: a two-column
+    alteration where the second altered column's cast fails on a committed
+    wrong-length row AFTER earlier column fragments were already rewritten.
+    Real staged data files appear in the dataset directory, yet nothing is
+    published: the version and both column schemas are unchanged and every
+    committed row is byte-identical through a fresh handle. Publication is
+    Lance's single atomic manifest commit — staged files without a manifest
+    reference are unreachable, so preservation is at the TABLE level (the
+    physical directory legitimately retains the aborted rewrite's files)."""
+    path = str(tmp_path / "real-midswap")
+    spec = _vec2_spec()
+    batch_one = [
+        _row2("a", vec_a=None, vec_b=None, content=_BLOB_A),
+        _row2("b", vec_a=[1.0, 2.0, 3.0], vec_b=[1.0, 2.0, 3.0], content=_BLOB_B, write_gen=2),
+    ]
+    seeder = _seed_committed_rows(path, batch_one, spec)
+    # A second physical fragment holding the row that breaks the SECOND altered
+    # column (sorted alteration order: vec_a rewrites first, vec_b then fails).
+    batch_two = [_row2("bad", vec_a=[4.0, 5.0, 6.0], vec_b=[0.1, 0.2], content=b"short", write_gen=3)]
+    seeder.write_rows("t", batch_two)
+    seed = [*batch_one, *batch_two]
+
+    data_dir = Path(path) / "t.lance" / "data"
+    files_before = {p.name for p in data_dir.iterdir()}
+    probe = LanceDBStore(path)
+    probe.open(spec, [])
+    version_before = probe._tables["t"].version
 
     store = LanceDBStore(path)
-    store.open(_vec_spec(), [])
-    table_type = type(store._tables["t"])
-    staged = Path(path) / "t.lance" / "data" / "zz-staged-replacement-not-committed.lance"
+    store.open(spec, [])
+    with pytest.raises(RuntimeError, match=r"(?s)'t'.*vec_a.*vec_b.*preserved"):
+        store.write_rows("t", [_row2("c", vec_a=[7.0, 8.0, 9.0], vec_b=[7.0, 8.0, 9.0], content=b"new", write_gen=4)])
 
-    def crash_mid_rewrite(table, *alterations, **kwargs):
-        staged.parent.mkdir(parents=True, exist_ok=True)
-        staged.write_bytes(b"\x00partial-replacement-column-data\xff")
-        raise RuntimeError("simulated crash mid-rewrite, before manifest commit")
+    staged = {p.name for p in data_dir.iterdir()} - files_before
+    assert staged, "Lance must have physically staged rewritten column files before the failure — the failpoint fired mid-rewrite"
 
-    monkeypatch.setattr(table_type, "alter_columns", crash_mid_rewrite)
-
-    with pytest.raises(RuntimeError, match="preserved"):
-        store.write_rows("t", [_row("c", vec=[0.1, 0.2, 0.3], content=b"new")])
-
-    assert staged.exists(), "the staged replacement artifact must physically exist for this proof"
-    _assert_rows_preserved(path, _SEED)
-    _fresh, _rows, vec_type = _fresh_committed_state(path)
-    assert vec_type == pa.list_(pa.float64()), "an unpublished replacement must not change the live schema"
+    fresh = LanceDBStore(path)
+    fresh.open(spec, [])
+    tbl = fresh._tables["t"]
+    assert tbl.version == version_before, "a failed alteration must not publish a new version"
+    assert tbl.schema.field("vec_a").type == pa.list_(pa.float64()), "no column of a failed multi-column alteration may be published"
+    assert tbl.schema.field("vec_b").type == pa.list_(pa.float64())
+    _assert_rows_preserved(path, seed, spec)  # exact set: the trigger row is absent
 
 
 # --- H1 failpoint (c): a REAL conversion failure during replacement, no mocks ---
@@ -301,48 +339,90 @@ def test_fresh_world_first_write_specializes_and_searches(tmp_path) -> None:
     assert [h["cid"] for h in hits] == ["a"]
 
 
-# --- Historical drop/recreate seams (the #206 RED proofs) ----------------------
-# These two inject at the physical seams where the pre-#206 implementation lost
-# data: ``create_table`` (fired after the destructive drop — rows destroyed) and
-# ``Table.add`` (fired while re-adding data to the replacement — rows hidden).
-# Against that implementation both FAILED with "readable rows: []". They stay in
-# the suite as trip-wires: any regression toward a drop/recreate window loses
-# committed rows again and trips the subset-preservation assertion.
+# --- Crash AFTER publish: the trigger-row append fails post-specialization ------
+# Historical note: at this ``Table.add`` seam the pre-#206 implementation
+# re-added ALL data to a freshly recreated table and an injected crash hid every
+# row (RED proof for gate H1(c): "readable rows: []"). Its sibling seam,
+# create_table-after-drop, cannot fire at all under the failure-safe
+# implementation and is pinned shut by the drop/recreate sentinel above. Today
+# ``Table.add`` fires only for the ordinary trigger-row append, AFTER the
+# alteration commit — so this test pins two guarantees at once: a crashed append
+# hides nothing, and the specialization commit is already durable.
 
 
-def test_crash_at_historical_create_table_seam_leaves_rows_readable(tmp_path, monkeypatch) -> None:
-    path = str(tmp_path / "red-after-drop")
-    _seed_committed_rows(path, _SEED)
-
-    store = LanceDBStore(path)
-    store.open(_vec_spec(), [])
-    connection_type = type(store._db)
-
-    def crash_create(connection, *args, **kwargs):
-        raise RuntimeError("simulated crash during replacement construction")
-
-    monkeypatch.setattr(connection_type, "create_table", crash_create)
-    with contextlib.suppress(RuntimeError):
-        store.write_rows("t", [_row("c", vec=[0.1, 0.2, 0.3], content=b"new")])
-    monkeypatch.undo()
-
-    _assert_seed_rows_readable(path, _SEED)
-
-
-def test_crash_at_historical_readd_seam_leaves_rows_readable(tmp_path, monkeypatch) -> None:
-    path = str(tmp_path / "red-during-readd")
+def test_crash_during_trigger_row_append_keeps_specialization_and_rows(tmp_path, monkeypatch) -> None:
+    path = str(tmp_path / "append-crash")
     _seed_committed_rows(path, _SEED)
 
     store = LanceDBStore(path)
     store.open(_vec_spec(), [])
     table_type = type(store._tables["t"])
+    fired = {"count": 0}
 
     def crash_add(table, *args, **kwargs):
-        raise RuntimeError("simulated crash while re-adding data to the replacement")
+        fired["count"] += 1
+        raise RuntimeError("simulated crash while appending the trigger row")
 
     monkeypatch.setattr(table_type, "add", crash_add)
-    with contextlib.suppress(RuntimeError):
+    with pytest.raises(RuntimeError, match="appending the trigger row"):
         store.write_rows("t", [_row("c", vec=[0.1, 0.2, 0.3], content=b"new")])
     monkeypatch.undo()
 
-    _assert_seed_rows_readable(path, _SEED)
+    assert fired["count"] == 1, "the failpoint must actually fire for this proof to mean anything"
+    _fresh, rows, vec_type = _fresh_committed_state(path)
+    assert [r["cid"] for r in rows] == ["a", "b"], "a crashed append must neither hide committed rows nor publish a partial trigger row"
+    assert rows[0]["content"] == _BLOB_A and rows[1]["content"] == _BLOB_B
+    assert vec_type == pa.list_(pa.float32(), 3), "the specialization commit is durable even when the following append crashes"
+
+
+# --- Cached-handle coherence: no reopen needed after specialization -------------
+
+
+def test_cached_handle_serves_new_schema_and_next_write_without_reopen(tmp_path) -> None:
+    path = str(tmp_path / "cached-handle")
+    _seed_committed_rows(path, _SEED)
+
+    store = LanceDBStore(path)
+    store.open(_vec_spec(), [])
+    handle_before = store._tables["t"]
+
+    store.write_rows("t", [_row("c", vec=[0.1, 0.2, 0.3], content=b"new", write_gen=3)])
+
+    assert store._tables["t"] is handle_before, "specialization must advance the cached handle in place, never swap it"
+    assert handle_before.schema.field("vec").type == pa.list_(pa.float32(), 3), "the cached handle must serve the specialized schema immediately"
+
+    store.write_rows("t", [_row("d", vec=[0.4, 0.5, 0.6], content=b"newer", write_gen=4)])
+
+    _fresh, rows, vec_type = _fresh_committed_state(path)
+    assert [r["cid"] for r in rows] == ["a", "b", "c", "d"], "a write through the cached handle after specialization must land without a reopen"
+    assert vec_type == pa.list_(pa.float32(), 3)
+
+
+# --- Multi-column success: both columns publish in ONE atomic version -----------
+
+
+def test_multi_column_specialization_publishes_one_atomic_version(tmp_path) -> None:
+    path = str(tmp_path / "multi-col")
+    spec = _vec2_spec()
+    seed = [
+        _row2("a", vec_a=None, vec_b=None, content=_BLOB_A),
+        _row2("b", vec_a=[1.0, 2.0, 3.0], vec_b=[1.0, 2.0, 3.0, 4.0], content=_BLOB_B, write_gen=2),
+    ]
+    _seed_committed_rows(path, seed, spec)
+
+    probe = LanceDBStore(path)
+    probe.open(spec, [])
+    version_before = probe._tables["t"].version
+
+    writer = LanceDBStore(path)
+    writer.open(spec, [])
+    trigger = _row2("c", vec_a=[7.0, 8.0, 9.0], vec_b=[6.0, 7.0, 8.0, 9.0], content=b"new", write_gen=3)
+    writer.write_rows("t", [trigger])
+
+    fresh = LanceDBStore(path)
+    fresh.open(spec, [])
+    tbl = fresh._tables["t"]
+    assert tbl.schema.field("vec_a").type == pa.list_(pa.float32(), 3)
+    assert tbl.schema.field("vec_b").type == pa.list_(pa.float32(), 4), "each column keeps its own detected dimension"
+    assert tbl.version == version_before + 2, "both column alterations must share ONE version commit (the second bump is the row append)"
+    _assert_rows_preserved(path, [*seed, trigger], spec)


### PR DESCRIPTION
Closes #206.

## Problem statement
`LanceDBStore._detect_and_fix_vectors()` specialized plain-list vector columns by reading the whole table, **dropping the live table**, recreating it, and re-adding data. A crash after the drop destroyed the table; a crash during re-add left an empty replacement published under the live name — both masquerading as '0 rows'.

## Before / after
```text
Before: to_arrow() → drop_table → create_table → add   (data-loss window; RED tests proved rows destroyed)
After:  Table.alter_columns(...) — in-place cast published by ONE atomic Lance
        manifest commit; failure at any point leaves the previous version live
```
A failed cast raises loudly, naming the table, columns, dims, and the preserved state. A sentinel test forbids drop/create during specialization outright.

## Test plan
- 10 tests incl. a REAL mid-rewrite failure (two-column alteration, second-column cast failure after the first fragment rewrote — genuine staged .lance files appear; version/schema/rows unchanged via fresh handle), fired-counter failpoints, cached-handle in-place schema serve, one-version multi-column atomicity, fresh-world, idempotence.
- Inversion witness: 7/10 tests fail when the pre-fix implementation is swapped back in.
- Cross-model adversarial review: SHIP (8/8 mid-rewrite repetitions; no label-only assertions).
- Full CI-equivalent: 3503 passed, 15 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vector schema specialization to preserve committed data during failures.
  * Prevented partial updates, duplicate rows, and hidden data when vector conversion or writes fail.
  * Ensured cached table views recognize newly specialized vector schemas without reopening.
  * Improved reliability for multiple vector columns and retries after invalid data is removed.

* **Tests**
  * Added comprehensive coverage for failure recovery, atomic updates, retries, searching, and multi-column specialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->