### PR TITLE
fix(runners): honor transitive routing decisions across chained gates

### DIFF
--- a/docs/03-patterns/02-routing.md
+++ b/docs/03-patterns/02-routing.md
@@ -489,6 +489,12 @@ def process(text: str) -> str:
 graph = Graph([check_length, check_quality, process])
 ```
 
+Termination is transitive across the chain: if `check_length` returns `END`,
+neither `check_quality` nor `process` executes — even when their data inputs
+(like `text` above) are already available as graph inputs. A node behind
+chained gates runs only when every gate along the selected path activates the
+next hop. Nodes on independent, ungated paths are unaffected and keep running.
+
 ## Next Steps
 
 - [API Reference: Gates](../06-api-reference/gates.md) - Complete IfElseNode, RouteNode, and @ifelse/@route documentation

--- a/docs/03-patterns/02-routing.md
+++ b/docs/03-patterns/02-routing.md
@@ -503,6 +503,11 @@ cancels in-flight selections; a gate whose earlier selection was simply
 consumed by its target keeps downstream selections live, which is what lets
 loops route through chained gates across iterations.
 
+Gates fire before their consequences: when a loop makes an upstream gate
+re-evaluate, in-flight selections further down the chain wait for its verdict
+instead of racing it in the same superstep. Unrelated nodes are not held up —
+independent work still runs in parallel with the re-evaluating gate.
+
 ## Next Steps
 
 - [API Reference: Gates](../06-api-reference/gates.md) - Complete IfElseNode, RouteNode, and @ifelse/@route documentation

--- a/docs/03-patterns/02-routing.md
+++ b/docs/03-patterns/02-routing.md
@@ -495,6 +495,14 @@ neither `check_quality` nor `process` executes — even when their data inputs
 chained gates runs only when every gate along the selected path activates the
 next hop. Nodes on independent, ungated paths are unaffected and keep running.
 
+This also covers decisions already in flight: if a mid-chain gate has selected
+targets that have not run yet, and an upstream gate then explicitly terminates
+the chain (`END`) or routes elsewhere, those pending selections are discarded —
+the not-yet-run targets do not execute. Only an explicit upstream decision
+cancels in-flight selections; a gate whose earlier selection was simply
+consumed by its target keeps downstream selections live, which is what lets
+loops route through chained gates across iterations.
+
 ## Next Steps
 
 - [API Reference: Gates](../06-api-reference/gates.md) - Complete IfElseNode, RouteNode, and @ifelse/@route documentation

--- a/src/hypergraph/runners/_shared/AGENTS.md
+++ b/src/hypergraph/runners/_shared/AGENTS.md
@@ -25,7 +25,8 @@ After collecting ready nodes, two filters apply:
 
 | Gate state | Node state | `default_open` | Entrypoints set | Result |
 |-----------|-----------|----------------|-----------------|--------|
-| Never executed | Never executed | True | No | **Activated** (first-pass startup) |
+| Never executed, gate itself activated | Never executed | True | No | **Activated** (first-pass startup) |
+| Never executed, gate itself blocked | Never executed | True | No | **Blocked** (transitive chain termination) |
 | Never executed | Never executed | True | Yes, node IS entrypoint | **Activated** |
 | Never executed | Never executed | True | Yes, node NOT entrypoint | **Blocked** (wait for gate) |
 | Never executed | Never executed | False | Any | **Blocked** |
@@ -34,6 +35,16 @@ After collecting ready nodes, two filters apply:
 | Executed, decision cleared (stale) | Any | Any | Any | **Blocked** |
 
 **Key insight**: the entrypoint restriction prevents inputless gate targets (like interrupt nodes) from firing before the gate on first pass.
+
+**Transitive chain termination** (issue #220): activation is a shrinking
+fixpoint. First-pass `default_open` permission requires the controlling gate
+itself to still be activated, so `gate_a -> gate_b -> target` blocks `target`
+when `gate_a` decides END or routes elsewhere — data readiness cannot bypass a
+dead control path. Decision-based activation ignores the fixpoint (an executed
+decision explicitly names its targets), which is what lets gates in cycles
+re-activate their targets on later iterations. Explicit entrypoint targets are
+exempt from the transitive requirement: the user asked to start there, and the
+controlling gate may be outside the active scope.
 
 ## Staleness (`_is_stale`)
 

--- a/src/hypergraph/runners/_shared/AGENTS.md
+++ b/src/hypergraph/runners/_shared/AGENTS.md
@@ -30,21 +30,35 @@ After collecting ready nodes, two filters apply:
 | Never executed | Never executed | True | Yes, node IS entrypoint | **Activated** |
 | Never executed | Never executed | True | Yes, node NOT entrypoint | **Blocked** (wait for gate) |
 | Never executed | Never executed | False | Any | **Blocked** |
-| Executed, decision=this node | Any | Any | Any | **Activated** |
+| Executed, live decision=this node | Any | Any | Any | **Activated** |
+| Executed, orphaned decision (gate cut off upstream) | Any | Any | Any | **Blocked** (decision dropped) |
 | Executed, decision=other | Any | Any | Any | **Blocked** |
 | Executed, decision cleared (stale) | Any | Any | Any | **Blocked** |
 
 **Key insight**: the entrypoint restriction prevents inputless gate targets (like interrupt nodes) from firing before the gate on first pass.
 
 **Transitive chain termination** (issue #220): activation is a shrinking
-fixpoint. First-pass `default_open` permission requires the controlling gate
-itself to still be activated, so `gate_a -> gate_b -> target` blocks `target`
-when `gate_a` decides END or routes elsewhere — data readiness cannot bypass a
-dead control path. Decision-based activation ignores the fixpoint (an executed
-decision explicitly names its targets), which is what lets gates in cycles
-re-activate their targets on later iterations. Explicit entrypoint targets are
-exempt from the transitive requirement: the user asked to start there, and the
-controlling gate may be outside the active scope.
+fixpoint (worklist — linear predicate calls regardless of declaration order).
+First-pass `default_open` permission requires the controlling gate itself to
+still be activated, so `gate_a -> gate_b -> target` blocks `target` when
+`gate_a` decides END or routes elsewhere — data readiness cannot bypass a dead
+control path. Explicit entrypoint targets are exempt from the transitive
+requirement: the user asked to start there, and the controlling gate may be
+outside the active scope.
+
+**Orphaned pending decisions** (issue #220, review finding): a pending
+decision is causally live only while its deciding gate is not *cut off* — a
+gate is cut off when every controlling gate either currently holds an explicit
+decision that excludes it (END or routed elsewhere) or is itself cut off.
+Cut-off gates' pending non-END decisions are DELETED before activation
+(`_drop_orphaned_decisions`), so a half-consumed multi-target selection cannot
+fire targets after the chain was explicitly terminated upstream. The
+distinguishing signal that keeps cycles working: a controller whose selection
+was merely CONSUMED (decision None) keeps its targets' pending decisions live —
+it may re-fire and route to them again. Deletion (not suppression) prevents an
+orphaned decision from resurrecting after the upstream exclusion is consumed.
+END decisions are never deleted: they activate nothing and stay as terminal
+markers.
 
 ## Staleness (`_is_stale`)
 

--- a/src/hypergraph/runners/_shared/AGENTS.md
+++ b/src/hypergraph/runners/_shared/AGENTS.md
@@ -32,7 +32,7 @@ After collecting ready nodes, two filters apply:
 | Never executed | Never executed | False | Any | **Blocked** |
 | Executed, live decision=this node | Any | Any | Any | **Activated** |
 | Executed, orphaned decision (gate cut off upstream) | Any | Any | Any | **Blocked** (non-END decision dropped) |
-| Executed, pending decision but a controller upstream is re-firing | Any | Any | Any | **Blocked** this superstep (suspended, decision kept) |
+| Executed, pending decision but a controller upstream is re-firing | Any | Any | Any | **Blocked** this superstep; if suspension alone empties the frontier, retry unsuspended (decision kept) |
 | Executed, decision=other | Any | Any | Any | **Blocked** |
 | Executed, decision cleared (stale) | Any | Any | Any | **Blocked** |
 

--- a/src/hypergraph/runners/_shared/AGENTS.md
+++ b/src/hypergraph/runners/_shared/AGENTS.md
@@ -31,7 +31,8 @@ After collecting ready nodes, two filters apply:
 | Never executed | Never executed | True | Yes, node NOT entrypoint | **Blocked** (wait for gate) |
 | Never executed | Never executed | False | Any | **Blocked** |
 | Executed, live decision=this node | Any | Any | Any | **Activated** |
-| Executed, orphaned decision (gate cut off upstream) | Any | Any | Any | **Blocked** (decision dropped) |
+| Executed, orphaned decision (gate cut off upstream) | Any | Any | Any | **Blocked** (non-END decision dropped) |
+| Executed, pending decision but a controller upstream is re-firing | Any | Any | Any | **Blocked** this superstep (suspended, decision kept) |
 | Executed, decision=other | Any | Any | Any | **Blocked** |
 | Executed, decision cleared (stale) | Any | Any | Any | **Blocked** |
 
@@ -59,6 +60,21 @@ it may re-fire and route to them again. Deletion (not suppression) prevents an
 orphaned decision from resurrecting after the upstream exclusion is consumed.
 END decisions are never deleted: they activate nothing and stay as terminal
 markers.
+
+**Gate-first re-evaluation** (issue #220, review round 2): when a controlling
+gate is scheduled to re-execute — the same `_needs_execution` signal that
+clears the gate's own stale decision — gates below it in the control chain
+are transiently *suspended* (`_compute_suspended_gates`): their pending
+decisions do not activate targets this superstep. The re-firing gate delivers
+its verdict first; consequences propagate on the next evaluation (a
+re-selection re-runs the mid-gate and refreshes its decision; an exclusion
+orphans it). Suspension is recomputed from state every evaluation — nothing
+is persisted, decisions are kept, and it lifts the moment the controller has
+re-fired. It distinguishes "controller decision None because harmlessly
+consumed" (downstream decisions stay live) from "controller decision None and
+controller is stale" (verdict pending). Independent nodes outside the
+re-firing gate's chain — including ungated nodes co-batched in the same
+superstep — are unaffected.
 
 ## Staleness (`_is_stale`)
 

--- a/src/hypergraph/runners/_shared/readiness.py
+++ b/src/hypergraph/runners/_shared/readiness.py
@@ -182,15 +182,22 @@ def gate_permits_startup(
     The early returns mirror the canonical gate-activation decision table.
     Executed decisions take precedence over startup-only defaults.
 
-    ``gate_activated`` says whether the controlling gate itself is currently
-    activated. First-pass ``default_open`` permission is only as alive as the
-    gate handing it out: a gate whose own control path is already blocked can
-    never fire, so its targets must not start on data readiness alone
-    (transitive chain termination, issue #220). Explicit entrypoints are
-    exempt — the user asked to start there, and the controlling gate may be
-    outside the active scope entirely.
+    ``gate_activated`` says whether the controlling gate's authority is still
+    causally live, and it scopes both branches (issue #220):
+
+    - Decision branch: a pending decision activates its targets only while
+      the deciding gate is not cut off upstream (see ``_compute_cut_gates``).
+      An orphaned decision — the deciding gate's own control path was
+      explicitly terminated or routed away — must not fire anything.
+    - First-pass ``default_open`` branch: permission is only as alive as the
+      gate handing it out; a gate whose own control path is already blocked
+      can never fire, so its targets must not start on data readiness alone.
+      Explicit entrypoints are exempt — the user asked to start there, and
+      the controlling gate may be outside the active scope entirely.
     """
     if decision is not None:
+        if not gate_activated:
+            return False
         return _is_node_activated_by_decision(node_name, decision)
     if gate_executed:
         return False
@@ -212,23 +219,39 @@ def _get_activated_nodes(graph: Graph, state: GraphState) -> set[str]:
     first-pass ``default_open`` permission through ``gate_b``. Starting from
     "everything activated" (greatest fixpoint) preserves first-pass startup
     for undecided gate chains, including gates that control each other in a
-    cycle. Decision-based activation never depends on the fixpoint, so gate
-    re-firing in cycles re-activates targets as before.
+    cycle. Live decision-based activation never depends on the fixpoint, so
+    gate re-firing in cycles re-activates targets as before; orphaned
+    decisions of cut-off gates are dropped first and activate nothing.
+
+    Implemented as a worklist: a node is re-examined only when one of its
+    controlling gates was just deactivated, keeping the total predicate-call
+    count linear in graph size regardless of node declaration order.
     """
-    # Stale decisions must be cleared before any activation is evaluated.
+    from collections import deque
+
+    # Stale decisions must be cleared before any activation is evaluated,
+    # then orphaned decisions of cut-off gates dropped (issue #220).
     _clear_stale_gate_decisions(graph, state)
+    controls = _build_controls_map(graph)
+    cut_gates = _compute_cut_gates(graph, state, controls)
+    _drop_orphaned_decisions(state, cut_gates)
 
     activated = set(graph._nodes)
     gated_names = [name for name in graph._nodes if graph.controlled_by.get(name)]
-    changed = True
-    while changed:
-        changed = False
-        for node_name in gated_names:
-            if node_name not in activated:
-                continue
-            if not _any_gate_permits_startup(node_name, graph, state, activated):
-                activated.discard(node_name)
-                changed = True
+    queue = deque(gated_names)
+    queued = set(gated_names)
+    while queue:
+        node_name = queue.popleft()
+        queued.discard(node_name)
+        if node_name not in activated:
+            continue
+        if _any_gate_permits_startup(node_name, graph, state, activated, cut_gates):
+            continue
+        activated.discard(node_name)
+        for dependent in controls.get(node_name, ()):
+            if dependent in activated and dependent not in queued:
+                queue.append(dependent)
+                queued.add(dependent)
 
     return activated
 
@@ -238,23 +261,111 @@ def _any_gate_permits_startup(
     graph: Graph,
     state: GraphState,
     activated: set[str],
+    cut_gates: set[str],
 ) -> bool:
     """Whether at least one controlling gate permits this node to start."""
     for gate_name in graph.controlled_by.get(node_name, []):
         gate = graph._nodes.get(gate_name)
         if gate is None:
             continue
+        decision = state.routing_decisions.get(gate_name)
+        # The liveness signal matches the branch the predicate will take:
+        # a pending decision is live while its gate is not cut off; first-pass
+        # default_open permission is live while the gate is still activated.
+        alive = gate_name not in cut_gates if decision is not None else gate_name in activated
         if gate_permits_startup(
             node_name,
-            decision=state.routing_decisions.get(gate_name),
+            decision=decision,
             gate_executed=gate_name in state.node_executions,
             node_executed=node_name in state.node_executions,
             default_open=getattr(gate, "default_open", True),
             entrypoints=graph.entrypoints_config,
-            gate_activated=gate_name in activated,
+            gate_activated=alive,
         ):
             return True
     return False
+
+
+def _build_controls_map(graph: Graph) -> dict[str, list[str]]:
+    """Invert ``controlled_by``: gate name -> nodes it controls."""
+    controls: dict[str, list[str]] = {}
+    for target, gates in graph.controlled_by.items():
+        for gate_name in gates:
+            controls.setdefault(gate_name, []).append(target)
+    return controls
+
+
+def _compute_cut_gates(
+    graph: Graph,
+    state: GraphState,
+    controls: dict[str, list[str]],
+) -> set[str]:
+    """Gates whose control path is explicitly severed upstream (worklist).
+
+    A gate is *cut off* when every controlling gate either currently holds an
+    explicit decision that excludes it (END or routed elsewhere) or is itself
+    cut off. A controller with no current decision — never fired, or its
+    selection was already consumed — keeps its targets alive: it may still
+    (re-)fire and route to them. That consumed-means-live rule is what keeps
+    in-flight pending decisions working across cycle iterations.
+    """
+    from collections import deque
+
+    from hypergraph.nodes.gate import GateNode
+
+    controlled_gates = [name for name, node in graph._nodes.items() if isinstance(node, GateNode) and graph.controlled_by.get(name)]
+    cut: set[str] = set()
+    queue = deque(controlled_gates)
+    queued = set(controlled_gates)
+    while queue:
+        gate_name = queue.popleft()
+        queued.discard(gate_name)
+        if gate_name in cut:
+            continue
+        if _any_controller_keeps_alive(gate_name, graph, state, cut):
+            continue
+        cut.add(gate_name)
+        for dependent in controls.get(gate_name, ()):
+            if isinstance(graph._nodes.get(dependent), GateNode) and dependent not in cut and dependent not in queued:
+                queue.append(dependent)
+                queued.add(dependent)
+
+    return cut
+
+
+def _any_controller_keeps_alive(
+    gate_name: str,
+    graph: Graph,
+    state: GraphState,
+    cut: set[str],
+) -> bool:
+    """Whether any controlling gate can still (re-)route to this gate."""
+    for controller in graph.controlled_by.get(gate_name, []):
+        if controller not in graph._nodes:
+            continue
+        if controller in cut:
+            continue
+        decision = state.routing_decisions.get(controller)
+        if decision is None or _is_node_activated_by_decision(gate_name, decision):
+            return True
+    return False
+
+
+def _drop_orphaned_decisions(state: GraphState, cut_gates: set[str]) -> None:
+    """Delete pending decisions made by cut-off gates.
+
+    Once a gate's control path is explicitly severed, its in-flight selection
+    is causally dead — deleting it (rather than suppressing it) prevents the
+    decision from resurrecting later, e.g. after the upstream exclusion is
+    itself consumed. END decisions are kept: they activate nothing and remain
+    a truthful terminal marker.
+    """
+    from hypergraph.nodes.gate import END
+
+    for gate_name in cut_gates:
+        decision = state.routing_decisions.get(gate_name)
+        if decision is not None and decision is not END:
+            del state.routing_decisions[gate_name]
 
 
 def _clear_stale_gate_decisions(graph: Graph, state: GraphState) -> None:

--- a/src/hypergraph/runners/_shared/readiness.py
+++ b/src/hypergraph/runners/_shared/readiness.py
@@ -31,6 +31,11 @@ def get_ready_nodes(
 ) -> list[HyperNode]:
     """Find nodes whose inputs are all satisfied and not stale.
 
+    Suspension is a same-superstep ordering rule, never a reachability rule.
+    If suspension alone empties the ready frontier, activation is recomputed
+    once without it. The controller was not in the empty frontier and cannot
+    fire, so gate-first ordering is vacuous and master reachability applies.
+
     A node is ready when:
     1. All its inputs have values in state (or have defaults/bounds)
     2. The node hasn't been executed yet, OR
@@ -53,49 +58,57 @@ def get_ready_nodes(
     Returns:
         List of nodes ready to execute
     """
-    # First, identify which nodes are activated by gates
-    activated_nodes = _get_activated_nodes(graph, state)
     if startup_predecessors is None:
         startup_predecessors = compute_startup_predecessors(graph, active_nodes=active_nodes)
 
     candidate_set = set(candidate_nodes) if candidate_nodes is not None else None
     ordered_names = tuple(execution_order) if execution_order is not None else tuple(graph._nodes)
 
-    ready = []
-    for node_name in ordered_names:
-        node = graph._nodes[node_name]
-        if active_nodes is not None and node.name not in active_nodes:
-            continue
-        if candidate_set is not None and node.name not in candidate_set:
-            continue
-        if _is_node_ready(node, graph, state, activated_nodes, startup_predecessors=startup_predecessors):
-            ready.append(node)
-
-    # If a gate is ready, its routing decision should apply before targets run.
-    # Block targets of ready gates for this superstep so decisions take effect
-    # on the next iteration.
     from hypergraph.nodes.gate import END, GateNode
 
-    ready_gate_names = {n.name for n in ready if isinstance(n, GateNode)}
-    if ready_gate_names:
-        blocked_targets: set[str] = set()
-        for gate_name in ready_gate_names:
-            gate = graph._nodes.get(gate_name)
-            if gate is None:
+    activated_nodes = _get_activated_nodes(graph, state)
+    suspension_lifted = False
+    while True:
+        ready = []
+        for node_name in ordered_names:
+            node = graph._nodes[node_name]
+            if active_nodes is not None and node.name not in active_nodes:
                 continue
-            for target in gate.targets:
-                if target is END:
-                    continue
-                if target == gate_name:
-                    continue
-                blocked_targets.add(target)
-        if blocked_targets:
-            ready = [n for n in ready if n.name not in blocked_targets]
+            if candidate_set is not None and node.name not in candidate_set:
+                continue
+            if _is_node_ready(node, graph, state, activated_nodes, startup_predecessors=startup_predecessors):
+                ready.append(node)
 
-    # Defer wait_for consumers whose producers are also ready this superstep
-    ready = _defer_wait_for_nodes(ready, graph, state)
+        # If a gate is ready, its routing decision should apply before targets
+        # run. Block targets of ready gates for this superstep so decisions
+        # take effect on the next iteration.
+        ready_gate_names = {n.name for n in ready if isinstance(n, GateNode)}
+        if ready_gate_names:
+            blocked_targets: set[str] = set()
+            for gate_name in ready_gate_names:
+                gate = graph._nodes.get(gate_name)
+                if gate is None:
+                    continue
+                for target in gate.targets:
+                    if target is END:
+                        continue
+                    if target == gate_name:
+                        continue
+                    blocked_targets.add(target)
+            if blocked_targets:
+                ready = [n for n in ready if n.name not in blocked_targets]
 
-    return ready
+        # Defer wait_for consumers whose producers are also ready this
+        # superstep.
+        ready = _defer_wait_for_nodes(ready, graph, state)
+        if ready or suspension_lifted:
+            return ready
+
+        unsuspended_nodes = _get_activated_nodes(graph, state, suspend_pending_decisions=False)
+        if not unsuspended_nodes - activated_nodes:
+            return ready
+        activated_nodes = unsuspended_nodes
+        suspension_lifted = True
 
 
 def get_ready_nodes_in_component(
@@ -210,7 +223,12 @@ def gate_permits_startup(
     return gate_activated
 
 
-def _get_activated_nodes(graph: Graph, state: GraphState) -> set[str]:
+def _get_activated_nodes(
+    graph: Graph,
+    state: GraphState,
+    *,
+    suspend_pending_decisions: bool = True,
+) -> set[str]:
     """Get all nodes activated by gate routing or first-pass startup.
 
     Computed as a shrinking fixpoint so blocking propagates through chained
@@ -236,7 +254,7 @@ def _get_activated_nodes(graph: Graph, state: GraphState) -> set[str]:
     controls = _build_controls_map(graph)
     cut_gates = _compute_cut_gates(graph, state, controls)
     _drop_orphaned_decisions(state, cut_gates)
-    suspended_gates = _compute_suspended_gates(graph, state, controls)
+    suspended_gates = _compute_suspended_gates(graph, state, controls) if suspend_pending_decisions else set()
 
     activated = set(graph._nodes)
     gated_names = [name for name in graph._nodes if graph.controlled_by.get(name)]

--- a/src/hypergraph/runners/_shared/readiness.py
+++ b/src/hypergraph/runners/_shared/readiness.py
@@ -230,11 +230,13 @@ def _get_activated_nodes(graph: Graph, state: GraphState) -> set[str]:
     from collections import deque
 
     # Stale decisions must be cleared before any activation is evaluated,
-    # then orphaned decisions of cut-off gates dropped (issue #220).
+    # then orphaned decisions of cut-off gates dropped, then gates downstream
+    # of a re-firing controller transiently suspended (issue #220).
     _clear_stale_gate_decisions(graph, state)
     controls = _build_controls_map(graph)
     cut_gates = _compute_cut_gates(graph, state, controls)
     _drop_orphaned_decisions(state, cut_gates)
+    suspended_gates = _compute_suspended_gates(graph, state, controls)
 
     activated = set(graph._nodes)
     gated_names = [name for name in graph._nodes if graph.controlled_by.get(name)]
@@ -245,7 +247,7 @@ def _get_activated_nodes(graph: Graph, state: GraphState) -> set[str]:
         queued.discard(node_name)
         if node_name not in activated:
             continue
-        if _any_gate_permits_startup(node_name, graph, state, activated, cut_gates):
+        if _any_gate_permits_startup(node_name, graph, state, activated, cut_gates, suspended_gates):
             continue
         activated.discard(node_name)
         for dependent in controls.get(node_name, ()):
@@ -262,6 +264,7 @@ def _any_gate_permits_startup(
     state: GraphState,
     activated: set[str],
     cut_gates: set[str],
+    suspended_gates: set[str],
 ) -> bool:
     """Whether at least one controlling gate permits this node to start."""
     for gate_name in graph.controlled_by.get(node_name, []):
@@ -270,9 +273,10 @@ def _any_gate_permits_startup(
             continue
         decision = state.routing_decisions.get(gate_name)
         # The liveness signal matches the branch the predicate will take:
-        # a pending decision is live while its gate is not cut off; first-pass
-        # default_open permission is live while the gate is still activated.
-        alive = gate_name not in cut_gates if decision is not None else gate_name in activated
+        # a pending decision is live while its gate is neither cut off nor
+        # suspended behind a re-firing controller; first-pass default_open
+        # permission is live while the gate is still activated.
+        alive = (gate_name not in cut_gates and gate_name not in suspended_gates) if decision is not None else gate_name in activated
         if gate_permits_startup(
             node_name,
             decision=decision,
@@ -349,6 +353,47 @@ def _any_controller_keeps_alive(
         if decision is None or _is_node_activated_by_decision(gate_name, decision):
             return True
     return False
+
+
+def _compute_suspended_gates(
+    graph: Graph,
+    state: GraphState,
+    controls: dict[str, list[str]],
+) -> set[str]:
+    """Gates whose pending decisions must wait for an upstream re-fire.
+
+    When a controlling gate is scheduled to re-execute — the exact signal
+    that already clears the gate's own stale decision — its verdict is
+    pending, and chains below it must not act on previously-pending
+    downstream decisions in the same superstep: the gate fires first, then
+    its consequences propagate. Suspension spreads transitively down control
+    edges (gates only) and is recomputed from current state on every
+    evaluation, so nothing is persisted: it lifts as soon as the controller
+    has re-fired. This is what distinguishes 'controller decision None
+    because harmlessly consumed' (downstream decisions stay live) from
+    'controller decision None and controller is stale' (verdict pending —
+    wait one superstep). Independent nodes outside the re-firing gate's
+    chain are unaffected.
+    """
+    from collections import deque
+
+    from hypergraph.nodes.gate import GateNode
+
+    refiring = [
+        name
+        for name, gate in graph._nodes.items()
+        if isinstance(gate, GateNode) and name in state.node_executions and _needs_execution(gate, graph, state)
+    ]
+    suspended: set[str] = set()
+    queue = deque(refiring)
+    while queue:
+        gate_name = queue.popleft()
+        for dependent in controls.get(gate_name, ()):
+            if isinstance(graph._nodes.get(dependent), GateNode) and dependent not in suspended:
+                suspended.add(dependent)
+                queue.append(dependent)
+
+    return suspended
 
 
 def _drop_orphaned_decisions(state: GraphState, cut_gates: set[str]) -> None:

--- a/src/hypergraph/runners/_shared/readiness.py
+++ b/src/hypergraph/runners/_shared/readiness.py
@@ -175,11 +175,20 @@ def gate_permits_startup(
     node_executed: bool,
     default_open: bool,
     entrypoints: tuple[str, ...] | None,
+    gate_activated: bool = True,
 ) -> bool:
     """Return whether one controlling gate permits a target to start.
 
     The early returns mirror the canonical gate-activation decision table.
     Executed decisions take precedence over startup-only defaults.
+
+    ``gate_activated`` says whether the controlling gate itself is currently
+    activated. First-pass ``default_open`` permission is only as alive as the
+    gate handing it out: a gate whose own control path is already blocked can
+    never fire, so its targets must not start on data readiness alone
+    (transitive chain termination, issue #220). Explicit entrypoints are
+    exempt — the user asked to start there, and the controlling gate may be
+    outside the active scope entirely.
     """
     if decision is not None:
         return _is_node_activated_by_decision(node_name, decision)
@@ -189,40 +198,63 @@ def gate_permits_startup(
         return False
     if not default_open:
         return False
-    # Keep this branch explicit so the predicate mirrors the canonical table.
-    if entrypoints and node_name not in entrypoints:  # noqa: SIM103
-        return False
-    return True
+    if entrypoints:
+        return node_name in entrypoints
+    return gate_activated
 
 
 def _get_activated_nodes(graph: Graph, state: GraphState) -> set[str]:
-    """Get all nodes activated by gate routing or first-pass startup."""
+    """Get all nodes activated by gate routing or first-pass startup.
+
+    Computed as a shrinking fixpoint so blocking propagates through chained
+    gates (``gate_a -> gate_b -> target``): when ``gate_a`` decides END or
+    routes elsewhere, ``gate_b`` is deactivated, and ``target`` loses its
+    first-pass ``default_open`` permission through ``gate_b``. Starting from
+    "everything activated" (greatest fixpoint) preserves first-pass startup
+    for undecided gate chains, including gates that control each other in a
+    cycle. Decision-based activation never depends on the fixpoint, so gate
+    re-firing in cycles re-activates targets as before.
+    """
     # Stale decisions must be cleared before any activation is evaluated.
     _clear_stale_gate_decisions(graph, state)
 
-    activated: set[str] = set()
-    for node_name in graph._nodes:
-        gates = graph.controlled_by.get(node_name, [])
-        if not gates:
-            activated.add(node_name)
-            continue
-
-        for gate_name in gates:
-            gate = graph._nodes.get(gate_name)
-            if gate is None:
+    activated = set(graph._nodes)
+    gated_names = [name for name in graph._nodes if graph.controlled_by.get(name)]
+    changed = True
+    while changed:
+        changed = False
+        for node_name in gated_names:
+            if node_name not in activated:
                 continue
-            if gate_permits_startup(
-                node_name,
-                decision=state.routing_decisions.get(gate_name),
-                gate_executed=gate_name in state.node_executions,
-                node_executed=node_name in state.node_executions,
-                default_open=getattr(gate, "default_open", True),
-                entrypoints=graph.entrypoints_config,
-            ):
-                activated.add(node_name)
-                break
+            if not _any_gate_permits_startup(node_name, graph, state, activated):
+                activated.discard(node_name)
+                changed = True
 
     return activated
+
+
+def _any_gate_permits_startup(
+    node_name: str,
+    graph: Graph,
+    state: GraphState,
+    activated: set[str],
+) -> bool:
+    """Whether at least one controlling gate permits this node to start."""
+    for gate_name in graph.controlled_by.get(node_name, []):
+        gate = graph._nodes.get(gate_name)
+        if gate is None:
+            continue
+        if gate_permits_startup(
+            node_name,
+            decision=state.routing_decisions.get(gate_name),
+            gate_executed=gate_name in state.node_executions,
+            node_executed=node_name in state.node_executions,
+            default_open=getattr(gate, "default_open", True),
+            entrypoints=graph.entrypoints_config,
+            gate_activated=gate_name in activated,
+        ):
+            return True
+    return False
 
 
 def _clear_stale_gate_decisions(graph: Graph, state: GraphState) -> None:

--- a/tests/test_gate_activation_scheduling.py
+++ b/tests/test_gate_activation_scheduling.py
@@ -78,7 +78,7 @@ class TestGatePermitsStartupTable:
             pytest.param(False, False, True, ("other",), None, True, False, id="non-entrypoint-waits"),
             pytest.param(False, False, False, None, None, True, False, id="default-closed-waits"),
             pytest.param(True, False, False, ("other",), "target", True, True, id="decision-target-wins"),
-            pytest.param(True, False, False, ("other",), "target", False, True, id="decision-ignores-transitive-blocking"),
+            pytest.param(True, False, False, ("other",), "target", False, False, id="orphaned-decision-blocks"),
             pytest.param(True, True, True, None, "other", True, False, id="decision-other-blocks"),
             pytest.param(True, False, True, None, None, True, False, id="stale-cleared-decision-blocks"),
         ],
@@ -270,6 +270,145 @@ class TestTransitiveChainActivation:
 
         assert "gate_b" in activated, "gate_a's decision activates gate_b"
         assert "target" in activated, "default_open flows through the activated gate_b"
+
+
+class TestOrphanedDecisionClearing:
+    """A pending decision is live only while its gate is not cut off upstream."""
+
+    @staticmethod
+    def _executed(node_name: str, input_versions: dict | None = None) -> NodeExecution:
+        return NodeExecution(node_name=node_name, input_versions=input_versions or {"x": 1}, outputs={})
+
+    @staticmethod
+    def _chain_graph():
+        @node(output_name="result")
+        def target(x: int) -> int:
+            return x
+
+        @route(targets=["target", END])
+        def gate_b(x: int) -> str:
+            return "target"
+
+        @route(targets=["gate_b", END])
+        def gate_a(x: int) -> str:
+            return "gate_b"
+
+        return Graph([gate_a, gate_b, target])
+
+    def _state(self, decisions: dict, executed: tuple[str, ...]) -> GraphState:
+        return GraphState(
+            values={"x": 1},
+            versions={"x": 1},
+            node_executions={name: self._executed(name) for name in executed},
+            routing_decisions=dict(decisions),
+        )
+
+    def test_explicit_upstream_end_orphans_pending_decision(self):
+        graph = self._chain_graph()
+        state = self._state({"gate_a": END, "gate_b": "target"}, executed=("gate_a", "gate_b"))
+
+        activated = readiness_module._get_activated_nodes(graph, state)
+
+        assert "gate_b" not in state.routing_decisions, "orphaned decision must be dropped"
+        assert "target" not in activated
+        assert state.routing_decisions.get("gate_a") is END, "END stays as terminal marker"
+
+    def test_consumed_upstream_selection_keeps_pending_decision(self):
+        graph = self._chain_graph()
+        # gate_a executed and its selection was consumed (no current decision).
+        state = self._state({"gate_b": "target"}, executed=("gate_a", "gate_b"))
+
+        activated = readiness_module._get_activated_nodes(graph, state)
+
+        assert state.routing_decisions.get("gate_b") == "target", "consumed upstream keeps decision live"
+        assert "target" in activated
+
+    def test_orphaning_is_transitive_across_gates(self):
+        @node(output_name="result")
+        def target(x: int) -> int:
+            return x
+
+        @route(targets=["target", END])
+        def gate_c(x: int) -> str:
+            return "target"
+
+        @route(targets=["gate_c", END])
+        def gate_b(x: int) -> str:
+            return "gate_c"
+
+        @route(targets=["gate_b", END])
+        def gate_a(x: int) -> str:
+            return "gate_b"
+
+        graph = Graph([gate_a, gate_b, gate_c, target])
+        state = self._state(
+            {"gate_a": END, "gate_b": "gate_c", "gate_c": "target"},
+            executed=("gate_a", "gate_b", "gate_c"),
+        )
+
+        activated = readiness_module._get_activated_nodes(graph, state)
+
+        assert "gate_b" not in state.routing_decisions
+        assert "gate_c" not in state.routing_decisions, "orphaning must cascade through the chain"
+        assert "target" not in activated
+
+    def test_cut_gate_keeps_its_end_decision(self):
+        graph = self._chain_graph()
+        state = self._state({"gate_a": END, "gate_b": END}, executed=("gate_a", "gate_b"))
+
+        readiness_module._get_activated_nodes(graph, state)
+
+        assert state.routing_decisions.get("gate_b") is END, "END activates nothing and is kept"
+
+
+class TestActivationCostLinear:
+    """C10: activation is a worklist — linear predicate calls on long chains."""
+
+    N = 2000
+
+    @classmethod
+    def _chain_nodes(cls):
+        from hypergraph.nodes.gate import RouteNode
+
+        def make_router(next_name: str):
+            def router(x: int) -> str:
+                return next_name
+
+            return router
+
+        gates = [RouteNode(make_router(f"g{i + 1}"), targets=[f"g{i + 1}"], name=f"g{i}") for i in range(cls.N - 1)]
+
+        @node(output_name="terminal_out")
+        def terminal(x: int) -> int:
+            return x
+
+        gates.append(RouteNode(make_router("terminal"), targets=["terminal"], name=f"g{cls.N - 1}"))
+        return [*gates, terminal]
+
+    @pytest.mark.parametrize("order", ["forward", "reversed"])
+    def test_end_at_head_costs_linear_predicate_calls(self, order, monkeypatch):
+        nodes = self._chain_nodes()
+        graph = Graph(nodes if order == "forward" else list(reversed(nodes)))
+        state = GraphState(
+            values={"x": 1},
+            versions={"x": 1},
+            node_executions={"g0": NodeExecution(node_name="g0", input_versions={"x": 1}, outputs={})},
+            routing_decisions={"g0": END},
+        )
+
+        calls = {"count": 0}
+        real_predicate = readiness_module.gate_permits_startup
+
+        def counting_predicate(*args, **kwargs):
+            calls["count"] += 1
+            return real_predicate(*args, **kwargs)
+
+        monkeypatch.setattr(readiness_module, "gate_permits_startup", counting_predicate)
+
+        activated = readiness_module._get_activated_nodes(graph, state)
+
+        assert activated == {"g0"}, "END at the head deactivates the whole chain"
+        assert calls["count"] <= 5 * self.N, f"expected linear predicate calls, got {calls['count']}"
 
 
 class TestPendingActivationRetrigger:

--- a/tests/test_gate_activation_scheduling.py
+++ b/tests/test_gate_activation_scheduling.py
@@ -67,16 +67,20 @@ class TestGatePermitsStartupTable:
             "default_open",
             "entrypoints",
             "decision",
+            "gate_activated",
             "expected",
         ),
         [
-            pytest.param(False, False, True, None, None, True, id="never-never-default-open"),
-            pytest.param(False, False, True, ("target",), None, True, id="entrypoint-target-starts"),
-            pytest.param(False, False, True, ("other",), None, False, id="non-entrypoint-waits"),
-            pytest.param(False, False, False, None, None, False, id="default-closed-waits"),
-            pytest.param(True, False, False, ("other",), "target", True, id="decision-target-wins"),
-            pytest.param(True, True, True, None, "other", False, id="decision-other-blocks"),
-            pytest.param(True, False, True, None, None, False, id="stale-cleared-decision-blocks"),
+            pytest.param(False, False, True, None, None, True, True, id="never-never-default-open"),
+            pytest.param(False, False, True, None, None, False, False, id="gate-itself-blocked-transitive"),
+            pytest.param(False, False, True, ("target",), None, True, True, id="entrypoint-target-starts"),
+            pytest.param(False, False, True, ("target",), None, False, True, id="entrypoint-target-exempt-from-transitive"),
+            pytest.param(False, False, True, ("other",), None, True, False, id="non-entrypoint-waits"),
+            pytest.param(False, False, False, None, None, True, False, id="default-closed-waits"),
+            pytest.param(True, False, False, ("other",), "target", True, True, id="decision-target-wins"),
+            pytest.param(True, False, False, ("other",), "target", False, True, id="decision-ignores-transitive-blocking"),
+            pytest.param(True, True, True, None, "other", True, False, id="decision-other-blocks"),
+            pytest.param(True, False, True, None, None, True, False, id="stale-cleared-decision-blocks"),
         ],
     )
     def test_canonical_decision_table(
@@ -86,6 +90,7 @@ class TestGatePermitsStartupTable:
         default_open,
         entrypoints,
         decision,
+        gate_activated,
         expected,
     ):
         assert (
@@ -96,6 +101,7 @@ class TestGatePermitsStartupTable:
                 node_executed=node_executed,
                 default_open=default_open,
                 entrypoints=entrypoints,
+                gate_activated=gate_activated,
             )
             is expected
         )
@@ -198,6 +204,72 @@ class TestGatePermitsStartupTable:
 
         assert (gate.name in state.routing_decisions) is expected_present
         assert (target.name in activated) is expected_activated
+
+
+class TestTransitiveChainActivation:
+    """Blocking propagates through chained gates via the activation fixpoint."""
+
+    @staticmethod
+    def _chain_graph():
+        @node(output_name="result")
+        def target(x: int) -> int:
+            return x
+
+        @route(targets=["target", END])
+        def gate_b(x: int) -> str:
+            return "target"
+
+        @route(targets=["gate_b", END])
+        def gate_a(x: int) -> str:
+            return "gate_b"
+
+        return Graph([gate_a, gate_b, target])
+
+    def test_undecided_chain_is_fully_open_on_first_pass(self):
+        graph = self._chain_graph()
+        activated = readiness_module._get_activated_nodes(graph, GraphState())
+        assert activated == {"gate_a", "gate_b", "target"}
+
+    def test_end_at_head_deactivates_whole_chain(self):
+        graph = self._chain_graph()
+        state = GraphState(
+            values={"x": 1},
+            versions={"x": 1},
+            node_executions={
+                "gate_a": NodeExecution(
+                    node_name="gate_a",
+                    input_versions={"x": 1},
+                    outputs={},
+                )
+            },
+            routing_decisions={"gate_a": END},
+        )
+
+        activated = readiness_module._get_activated_nodes(graph, state)
+
+        assert "gate_b" not in activated, "END at gate_a blocks gate_b"
+        assert "target" not in activated, "blocking must propagate through gate_b"
+        assert "gate_a" in activated
+
+    def test_decision_for_mid_gate_keeps_chain_alive(self):
+        graph = self._chain_graph()
+        state = GraphState(
+            values={"x": 1},
+            versions={"x": 1},
+            node_executions={
+                "gate_a": NodeExecution(
+                    node_name="gate_a",
+                    input_versions={"x": 1},
+                    outputs={},
+                )
+            },
+            routing_decisions={"gate_a": "gate_b"},
+        )
+
+        activated = readiness_module._get_activated_nodes(graph, state)
+
+        assert "gate_b" in activated, "gate_a's decision activates gate_b"
+        assert "target" in activated, "default_open flows through the activated gate_b"
 
 
 class TestPendingActivationRetrigger:

--- a/tests/test_gate_activation_scheduling.py
+++ b/tests/test_gate_activation_scheduling.py
@@ -361,6 +361,58 @@ class TestOrphanedDecisionClearing:
         assert state.routing_decisions.get("gate_b") is END, "END activates nothing and is kept"
 
 
+class TestSuspendedPendingDecisions:
+    """C12: a pending decision waits while an upstream controller re-fires."""
+
+    @staticmethod
+    def _refire_graph():
+        @node(output_name="result")
+        def target(x: int) -> int:
+            return x
+
+        @route(targets=["target", END])
+        def gate_b(x: int) -> str:
+            return "target"
+
+        @route(targets=["gate_b", END])
+        def gate_a(x: int, y: int) -> str:
+            return "gate_b"
+
+        return Graph([gate_a, gate_b, target])
+
+    @staticmethod
+    def _state(*, gate_a_stale: bool) -> GraphState:
+        # y changed after gate_a executed iff gate_a_stale; gate_b's own
+        # inputs (x only) are unchanged either way.
+        return GraphState(
+            values={"x": 1, "y": 2},
+            versions={"x": 1, "y": 2 if gate_a_stale else 1},
+            node_executions={
+                "gate_a": NodeExecution(node_name="gate_a", input_versions={"x": 1, "y": 1}, outputs={}),
+                "gate_b": NodeExecution(node_name="gate_b", input_versions={"x": 1}, outputs={}),
+            },
+            routing_decisions={"gate_b": "target"},
+        )
+
+    def test_pending_decision_suspended_while_controller_refires(self):
+        graph = self._refire_graph()
+        state = self._state(gate_a_stale=True)
+
+        activated = readiness_module._get_activated_nodes(graph, state)
+
+        assert "target" not in activated, "verdict pending: decision must wait for gate_a's re-fire"
+        assert state.routing_decisions.get("gate_b") == "target", "suspension is transient — decision is kept, not dropped"
+        assert "gate_a" in activated
+
+    def test_pending_decision_live_when_controller_quiescent(self):
+        graph = self._refire_graph()
+        state = self._state(gate_a_stale=False)
+
+        activated = readiness_module._get_activated_nodes(graph, state)
+
+        assert "target" in activated, "quiescent consumed controller keeps the decision live"
+
+
 class TestActivationCostLinear:
     """C10: activation is a worklist — linear predicate calls on long chains."""
 

--- a/tests/test_transitive_gate_routing.py
+++ b/tests/test_transitive_gate_routing.py
@@ -426,6 +426,110 @@ async def test_pending_decision_survives_consumed_upstream_selection(runner_kind
 
 
 # ---------------------------------------------------------------------------
+# C12 — same-SCC escape: a pending decision must wait for an upstream re-fire
+# ---------------------------------------------------------------------------
+
+
+def build_same_scc_graph():
+    """Reviewer's same-SCC falsifier: target feeds back into gate_a
+    (target_out), so the whole chain shares one execution component and the
+    frontier defers nothing. ``fuel`` (produced by advance) makes target ready
+    in exactly the superstep where gate_a goes stale and re-fires."""
+
+    @node(output_name="n")
+    def start(x: int) -> int:
+        return x
+
+    @route(targets=["gate_b", END])
+    def gate_a(n: int, bump: int = 0, target_out: int = 0):
+        return "gate_b" if bump == 0 else END
+
+    @route(targets=["advance", "target"], multi_target=True)
+    def gate_b(n: int) -> list[str]:
+        return ["advance", "target"]
+
+    @node(output_name=("bump", "fuel"))
+    def advance(n: int) -> tuple[int, int]:
+        return 1, 1
+
+    @node(output_name="target_out")
+    def target(n: int, fuel: int) -> int:
+        return n * 420
+
+    return Graph(
+        [start, gate_a, gate_b, advance, target],
+        name="same_scc_orphan",
+        entrypoint="start",
+    )
+
+
+@pytest.mark.parametrize("runner_kind", RUNNER_KINDS)
+async def test_same_scc_pending_decision_waits_for_upstream_refire(runner_kind):
+    """target sits INSIDE the cycle SCC, so it becomes ready in exactly the
+    superstep where gate_a re-fires with END. gate_b's leftover ["target"]
+    selection must not start target in that superstep: the re-firing gate's
+    verdict comes first, then its consequences propagate."""
+
+    graph = build_same_scc_graph()
+    listener = ListProcessor()
+
+    result = await run_graph(
+        runner_kind,
+        graph,
+        {"x": 1},
+        event_processors=[listener],
+    )
+
+    assert result.completed
+    assert result["bump"] == 1, "advance legitimately ran off gate_b's selection"
+    assert "target_out" not in result.values, "pending decision must wait for the upstream re-fire verdict"
+    assert "target" not in listener.node_names()
+    assert {"start", "gate_a", "gate_b", "advance"} <= listener.node_names()
+
+
+@pytest.mark.parametrize("runner_kind", RUNNER_KINDS)
+async def test_ungated_sibling_runs_in_the_refire_superstep(runner_kind):
+    """The parallelism falsifier for C12: suppression is scoped to the
+    re-firing gate's chain. An ungated sibling inside the same SCC that goes
+    stale on the loop counter still runs — co-batched with the very
+    supersteps in which the gate re-fires."""
+
+    @node(output_name="count")
+    def increment(count: int) -> int:
+        return count + 1
+
+    @route(targets=["gate_inner", END])
+    def gate_outer(count: int, side_out: int = 0):
+        return "gate_inner" if count < 3 else END
+
+    @route(targets=["increment"])
+    def gate_inner(count: int) -> str:
+        return "increment"
+
+    @node(output_name="side_out")
+    def side(count: int) -> int:
+        return count * 10
+
+    graph = Graph(
+        [increment, gate_outer, gate_inner, side],
+        name="cycle_with_sibling",
+        entrypoint="increment",
+    )
+
+    result = await run_graph(runner_kind, graph, {"count": 0})
+
+    assert result.completed
+    assert result["count"] == 3
+    assert result["side_out"] == 30, "ungated sibling must keep re-running with the loop"
+
+    gate_supersteps = [record.superstep for record in result.log.steps if record.node_name == "gate_outer"]
+    side_supersteps = [record.superstep for record in result.log.steps if record.node_name == "side"]
+    refire_supersteps = set(gate_supersteps[1:])
+    assert refire_supersteps, "gate_outer must have re-fired"
+    assert set(side_supersteps) & refire_supersteps, "side must co-batch with a gate_outer re-fire superstep"
+
+
+# ---------------------------------------------------------------------------
 # C7 — chained gates in a cycle: gate-driven re-activation still re-executes
 # ---------------------------------------------------------------------------
 

--- a/tests/test_transitive_gate_routing.py
+++ b/tests/test_transitive_gate_routing.py
@@ -1,0 +1,366 @@
+"""Transitive routing across chained gates (issue #220).
+
+For a chain ``gate_a -> gate_b -> process`` where every node can read a graph
+input directly, terminating the route at ``gate_a`` must also block ``gate_b``
+and ``process``. Data readiness must not bypass an unselected or terminated
+control path — and flipping the gate decisions must flip the outcome (no
+over-blocking).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hypergraph import END, AsyncRunner, Graph, SyncRunner, node, route
+from hypergraph.events import EventProcessor
+from hypergraph.events.types import NodeEndEvent, NodeStartEvent
+
+RUNNER_KINDS = ("sync", "async")
+
+
+class ListProcessor(EventProcessor):
+    """Collects all events for assertion."""
+
+    def __init__(self):
+        self.events: list = []
+
+    def on_event(self, event):
+        self.events.append(event)
+
+    def node_names(self, *event_types) -> set[str]:
+        types = event_types or (NodeStartEvent, NodeEndEvent)
+        return {e.node_name for e in self.events if isinstance(e, types)}
+
+
+async def run_graph(runner_kind: str, graph: Graph, inputs: dict, **kwargs):
+    if runner_kind == "sync":
+        return SyncRunner().run(graph, inputs, **kwargs)
+    return await AsyncRunner().run(graph, inputs, **kwargs)
+
+
+def build_chain_graph() -> Graph:
+    """gate_a -> gate_b -> process, all three read graph input ``x``."""
+
+    @node(output_name="processed")
+    def process(x: int) -> int:
+        return x * 10
+
+    @route(targets=["process", END])
+    def gate_b(x: int, b_end: bool):
+        return END if b_end else "process"
+
+    @route(targets=["gate_b", END])
+    def gate_a(x: int, a_end: bool):
+        return END if a_end else "gate_b"
+
+    return Graph([gate_a, gate_b, process], name="chain")
+
+
+# ---------------------------------------------------------------------------
+# C1 — END at the first gate blocks the whole downstream chain
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("runner_kind", RUNNER_KINDS)
+async def test_end_at_first_gate_blocks_terminal_node(runner_kind):
+    graph = build_chain_graph()
+    listener = ListProcessor()
+
+    result = await run_graph(
+        runner_kind,
+        graph,
+        {"x": 1, "a_end": True, "b_end": False},
+        event_processors=[listener],
+    )
+
+    assert result.completed
+    assert "processed" not in result.values, "process must not run when gate_a returns END"
+    executed = listener.node_names()
+    assert "process" not in executed
+    assert "gate_b" not in executed
+    assert "gate_a" in executed
+
+
+# ---------------------------------------------------------------------------
+# C2 — falsifier: both gates select, terminal node runs normally
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("runner_kind", RUNNER_KINDS)
+async def test_both_gates_select_terminal_node_executes(runner_kind):
+    graph = build_chain_graph()
+    listener = ListProcessor()
+
+    result = await run_graph(
+        runner_kind,
+        graph,
+        {"x": 1, "a_end": False, "b_end": False},
+        event_processors=[listener],
+    )
+
+    assert result.completed
+    assert result["processed"] == 10
+    executed = listener.node_names()
+    assert {"gate_a", "gate_b", "process"} <= executed
+
+
+# ---------------------------------------------------------------------------
+# C3 — mid-chain END: first gate selects, second gate terminates
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("runner_kind", RUNNER_KINDS)
+async def test_mid_chain_end_blocks_terminal_node(runner_kind):
+    graph = build_chain_graph()
+    listener = ListProcessor()
+
+    result = await run_graph(
+        runner_kind,
+        graph,
+        {"x": 1, "a_end": False, "b_end": True},
+        event_processors=[listener],
+    )
+
+    assert result.completed
+    assert "processed" not in result.values
+    executed = listener.node_names()
+    assert "process" not in executed
+    assert {"gate_a", "gate_b"} <= executed
+
+
+# ---------------------------------------------------------------------------
+# C4 — a blocked node leaves no execution artifacts on any surface:
+#      result values, events, checkpoint steps, progress rows.
+# ---------------------------------------------------------------------------
+
+
+def _progress_row_names(progress) -> set[str]:
+    return {state.name for state in progress._tracker.node_bars.values()}
+
+
+async def test_blocked_node_has_no_artifacts_async_runner():
+    from hypergraph.checkpointers import MemoryCheckpointer
+    from hypergraph.events.rich_progress import RichProgressProcessor
+
+    graph = build_chain_graph()
+    listener = ListProcessor()
+    progress = RichProgressProcessor(force_mode="non-tty", transient=True)
+    checkpointer = MemoryCheckpointer()
+    runner = AsyncRunner(checkpointer=checkpointer)
+
+    result = await runner.run(
+        graph,
+        {"x": 1, "a_end": True, "b_end": False},
+        workflow_id="wf-blocked",
+        event_processors=[listener, progress],
+    )
+
+    assert result.completed
+    steps = await checkpointer.get_steps("wf-blocked")
+    step_names = {step.node_name for step in steps}
+    log_names = {record.node_name for record in result.log.steps} if result.log else set()
+
+    for blocked in ("gate_b", "process"):
+        assert blocked not in result.values
+        assert "processed" not in result.values
+        assert blocked not in listener.node_names()
+        assert blocked not in step_names, f"no checkpoint StepRecord for {blocked}"
+        assert blocked not in log_names, f"no RunLog record for {blocked}"
+        assert blocked not in _progress_row_names(progress), f"no progress row for {blocked}"
+
+    # The other direction: the node that DID run has every artifact.
+    assert "gate_a" in listener.node_names()
+    assert "gate_a" in step_names
+    assert "gate_a" in log_names
+    assert "gate_a" in _progress_row_names(progress)
+
+
+def test_blocked_node_has_no_artifacts_sync_runner(tmp_path):
+    pytest.importorskip("aiosqlite")
+    from hypergraph.checkpointers import SqliteCheckpointer
+    from hypergraph.checkpointers._migrate import ensure_schema
+    from hypergraph.events.rich_progress import RichProgressProcessor
+
+    checkpointer = SqliteCheckpointer(str(tmp_path / "chain.db"))
+    db = checkpointer._sync_db()
+    ensure_schema(db)
+    try:
+        graph = build_chain_graph()
+        listener = ListProcessor()
+        progress = RichProgressProcessor(force_mode="non-tty", transient=True)
+        runner = SyncRunner(checkpointer=checkpointer)
+
+        result = runner.run(
+            graph,
+            {"x": 1, "a_end": True, "b_end": False},
+            workflow_id="wf-blocked-sync",
+            event_processors=[listener, progress],
+        )
+
+        assert result.completed
+        rows = db.execute(
+            "SELECT node_name FROM steps WHERE run_id = ?",
+            ("wf-blocked-sync",),
+        ).fetchall()
+        step_names = {row[0] for row in rows}
+        log_names = {record.node_name for record in result.log.steps} if result.log else set()
+
+        for blocked in ("gate_b", "process"):
+            assert "processed" not in result.values
+            assert blocked not in listener.node_names()
+            assert blocked not in step_names, f"no checkpoint StepRecord for {blocked}"
+            assert blocked not in log_names, f"no RunLog record for {blocked}"
+            assert blocked not in _progress_row_names(progress), f"no progress row for {blocked}"
+
+        assert "gate_a" in listener.node_names()
+        assert "gate_a" in step_names
+        assert "gate_a" in log_names
+        assert "gate_a" in _progress_row_names(progress)
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# C6 — no collateral damage: independent (ungated) paths keep running
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("runner_kind", RUNNER_KINDS)
+async def test_ungated_sibling_still_runs_when_chain_terminates(runner_kind):
+    """A node with no controlling gate runs regardless of the gate chain."""
+
+    @node(output_name="processed")
+    def process(x: int) -> int:
+        return x * 10
+
+    @node(output_name="side_out")
+    def side(x: int) -> int:
+        return x + 100
+
+    @route(targets=["process", END])
+    def gate_b(x: int, b_end: bool):
+        return END if b_end else "process"
+
+    @route(targets=["gate_b", END])
+    def gate_a(x: int, a_end: bool):
+        return END if a_end else "gate_b"
+
+    graph = Graph([gate_a, gate_b, process, side], name="chain_with_side")
+
+    result = await run_graph(runner_kind, graph, {"x": 1, "a_end": True, "b_end": False})
+
+    assert result.completed
+    assert result["side_out"] == 101, "ungated node must keep running"
+    assert "processed" not in result.values
+
+
+@pytest.mark.parametrize("runner_kind", RUNNER_KINDS)
+async def test_gated_node_with_ungated_data_feed_is_still_blocked(runner_kind):
+    """A node whose ONLY control path is a dead gate chain stays blocked even
+    when an ungated node produces its data input."""
+
+    @node(output_name="prepared")
+    def prep(x: int) -> int:
+        return x + 1
+
+    @node(output_name="final")
+    def consume(prepared: int) -> int:
+        return prepared * 2
+
+    @route(targets=["consume", END])
+    def gate_b(x: int, b_end: bool):
+        return END if b_end else "consume"
+
+    @route(targets=["gate_b", END])
+    def gate_a(x: int, a_end: bool):
+        return END if a_end else "gate_b"
+
+    graph = Graph([gate_a, gate_b, prep, consume], name="chain_with_feed")
+    listener = ListProcessor()
+
+    result = await run_graph(
+        runner_kind,
+        graph,
+        {"x": 1, "a_end": True, "b_end": False},
+        event_processors=[listener],
+    )
+
+    assert result.completed
+    assert result["prepared"] == 2, "ungated producer still runs"
+    assert "final" not in result.values, "gate-targeted consumer must stay blocked"
+    assert "consume" not in listener.node_names()
+
+
+@pytest.mark.parametrize("runner_kind", RUNNER_KINDS)
+@pytest.mark.parametrize("head_end", [True, False])
+async def test_multi_target_gate_behind_terminated_gate(runner_kind, head_end):
+    """A multi-target gate chained behind a routing gate: END upstream blocks
+    every fanned-out target; selection activates all of them."""
+
+    @node(output_name="left_out")
+    def left(x: int) -> int:
+        return x + 1
+
+    @node(output_name="right_out")
+    def right(x: int) -> int:
+        return x + 2
+
+    @route(targets=["left", "right"], multi_target=True)
+    def fanout(x: int) -> list[str]:
+        return ["left", "right"]
+
+    @route(targets=["fanout", END])
+    def gate_head(x: int, head_end: bool):
+        return END if head_end else "fanout"
+
+    graph = Graph([gate_head, fanout, left, right], name="chain_multi")
+
+    result = await run_graph(runner_kind, graph, {"x": 1, "head_end": head_end})
+
+    assert result.completed
+    if head_end:
+        assert "left_out" not in result.values
+        assert "right_out" not in result.values
+    else:
+        assert result["left_out"] == 2
+        assert result["right_out"] == 3
+
+
+# ---------------------------------------------------------------------------
+# C7 — chained gates in a cycle: gate-driven re-activation still re-executes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("runner_kind", RUNNER_KINDS)
+async def test_chained_gate_cycle_refires_until_end(runner_kind):
+    """increment -> gate_outer -> gate_inner -> increment loops until END.
+
+    The transitive-blocking fix must not latch a gated node as permanently
+    blocked: each iteration's routing decision re-activates the chain.
+    """
+
+    @node(output_name="count")
+    def increment(count: int) -> int:
+        return count + 1
+
+    @route(targets=["increment"])
+    def gate_inner(count: int) -> str:
+        return "increment"
+
+    @route(targets=["gate_inner", END])
+    def gate_outer(count: int):
+        return "gate_inner" if count < 3 else END
+
+    graph = Graph(
+        [increment, gate_outer, gate_inner],
+        name="chained_gate_cycle",
+        entrypoint="increment",
+    )
+    listener = ListProcessor()
+
+    result = await run_graph(runner_kind, graph, {"count": 0}, event_processors=[listener])
+
+    assert result.completed
+    assert result["count"] == 3
+    increments = [e for e in listener.events if isinstance(e, NodeEndEvent) and e.node_name == "increment"]
+    assert len(increments) == 3, "gate-controlled node must re-fire on each routed iteration"

--- a/tests/test_transitive_gate_routing.py
+++ b/tests/test_transitive_gate_routing.py
@@ -327,6 +327,105 @@ async def test_multi_target_gate_behind_terminated_gate(runner_kind, head_end):
 
 
 # ---------------------------------------------------------------------------
+# C9 — an unconsumed mid-chain decision dies when upstream explicitly ENDs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("runner_kind", RUNNER_KINDS)
+async def test_orphaned_mid_chain_decision_does_not_fire_target(runner_kind):
+    """Reviewer repro: start -> gate_a -> gate_b(selects [advance, target]) ->
+    advance runs -> advance's output re-fires gate_a with END -> target must
+    NOT run off gate_b's leftover pending decision.
+
+    ``target`` sits outside the cycle SCC, so the frontier defers it until the
+    cycle quiesces — by which time gate_a has explicitly terminated the chain.
+    gate_b's half-consumed ["target"] selection is causally dead and must not
+    activate anything.
+    """
+
+    @node(output_name="n")
+    def start(x: int) -> int:
+        return x
+
+    @route(targets=["gate_b", END])
+    def gate_a(n: int, bump: int = 0):
+        return "gate_b" if bump == 0 else END
+
+    @route(targets=["advance", "target"], multi_target=True)
+    def gate_b(n: int) -> list[str]:
+        return ["advance", "target"]
+
+    @node(output_name="bump")
+    def advance(n: int) -> int:
+        return 1
+
+    @node(output_name="target_out")
+    def target(n: int) -> int:
+        return n * 420
+
+    graph = Graph(
+        [start, gate_a, gate_b, advance, target],
+        name="orphaned_decision",
+        entrypoint="start",
+    )
+    listener = ListProcessor()
+
+    result = await run_graph(
+        runner_kind,
+        graph,
+        {"x": 1},
+        event_processors=[listener],
+    )
+
+    assert result.completed
+    assert result["bump"] == 1, "advance legitimately ran off gate_b's selection"
+    assert "target_out" not in result.values, "orphaned pending decision must not fire target"
+    executed = listener.node_names()
+    assert "target" not in executed
+    assert {"start", "gate_a", "gate_b", "advance"} <= executed
+
+
+@pytest.mark.parametrize("runner_kind", RUNNER_KINDS)
+async def test_pending_decision_survives_consumed_upstream_selection(runner_kind):
+    """The falsifier for orphaning: when upstream merely CONSUMED its decision
+    (None) rather than explicitly excluding the mid-gate, the mid-gate's
+    pending selection stays live and its target runs."""
+
+    @node(output_name="n")
+    def start(x: int) -> int:
+        return x
+
+    @route(targets=["gate_b", END])
+    def gate_a(n: int, bump: int = 0):
+        return "gate_b" if bump == 0 else END
+
+    @route(targets=["advance", "target"], multi_target=True)
+    def gate_b(n: int) -> list[str]:
+        return ["advance", "target"]
+
+    @node(output_name="bump")
+    def advance(n: int) -> int:
+        # bump stays 0: no version change, gate_a never re-fires, and its
+        # already-consumed selection (None) never excludes gate_b.
+        return 0
+
+    @node(output_name="target_out")
+    def target(n: int) -> int:
+        return n * 420
+
+    graph = Graph(
+        [start, gate_a, gate_b, advance, target],
+        name="live_decision",
+        entrypoint="start",
+    )
+
+    result = await run_graph(runner_kind, graph, {"x": 1})
+
+    assert result.completed
+    assert result["target_out"] == 420, "live pending decision must still fire target"
+
+
+# ---------------------------------------------------------------------------
 # C7 — chained gates in a cycle: gate-driven re-activation still re-executes
 # ---------------------------------------------------------------------------
 

--- a/tests/test_transitive_gate_routing.py
+++ b/tests/test_transitive_gate_routing.py
@@ -530,6 +530,65 @@ async def test_ungated_sibling_runs_in_the_refire_superstep(runner_kind):
 
 
 # ---------------------------------------------------------------------------
+# C14 — suspension must never change reachability: quiesce-time lift
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("runner_kind", RUNNER_KINDS)
+async def test_starved_stale_controller_does_not_strand_pending_target(runner_kind):
+    """gate_a goes stale (helper wrote sig) but can never re-fire: its own
+    controller gate_top already consumed its selection, so gate_a is
+    unroutable. Suspension of gate_b must not strand gate_b's pending
+    ["target"] selection forever — when nothing else can make progress,
+    gate-first is vacuous and master semantics apply: target runs."""
+
+    @node(output_name="n")
+    def start(x: int) -> int:
+        return x
+
+    @route(targets=["gate_a"])
+    def gate_top(n: int) -> str:
+        return "gate_a"
+
+    @route(targets=["gate_b", END])
+    def gate_a(n: int, sig: int = 0):
+        return "gate_b"
+
+    @route(targets=["helper", "target"], multi_target=True)
+    def gate_b(n: int) -> list[str]:
+        return ["helper", "target"]
+
+    @node(output_name=("sig", "fuel"))
+    def helper(n: int) -> tuple[int, int]:
+        return 1, 1
+
+    @node(output_name="target_out")
+    def target(n: int, fuel: int) -> int:
+        return n * 420
+
+    graph = Graph(
+        [start, gate_top, gate_a, gate_b, helper, target],
+        name="starved_controller",
+        entrypoint="start",
+    )
+    listener = ListProcessor()
+
+    result = await run_graph(
+        runner_kind,
+        graph,
+        {"x": 1},
+        event_processors=[listener],
+    )
+
+    assert result.completed
+    assert result["sig"] == 1, "helper legitimately ran off gate_b's selection"
+    assert result.values.get("target_out") == 420, "starved suspension must lift: target is reachable on master"
+
+    gate_a_runs = [e for e in listener.events if isinstance(e, NodeEndEvent) and e.node_name == "gate_a"]
+    assert len(gate_a_runs) == 1, "gate_a stays starved — the lift must not force-fire it"
+
+
+# ---------------------------------------------------------------------------
 # C7 — chained gates in a cycle: gate-driven re-activation still re-executes
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #220.

## Problem statement
For `gate_a → gate_b → process` where downstream nodes can read graph inputs directly, `process` executed even when `gate_a` returned `END` — data readiness bypassed the unselected control path, in both runners.

## Before / after
```text
Before: gate_a END → gate_b blocked, but process runs anyway (data was ready)
After:  gate-chain termination propagates transitively; process never runs,
        and no output/event/StepRecord/progress artifact is fabricated for it
```

Three adversarial review rounds hardened the fix beyond the original bug:
- **Orphaned decisions**: a mid-chain gate's unconsumed selection is deleted (transitively, cut-gate worklist) when an upstream gate's explicit current decision excludes it — merely-consumed selections stay live, preserving cycle re-firing.
- **Same-SCC gate-first**: gates below a controller about to re-fire are transiently suspended (decision kept, nothing persisted) so a pending target cannot pre-empt or co-batch with the controller's re-evaluation.
- **No reachability change**: a quiesce-time lift guarantees suspension is a same-superstep ordering rule only — if suspension is the sole thing blocking progress, it lifts (starvation falsifier proves master-equivalent completion).
- **Cost**: activation is a worklist fixpoint — 2,000-gate chain: 3,999 predicate calls (was ~2,001,000 in adverse order), proven by a counting test.

## Test plan
4 RED/GREEN commit pairs; 64 focused tests (both runners) incl. artifact-absence on four surfaces, flip-the-decision falsifiers, cycle re-fire, consumed-vs-orphaned twins, ungated-sibling parallelism, starvation lift; AGENTS.md decision table + routing docs updated. Full CI-equivalent: 3535 passed, 15 skipped. Cross-model adversarial review: 3 rounds, all findings closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chained routing behavior so termination correctly prevents downstream gates and targets from running.
  * Prevented stale or orphaned routing decisions from incorrectly reactivating blocked nodes.
  * Ensured gate re-evaluation follows the correct order, avoiding race conditions and stranded pending work.
  * Preserved parallel execution for unrelated nodes.

* **Documentation**
  * Expanded guidance on chained gates, termination, cancellation, pending decisions, and re-evaluation behavior.

* **Tests**
  * Added broad coverage for chained, cyclic, synchronous, and asynchronous routing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->