### PR TITLE
fix(runners): restore completed nested children on crash resume

### DIFF
--- a/docs/06-api-reference/checkpointers.md
+++ b/docs/06-api-reference/checkpointers.md
@@ -142,13 +142,14 @@ child is never restored as success — resume follows the ordinary failure path,
 re-executing the failed child nodes and resurfacing their error under the
 run's `error_handling` mode.
 
-Recovery is evidence-gated so it never shadows a legitimate re-execution.
-Under `retention="windowed"`, a prior completion of the same GraphNode may
-survive only as folded values in the hidden retention carrier; resume checks
-the raw step history for that evidence. When it exists (for example the next
-turn of a multi-turn conversation), the child re-executes under a fresh
-suffixed child id (`order-100/enrich/1`) with its current inputs — restore
-only happens when no trace of a prior completion exists anywhere.
+Recovery is evidence-gated so it never shadows a legitimate re-execution. A
+real persisted `COMPLETED` parent step is proof that the nested graph completed;
+folded carrier values are not, because they lack producer provenance.
+Windowed/compacted retention with nested crash-window recovery is therefore
+explicitly rejected once parent history has been compacted. Use
+`retention="full"` or `retention="latest"` for workflows that combine nested
+graphs with resume/crash recovery, or fork the workflow. Windowed support is
+tracked in #277.
 
 With a delegated runner (`as_node(runner=...)`), the child workflow persists
 in the delegated runner's checkpointer. Crash recovery reads the child's

--- a/docs/06-api-reference/checkpointers.md
+++ b/docs/06-api-reference/checkpointers.md
@@ -108,6 +108,40 @@ synchronous; async and exit modes retain their existing guarantees and report
 best-effort gaps through `result.checkpoint_ok` and
 `result.checkpoint_errors`.
 
+## Nested Recovery
+
+A nested `GraphNode` runs its child graph as its own child workflow
+(`"order-100/enrich"` under `"order-100"`). The child commits its terminal
+status before the parent writes the StepRecord for the `GraphNode`, so a crash
+can land exactly between the two:
+
+```text
+child workflow "order-100/enrich": COMPLETED
+parent StepRecord for "enrich":    missing
+```
+
+Resuming `workflow_id="order-100"` recovers this state by restoring, not
+re-running:
+
+```python
+# Before (bug): resume re-invoked the terminal child.
+runner.run(order_graph, workflow_id="order-100")
+# WorkflowAlreadyCompletedError: Workflow 'order-100/enrich' is already completed.
+
+# After: resume restores the child's persisted outputs and commits the
+# missing parent step. The child's inner nodes do not execute again.
+result = runner.run(order_graph, workflow_id="order-100")
+# result.values contains the child's outputs; the parent step is COMPLETED
+# with child_run_id "order-100/enrich".
+```
+
+The restore is truthful: no fresh child-node execution events are emitted, and
+the recovery recurses through deeper nesting (a terminal grandchild under a
+crashed middle parent heals the same way, level by level). A terminal `FAILED`
+child is never restored as success — resume follows the ordinary failure path,
+re-executing the failed child nodes and resurfacing their error under the
+run's `error_handling` mode.
+
 ## Checkpointer ABC
 
 Every checkpointer implements the same contract, so runners don't need to know which backend is behind `checkpointer=`:

--- a/docs/06-api-reference/checkpointers.md
+++ b/docs/06-api-reference/checkpointers.md
@@ -142,6 +142,19 @@ child is never restored as success — resume follows the ordinary failure path,
 re-executing the failed child nodes and resurfacing their error under the
 run's `error_handling` mode.
 
+Recovery is evidence-gated so it never shadows a legitimate re-execution.
+Under `retention="windowed"`, a prior completion of the same GraphNode may
+survive only as folded values in the hidden retention carrier; resume checks
+the raw step history for that evidence. When it exists (for example the next
+turn of a multi-turn conversation), the child re-executes under a fresh
+suffixed child id (`order-100/enrich/1`) with its current inputs — restore
+only happens when no trace of a prior completion exists anywhere.
+
+With a delegated runner (`as_node(runner=...)`), the child workflow persists
+in the delegated runner's checkpointer. Crash recovery reads the child's
+status and outputs from that store, while the parent's own step receipts stay
+in the parent runner's checkpointer.
+
 ## Checkpointer ABC
 
 Every checkpointer implements the same contract, so runners don't need to know which backend is behind `checkpointer=`:

--- a/src/hypergraph/__init__.py
+++ b/src/hypergraph/__init__.py
@@ -29,6 +29,7 @@ from hypergraph.events import (
 )
 from hypergraph.events.rich_progress import RichProgressProcessor
 from hypergraph.exceptions import (
+    CompactedRetentionError,
     ExecutionError,
     GraphChangedError,
     IncompatibleRunnerError,
@@ -115,6 +116,7 @@ __all__ = [
     # Errors
     "RenameError",
     "GraphConfigError",
+    "CompactedRetentionError",
     "MissingInputError",
     "InfiniteLoopError",
     "IncompatibleRunnerError",

--- a/src/hypergraph/exceptions.py
+++ b/src/hypergraph/exceptions.py
@@ -268,6 +268,22 @@ class WorkflowAlreadyCompletedError(Exception):
         super().__init__(f"Workflow '{workflow_id}' is already completed. Fork to create a new lineage.")
 
 
+class CompactedRetentionError(Exception):
+    """Raised when compacted history makes nested recovery ambiguous."""
+
+    def __init__(self, node_name: str) -> None:
+        self.node_name = node_name
+        super().__init__(
+            f"Cannot safely recover nested graph '{node_name}': windowed/compacted retention "
+            "may have pruned the parent step history, so Hypergraph cannot distinguish a "
+            "crash-window restore from a legitimate re-execution.\n\n"
+            "How to fix:\n"
+            "  Use retention='full' or retention='latest' for workflows that combine nested "
+            "graphs with resume/crash recovery, or fork the workflow.\n\n"
+            "Windowed nested recovery support is tracked in #277."
+        )
+
+
 class WorkflowStoppedError(Exception):
     """Raised when a stopped workflow is rerun without an explicit signal."""
 

--- a/src/hypergraph/runners/_shared/checkpoint_helpers.py
+++ b/src/hypergraph/runners/_shared/checkpoint_helpers.py
@@ -53,7 +53,13 @@ def build_superstep_records(
         execution = state.node_executions.get(name)
         now = _utcnow()
         node_type = type(graph._nodes[name]).__name__ if name in graph._nodes else None
-        if child_run_ids is not None and name in child_run_ids:
+        # The executor records the child id it actually used (crash-window
+        # restore and retention-pruned re-executions can diverge from the
+        # precomputed candidate); prefer that ground truth for the receipt.
+        recorded_child_run_id = state.graphnode_child_run_ids.get(name)
+        if recorded_child_run_id is not None:
+            child_run_id = recorded_child_run_id
+        elif child_run_ids is not None and name in child_run_ids:
             child_run_id = child_run_ids[name]
         else:
             child_run_id = _compute_child_run_id(

--- a/src/hypergraph/runners/_shared/state.py
+++ b/src/hypergraph/runners/_shared/state.py
@@ -154,6 +154,12 @@ class GraphState:
     resume_values: frozenset[str] = frozenset()
     stopped: bool = False
     stop_info: Any = None
+    # Actual child workflow id used by each GraphNode's latest execution,
+    # recorded by the executors so StepRecord receipts report the id that
+    # really ran (crash-window restore and retention-pruned re-executions can
+    # diverge from the loop's precomputed candidate). Runtime-only: checkpoint
+    # restores start fresh.
+    graphnode_child_run_ids: dict[str, str] = field(default_factory=dict)
 
     def update_value(self, name: str, value: Any) -> None:
         """Update a value and increment its version if value changed.
@@ -218,4 +224,5 @@ class GraphState:
             resume_values=frozenset(self.resume_values),
             stopped=self.stopped,
             stop_info=self.stop_info,
+            graphnode_child_run_ids=dict(self.graphnode_child_run_ids),
         )

--- a/src/hypergraph/runners/_shared/state_restore.py
+++ b/src/hypergraph/runners/_shared/state_restore.py
@@ -384,6 +384,41 @@ def graphnode_child_workflow_id(
     return f"{base}/{iteration}"
 
 
+# Mirrors the private retention-carrier constants in
+# checkpointers/sqlite.py and checkpointers/memory.py.
+_RETENTION_BASELINE_NODE_NAME = "__retained_state__"
+_RETENTION_BASELINE_NODE_TYPE = "RetentionBaseline"
+
+
+def has_prior_completion_evidence(
+    steps: list[StepRecord],
+    node: GraphNode,
+) -> bool:
+    """Durable proof that this parent run already completed this GraphNode.
+
+    Callers must pass raw step history queried with ``show_internal=True``:
+    retention compaction hides its carrier rows from public step reads, and
+    the compacted carrier is exactly where the evidence survives. Two forms:
+
+    - a COMPLETED StepRecord for the node itself (normally consumed by
+      checkpoint replay before the executor runs; kept as belt-and-suspenders),
+    - a retention-baseline carrier whose folded values contain any of the
+      node's outputs — compaction drops the node's own row but keeps its
+      produced values, which proves a prior completion.
+
+    PAUSED/FAILED rows for the node are attempt evidence, not completion
+    evidence: the crash window legitimately contains them.
+    """
+    output_names = set(node.outputs)
+    for step in steps:
+        if step.node_name == node.name and step.status is StepStatus.COMPLETED:
+            return True
+        is_baseline = step.node_name == _RETENTION_BASELINE_NODE_NAME or step.node_type == _RETENTION_BASELINE_NODE_TYPE
+        if is_baseline and step.values and output_names.intersection(step.values):
+            return True
+    return False
+
+
 def restore_completed_child_outputs(
     node: GraphNode,
     child_values: dict[str, Any],

--- a/src/hypergraph/runners/_shared/state_restore.py
+++ b/src/hypergraph/runners/_shared/state_restore.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 from hypergraph.checkpointers.types import StepRecord, StepStatus
+from hypergraph.exceptions import CompactedRetentionError
 from hypergraph.nodes.base import HyperNode
 from hypergraph.runners._shared.state import GraphState, NodeExecution
 
@@ -394,28 +395,29 @@ def has_prior_completion_evidence(
     steps: list[StepRecord],
     node: GraphNode,
 ) -> bool:
-    """Durable proof that this parent run already completed this GraphNode.
+    """Return durable proof that this parent run completed this GraphNode.
 
     Callers must pass raw step history queried with ``show_internal=True``:
-    retention compaction hides its carrier rows from public step reads, and
-    the compacted carrier is exactly where the evidence survives. Two forms:
+    retention compaction hides its carrier rows from public step reads.
 
-    - a COMPLETED StepRecord for the node itself (normally consumed by
-      checkpoint replay before the executor runs; kept as belt-and-suspenders),
-    - a retention-baseline carrier whose folded values contain any of the
-      node's outputs — compaction drops the node's own row but keeps its
-      produced values, which proves a prior completion.
+    A COMPLETED StepRecord for the node itself is durable evidence (normally
+    consumed by checkpoint replay before the executor runs; kept here as
+    belt-and-suspenders). A retention-baseline carrier is not evidence: it
+    folds values without producer provenance. Without the node's own row,
+    compacted history makes restore versus re-execution ambiguous and must be
+    rejected until provenance support tracked in #277 exists.
 
     PAUSED/FAILED rows for the node are attempt evidence, not completion
     evidence: the crash window legitimately contains them.
     """
-    output_names = set(node.outputs)
+    has_retention_baseline = False
     for step in steps:
         if step.node_name == node.name and step.status is StepStatus.COMPLETED:
             return True
         is_baseline = step.node_name == _RETENTION_BASELINE_NODE_NAME or step.node_type == _RETENTION_BASELINE_NODE_TYPE
-        if is_baseline and step.values and output_names.intersection(step.values):
-            return True
+        has_retention_baseline = has_retention_baseline or is_baseline
+    if has_retention_baseline:
+        raise CompactedRetentionError(node.name)
     return False
 
 

--- a/src/hypergraph/runners/_shared/state_restore.py
+++ b/src/hypergraph/runners/_shared/state_restore.py
@@ -72,6 +72,11 @@ def _extract_model_type(hint: Any) -> type | None:
             return hint  # return the full list[Model] hint
         return None
 
+    # tuple[...] — JSON persistence round-trips tuples as lists, so any
+    # parameterized tuple annotation is worth reconstructing on restore.
+    if origin is tuple:
+        return hint
+
     # Optional[Model] / Union[Model, None] / Model | None (PEP 604)
     if origin is Union or isinstance(hint, _types.UnionType):
         args = [a for a in get_args(hint) if a is not type(None)]
@@ -115,11 +120,34 @@ def _coerce_value(value: Any, hint: Any) -> Any:
         elem_type = args[0]
         return [_coerce_single(item, elem_type) for item in value]
 
+    # tuple[...] — rebuild the tuple, coercing model elements where annotated
+    if origin is tuple:
+        return _coerce_tuple(value, hint)
+
     # Scalar model
     if isinstance(hint, type):
         return _coerce_single(value, hint)
 
     return value
+
+
+def _coerce_tuple(value: Any, hint: Any) -> Any:
+    """Reconstruct an annotated tuple from a JSON-deserialized list."""
+    from typing import get_args
+
+    if not isinstance(value, (list, tuple)):
+        return value
+    args = get_args(hint)
+    if len(args) == 2 and args[1] is Ellipsis:
+        elem = args[0]
+        if isinstance(elem, type) and _is_model_class(elem):
+            return tuple(_coerce_single(item, elem) for item in value)
+        return tuple(value)
+    if args and len(args) == len(value):
+        return tuple(
+            _coerce_single(item, elem) if isinstance(elem, type) and _is_model_class(elem) else item for item, elem in zip(value, args, strict=False)
+        )
+    return tuple(value)
 
 
 def _coerce_single(value: Any, model: type) -> Any:

--- a/src/hypergraph/runners/_shared/state_restore.py
+++ b/src/hypergraph/runners/_shared/state_restore.py
@@ -13,6 +13,7 @@ from hypergraph.runners._shared.state import GraphState, NodeExecution
 if TYPE_CHECKING:
     from hypergraph.checkpointers.types import Checkpoint
     from hypergraph.graph import Graph
+    from hypergraph.nodes.graph_node import GraphNode
 
 
 def initialize_state(
@@ -353,6 +354,28 @@ def graphnode_child_workflow_id(
     # so advance one step beyond the highest seen value.
     iteration = max(execution.output_versions.values()) if execution.output_versions else max(execution.input_versions.values(), default=0) + 1
     return f"{base}/{iteration}"
+
+
+def restore_completed_child_outputs(
+    node: GraphNode,
+    child_values: dict[str, Any],
+) -> dict[str, Any]:
+    """Project a terminal COMPLETED child workflow's persisted state onto the parent.
+
+    Crash-window recovery: the child workflow committed COMPLETED, but the
+    parent crashed before writing its GraphNode StepRecord. On resume the
+    parent must not re-invoke the terminal child (that raises
+    ``WorkflowAlreadyCompletedError``); instead it restores the child's
+    persisted outputs so the missing parent step commits with truthful values.
+
+    Mirrors the normal execution path: values are coerced with the child
+    graph's type map (as a real child resume would), filtered to the child
+    graph's outputs, and projected through the GraphNode boundary map.
+    """
+    from hypergraph.runners._shared.outputs import filter_outputs
+
+    restored = GraphState(values=coerce_checkpoint_values(node.graph, child_values))
+    return node.map_outputs_from_original(filter_outputs(restored, node.graph))
 
 
 def validate_workflow_id(workflow_id: str | None, parent_run_id: str | None) -> None:

--- a/src/hypergraph/runners/async_/executors/graph_node.py
+++ b/src/hypergraph/runners/async_/executors/graph_node.py
@@ -64,6 +64,14 @@ class AsyncGraphNodeExecutor:
         child_workflow_id = graphnode_child_workflow_id(ctx.workflow_id, node.name, state)
         map_config = node.map_config
 
+        # Resolve the effective runner before any persistence reads: a
+        # delegated runner (runner_override) owns the child workflow's
+        # persistence boundary, while the parent's own receipts stay in the
+        # parent runner's checkpointer.
+        runner = node.runner_override or self.runner
+        parent_cp = self.runner._checkpointer
+        child_cp = getattr(runner, "_checkpointer", None)
+
         # Route interrupt resume values into the inner graph. The parent sees
         # the GraphNode's resolved output address ("decision", "review.verdict",
         # etc.); the child run resumes with the inner graph's local output name.
@@ -98,8 +106,8 @@ class AsyncGraphNodeExecutor:
                 }
             )
 
-            if map_config is None and child_workflow_id is not None and self.runner._checkpointer is not None:
-                existing_child_run = await self.runner._checkpointer.get_run_async(child_workflow_id)
+            if map_config is None and child_workflow_id is not None and parent_cp is not None and child_cp is not None:
+                existing_child_run = await child_cp.get_run_async(child_workflow_id)
                 if existing_child_run is not None:
                     if existing_child_run.status is WorkflowStatus.COMPLETED:
                         # Crash-window recovery: the child committed COMPLETED but
@@ -108,19 +116,17 @@ class AsyncGraphNodeExecutor:
                         # would raise WorkflowAlreadyCompletedError). Terminal
                         # FAILED children fall through to the resume path below so
                         # their failure resurfaces — never restored-as-success.
-                        child_values = await self.runner._checkpointer.get_state(child_workflow_id)
+                        child_values = await child_cp.get_state(child_workflow_id)
                         return restore_completed_child_outputs(node, child_values)
                     inner_inputs = {}
                 elif resume_values:
-                    current_parent_run = await self.runner._checkpointer.get_run_async(ctx.workflow_id) if ctx.workflow_id else None
+                    current_parent_run = await parent_cp.get_run_async(ctx.workflow_id) if ctx.workflow_id else None
                     source_parent_run_id = None
                     if current_parent_run is not None:
                         source_parent_run_id = current_parent_run.retry_of or current_parent_run.forked_from
                     if source_parent_run_id is not None:
                         source_child_run_id = graphnode_child_workflow_id(source_parent_run_id, node.name, state)
-                        source_child_run = (
-                            await self.runner._checkpointer.get_run_async(source_child_run_id) if source_child_run_id is not None else None
-                        )
+                        source_child_run = await child_cp.get_run_async(source_child_run_id) if source_child_run_id is not None else None
                         if source_child_run is not None:
                             inner_inputs = {}
                             if current_parent_run is not None and current_parent_run.retry_of is not None:
@@ -133,8 +139,6 @@ class AsyncGraphNodeExecutor:
             child_fork_from = None
             child_retry_from = None
 
-        # Use delegated runner if configured, otherwise inherit parent
-        runner = node.runner_override or self.runner
         accepts_checkpoint_error_sink = isinstance(runner, CheckpointErrorSinkRunner) and runner._accepts_checkpoint_error_sink is True
         if (
             ctx.checkpoint_error_sink is not None

--- a/src/hypergraph/runners/async_/executors/graph_node.py
+++ b/src/hypergraph/runners/async_/executors/graph_node.py
@@ -14,6 +14,7 @@ from hypergraph.runners._shared.results import PauseInfo, RunResult, RunStatus
 from hypergraph.runners._shared.state import PauseExecution
 from hypergraph.runners._shared.state_restore import (
     graphnode_child_workflow_id,
+    has_prior_completion_evidence,
     restore_completed_child_outputs,
 )
 
@@ -110,15 +111,42 @@ class AsyncGraphNodeExecutor:
                 existing_child_run = await child_cp.get_run_async(child_workflow_id)
                 if existing_child_run is not None:
                     if existing_child_run.status is WorkflowStatus.COMPLETED:
-                        # Crash-window recovery: the child committed COMPLETED but
-                        # this parent step was never persisted. Restore the child's
-                        # outputs instead of re-invoking the terminal child (which
-                        # would raise WorkflowAlreadyCompletedError). Terminal
-                        # FAILED children fall through to the resume path below so
-                        # their failure resurfaces — never restored-as-success.
-                        child_values = await child_cp.get_state(child_workflow_id)
-                        return restore_completed_child_outputs(node, child_values)
-                    inner_inputs = {}
+                        parent_steps = await parent_cp.get_steps(ctx.workflow_id, show_internal=True)
+                        if not has_prior_completion_evidence(parent_steps, node):
+                            # Crash-window recovery: the child committed COMPLETED
+                            # but this parent step was never persisted. Restore the
+                            # child's outputs instead of re-invoking the terminal
+                            # child (which would raise
+                            # WorkflowAlreadyCompletedError). Terminal FAILED
+                            # children fall through to the resume path below so
+                            # their failure resurfaces — never restored-as-success.
+                            state.graphnode_child_run_ids[node.name] = child_workflow_id
+                            child_values = await child_cp.get_state(child_workflow_id)
+                            return restore_completed_child_outputs(node, child_values)
+                        # A prior completion exists but its execution row was
+                        # compacted away (e.g. windowed retention), so replay
+                        # could not derive the next iteration's suffix. This is
+                        # a legitimate re-execution: advance past completed
+                        # iterations to the in-flight or first free child id.
+                        index = 1
+                        while True:
+                            candidate = f"{child_workflow_id}/{index}"
+                            candidate_run = await child_cp.get_run_async(candidate)
+                            if candidate_run is None:
+                                # Fresh iteration: mirror the already-executed
+                                # path — current inputs, no resume injection.
+                                child_workflow_id = candidate
+                                resume_values = {}
+                                break
+                            if candidate_run.status is not WorkflowStatus.COMPLETED:
+                                # In-flight iteration (paused/failed/stopped):
+                                # resume it from its own checkpoint.
+                                child_workflow_id = candidate
+                                inner_inputs = {}
+                                break
+                            index += 1
+                    else:
+                        inner_inputs = {}
                 elif resume_values:
                     current_parent_run = await parent_cp.get_run_async(ctx.workflow_id) if ctx.workflow_id else None
                     source_parent_run_id = None
@@ -138,6 +166,12 @@ class AsyncGraphNodeExecutor:
         else:
             child_fork_from = None
             child_retry_from = None
+
+        # Record the id this execution actually uses so StepRecord receipts
+        # stay truthful even when resolution diverged from the precomputed
+        # candidate (crash-window restore records inside its branch above).
+        if child_workflow_id is not None:
+            state.graphnode_child_run_ids[node.name] = child_workflow_id
 
         accepts_checkpoint_error_sink = isinstance(runner, CheckpointErrorSinkRunner) and runner._accepts_checkpoint_error_sink is True
         if (

--- a/src/hypergraph/runners/async_/executors/graph_node.py
+++ b/src/hypergraph/runners/async_/executors/graph_node.py
@@ -5,13 +5,17 @@ from __future__ import annotations
 import inspect
 from typing import TYPE_CHECKING, Any
 
+from hypergraph.checkpointers.types import WorkflowStatus
 from hypergraph.exceptions import IncompatibleRunnerError
 from hypergraph.runners._shared._inspect import current_inspection
 from hypergraph.runners._shared.outputs import collect_as_lists
 from hypergraph.runners._shared.protocols import CheckpointErrorSinkRunner
 from hypergraph.runners._shared.results import PauseInfo, RunResult, RunStatus
 from hypergraph.runners._shared.state import PauseExecution
-from hypergraph.runners._shared.state_restore import graphnode_child_workflow_id
+from hypergraph.runners._shared.state_restore import (
+    graphnode_child_workflow_id,
+    restore_completed_child_outputs,
+)
 
 if TYPE_CHECKING:
     from hypergraph.nodes.graph_node import GraphNode
@@ -97,6 +101,15 @@ class AsyncGraphNodeExecutor:
             if map_config is None and child_workflow_id is not None and self.runner._checkpointer is not None:
                 existing_child_run = await self.runner._checkpointer.get_run_async(child_workflow_id)
                 if existing_child_run is not None:
+                    if existing_child_run.status is WorkflowStatus.COMPLETED:
+                        # Crash-window recovery: the child committed COMPLETED but
+                        # this parent step was never persisted. Restore the child's
+                        # outputs instead of re-invoking the terminal child (which
+                        # would raise WorkflowAlreadyCompletedError). Terminal
+                        # FAILED children fall through to the resume path below so
+                        # their failure resurfaces — never restored-as-success.
+                        child_values = await self.runner._checkpointer.get_state(child_workflow_id)
+                        return restore_completed_child_outputs(node, child_values)
                     inner_inputs = {}
                 elif resume_values:
                     current_parent_run = await self.runner._checkpointer.get_run_async(ctx.workflow_id) if ctx.workflow_id else None

--- a/src/hypergraph/runners/sync/executors/graph_node.py
+++ b/src/hypergraph/runners/sync/executors/graph_node.py
@@ -54,6 +54,14 @@ class SyncGraphNodeExecutor:
         child_workflow_id = graphnode_child_workflow_id(ctx.workflow_id, node.name, state)
         map_config = node.map_config
 
+        # Resolve the effective runner before any persistence reads: a
+        # delegated runner (runner_override) owns the child workflow's
+        # persistence boundary, while the parent's own receipts stay in the
+        # parent runner's checkpointer.
+        runner = node.runner_override or self.runner
+        parent_cp = self.runner._get_sync_checkpointer(ctx.workflow_id)
+        child_cp = runner._get_sync_checkpointer(child_workflow_id) if hasattr(runner, "_get_sync_checkpointer") else None
+
         # Route interrupt resume values into the inner graph. The parent sees
         # the GraphNode's resolved output address ("decision", "review.verdict",
         # etc.); the child run resumes with the inner graph's local output name.
@@ -88,9 +96,8 @@ class SyncGraphNodeExecutor:
             child_fork_from: str | None = None
             child_retry_from: str | None = None
 
-            sync_cp = self.runner._get_sync_checkpointer(child_workflow_id)
-            if map_config is None and sync_cp is not None:
-                existing_child_run = sync_cp.get_run(child_workflow_id)
+            if map_config is None and child_workflow_id is not None and parent_cp is not None and child_cp is not None:
+                existing_child_run = child_cp.get_run(child_workflow_id)
                 if existing_child_run is not None:
                     if existing_child_run.status is WorkflowStatus.COMPLETED:
                         # Crash-window recovery: the child committed COMPLETED but
@@ -99,16 +106,16 @@ class SyncGraphNodeExecutor:
                         # would raise WorkflowAlreadyCompletedError). Terminal
                         # FAILED children fall through to the resume path below so
                         # their failure resurfaces — never restored-as-success.
-                        return restore_completed_child_outputs(node, sync_cp.state(child_workflow_id))
+                        return restore_completed_child_outputs(node, child_cp.state(child_workflow_id))
                     inner_inputs = {}
                 elif resume_values:
-                    current_parent_run = sync_cp.get_run(ctx.workflow_id) if ctx.workflow_id else None
+                    current_parent_run = parent_cp.get_run(ctx.workflow_id) if ctx.workflow_id else None
                     source_parent_run_id = None
                     if current_parent_run is not None:
                         source_parent_run_id = current_parent_run.retry_of or current_parent_run.forked_from
                     if source_parent_run_id is not None:
                         source_child_run_id = graphnode_child_workflow_id(source_parent_run_id, node.name, state)
-                        source_child_run = sync_cp.get_run(source_child_run_id) if source_child_run_id is not None else None
+                        source_child_run = child_cp.get_run(source_child_run_id) if source_child_run_id is not None else None
                         if source_child_run is not None:
                             inner_inputs = {}
                             if current_parent_run is not None and current_parent_run.retry_of is not None:
@@ -120,9 +127,6 @@ class SyncGraphNodeExecutor:
         else:
             child_fork_from = None
             child_retry_from = None
-
-        # Use delegated runner if configured, otherwise inherit parent
-        runner = node.runner_override or self.runner
 
         if map_config:
             _, mode, error_handling = map_config

--- a/src/hypergraph/runners/sync/executors/graph_node.py
+++ b/src/hypergraph/runners/sync/executors/graph_node.py
@@ -9,6 +9,7 @@ from hypergraph.runners._shared._inspect import current_inspection
 from hypergraph.runners._shared.outputs import collect_as_lists
 from hypergraph.runners._shared.state_restore import (
     graphnode_child_workflow_id,
+    has_prior_completion_evidence,
     restore_completed_child_outputs,
 )
 
@@ -100,14 +101,41 @@ class SyncGraphNodeExecutor:
                 existing_child_run = child_cp.get_run(child_workflow_id)
                 if existing_child_run is not None:
                     if existing_child_run.status is WorkflowStatus.COMPLETED:
-                        # Crash-window recovery: the child committed COMPLETED but
-                        # this parent step was never persisted. Restore the child's
-                        # outputs instead of re-invoking the terminal child (which
-                        # would raise WorkflowAlreadyCompletedError). Terminal
-                        # FAILED children fall through to the resume path below so
-                        # their failure resurfaces — never restored-as-success.
-                        return restore_completed_child_outputs(node, child_cp.state(child_workflow_id))
-                    inner_inputs = {}
+                        parent_steps = parent_cp.steps(ctx.workflow_id, show_internal=True)
+                        if not has_prior_completion_evidence(parent_steps, node):
+                            # Crash-window recovery: the child committed COMPLETED
+                            # but this parent step was never persisted. Restore the
+                            # child's outputs instead of re-invoking the terminal
+                            # child (which would raise
+                            # WorkflowAlreadyCompletedError). Terminal FAILED
+                            # children fall through to the resume path below so
+                            # their failure resurfaces — never restored-as-success.
+                            state.graphnode_child_run_ids[node.name] = child_workflow_id
+                            return restore_completed_child_outputs(node, child_cp.state(child_workflow_id))
+                        # A prior completion exists but its execution row was
+                        # compacted away (e.g. windowed retention), so replay
+                        # could not derive the next iteration's suffix. This is
+                        # a legitimate re-execution: advance past completed
+                        # iterations to the in-flight or first free child id.
+                        index = 1
+                        while True:
+                            candidate = f"{child_workflow_id}/{index}"
+                            candidate_run = child_cp.get_run(candidate)
+                            if candidate_run is None:
+                                # Fresh iteration: mirror the already-executed
+                                # path — current inputs, no resume injection.
+                                child_workflow_id = candidate
+                                resume_values = {}
+                                break
+                            if candidate_run.status is not WorkflowStatus.COMPLETED:
+                                # In-flight iteration (paused/failed/stopped):
+                                # resume it from its own checkpoint.
+                                child_workflow_id = candidate
+                                inner_inputs = {}
+                                break
+                            index += 1
+                    else:
+                        inner_inputs = {}
                 elif resume_values:
                     current_parent_run = parent_cp.get_run(ctx.workflow_id) if ctx.workflow_id else None
                     source_parent_run_id = None
@@ -127,6 +155,12 @@ class SyncGraphNodeExecutor:
         else:
             child_fork_from = None
             child_retry_from = None
+
+        # Record the id this execution actually uses so StepRecord receipts
+        # stay truthful even when resolution diverged from the precomputed
+        # candidate (crash-window restore records inside its branch above).
+        if child_workflow_id is not None:
+            state.graphnode_child_run_ids[node.name] = child_workflow_id
 
         if map_config:
             _, mode, error_handling = map_config

--- a/src/hypergraph/runners/sync/executors/graph_node.py
+++ b/src/hypergraph/runners/sync/executors/graph_node.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from hypergraph.checkpointers.types import WorkflowStatus
 from hypergraph.runners._shared._inspect import current_inspection
 from hypergraph.runners._shared.outputs import collect_as_lists
-from hypergraph.runners._shared.state_restore import graphnode_child_workflow_id
+from hypergraph.runners._shared.state_restore import (
+    graphnode_child_workflow_id,
+    restore_completed_child_outputs,
+)
 
 if TYPE_CHECKING:
     from hypergraph.nodes.graph_node import GraphNode
@@ -88,6 +92,14 @@ class SyncGraphNodeExecutor:
             if map_config is None and sync_cp is not None:
                 existing_child_run = sync_cp.get_run(child_workflow_id)
                 if existing_child_run is not None:
+                    if existing_child_run.status is WorkflowStatus.COMPLETED:
+                        # Crash-window recovery: the child committed COMPLETED but
+                        # this parent step was never persisted. Restore the child's
+                        # outputs instead of re-invoking the terminal child (which
+                        # would raise WorkflowAlreadyCompletedError). Terminal
+                        # FAILED children fall through to the resume path below so
+                        # their failure resurfaces — never restored-as-success.
+                        return restore_completed_child_outputs(node, sync_cp.state(child_workflow_id))
                     inner_inputs = {}
                 elif resume_values:
                     current_parent_run = sync_cp.get_run(ctx.workflow_id) if ctx.workflow_id else None

--- a/tests/test_checkpointer/test_checkpoint_type_coercion.py
+++ b/tests/test_checkpointer/test_checkpoint_type_coercion.py
@@ -242,3 +242,44 @@ class TestDataclassRestore:
         graph2 = Graph(nodes=[format_metric])
         result2 = await runner.run(graph2, checkpoint=checkpoint, workflow_id="fork-dc")
         assert result2["report"] == "accuracy=0.95"
+
+
+class TestTupleOutputRestore:
+    """JSON round-trip turns tuples into lists; restore must coerce them back.
+
+    Systemic companion to the nested crash-window restore tests: ordinary
+    checkpoint resume flows through the same coerce_checkpoint_values.
+    """
+
+    async def test_ordinary_resume_restores_annotated_tuple_output(self, tmp_path):
+        received: list[object] = []
+        fail = [True]
+
+        @node(output_name="pair")
+        def make_pair(x: int) -> tuple[int, int]:
+            return (x, x + 1)
+
+        @node(output_name="total")
+        def consume(pair: tuple[int, int]) -> int:
+            if fail[0]:
+                raise RuntimeError("boom on first run")
+            received.append(pair)
+            return pair[0] + pair[1]
+
+        graph = Graph(nodes=[make_pair, consume], name="g")
+        cp = SqliteCheckpointer(str(tmp_path / "test.db"), durability="sync")
+        try:
+            runner = AsyncRunner(checkpointer=cp)
+            with pytest.raises(RuntimeError, match="boom on first run"):
+                await runner.run(graph, {"x": 4}, workflow_id="wf")
+
+            fail[0] = False
+            result = await runner.run(graph, workflow_id="wf")
+
+            assert result.values["total"] == 9
+            assert received == [(4, 5)]
+            assert isinstance(received[0], tuple)
+            assert result.values["pair"] == (4, 5)
+            assert isinstance(result.values["pair"], tuple)
+        finally:
+            await cp.close()

--- a/tests/test_checkpointer/test_nested_crash_resume.py
+++ b/tests/test_checkpointer/test_nested_crash_resume.py
@@ -10,12 +10,13 @@ FAILED child as success.
 
 import pytest
 
-from hypergraph import AsyncRunner, Graph, SyncRunner, node
-from hypergraph.checkpointers import SqliteCheckpointer, WorkflowStatus
+from hypergraph import END, AsyncRunner, Graph, SyncRunner, interrupt, node, route
+from hypergraph.checkpointers import CheckpointPolicy, SqliteCheckpointer, WorkflowStatus
 from hypergraph.checkpointers.types import StepStatus
 from hypergraph.events import EventProcessor
 from hypergraph.events.types import NodeEndEvent, NodeStartEvent, RunStartEvent
 from hypergraph.runners._shared.results import RunStatus
+from tests._interrupt_questions import StringQuestion
 
 aiosqlite = pytest.importorskip("aiosqlite")
 
@@ -63,7 +64,7 @@ class CrashingStepCheckpointer(SqliteCheckpointer):
         super().save_step_sync(record)
 
 
-def build_nested_graph():
+def build_nested_graph(child_runner=None):
     """parent: prepare -> child_wf(double) -> consume, with invocation counters."""
     counters = {"prepare": 0, "double": 0, "consume": 0}
 
@@ -83,8 +84,42 @@ def build_nested_graph():
         return doubled + 1
 
     child = Graph(nodes=[double], name="child")
-    parent = Graph(nodes=[prepare, child.as_node(name="child_wf"), consume], name="parent")
+    parent = Graph(nodes=[prepare, child.as_node(name="child_wf", runner=child_runner), consume], name="parent")
     return parent, counters
+
+
+def build_multi_turn_graph():
+    """Cyclic chat shape: ask (interrupt) -> child_wf(respond) -> gate -> ask.
+
+    Each turn ends in a pause; every resume that supplies a new answer must
+    RE-execute the nested child under a fresh suffixed child id — never treat
+    the previous turn's terminal child as a crash window to restore from.
+    """
+    calls: list[str] = []
+
+    @interrupt(answer_name="answer")
+    def ask(prompt: str = "next?") -> StringQuestion:
+        return StringQuestion(prompt=prompt)
+
+    @node(output_name="reply")
+    def respond(answer: str) -> str:
+        calls.append(answer)
+        return f"reply:{answer}"
+
+    child = Graph(nodes=[respond], name="turn")
+
+    @route(targets=["ask", END])
+    def gate(reply: str) -> str:
+        return END if reply == "reply:two" else "ask"
+
+    parent = Graph(nodes=[ask, child.as_node(name="child_wf"), gate], name="chat", entrypoint="ask")
+    return parent, calls
+
+
+def retention_policy(retention: str) -> CheckpointPolicy:
+    if retention == "windowed":
+        return CheckpointPolicy(durability="sync", retention="windowed", window=1)
+    return CheckpointPolicy(durability="sync", retention=retention)
 
 
 def build_two_level_graph():
@@ -475,3 +510,228 @@ class TestSyncNestedCrashResume:
         finally:
             if cp._sync_conn:
                 cp._sync_conn.close()
+
+
+class TestRetentionShadowedReExecution:
+    """F1 (review): a pruned prior completion must not look like a crash window.
+
+    Windowed retention compacts the parent GraphNode's COMPLETED step into a
+    hidden value-only baseline. On the next legitimate turn the node is absent
+    from replayed executions while the previous child run is terminal
+    COMPLETED — exactly the crash-window shape. Recovery must consult durable
+    evidence (raw step history including retention carriers) and re-execute
+    under a fresh child id instead of restoring stale outputs.
+    """
+
+    @pytest.mark.parametrize("retention", ["full", "latest", "windowed"])
+    async def test_async_multi_turn_reexecution_survives_retention(self, tmp_path, retention):
+        parent, calls = build_multi_turn_graph()
+        cp = SqliteCheckpointer(str(tmp_path / "test.db"), policy=retention_policy(retention))
+        try:
+            runner = AsyncRunner(checkpointer=cp)
+            first = await runner.run(parent, {}, workflow_id="wfm")
+            assert first.status is RunStatus.PAUSED
+
+            second = await runner.run(parent, {"answer": "one"}, workflow_id="wfm")
+            assert second.status is RunStatus.PAUSED
+            assert calls == ["one"]
+
+            third = await runner.run(parent, {"answer": "two"}, workflow_id="wfm")
+            assert third.status is RunStatus.COMPLETED
+            assert third.values["reply"] == "reply:two"
+            # The child re-executed with the new answer — no stale restore.
+            assert calls == ["one", "two"]
+
+            # The re-execution ran under a fresh suffixed child id.
+            turn2_run = await cp.get_run_async("wfm/child_wf/1")
+            assert turn2_run is not None
+            assert turn2_run.status is WorkflowStatus.COMPLETED
+            if retention != "windowed":
+                # Truthful receipt (windowed prunes the row itself later).
+                child_steps = [step for step in await cp.get_steps("wfm") if step.node_name == "child_wf" and step.status is StepStatus.COMPLETED]
+                assert child_steps
+                assert child_steps[-1].child_run_id == "wfm/child_wf/1"
+        finally:
+            await cp.close()
+
+    def test_sync_windowed_pruned_completion_reexecutes_child(self, tmp_path):
+        """Sync parity for the evidence branch.
+
+        SyncRunner does not support interrupts (validated capability boundary:
+        IncompatibleRunnerError says "Use AsyncRunner instead"), so the
+        multi-turn interrupt repro is structurally impossible on sync. This
+        variant changes the child's input across a FAILED-parent resume via an
+        impure upstream node: windowed retention prunes the prior completion,
+        and a stale restore would feed the downstream node outdated output.
+        """
+        child_inputs: list[int] = []
+        run_counter = {"n": 0}
+        flaky_armed = [True]
+
+        @node(output_name="prepared")
+        def prepare(x: int = 5) -> int:
+            run_counter["n"] += 1
+            return x + 100 * run_counter["n"]
+
+        @node(output_name="doubled")
+        def double(prepared: int) -> int:
+            child_inputs.append(prepared)
+            return prepared * 2
+
+        @node(output_name="final")
+        def flaky(doubled: int) -> int:
+            if flaky_armed[0]:
+                raise RuntimeError("flaky failure")
+            return doubled + 1
+
+        child = Graph(nodes=[double], name="child")
+        parent = Graph(nodes=[prepare, child.as_node(name="child_wf"), flaky], name="parent")
+
+        cp = SqliteCheckpointer(str(tmp_path / "test.db"), policy=retention_policy("windowed"))
+        cp._sync_db()
+        try:
+            runner = SyncRunner(checkpointer=cp)
+            with pytest.raises(RuntimeError, match="flaky failure"):
+                runner.run(parent, {}, workflow_id="wfw")
+            assert child_inputs == [105]
+            assert cp.get_run("wfw/child_wf").status is WorkflowStatus.COMPLETED
+            # windowed retention pruned the parent's completed rows.
+            assert "child_wf" not in {step.node_name for step in cp.steps("wfw")}
+
+            flaky_armed[0] = False
+            result = runner.run(parent, workflow_id="wfw")
+
+            # prepare re-ran (its row was pruned) and produced a NEW value, so
+            # the child must re-execute — restoring doubled=210 would be stale.
+            assert child_inputs == [105, 205]
+            assert result.values["final"] == 411
+            turn2_run = cp.get_run("wfw/child_wf/1")
+            assert turn2_run is not None
+            assert turn2_run.status is WorkflowStatus.COMPLETED
+        finally:
+            if cp._sync_conn:
+                cp._sync_conn.close()
+
+
+class TestDelegatedRunnerCrashResume:
+    """F2 (review): a delegated runner owns the child's persistence boundary.
+
+    The child's terminal COMPLETED state lives in the runner_override's
+    checkpointer, not the parent's. Crash-window recovery must read child
+    status and state from the effective runner's persistence.
+    """
+
+    async def test_async_delegated_child_checkpointer_crash_resume(self, tmp_path):
+        child_cp = SqliteCheckpointer(str(tmp_path / "child.db"), durability="sync")
+        parent, counters = build_nested_graph(child_runner=AsyncRunner(checkpointer=child_cp))
+        parent_cp = CrashingStepCheckpointer(str(tmp_path / "parent.db"), {("wf", "child_wf")})
+        try:
+            runner = AsyncRunner(checkpointer=parent_cp)
+            with pytest.raises(RuntimeError, match=CRASH_MESSAGE):
+                await runner.run(parent, {"x": 5}, workflow_id="wf")
+
+            # The witness lives across two stores: the child completed in the
+            # delegated checkpointer; the parent has no child row at all.
+            child_run = await child_cp.get_run_async("wf/child_wf")
+            assert child_run is not None
+            assert child_run.status is WorkflowStatus.COMPLETED
+            assert await parent_cp.get_run_async("wf/child_wf") is None
+            assert "child_wf" not in {step.node_name for step in await parent_cp.get_steps("wf")}
+            assert counters == {"prepare": 1, "double": 1, "consume": 0}
+
+            parent_cp.armed = False
+            result = await runner.run(parent, workflow_id="wf")
+
+            assert result.values["doubled"] == 210
+            assert result.values["final"] == 211
+            assert counters["double"] == 1
+            assert counters["consume"] == 1
+
+            steps = {step.node_name: step for step in await parent_cp.get_steps("wf")}
+            child_step = steps["child_wf"]
+            assert child_step.status is StepStatus.COMPLETED
+            assert child_step.values == {"doubled": 210}
+            assert child_step.child_run_id == "wf/child_wf"
+        finally:
+            await parent_cp.close()
+            await child_cp.close()
+
+    def test_sync_delegated_child_checkpointer_crash_resume(self, tmp_path):
+        child_cp = SqliteCheckpointer(str(tmp_path / "child.db"), durability="sync")
+        child_cp._sync_db()
+        parent, counters = build_nested_graph(child_runner=SyncRunner(checkpointer=child_cp))
+        parent_cp = CrashingStepCheckpointer(str(tmp_path / "parent.db"), {("wf", "child_wf")})
+        parent_cp._sync_db()
+        try:
+            runner = SyncRunner(checkpointer=parent_cp)
+            with pytest.raises(RuntimeError, match=CRASH_MESSAGE):
+                runner.run(parent, {"x": 5}, workflow_id="wf")
+
+            child_run = child_cp.get_run("wf/child_wf")
+            assert child_run is not None
+            assert child_run.status is WorkflowStatus.COMPLETED
+            assert parent_cp.get_run("wf/child_wf") is None
+            assert counters == {"prepare": 1, "double": 1, "consume": 0}
+
+            parent_cp.armed = False
+            result = runner.run(parent, workflow_id="wf")
+
+            assert result.values["doubled"] == 210
+            assert result.values["final"] == 211
+            assert counters["double"] == 1
+            assert counters["consume"] == 1
+
+            steps = {step.node_name: step for step in parent_cp.steps("wf")}
+            child_step = steps["child_wf"]
+            assert child_step.status is StepStatus.COMPLETED
+            assert child_step.values == {"doubled": 210}
+            assert child_step.child_run_id == "wf/child_wf"
+        finally:
+            if child_cp._sync_conn:
+                child_cp._sync_conn.close()
+            if parent_cp._sync_conn:
+                parent_cp._sync_conn.close()
+
+
+class TestCrashRestoreTupleOutputs:
+    """F3 (review): restored outputs must mirror real execution for tuples.
+
+    JSON persistence turns tuples into lists; the restore path (like ordinary
+    checkpoint resume) must coerce annotated tuple outputs back.
+    """
+
+    async def test_restored_tuple_output_reaches_downstream_as_tuple(self, tmp_path):
+        received: list[object] = []
+
+        @node(output_name="prepared")
+        def prepare(x: int) -> int:
+            return x + 100
+
+        @node(output_name="pair")
+        def make_pair(prepared: int) -> tuple[int, int]:
+            return (prepared, prepared + 1)
+
+        @node(output_name="total")
+        def consume(pair: tuple[int, int]) -> int:
+            received.append(pair)
+            return pair[0] + pair[1]
+
+        child = Graph(nodes=[make_pair], name="child")
+        parent = Graph(nodes=[prepare, child.as_node(name="child_wf"), consume], name="parent")
+
+        cp = CrashingStepCheckpointer(str(tmp_path / "test.db"), {("wf", "child_wf")})
+        try:
+            runner = AsyncRunner(checkpointer=cp)
+            with pytest.raises(RuntimeError, match=CRASH_MESSAGE):
+                await runner.run(parent, {"x": 5}, workflow_id="wf")
+            cp.armed = False
+
+            result = await runner.run(parent, workflow_id="wf")
+
+            assert result.values["total"] == 211
+            assert received == [(105, 106)]
+            assert isinstance(received[0], tuple)
+            assert result.values["pair"] == (105, 106)
+            assert isinstance(result.values["pair"], tuple)
+        finally:
+            await cp.close()

--- a/tests/test_checkpointer/test_nested_crash_resume.py
+++ b/tests/test_checkpointer/test_nested_crash_resume.py
@@ -254,6 +254,56 @@ class TestAsyncNestedCrashResume:
         finally:
             await cp.close()
 
+    async def test_resume_restores_namespaced_child_boundary(self, tmp_path):
+        """Restored outputs project through a namespaced GraphNode boundary."""
+        counters = {"double": 0}
+
+        @node(output_name="prepared")
+        def prepare(x: int) -> int:
+            return x + 100
+
+        @node(output_name="doubled")
+        def double(prepared: int) -> int:
+            counters["double"] += 1
+            return prepared * 2
+
+        @node(output_name="final")
+        def consume(doubled: int) -> int:
+            return doubled + 1
+
+        child = Graph(nodes=[double], name="child")
+        child_node = child.as_node(name="child_wf", namespaced=True).expose("prepared")
+        parent = Graph(
+            nodes=[
+                prepare,
+                child_node,
+                consume.with_inputs(doubled="child_wf.doubled"),
+            ],
+            name="parent",
+        )
+
+        cp = CrashingStepCheckpointer(str(tmp_path / "test.db"), {("wf", "child_wf")})
+        try:
+            runner = AsyncRunner(checkpointer=cp)
+            with pytest.raises(RuntimeError, match=CRASH_MESSAGE):
+                await runner.run(parent, {"x": 5}, workflow_id="wf")
+            child_run = await cp.get_run_async("wf/child_wf")
+            assert child_run is not None
+            assert child_run.status is WorkflowStatus.COMPLETED
+            assert counters["double"] == 1
+
+            cp.armed = False
+            result = await runner.run(parent, workflow_id="wf")
+
+            assert result.values["child_wf.doubled"] == 210
+            assert result.values["final"] == 211
+            assert counters["double"] == 1
+            steps = {step.node_name: step for step in await cp.get_steps("wf")}
+            assert steps["child_wf"].status is StepStatus.COMPLETED
+            assert steps["child_wf"].values == {"child_wf.doubled": 210}
+        finally:
+            await cp.close()
+
     @pytest.mark.parametrize("error_handling", ["raise", "continue"])
     async def test_resume_does_not_mask_failed_child(self, tmp_path, error_handling):
         """B6: a FAILED terminal child surfaces its failure — no restore-as-success."""

--- a/tests/test_checkpointer/test_nested_crash_resume.py
+++ b/tests/test_checkpointer/test_nested_crash_resume.py
@@ -10,7 +10,7 @@ FAILED child as success.
 
 import pytest
 
-from hypergraph import END, AsyncRunner, Graph, SyncRunner, interrupt, node, route
+from hypergraph import END, AsyncRunner, CompactedRetentionError, Graph, SyncRunner, interrupt, node, route
 from hypergraph.checkpointers import CheckpointPolicy, SqliteCheckpointer, WorkflowStatus
 from hypergraph.checkpointers.types import StepStatus
 from hypergraph.events import EventProcessor
@@ -45,8 +45,17 @@ class CrashingStepCheckpointer(SqliteCheckpointer):
     against the same database.
     """
 
-    def __init__(self, path: str, targets: set[tuple[str, str]]):
-        super().__init__(path, durability="sync")
+    def __init__(
+        self,
+        path: str,
+        targets: set[tuple[str, str]],
+        *,
+        policy: CheckpointPolicy | None = None,
+    ):
+        if policy is None:
+            super().__init__(path, durability="sync")
+        else:
+            super().__init__(path, policy=policy)
         self.targets = targets
         self.armed = True
 
@@ -120,6 +129,17 @@ def retention_policy(retention: str) -> CheckpointPolicy:
     if retention == "windowed":
         return CheckpointPolicy(durability="sync", retention="windowed", window=1)
     return CheckpointPolicy(durability="sync", retention=retention)
+
+
+def assert_compacted_retention_guidance(error: pytest.ExceptionInfo[BaseException]) -> None:
+    """The rejection names the boundary and both supported escape hatches."""
+    message = str(error.value)
+    assert "windowed" in message
+    assert "compacted" in message
+    assert "retention='full'" in message
+    assert "retention='latest'" in message
+    assert "fork" in message.lower()
+    assert "#277" in message
 
 
 def build_two_level_graph():
@@ -512,19 +532,11 @@ class TestSyncNestedCrashResume:
                 cp._sync_conn.close()
 
 
-class TestRetentionShadowedReExecution:
-    """F1 (review): a pruned prior completion must not look like a crash window.
+class TestCompactedRetentionNestedRecovery:
+    """F1 re-review: compacted parent history is not completion provenance."""
 
-    Windowed retention compacts the parent GraphNode's COMPLETED step into a
-    hidden value-only baseline. On the next legitimate turn the node is absent
-    from replayed executions while the previous child run is terminal
-    COMPLETED — exactly the crash-window shape. Recovery must consult durable
-    evidence (raw step history including retention carriers) and re-execute
-    under a fresh child id instead of restoring stale outputs.
-    """
-
-    @pytest.mark.parametrize("retention", ["full", "latest", "windowed"])
-    async def test_async_multi_turn_reexecution_survives_retention(self, tmp_path, retention):
+    @pytest.mark.parametrize("retention", ["full", "latest"])
+    async def test_async_multi_turn_reexecution_survives_non_windowed_retention(self, tmp_path, retention):
         parent, calls = build_multi_turn_graph()
         cp = SqliteCheckpointer(str(tmp_path / "test.db"), policy=retention_policy(retention))
         try:
@@ -546,16 +558,34 @@ class TestRetentionShadowedReExecution:
             turn2_run = await cp.get_run_async("wfm/child_wf/1")
             assert turn2_run is not None
             assert turn2_run.status is WorkflowStatus.COMPLETED
-            if retention != "windowed":
-                # Truthful receipt (windowed prunes the row itself later).
-                child_steps = [step for step in await cp.get_steps("wfm") if step.node_name == "child_wf" and step.status is StepStatus.COMPLETED]
-                assert child_steps
-                assert child_steps[-1].child_run_id == "wfm/child_wf/1"
+            child_steps = [step for step in await cp.get_steps("wfm") if step.node_name == "child_wf" and step.status is StepStatus.COMPLETED]
+            assert child_steps
+            assert child_steps[-1].child_run_id == "wfm/child_wf/1"
         finally:
             await cp.close()
 
-    def test_sync_windowed_pruned_completion_reexecutes_child(self, tmp_path):
-        """Sync parity for the evidence branch.
+    async def test_async_windowed_multi_turn_rejects_ambiguous_resume(self, tmp_path):
+        parent, calls = build_multi_turn_graph()
+        cp = SqliteCheckpointer(str(tmp_path / "test.db"), policy=retention_policy("windowed"))
+        try:
+            runner = AsyncRunner(checkpointer=cp)
+            first = await runner.run(parent, {}, workflow_id="wfm")
+            assert first.status is RunStatus.PAUSED
+
+            second = await runner.run(parent, {"answer": "one"}, workflow_id="wfm")
+            assert second.status is RunStatus.PAUSED
+            assert calls == ["one"]
+
+            with pytest.raises(CompactedRetentionError) as error:
+                await runner.run(parent, {"answer": "two"}, workflow_id="wfm")
+
+            assert_compacted_retention_guidance(error)
+            assert calls == ["one"]
+        finally:
+            await cp.close()
+
+    def test_sync_windowed_pruned_completion_rejects_ambiguous_resume(self, tmp_path):
+        """Sync parity for the compacted-history rejection.
 
         SyncRunner does not support interrupts (validated capability boundary:
         IncompatibleRunnerError says "Use AsyncRunner instead"), so the
@@ -599,15 +629,63 @@ class TestRetentionShadowedReExecution:
             assert "child_wf" not in {step.node_name for step in cp.steps("wfw")}
 
             flaky_armed[0] = False
-            result = runner.run(parent, workflow_id="wfw")
+            with pytest.raises(CompactedRetentionError) as error:
+                runner.run(parent, workflow_id="wfw")
 
-            # prepare re-ran (its row was pruned) and produced a NEW value, so
-            # the child must re-execute — restoring doubled=210 would be stale.
-            assert child_inputs == [105, 205]
-            assert result.values["final"] == 411
-            turn2_run = cp.get_run("wfw/child_wf/1")
-            assert turn2_run is not None
-            assert turn2_run.status is WorkflowStatus.COMPLETED
+            assert_compacted_retention_guidance(error)
+            assert child_inputs == [105]
+        finally:
+            if cp._sync_conn:
+                cp._sync_conn.close()
+
+    def test_windowed_same_named_shared_value_is_not_completion_evidence(self, tmp_path):
+        """A carrier value from another producer cannot prove child completion."""
+        calls: list[int] = []
+
+        @node(output_name=("prepared", "result"))
+        def prepare(x: int = 2) -> tuple[int, int]:
+            return x, x * 10
+
+        @node(output_name="ready")
+        def order_after_prepare(prepared: int) -> int:
+            return prepared
+
+        @node(output_name="result")
+        def child_work(ready: int, result: int) -> int:
+            calls.append(ready)
+            return ready * 100 + result
+
+        child = Graph(nodes=[child_work], name="child", shared=["result"])
+        parent = Graph(
+            nodes=[prepare, order_after_prepare, child.as_node(name="child_wf")],
+            name="parent",
+            shared=["result"],
+        )
+
+        cp = CrashingStepCheckpointer(
+            str(tmp_path / "test.db"),
+            {("wfe", "child_wf")},
+            policy=retention_policy("windowed"),
+        )
+        cp._sync_db()
+        try:
+            runner = SyncRunner(checkpointer=cp)
+            with pytest.raises(RuntimeError, match=CRASH_MESSAGE):
+                runner.run(parent, {"result": 0}, workflow_id="wfe")
+
+            assert calls == [2]
+            internal_steps = cp.steps("wfe", show_internal=True)
+            baseline = next(step for step in internal_steps if step.node_type == "RetentionBaseline")
+            assert baseline.values is not None
+            assert baseline.values["result"] == 20
+            assert cp.get_run("wfe/child_wf").status is WorkflowStatus.COMPLETED
+
+            cp.armed = False
+            with pytest.raises(CompactedRetentionError) as error:
+                runner.run(parent, workflow_id="wfe")
+
+            assert_compacted_retention_guidance(error)
+            assert calls == [2]
         finally:
             if cp._sync_conn:
                 cp._sync_conn.close()

--- a/tests/test_checkpointer/test_nested_crash_resume.py
+++ b/tests/test_checkpointer/test_nested_crash_resume.py
@@ -1,0 +1,427 @@
+"""Crash-window recovery for nested GraphNodes (issue #235).
+
+Witness (reproduced during the #187 investigation): a crash lands between a
+child workflow committing terminal COMPLETED and the parent writing its
+GraphNode StepRecord. On resume the parent must RESTORE the child's persisted
+outputs and commit the missing parent step — not re-invoke the terminal child
+(which raises ``WorkflowAlreadyCompletedError``) and never silently restore a
+FAILED child as success.
+"""
+
+import pytest
+
+from hypergraph import AsyncRunner, Graph, SyncRunner, node
+from hypergraph.checkpointers import SqliteCheckpointer, WorkflowStatus
+from hypergraph.checkpointers.types import StepStatus
+from hypergraph.events import EventProcessor
+from hypergraph.events.types import NodeEndEvent, NodeStartEvent, RunStartEvent
+from hypergraph.runners._shared.results import RunStatus
+
+aiosqlite = pytest.importorskip("aiosqlite")
+
+CRASH_MESSAGE = "simulated crash before parent step write"
+
+
+class EventCollector(EventProcessor):
+    """Collect execution events without adding behavior to the runner."""
+
+    def __init__(self):
+        self.events: list[object] = []
+
+    def on_event(self, event):
+        self.events.append(event)
+
+    def of_type(self, event_type):
+        return [event for event in self.events if isinstance(event, event_type)]
+
+
+class CrashingStepCheckpointer(SqliteCheckpointer):
+    """Raise on targeted (run_id, node_name) step writes while armed.
+
+    Simulates the crash window: the child workflow has already committed
+    terminal status, but the parent's StepRecord for the GraphNode is never
+    persisted. Disarm (``armed = False``) to model a healthy process resuming
+    against the same database.
+    """
+
+    def __init__(self, path: str, targets: set[tuple[str, str]]):
+        super().__init__(path, durability="sync")
+        self.targets = targets
+        self.armed = True
+
+    def _hit(self, record) -> bool:
+        return self.armed and (record.run_id, record.node_name) in self.targets
+
+    async def save_step(self, record) -> None:
+        if self._hit(record):
+            raise RuntimeError(CRASH_MESSAGE)
+        await super().save_step(record)
+
+    def save_step_sync(self, record) -> None:
+        if self._hit(record):
+            raise RuntimeError(CRASH_MESSAGE)
+        super().save_step_sync(record)
+
+
+def build_nested_graph():
+    """parent: prepare -> child_wf(double) -> consume, with invocation counters."""
+    counters = {"prepare": 0, "double": 0, "consume": 0}
+
+    @node(output_name="prepared")
+    def prepare(x: int) -> int:
+        counters["prepare"] += 1
+        return x + 100
+
+    @node(output_name="doubled")
+    def double(prepared: int) -> int:
+        counters["double"] += 1
+        return prepared * 2
+
+    @node(output_name="final")
+    def consume(doubled: int) -> int:
+        counters["consume"] += 1
+        return doubled + 1
+
+    child = Graph(nodes=[double], name="child")
+    parent = Graph(nodes=[prepare, child.as_node(name="child_wf"), consume], name="parent")
+    return parent, counters
+
+
+def build_two_level_graph():
+    """outer: outer_prep -> mid_wf(mid_prep -> grand_wf(innermost)) -> outer_consume."""
+    counters = {"outer_prep": 0, "mid_prep": 0, "innermost": 0, "outer_consume": 0}
+
+    @node(output_name="seed")
+    def outer_prep(x: int) -> int:
+        counters["outer_prep"] += 1
+        return x + 1
+
+    @node(output_name="mid_ready")
+    def mid_prep(seed: int) -> int:
+        counters["mid_prep"] += 1
+        return seed * 10
+
+    @node(output_name="tripled")
+    def innermost(mid_ready: int) -> int:
+        counters["innermost"] += 1
+        return mid_ready * 3
+
+    @node(output_name="final")
+    def outer_consume(tripled: int) -> int:
+        counters["outer_consume"] += 1
+        return tripled + 7
+
+    grand = Graph(nodes=[innermost], name="grand")
+    mid = Graph(nodes=[mid_prep, grand.as_node(name="grand_wf")], name="mid")
+    outer = Graph(nodes=[outer_prep, mid.as_node(name="mid_wf"), outer_consume], name="outer")
+    return outer, counters
+
+
+def build_failing_child_graph():
+    """parent whose nested child fails deterministically.
+
+    The failing node's input comes from a completed inner step (``staged``),
+    so the child itself is mechanically resumable — resume re-executes only
+    the failed node, which fails again. That isolates B6 on failure surfacing
+    rather than on child-input recovery.
+    """
+    counters = {"boom": 0}
+
+    @node(output_name="prepared")
+    def prepare(x: int) -> int:
+        return x + 100
+
+    @node(output_name="staged")
+    def stage(prepared: int) -> int:
+        return prepared + 1
+
+    @node(output_name="doubled")
+    def boom(staged: int) -> int:
+        counters["boom"] += 1
+        raise ValueError("child exploded")
+
+    @node(output_name="final")
+    def consume(doubled: int) -> int:
+        return doubled + 1
+
+    child = Graph(nodes=[stage, boom], name="child")
+    parent = Graph(nodes=[prepare, child.as_node(name="child_wf"), consume], name="parent")
+    return parent, counters
+
+
+class TestAsyncNestedCrashResume:
+    async def test_resume_restores_completed_child_after_parent_step_crash(self, tmp_path):
+        """B1/B2/B3: resume restores the child's outputs instead of re-invoking."""
+        parent, counters = build_nested_graph()
+        cp = CrashingStepCheckpointer(str(tmp_path / "test.db"), {("wf", "child_wf")})
+        try:
+            runner = AsyncRunner(checkpointer=cp)
+            with pytest.raises(RuntimeError, match=CRASH_MESSAGE):
+                await runner.run(parent, {"x": 5}, workflow_id="wf")
+
+            # The witness: child terminal COMPLETED, parent GraphNode step missing.
+            child_run = await cp.get_run_async("wf/child_wf")
+            assert child_run is not None
+            assert child_run.status is WorkflowStatus.COMPLETED
+            crash_steps = await cp.get_steps("wf")
+            assert "child_wf" not in {step.node_name for step in crash_steps}
+            assert counters == {"prepare": 1, "double": 1, "consume": 0}
+
+            cp.armed = False
+            result = await runner.run(parent, workflow_id="wf")
+
+            # B3: the resumed run carries the child's outputs.
+            assert result.values["doubled"] == 210
+            assert result.values["final"] == 211
+            # B2: the child's inner node did NOT re-execute on resume.
+            assert counters["double"] == 1
+            # Replayed upstream node did not re-run; downstream ran exactly once.
+            assert counters["prepare"] == 1
+            assert counters["consume"] == 1
+
+            # B3: the missing parent step is committed as COMPLETED.
+            steps = {step.node_name: step for step in await cp.get_steps("wf")}
+            child_step = steps["child_wf"]
+            assert child_step.status is StepStatus.COMPLETED
+            assert child_step.values == {"doubled": 210}
+            assert child_step.child_run_id == "wf/child_wf"
+            parent_run = await cp.get_run_async("wf")
+            assert parent_run is not None
+            assert parent_run.status is WorkflowStatus.COMPLETED
+        finally:
+            await cp.close()
+
+    async def test_resume_emits_no_child_execution_events(self, tmp_path):
+        """B7: the restore path emits zero fresh child-node execution events."""
+        parent, counters = build_nested_graph()
+        cp = CrashingStepCheckpointer(str(tmp_path / "test.db"), {("wf", "child_wf")})
+        try:
+            runner = AsyncRunner(checkpointer=cp)
+            with pytest.raises(RuntimeError, match=CRASH_MESSAGE):
+                await runner.run(parent, {"x": 5}, workflow_id="wf")
+            cp.armed = False
+
+            collector = EventCollector()
+            result = await runner.run(parent, workflow_id="wf", event_processors=[collector])
+            assert result.values["final"] == 211
+
+            child_starts = [event for event in collector.of_type(NodeStartEvent) if event.workflow_id == "wf/child_wf" or event.node_name == "double"]
+            child_ends = [event for event in collector.of_type(NodeEndEvent) if event.workflow_id == "wf/child_wf" or event.node_name == "double"]
+            child_run_starts = [event for event in collector.of_type(RunStartEvent) if event.workflow_id == "wf/child_wf"]
+            assert child_starts == []
+            assert child_ends == []
+            assert child_run_starts == []
+            # The parent GraphNode's own commit stays visible (truthful restore).
+            parent_ends = [event for event in collector.of_type(NodeEndEvent) if event.node_name == "child_wf"]
+            assert len(parent_ends) == 1
+        finally:
+            await cp.close()
+
+    async def test_two_level_crash_restores_grandchild(self, tmp_path):
+        """B5: grandchild terminal COMPLETED with both ancestor steps missing."""
+        outer, counters = build_two_level_graph()
+        targets = {("wf2/mid_wf", "grand_wf"), ("wf2", "mid_wf")}
+        cp = CrashingStepCheckpointer(str(tmp_path / "test.db"), targets)
+        try:
+            runner = AsyncRunner(checkpointer=cp)
+            with pytest.raises(RuntimeError, match=CRASH_MESSAGE):
+                await runner.run(outer, {"x": 2}, workflow_id="wf2")
+
+            grand_run = await cp.get_run_async("wf2/mid_wf/grand_wf")
+            assert grand_run is not None
+            assert grand_run.status is WorkflowStatus.COMPLETED
+            assert "grand_wf" not in {step.node_name for step in await cp.get_steps("wf2/mid_wf")}
+            assert "mid_wf" not in {step.node_name for step in await cp.get_steps("wf2")}
+            assert counters == {"outer_prep": 1, "mid_prep": 1, "innermost": 1, "outer_consume": 0}
+
+            cp.armed = False
+            result = await runner.run(outer, workflow_id="wf2")
+
+            assert result.values["final"] == 97  # ((2+1)*10)*3 + 7
+            assert counters["innermost"] == 1  # grandchild not re-invoked
+            assert counters["mid_prep"] == 1
+            assert counters["outer_prep"] == 1
+            assert counters["outer_consume"] == 1
+
+            mid_steps = {step.node_name: step for step in await cp.get_steps("wf2/mid_wf")}
+            assert mid_steps["grand_wf"].status is StepStatus.COMPLETED
+            outer_steps = {step.node_name: step for step in await cp.get_steps("wf2")}
+            assert outer_steps["mid_wf"].status is StepStatus.COMPLETED
+            for run_id in ("wf2", "wf2/mid_wf", "wf2/mid_wf/grand_wf"):
+                run = await cp.get_run_async(run_id)
+                assert run is not None
+                assert run.status is WorkflowStatus.COMPLETED
+        finally:
+            await cp.close()
+
+    @pytest.mark.parametrize("error_handling", ["raise", "continue"])
+    async def test_resume_does_not_mask_failed_child(self, tmp_path, error_handling):
+        """B6: a FAILED terminal child surfaces its failure — no restore-as-success."""
+        parent, counters = build_failing_child_graph()
+        cp = SqliteCheckpointer(str(tmp_path / "test.db"), durability="sync")
+        try:
+            runner = AsyncRunner(checkpointer=cp)
+            if error_handling == "raise":
+                with pytest.raises(ValueError, match="child exploded"):
+                    await runner.run(parent, {"x": 5}, workflow_id="wf", error_handling=error_handling)
+            else:
+                first = await runner.run(parent, {"x": 5}, workflow_id="wf", error_handling=error_handling)
+                assert first.status is RunStatus.FAILED
+
+            child_run = await cp.get_run_async("wf/child_wf")
+            assert child_run is not None
+            assert child_run.status is WorkflowStatus.FAILED
+            assert counters["boom"] == 1
+
+            if error_handling == "raise":
+                with pytest.raises(ValueError, match="child exploded"):
+                    await runner.run(parent, workflow_id="wf", error_handling=error_handling)
+            else:
+                result = await runner.run(parent, workflow_id="wf", error_handling=error_handling)
+                assert result.status is RunStatus.FAILED
+                assert isinstance(result.error, ValueError)
+                assert "doubled" not in result.values
+                assert "final" not in result.values
+
+            # Existing semantics: the failed child re-executes (and fails again).
+            assert counters["boom"] == 2
+            child_run = await cp.get_run_async("wf/child_wf")
+            assert child_run is not None
+            assert child_run.status is WorkflowStatus.FAILED
+        finally:
+            await cp.close()
+
+
+class TestSyncNestedCrashResume:
+    """B4: sync-runner parity for the crash-window restore."""
+
+    def _sync_cp(self, tmp_path, targets):
+        cp = CrashingStepCheckpointer(str(tmp_path / "test.db"), targets)
+        cp._sync_db()  # triggers schema creation
+        return cp
+
+    def test_resume_restores_completed_child_after_parent_step_crash(self, tmp_path):
+        parent, counters = build_nested_graph()
+        cp = self._sync_cp(tmp_path, {("wf", "child_wf")})
+        try:
+            runner = SyncRunner(checkpointer=cp)
+            with pytest.raises(RuntimeError, match=CRASH_MESSAGE):
+                runner.run(parent, {"x": 5}, workflow_id="wf")
+
+            child_run = cp.get_run("wf/child_wf")
+            assert child_run is not None
+            assert child_run.status is WorkflowStatus.COMPLETED
+            assert "child_wf" not in {step.node_name for step in cp.steps("wf")}
+            assert counters == {"prepare": 1, "double": 1, "consume": 0}
+
+            cp.armed = False
+            result = runner.run(parent, workflow_id="wf")
+
+            assert result.values["doubled"] == 210
+            assert result.values["final"] == 211
+            assert counters["double"] == 1
+            assert counters["prepare"] == 1
+            assert counters["consume"] == 1
+
+            steps = {step.node_name: step for step in cp.steps("wf")}
+            child_step = steps["child_wf"]
+            assert child_step.status is StepStatus.COMPLETED
+            assert child_step.values == {"doubled": 210}
+            assert child_step.child_run_id == "wf/child_wf"
+            parent_run = cp.get_run("wf")
+            assert parent_run is not None
+            assert parent_run.status is WorkflowStatus.COMPLETED
+        finally:
+            if cp._sync_conn:
+                cp._sync_conn.close()
+
+    def test_resume_emits_no_child_execution_events(self, tmp_path):
+        parent, counters = build_nested_graph()
+        cp = self._sync_cp(tmp_path, {("wf", "child_wf")})
+        try:
+            runner = SyncRunner(checkpointer=cp)
+            with pytest.raises(RuntimeError, match=CRASH_MESSAGE):
+                runner.run(parent, {"x": 5}, workflow_id="wf")
+            cp.armed = False
+
+            collector = EventCollector()
+            result = runner.run(parent, workflow_id="wf", event_processors=[collector])
+            assert result.values["final"] == 211
+
+            child_starts = [event for event in collector.of_type(NodeStartEvent) if event.workflow_id == "wf/child_wf" or event.node_name == "double"]
+            child_ends = [event for event in collector.of_type(NodeEndEvent) if event.workflow_id == "wf/child_wf" or event.node_name == "double"]
+            child_run_starts = [event for event in collector.of_type(RunStartEvent) if event.workflow_id == "wf/child_wf"]
+            assert child_starts == []
+            assert child_ends == []
+            assert child_run_starts == []
+            parent_ends = [event for event in collector.of_type(NodeEndEvent) if event.node_name == "child_wf"]
+            assert len(parent_ends) == 1
+        finally:
+            if cp._sync_conn:
+                cp._sync_conn.close()
+
+    def test_two_level_crash_restores_grandchild(self, tmp_path):
+        outer, counters = build_two_level_graph()
+        cp = self._sync_cp(tmp_path, {("wf2/mid_wf", "grand_wf"), ("wf2", "mid_wf")})
+        try:
+            runner = SyncRunner(checkpointer=cp)
+            with pytest.raises(RuntimeError, match=CRASH_MESSAGE):
+                runner.run(outer, {"x": 2}, workflow_id="wf2")
+
+            grand_run = cp.get_run("wf2/mid_wf/grand_wf")
+            assert grand_run is not None
+            assert grand_run.status is WorkflowStatus.COMPLETED
+            assert counters == {"outer_prep": 1, "mid_prep": 1, "innermost": 1, "outer_consume": 0}
+
+            cp.armed = False
+            result = runner.run(outer, workflow_id="wf2")
+
+            assert result.values["final"] == 97
+            assert counters["innermost"] == 1
+            assert counters["mid_prep"] == 1
+            assert counters["outer_consume"] == 1
+
+            mid_steps = {step.node_name: step for step in cp.steps("wf2/mid_wf")}
+            assert mid_steps["grand_wf"].status is StepStatus.COMPLETED
+            outer_steps = {step.node_name: step for step in cp.steps("wf2")}
+            assert outer_steps["mid_wf"].status is StepStatus.COMPLETED
+        finally:
+            if cp._sync_conn:
+                cp._sync_conn.close()
+
+    @pytest.mark.parametrize("error_handling", ["raise", "continue"])
+    def test_resume_does_not_mask_failed_child(self, tmp_path, error_handling):
+        parent, counters = build_failing_child_graph()
+        cp = SqliteCheckpointer(str(tmp_path / "test.db"), durability="sync")
+        cp._sync_db()
+        try:
+            runner = SyncRunner(checkpointer=cp)
+            if error_handling == "raise":
+                with pytest.raises(ValueError, match="child exploded"):
+                    runner.run(parent, {"x": 5}, workflow_id="wf", error_handling=error_handling)
+            else:
+                first = runner.run(parent, {"x": 5}, workflow_id="wf", error_handling=error_handling)
+                assert first.status is RunStatus.FAILED
+
+            child_run = cp.get_run("wf/child_wf")
+            assert child_run is not None
+            assert child_run.status is WorkflowStatus.FAILED
+            assert counters["boom"] == 1
+
+            if error_handling == "raise":
+                with pytest.raises(ValueError, match="child exploded"):
+                    runner.run(parent, workflow_id="wf", error_handling=error_handling)
+            else:
+                result = runner.run(parent, workflow_id="wf", error_handling=error_handling)
+                assert result.status is RunStatus.FAILED
+                assert isinstance(result.error, ValueError)
+                assert "doubled" not in result.values
+                assert "final" not in result.values
+
+            assert counters["boom"] == 2
+            child_run = cp.get_run("wf/child_wf")
+            assert child_run is not None
+            assert child_run.status is WorkflowStatus.FAILED
+        finally:
+            if cp._sync_conn:
+                cp._sync_conn.close()

--- a/tests/test_runners/test_type_ownership.py
+++ b/tests/test_runners/test_type_ownership.py
@@ -43,6 +43,7 @@ ROOT_EXPORTS = (
     "RunStatus",
     "RenameError",
     "GraphConfigError",
+    "CompactedRetentionError",
     "MissingInputError",
     "InfiniteLoopError",
     "IncompatibleRunnerError",


### PR DESCRIPTION
Closes #235.

## Problem statement
Crash window: a nested child workflow commits COMPLETED, the process dies before the parent GraphNode's StepRecord is written. On resume, the parent re-invoked the terminal child → `WorkflowAlreadyCompletedError`. Physically witnessed during the #187 investigation.

## Before / after
```text
Before: resume → WorkflowAlreadyCompletedError (workflow bricked)
After:  resume restores the child's persisted outputs, commits the missing
        parent step, emits no fake child-execution events; downstream runs once
```
Review-hardened beyond the original fix:
- **Delegated runners**: child status/state read from the EFFECTIVE runner's checkpointer (override resolved first), parent evidence from the parent's.
- **Tuple truth**: persisted JSON turned tuple outputs into lists on EVERY resume path — fixed once in shared `coerce_checkpoint_values`.
- **Multi-turn safety**: a legitimately stale parent re-executes the child under a suffixed id; restoration is gated on durable completion evidence.
- **Honest boundary**: windowed/compacted retention + nested crash recovery has NO sound evidence source today (retention carriers lack producer provenance — proven fabrication repro) → raises actionable `CompactedRetentionError` naming the fixes, pending #277. Strictly better than master's behavior (which raised `WorkflowAlreadyCompletedError` there too). #278 filed for the adjacent runtime-only interrupt-answer gap.

## Test plan
9 commits (4 RED/GREEN rounds); 25 focused tests: fault-injected crash windows (1- and 2-level), no-reinvocation counters, event-absence asserts, FAILED-not-masked (raise+continue), delegated two-checkpointer repros, tuple coercion both paths, retention matrix (full/latest restore; windowed → actionable error incl. the false-evidence fabrication repro). Cross-model adversarial review: 2 full rounds + final confirmation = SHIP. Full CI-equivalent: 3513 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved recovery for nested workflows after crashes, restoring completed child results without rerunning work.
  * Added support for preserving typed tuple outputs during checkpoint recovery.
  * Added a publicly available error for ambiguous recovery with compacted history.
* **Bug Fixes**
  * Failed child workflows are no longer incorrectly restored as successful.
  * Recovery now correctly handles delegated execution and multi-level nested workflows.
* **Documentation**
  * Added guidance on nested recovery, retention settings, and delegated execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->