### PR TITLE
fix(materialization): pin recipe identity to construction-time node hashes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -76,6 +76,17 @@
   state cannot be fingerprinted now fail loudly with guidance to define
   `cache_key()` instead of drifting forever, and a non-callable that carries
   no `definition_hash` is rejected instead of silently hashing its repr.
+  Routed union columns (several producers writing one column): a named
+  index's recipe fingerprint is now the order-free combination of EVERY
+  producer's recipe — previously it hashed the producer tuple's repr, which
+  differed in every process, so such indexes always read as stale; existing
+  union-column indexes flag stale once more and then stay current. And
+  `explain()` no longer attributes a union column to whichever producer was
+  listed first in the graph: it returns
+  `{"producers": {<node name>: {"provenance", "source"}}}` with every
+  producer labeled (single-producer columns keep the flat
+  `{"provenance", "source"}` shape); row-actual attribution would require a
+  durable producer identifier on the row and is not recorded.
 
 - **Truthful notebook scheduler availability** — before, an
   `add_callback`-only kernel could look cross-thread capable while lacking the

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -50,6 +50,25 @@
 
 ### Fixed
 
+- **HyperTable definition fingerprints harden to `hash_definition`** — before,
+  a derive node that was a bound method of a configured object
+  (`summarizer.summarize` with `model="gpt-4"` vs `model="o3"`) produced the
+  SAME recipe fingerprint, so changing the configuration silently skipped the
+  re-derive; and a dynamically-created function (exec/eval, no retrievable
+  source) hashed its `repr` — a per-process memory address — so its rows
+  re-derived on every run. Now `compute_definition_hash` delegates to the
+  repo's single definition-identity function `hash_definition`: bound methods
+  mix in the instance's state, dynamic functions hash their bytecode, and
+  builtins hash their qualified name. One-time migration consequence: rows
+  whose recipes involve bound methods, dynamically-created functions,
+  builtins, partials, or callable objects carry a changed fingerprint and
+  re-derive once on the next `insert`/`update`/`sync`; component-config and
+  bound-value journal entries re-journal under content hashes. Rows derived
+  from ordinary module-level functions keep their exact previous fingerprint
+  (both schemes hash the function's source text) and are not re-derived.
+  Callable objects whose state cannot be fingerprinted now fail loudly with
+  guidance to define `cache_key()` instead of drifting forever.
+
 - **Truthful notebook scheduler availability** — before, an
   `add_callback`-only kernel could look cross-thread capable while lacking the
   delayed owner-thread call needed for the 250 ms live-inspection update. Now

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -50,24 +50,32 @@
 
 ### Fixed
 
-- **HyperTable definition fingerprints harden to `hash_definition`** — before,
-  a derive node that was a bound method of a configured object
-  (`summarizer.summarize` with `model="gpt-4"` vs `model="o3"`) produced the
-  SAME recipe fingerprint, so changing the configuration silently skipped the
-  re-derive; and a dynamically-created function (exec/eval, no retrievable
-  source) hashed its `repr` — a per-process memory address — so its rows
-  re-derived on every run. Now `compute_definition_hash` delegates to the
-  repo's single definition-identity function `hash_definition`: bound methods
-  mix in the instance's state, dynamic functions hash their bytecode, and
-  builtins hash their qualified name. One-time migration consequence: rows
-  whose recipes involve bound methods, dynamically-created functions,
-  builtins, partials, or callable objects carry a changed fingerprint and
-  re-derive once on the next `insert`/`update`/`sync`; component-config and
-  bound-value journal entries re-journal under content hashes. Rows derived
-  from ordinary module-level functions keep their exact previous fingerprint
-  (both schemes hash the function's source text) and are not re-derived.
-  Callable objects whose state cannot be fingerprinted now fail loudly with
-  guidance to define `cache_key()` instead of drifting forever.
+- **HyperTable definition fingerprints harden to construction-time
+  `hash_definition`** — before, a derive node that was a bound method of a
+  configured object (`summarizer.summarize` with `model="gpt-4"` vs
+  `model="o3"`) produced the SAME recipe fingerprint, so changing the
+  configuration silently skipped the re-derive; and a dynamically-created
+  function (exec/eval, no retrievable source) hashed its `repr` — a
+  per-process memory address — so its rows re-derived on every run. Now a
+  producing node's recipe identity is its `definition_hash`, captured ONCE at
+  node construction via the repo's single definition-identity function
+  `hash_definition`: bound methods mix in the instance's configuration,
+  dynamic functions hash their bytecode, and builtins hash their qualified
+  name. Because identity is frozen at construction, instance state that
+  mutates during execution (a call counter, a cache, a client) does NOT drift
+  the recipe — three inserts through the same node stamp one fingerprint.
+  One-time migration consequence: rows whose recipes involve bound methods,
+  dynamically-created functions, builtins, partials, or callable objects
+  carry a changed fingerprint and re-derive once on the next
+  `insert`/`update`/`sync`; component-config and bound-value journal entries
+  re-journal under content hashes, and a functionless subgraph producer's
+  journal entry re-keys from a meaningless shared hash-of-`None` to the
+  node's own definition hash. Rows derived from ordinary module-level
+  functions keep their exact previous fingerprint (both schemes hash the
+  function's source text) and are not re-derived. Callable objects whose
+  state cannot be fingerprinted now fail loudly with guidance to define
+  `cache_key()` instead of drifting forever, and a non-callable that carries
+  no `definition_hash` is rejected instead of silently hashing its repr.
 
 - **Truthful notebook scheduler availability** — before, an
   `add_callback`-only kernel could look cross-thread capable while lacking the

--- a/src/hypergraph/materialization/_fingerprint.py
+++ b/src/hypergraph/materialization/_fingerprint.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections.abc import Iterable
 from typing import Any
 
 from hypergraph._utils import hash_definition
@@ -74,6 +75,17 @@ def compute_payload_hash(payload: str) -> str:
     Journal keys for non-callable recipe text: a payload is data, not a
     function definition, so it hashes by content.
     """
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+def combine_recipe_fingerprints(fingerprints: Iterable[str]) -> str:
+    """One recipe identity for a column with several producers (a routed union).
+
+    The hash of the SORTED per-producer recipe fingerprints — order-free, so
+    graph insertion order does not matter, and a code or config change in ANY
+    branch flips the combined recipe.
+    """
+    payload = json.dumps(sorted(fingerprints))
     return hashlib.sha256(payload.encode()).hexdigest()
 
 

--- a/src/hypergraph/materialization/_fingerprint.py
+++ b/src/hypergraph/materialization/_fingerprint.py
@@ -15,6 +15,7 @@ import json
 from typing import Any
 
 from hypergraph._utils import hash_definition
+from hypergraph.materialization._schema import node_func
 
 
 def compute_definition_hash(fn: Any) -> str:
@@ -29,11 +30,42 @@ def compute_definition_hash(fn: Any) -> str:
     the instance's state into the hash (two differently-configured components
     are different recipes), and a dynamically-created function with no
     retrievable source hashes its bytecode instead of a per-process repr.
+
+    A non-callable that carries no ``definition_hash`` has no definition to
+    hash — silently hashing its repr would differ in every process, so it is
+    rejected loudly instead.
     """
     node_hash = getattr(fn, "definition_hash", None)
     if isinstance(node_hash, str) and node_hash:
         return node_hash
+    if not callable(fn):
+        raise TypeError(
+            f"Cannot fingerprint {type(fn).__name__}: expected a node exposing "
+            "definition_hash or a callable definition (recipe payload strings "
+            "hash via compute_payload_hash)"
+        )
     return hash_definition(fn)
+
+
+def compute_node_definition_hash(node: Any) -> str:
+    """Recipe identity of a producing node: its construction-time ``definition_hash``.
+
+    Every function-carrying node captures ``hash_definition(func)`` when it is
+    built (``FunctionNode``, gates, interrupts; a ``GraphNode``'s hash covers
+    its inner graph), so the node's own hash is the stable identity. Hashing
+    the LIVE callable instead would re-capture mutable instance state — a
+    counter, a cache, a client — on every computation and drift the recipe run
+    over run. A node exposing only a raw callable falls back to that callable;
+    anything else must be a definition in its own right or is rejected by
+    ``compute_definition_hash``.
+    """
+    node_hash = getattr(node, "definition_hash", None)
+    if isinstance(node_hash, str) and node_hash:
+        return node_hash
+    func = node_func(node)
+    if func is not None:
+        return compute_definition_hash(func)
+    return compute_definition_hash(node)
 
 
 def compute_payload_hash(payload: str) -> str:
@@ -48,16 +80,7 @@ def compute_payload_hash(payload: str) -> str:
 def _node_definition_hashes(graph: Any) -> list[str]:
     if graph is None:
         return []
-    hashes: list[str] = []
-    for n in graph.iter_nodes():
-        func = getattr(n, "func", None)
-        if func is not None:
-            hashes.append(compute_definition_hash(func))
-        elif getattr(n, "definition_hash", None):
-            # A function-less producer (GraphNode) participates through its own
-            # code-sensitive hash, so an inner-node edit flips the table recipe.
-            hashes.append(compute_definition_hash(n))
-    return hashes
+    return [compute_node_definition_hash(n) for n in graph.iter_nodes()]
 
 
 def _plain_value_payload(value: Any) -> str | None:
@@ -135,7 +158,7 @@ def compute_recipe_fingerprint(node_fn: Any, component_hashes: dict[str, str]) -
     """
     payload = json.dumps(
         {
-            "node": compute_definition_hash(node_fn),
+            "node": compute_node_definition_hash(node_fn),
             "components": component_hashes,
         },
         sort_keys=True,
@@ -166,7 +189,7 @@ def compute_column_provenance(node_fn: Any, inputs: dict[str, Any], component_ha
     """
     payload = json.dumps(
         {
-            "node": compute_definition_hash(node_fn),
+            "node": compute_node_definition_hash(node_fn),
             "inputs": {k: f"{type(v).__name__}:{v}" for k, v in sorted(inputs.items())},
             "components": component_hashes,
         },

--- a/src/hypergraph/materialization/_fingerprint.py
+++ b/src/hypergraph/materialization/_fingerprint.py
@@ -11,28 +11,38 @@ re-derives on the next insert/sync; otherwise it is skipped.
 from __future__ import annotations
 
 import hashlib
-import inspect
 import json
 from typing import Any
 
+from hypergraph._utils import hash_definition
+
 
 def compute_definition_hash(fn: Any) -> str:
-    """Hash the definition of a derive node: function source, or a node's own hash.
+    """Hash the definition of a derive node: a node's own hash, or ``hash_definition``.
 
     A column producer may be a subgraph (a GraphNode — e.g. a validation cycle
     wrapped as one node): it has no single source function, but its
     ``definition_hash`` already covers the inner graph's node code plus the
-    boundary projection, so that is the code-sensitive basis here. Plain
-    functions hash their source (falls back to repr).
+    boundary projection, so that is the code-sensitive basis here. Everything
+    else delegates to :func:`hypergraph._utils.hash_definition`, the repo's one
+    definition-identity function: a bound method of a configured instance mixes
+    the instance's state into the hash (two differently-configured components
+    are different recipes), and a dynamically-created function with no
+    retrievable source hashes its bytecode instead of a per-process repr.
     """
     node_hash = getattr(fn, "definition_hash", None)
     if isinstance(node_hash, str) and node_hash:
         return node_hash
-    try:
-        source = inspect.getsource(fn)
-    except (OSError, TypeError):
-        source = repr(fn)
-    return hashlib.sha256(source.encode()).hexdigest()
+    return hash_definition(fn)
+
+
+def compute_payload_hash(payload: str) -> str:
+    """Content hash of a recipe payload string (a config repr or bound-value text).
+
+    Journal keys for non-callable recipe text: a payload is data, not a
+    function definition, so it hashes by content.
+    """
+    return hashlib.sha256(payload.encode()).hexdigest()
 
 
 def _node_definition_hashes(graph: Any) -> list[str]:

--- a/src/hypergraph/materialization/_hypertable.py
+++ b/src/hypergraph/materialization/_hypertable.py
@@ -561,15 +561,24 @@ class HyperTable:
             return None
         return _public_row(row, self._spec)
 
-    def explain(self, identity_value: str) -> dict[str, dict[str, str | None]]:
+    def explain(self, identity_value: str) -> dict[str, dict[str, Any]]:
         """Resolve a row's per-column recipe to the readable source of THIS table's nodes.
 
-        For each derived column returns ``{"provenance": <node definition hash>,
-        "source": <node source verbatim>}``, pulled from the store's recipe
-        journal (commits or not). The ``provenance`` key is the node's DEFINITION
-        hash (stable across rows, the journal key), NOT the row's value-chained
-        ``_provenance_*`` stamp — the journal deliberately holds recipe meaning,
-        one payload per recipe, never one per row.
+        For each derived column with one producer returns ``{"provenance":
+        <node definition hash>, "source": <node source verbatim>}``, pulled
+        from the store's recipe journal (commits or not). The ``provenance``
+        key is the node's DEFINITION hash (stable across rows, the journal
+        key), NOT the row's value-chained ``_provenance_*`` stamp — the
+        journal deliberately holds recipe meaning, one payload per recipe,
+        never one per row.
+
+        A routed union column has SEVERAL producers, and which one derived
+        THIS row is not durably recorded — attributing it to any single node
+        would fabricate provenance. Such a column instead returns
+        ``{"producers": {<node name>: {"provenance": ..., "source": ...}}}``
+        with every producer's recipe labeled by node name. Row-actual
+        attribution would require a durable producer identifier on the row
+        and is out of scope here.
 
         The source reported is that of the node objects bound to THIS table
         instance — i.e. the recipe the row would derive under now. On a fresh or
@@ -585,15 +594,20 @@ class HyperTable:
         row = self._store.read_one(self._spec.name, self._identity, identity_value)
         if row is None:
             raise KeyError(identity_value)
-        explained: dict[str, dict[str, str | None]] = {}
+
+        def entry(producer: Any) -> dict[str, str | None]:
+            def_hash = compute_node_definition_hash(producer)
+            return {"provenance": def_hash, "source": self._write_planner.journal.resolve(def_hash)}
+
+        explained: dict[str, dict[str, Any]] = {}
         for c in self._provenance_policy.derived_columns():
             if c.produced_by is None:
                 continue
-            def_hash = compute_node_definition_hash(self._provenance_policy.column_producers(c)[0])
-            explained[c.name] = {
-                "provenance": def_hash,
-                "source": self._write_planner.journal.resolve(def_hash),
-            }
+            producers = self._provenance_policy.column_producers(c)
+            if len(producers) == 1:
+                explained[c.name] = entry(producers[0])
+            else:
+                explained[c.name] = {"producers": {getattr(producer, "name", repr(producer)): entry(producer) for producer in producers}}
         return explained
 
     def resolve_provenance(self, stamp: str) -> str | None:

--- a/src/hypergraph/materialization/_hypertable.py
+++ b/src/hypergraph/materialization/_hypertable.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from hypergraph import Graph
 from hypergraph.graph import GraphConfigError
-from hypergraph.materialization._fingerprint import compute_definition_hash
+from hypergraph.materialization._fingerprint import compute_node_definition_hash
 from hypergraph.materialization._hypertable_viz import render_hypertable
 from hypergraph.materialization._indexes import IndexPolicy
 from hypergraph.materialization._provenance import Provenance
@@ -20,7 +20,6 @@ from hypergraph.materialization._schema import (
     TableSpec,
     analyze_table,
     is_internal_column,
-    node_func,
     python_type_to_arrow,
 )
 from hypergraph.materialization._types import (
@@ -590,7 +589,7 @@ class HyperTable:
         for c in self._provenance_policy.derived_columns():
             if c.produced_by is None:
                 continue
-            def_hash = compute_definition_hash(node_func(c.produced_by))
+            def_hash = compute_node_definition_hash(self._provenance_policy.column_producers(c)[0])
             explained[c.name] = {
                 "provenance": def_hash,
                 "source": self._write_planner.journal.resolve(def_hash),

--- a/src/hypergraph/materialization/_indexes.py
+++ b/src/hypergraph/materialization/_indexes.py
@@ -36,7 +36,7 @@ class IndexPolicy:
     def _recipe_fingerprint(self, spec: TableSpec, vector: str) -> str | None:
         for column in self._provenance.derived_columns(spec):
             if column.name == vector and column.produced_by is not None:
-                return self._provenance.node_recipe(column.produced_by)
+                return self._provenance.column_recipe(column)
         return None
 
     def _queryable_columns(self, spec: TableSpec) -> set[str]:

--- a/src/hypergraph/materialization/_provenance.py
+++ b/src/hypergraph/materialization/_provenance.py
@@ -17,6 +17,7 @@ from hypergraph import Graph
 from hypergraph.materialization._fingerprint import (
     _component_config_hashes,
     _plain_value_payload,
+    combine_recipe_fingerprints,
     compute_child_fingerprint,
     compute_column_provenance,
     compute_node_definition_hash,
@@ -254,6 +255,15 @@ class Provenance:
         params = self.node_params(node)
         components = {name: value for name, value in self.components.items() if name in params}
         return compute_recipe_fingerprint(node, _component_config_hashes(components))
+
+    def column_recipe(self, column: Any) -> str:
+        """Recipe identity of a derived COLUMN: its producer's recipe — or, for a
+        routed union column with several producers, the order-free combination
+        of every producer's recipe, so a change in ANY branch flips it."""
+        producers = self.column_producers(column)
+        if len(producers) == 1:
+            return self.node_recipe(producers[0])
+        return combine_recipe_fingerprints([self.node_recipe(producer) for producer in producers])
 
     def root_fingerprint(self, graph_inputs: Mapping[str, Any]) -> str:
         return compute_row_fingerprint(self.graph, dict(self.components), dict(graph_inputs))

--- a/src/hypergraph/materialization/_provenance.py
+++ b/src/hypergraph/materialization/_provenance.py
@@ -19,7 +19,7 @@ from hypergraph.materialization._fingerprint import (
     _plain_value_payload,
     compute_child_fingerprint,
     compute_column_provenance,
-    compute_definition_hash,
+    compute_node_definition_hash,
     compute_payload_hash,
     compute_recipe_fingerprint,
     compute_row_fingerprint,
@@ -248,12 +248,12 @@ class Provenance:
                 inputs[name] = values[name]
             elif parameter.default is inspect.Parameter.empty:
                 return None
-        return compute_column_provenance(node_func(node) or node, inputs, _component_config_hashes(components))
+        return compute_column_provenance(node, inputs, _component_config_hashes(components))
 
     def node_recipe(self, node: Any) -> str:
         params = self.node_params(node)
         components = {name: value for name, value in self.components.items() if name in params}
-        return compute_recipe_fingerprint(node_func(node) or node, _component_config_hashes(components))
+        return compute_recipe_fingerprint(node, _component_config_hashes(components))
 
     def root_fingerprint(self, graph_inputs: Mapping[str, Any]) -> str:
         return compute_row_fingerprint(self.graph, dict(self.components), dict(graph_inputs))
@@ -278,7 +278,10 @@ class Provenance:
 
     def recipe_entries(self, node: Any) -> tuple[RecipeEntry, ...]:
         func = node_func(node)
-        entries = [RecipeEntry(compute_definition_hash(func), KIND_NODE_SOURCE, self.node_source(func))]
+        # Identity is the node's construction-time hash; the func is kept only
+        # for the readable source text (a functionless GraphNode reads as its
+        # repr — never as "None").
+        entries = [RecipeEntry(compute_node_definition_hash(node), KIND_NODE_SOURCE, self.node_source(func if func is not None else node))]
         params = self.node_params(node)
         for name, component in self.components.items():
             if name not in params:

--- a/src/hypergraph/materialization/_provenance.py
+++ b/src/hypergraph/materialization/_provenance.py
@@ -20,6 +20,7 @@ from hypergraph.materialization._fingerprint import (
     compute_child_fingerprint,
     compute_column_provenance,
     compute_definition_hash,
+    compute_payload_hash,
     compute_recipe_fingerprint,
     compute_row_fingerprint,
     compute_table_recipe_fingerprint,
@@ -284,7 +285,7 @@ class Provenance:
                 continue
             payload, kind = self.component_payload(component)
             if payload is not None:
-                entries.append(RecipeEntry(compute_definition_hash(payload), kind, payload))
+                entries.append(RecipeEntry(compute_payload_hash(payload), kind, payload))
         return tuple(entries)
 
     @staticmethod

--- a/src/hypergraph/materialization/_recipe_journal.py
+++ b/src/hypergraph/materialization/_recipe_journal.py
@@ -1,10 +1,11 @@
 """The recipe journal: a per-store table resolving a provenance stamp to readable text.
 
-Fingerprints hash the recipe — node source (``inspect.getsource``), component
-config reprs, bound plain-value payloads — and then discard the text (see
-``_fingerprint.py``). A stamp on a stored row can therefore detect that a row
-was "built under something else" but can never NAME what that was: an
-uncommitted node edit that derived rows is unrecoverable from the hash alone.
+Fingerprints hash the recipe — node definitions (``hash_definition``: source
+or bytecode, plus bound-instance state), component config reprs, bound
+plain-value payloads — and then discard the text (see ``_fingerprint.py``).
+A stamp on a stored row can therefore detect that a row was "built under
+something else" but can never NAME what that was: an uncommitted node edit
+that derived rows is unrecoverable from the hash alone.
 
 The journal closes that gap. At the moment a stamp is written onto a row the
 payload behind it is still in hand, so it is persisted — keyed by its own hash —

--- a/tests/test_hypertable_indexes.py
+++ b/tests/test_hypertable_indexes.py
@@ -11,7 +11,7 @@ from typing import TypedDict
 
 import pytest
 
-from hypergraph import Graph, node
+from hypergraph import Graph, ifelse, node
 from hypergraph.materialization import TableStore
 from hypergraph.materialization._lancedb_store import LanceDBStore
 from hypergraph.runners import SyncRunner
@@ -328,3 +328,39 @@ class TestManifestlessStoreFailsLoudOnCreateIndex:
         # A fresh instance over the same store sees no phantom index.
         fresh = make_table(store)
         assert fresh.list_indexes() == []
+
+
+class TestUnionColumnIndex:
+    def test_index_freshness_on_multi_producer_column(self, store):
+        """A named index on a routed union column (several producers) computes a
+        stable recipe fingerprint over ALL producers: create works, and a fresh
+        table instance over the same graph reads the index back as current."""
+
+        @ifelse(when_true="positive", when_false="negative")
+        def choose(positive_number: bool) -> bool:
+            return positive_number
+
+        @node(output_name="label_vec")
+        def positive(value: int) -> list[float]:
+            return [1.0, 0.0]
+
+        @node(output_name="label_vec")
+        def negative(value: int) -> list[float]:
+            return [0.0, 1.0]
+
+        def build():
+            return Graph([choose, positive, negative]).as_table(identity="item_id", store=store, runner=SyncRunner())
+
+        table = build()
+        table.insert(item_id="i1", positive_number=True, value=3)
+
+        table.create_index("routed", vector="label_vec")
+
+        specs = table.list_indexes()
+        assert len(specs) == 1
+        assert specs[0]["recipe_fingerprint"]
+        assert specs[0]["current"] is True
+
+        # Freshness is deterministic: a rebuilt table over the same recipe
+        # agrees, regardless of graph insertion order of the producers.
+        assert build().list_indexes()[0]["current"] is True

--- a/tests/test_hypertable_recipe_drift.py
+++ b/tests/test_hypertable_recipe_drift.py
@@ -23,12 +23,45 @@ from hypergraph import Graph, node
 from hypergraph.materialization import HyperTable, RecipeDrift
 from hypergraph.materialization._lancedb_store import LanceDBStore
 from hypergraph.materialization._schema import RECIPE_COLUMN
+from hypergraph.nodes import FunctionNode
 from hypergraph.runners import SyncRunner
 
 
 @node(output_name="upper")
 def to_upper(text: str, mode: str) -> str:
     return text.upper() if mode == "loud" else text
+
+
+class CountingUpper:
+    """A component whose execution mutates its own state (a call counter)."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def upper(self, text: str) -> str:
+        self.calls += 1
+        return text.upper()
+
+
+def test_mutable_instance_state_does_not_drift_the_recipe(tmp_path):
+    """Three inserts through a bound-method node whose instance mutates on every
+    call stamp ONE recipe fingerprint and read back zero drift: recipe identity
+    is captured at node construction, not from the live instance per execution."""
+    component = CountingUpper()
+    table = Graph([FunctionNode(component.upper, output_name="upper")]).as_table(
+        identity="doc_id", store=LanceDBStore(str(tmp_path)), runner=SyncRunner()
+    )
+
+    table.insert(doc_id="d1", text="a")
+    table.insert(doc_id="d2", text="b")
+    table.insert(doc_id="d3", text="c")
+    assert component.calls == 3
+
+    raw = LanceDBStore(str(tmp_path)).read_rows("doc")
+    assert len({row[RECIPE_COLUMN] for row in raw}) == 1
+
+    drift = table.recipe_drift()
+    assert (drift.total, drift.current, drift.drifted) == (3, 3, 0)
 
 
 def _table(tmp_path, mode: str) -> HyperTable:

--- a/tests/test_hypertable_recipe_journal.py
+++ b/tests/test_hypertable_recipe_journal.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import pytest
 
-from hypergraph import Graph, node
+from hypergraph import Graph, ifelse, node
 from hypergraph.materialization._lancedb_store import LanceDBStore
 from hypergraph.runners import SyncRunner
 
@@ -139,3 +139,38 @@ def test_fresh_table_resolves_old_stamps(tmp_path):
     resolved = table2.resolve_provenance(stamp)
     assert resolved is not None
     assert "text.strip().lower()" in resolved
+
+
+# ---------------------------------------------------------------------------
+# explain() on a routed union column: every producer, labeled — no fabricated
+# single attribution.
+# ---------------------------------------------------------------------------
+
+
+def test_explain_labels_every_producer_of_a_union_column(store):
+    """explain() on a multi-producer (routed union) column reports ALL
+    producers' recipes labeled by node name. The row was derived by the FALSE
+    branch — a single producers[0] attribution would report the wrong node."""
+
+    @ifelse(when_true="positive", when_false="negative")
+    def choose(positive_number: bool) -> bool:
+        return positive_number
+
+    @node(output_name="label")
+    def positive(value: int) -> str:
+        return f"positive:{value}"
+
+    @node(output_name="label")
+    def negative(value: int) -> str:
+        return f"negative:{value}"
+
+    table = Graph([choose, positive, negative]).as_table(identity="item_id", store=store, runner=SyncRunner())
+    table.insert(item_id="i1", positive_number=False, value=3)  # executes `negative`
+    assert table.get("i1")["label"] == "negative:3"
+
+    explained = table.explain("i1")["label"]
+
+    assert set(explained["producers"]) == {"positive", "negative"}
+    for entry in explained["producers"].values():
+        assert entry["provenance"]
+        assert "source" in entry

--- a/tests/test_materialization_types.py
+++ b/tests/test_materialization_types.py
@@ -17,7 +17,7 @@ from hypergraph.materialization import (
     TableReceipt,
     WriteOutcome,
 )
-from hypergraph.materialization._fingerprint import compute_definition_hash
+from hypergraph.materialization._fingerprint import compute_definition_hash, compute_payload_hash
 
 # ---------------------------------------------------------------------------
 # Definition hash
@@ -135,6 +135,17 @@ class TestDefinitionHash:
         bare_source_hash = hashlib.sha256(inspect.getsource(bound).encode()).hexdigest()
 
         assert compute_definition_hash(bound) != bare_source_hash
+
+
+class TestPayloadHash:
+    def test_payload_hash_is_content_hash(self):
+        """A recipe payload string (config repr, bound-value text) keys the journal
+        by its content, not by any function-identity scheme."""
+        payload = "str:'sentence'"
+
+        assert compute_payload_hash(payload) == hashlib.sha256(payload.encode()).hexdigest()
+        assert compute_payload_hash(payload) == compute_payload_hash(payload)
+        assert compute_payload_hash(payload) != compute_payload_hash("str:'paragraph'")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_materialization_types.py
+++ b/tests/test_materialization_types.py
@@ -10,6 +10,9 @@ import sys
 import textwrap
 from dataclasses import dataclass
 
+import pytest
+
+from hypergraph import Graph
 from hypergraph.materialization import (
     ErroredRow,
     RowReceipt,
@@ -17,7 +20,15 @@ from hypergraph.materialization import (
     TableReceipt,
     WriteOutcome,
 )
-from hypergraph.materialization._fingerprint import compute_definition_hash, compute_payload_hash
+from hypergraph.materialization._fingerprint import (
+    compute_definition_hash,
+    compute_payload_hash,
+    compute_table_recipe_fingerprint,
+)
+from hypergraph.materialization._provenance import Provenance
+from hypergraph.materialization._recipe_journal import KIND_NODE_SOURCE
+from hypergraph.materialization._schema import TableSpec
+from hypergraph.nodes import FunctionNode
 
 # ---------------------------------------------------------------------------
 # Definition hash
@@ -135,6 +146,62 @@ class TestDefinitionHash:
         bare_source_hash = hashlib.sha256(inspect.getsource(bound).encode()).hexdigest()
 
         assert compute_definition_hash(bound) != bare_source_hash
+
+
+class MutatingSummarizer:
+    """A component whose execution mutates its own state (a call counter)."""
+
+    def __init__(self, model: str):
+        self.model = model
+        self.calls = 0
+
+    def summarize(self, text: str) -> str:
+        self.calls += 1
+        return f"{self.model}:{text}"
+
+
+class TestNodeIdentity:
+    def test_recipe_fingerprint_stable_across_instance_mutation(self):
+        """Recipe identity is captured at NODE CONSTRUCTION: executing a
+        bound-method node that mutates its instance (a counter, a cache, a
+        client) must not change the table's recipe fingerprint run over run."""
+        summarizer = MutatingSummarizer(model="gpt-4")
+        n = FunctionNode(summarizer.summarize, output_name="summary")
+        graph = Graph([n])
+
+        before = compute_table_recipe_fingerprint(graph, {})
+        summarizer.summarize("hello")  # execution mutates self.calls
+        after = compute_table_recipe_fingerprint(graph, {})
+
+        assert before == after
+        assert before == compute_table_recipe_fingerprint(graph, {})
+
+    def test_recipe_entries_use_node_hash_for_functionless_nodes(self):
+        """A functionless producer (a GraphNode) journals under ITS definition
+        hash — never under a hash of None."""
+
+        class SubgraphNode:
+            definition_hash = "a" * 64
+            inputs = ()
+            name = "child"
+
+        provenance = Provenance(
+            graph=None,
+            spec=TableSpec(name="t", identity="id", columns=[]),
+            components={},
+            column_graphs={},
+        )
+
+        entries = provenance.recipe_entries(SubgraphNode())
+
+        assert entries[0].kind == KIND_NODE_SOURCE
+        assert entries[0].hash == "a" * 64
+
+    def test_non_callable_without_definition_hash_is_rejected(self):
+        """A non-callable that is neither a node nor a definition fails loudly —
+        a silent repr-based hash would differ in every process."""
+        with pytest.raises(TypeError, match="definition_hash"):
+            compute_definition_hash(object())
 
 
 class TestPayloadHash:

--- a/tests/test_materialization_types.py
+++ b/tests/test_materialization_types.py
@@ -22,6 +22,7 @@ from hypergraph.materialization import (
 )
 from hypergraph.materialization._fingerprint import (
     compute_definition_hash,
+    compute_node_definition_hash,
     compute_payload_hash,
     compute_table_recipe_fingerprint,
 )
@@ -202,6 +203,22 @@ class TestNodeIdentity:
         a silent repr-based hash would differ in every process."""
         with pytest.raises(TypeError, match="definition_hash"):
             compute_definition_hash(object())
+
+    def test_node_identity_is_construction_time_definition_hash(self):
+        """The identity used for recipes IS the node's captured hash, frozen at
+        construction — not a re-capture of the live instance."""
+        summarizer = MutatingSummarizer(model="gpt-4")
+        n = FunctionNode(summarizer.summarize, output_name="summary")
+        captured = n.definition_hash
+
+        summarizer.summarize("x")
+
+        assert compute_node_definition_hash(n) == captured
+
+    def test_raw_callable_falls_back_to_definition_hash(self):
+        """A raw callable that never passed through node construction hashes as
+        its own definition."""
+        assert compute_node_definition_hash(sample_derive) == compute_definition_hash(sample_derive)
 
 
 class TestPayloadHash:

--- a/tests/test_materialization_types.py
+++ b/tests/test_materialization_types.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+import hashlib
+import inspect
+import os
+import subprocess
+import sys
+import textwrap
 from dataclasses import dataclass
 
 from hypergraph.materialization import (
@@ -35,6 +41,16 @@ def sample_derive(utt: Utterance) -> EmbeddedUtterance:
     return EmbeddedUtterance(utt_id=utt.utt_id, text=utt.text, vector=[0.0])
 
 
+class Summarizer:
+    """A configured object whose bound method serves as a derive node."""
+
+    def __init__(self, model: str):
+        self.model = model
+
+    def summarize(self, text: str) -> str:
+        return f"{self.model}:{text}"
+
+
 class TestDefinitionHash:
     def test_deterministic(self):
         h1 = compute_definition_hash(sample_derive)
@@ -46,6 +62,79 @@ class TestDefinitionHash:
             return EmbeddedUtterance(utt_id=utt.utt_id, text=utt.text, vector=[1.0])
 
         assert compute_definition_hash(sample_derive) != compute_definition_hash(other)
+
+    def test_node_definition_hash_attribute_short_circuits(self):
+        """An object exposing ``definition_hash`` (a GraphNode) is its own basis."""
+
+        class FakeGraphNode:
+            definition_hash = "f" * 64
+
+        assert compute_definition_hash(FakeGraphNode()) == "f" * 64
+
+    def test_configured_instances_hash_differently(self):
+        """Bound methods of differently-configured instances are different recipes.
+
+        ``summarizer.summarize`` with ``model="gpt-4"`` derives different content
+        than with ``model="o3"`` — sharing a fingerprint would silently skip the
+        re-derive when the configuration changes.
+        """
+        gpt4 = Summarizer(model="gpt-4")
+        o3 = Summarizer(model="o3")
+
+        assert compute_definition_hash(gpt4.summarize) != compute_definition_hash(o3.summarize)
+
+    def test_same_config_instances_hash_identically(self):
+        """Equal configuration means equal recipe — no spurious re-derives."""
+        assert compute_definition_hash(Summarizer(model="gpt-4").summarize) == compute_definition_hash(Summarizer(model="gpt-4").summarize)
+
+    def test_dynamic_function_hash_is_stable_across_processes(self, tmp_path):
+        """An exec-created function (no retrievable source) fingerprints identically
+        in two separate interpreter processes — a per-process basis (repr address)
+        would mark every such row as drifted on every run."""
+        script = tmp_path / "dynamic_fingerprint.py"
+        script.write_text(
+            textwrap.dedent(
+                """
+                from hypergraph.materialization._fingerprint import compute_definition_hash
+
+                namespace = {}
+                exec("def derive(text): return text.upper()", namespace)
+                print(compute_definition_hash(namespace["derive"]))
+                """
+            ),
+            encoding="utf-8",
+        )
+
+        outputs = []
+        for seed in ("1", "2"):
+            result = subprocess.run(
+                [sys.executable, str(script)],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={**os.environ, "PYTHONHASHSEED": seed},
+            )
+            outputs.append(result.stdout.strip())
+
+        assert len(set(outputs)) == 1
+        assert len(outputs[0]) == 64
+
+    def test_ordinary_function_keeps_source_hash_basis(self):
+        """A module-level function's fingerprint is the sha256 of its source text —
+        the same value the pre-hardening scheme produced, so existing rows derived
+        from plain functions do NOT re-derive."""
+        expected = hashlib.sha256(inspect.getsource(sample_derive).encode()).hexdigest()
+
+        assert compute_definition_hash(sample_derive) == expected
+
+    def test_bound_method_hash_departs_from_bare_source_hash(self):
+        """A configured instance's bound method no longer hashes to bare source:
+        instance state joins the fingerprint. Rows previously derived from such
+        nodes re-derive once after this change (see changelog)."""
+        bound = Summarizer(model="gpt-4").summarize
+        bare_source_hash = hashlib.sha256(inspect.getsource(bound).encode()).hexdigest()
+
+        assert compute_definition_hash(bound) != bare_source_hash
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #247.

## Problem statement
Materialization fingerprinted the LIVE callable on every execution: a bound method of a configured instance collided across configs (silent staleness misses), mutable instance state produced a NEW recipe hash per execution (perpetual drift), dynamically-created functions hashed a per-process memory address, union-column index fingerprints were per-process-unstable (always stale), and `explain()` attributed multi-producer columns to whichever producer came first in graph order.

## Before / after
```text
Before: 3 executions of a counter-carrying bound-method node → 3 distinct recipe hashes
After:  3 executions → ONE stable fingerprint == the node's construction-time definition_hash

Before: explain() on a union column → the graph-list-first producer, even for rows the other branch derived
After:  explain() → {'producers': {name: {provenance, source}}} labeling EVERY producer
```
Migration (changelog): module-level function rows keep their exact previous fingerprints (no re-derive); bound-method/dynamic/builtin/partial/callable-object recipes and config/bound-value journal keys re-key once; union-column indexes show one final stale flag then stabilize.

## Test plan
Three red-green rounds (6 commits) driven by two cross-model adversarial reviews (mutable-lifecycle witness, two-process determinism, order-free union fingerprints, labeled-producers witness). Full CI-equivalent: 3508 passed, 15 skipped. Pre-commit clean.

Out-of-scope finding filed separately: the write path journals only the first producer of a union column, so non-first producers resolve source=None in explain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)