### PR TITLE
feat(runners): node-owned RetryPolicy with durable attempt coordinator

### DIFF
--- a/docs/05-how-to/retry-transient-failures.md
+++ b/docs/05-how-to/retry-transient-failures.md
@@ -157,6 +157,8 @@ With persistence, every attempt is durably reserved **before** your code runs, a
 
 This is an at-most-N-invocations guarantee, not exactly-once side effects: a crash mid-attempt cannot know whether the external call landed (the attempt is recorded as outcome-unknown). Payment-style APIs still need idempotency keys.
 
+Retry evidence deliberately overrides `CheckpointPolicy` durability timing: a retrying node's attempt records AND its series-closing StepRecord write through immediately under every durability mode (including `"async"` and `"exit"`), because the final outcome, its linked step, and the series closure must commit atomically. Non-retrying nodes buffer according to the configured durability as usual.
+
 ## What retry does NOT change
 
 - **Cache**: one lookup before any attempt; a hit invokes nothing and consumes no budget; one write after final success. Changing the policy never invalidates cached results.

--- a/docs/05-how-to/retry-transient-failures.md
+++ b/docs/05-how-to/retry-transient-failures.md
@@ -1,0 +1,170 @@
+# How to Retry Transient Failures
+
+External calls fail transiently — a model API times out, a rate limit trips, a connection drops. Declare on the node which failures are safe to repeat, and hypergraph runs the attempts for you: one logical step, capped-exponential backoff, and (with a checkpointer) a retry budget that survives restarts.
+
+## Before / After
+
+Before — one transient failure kills the run:
+
+```python
+from hypergraph import Graph, SyncRunner, node
+
+@node(output_name="profile")
+def fetch_profile(user_id: str) -> dict:
+    return api.get_profile(user_id)   # raises ConnectionError once in a while
+
+runner = SyncRunner()
+runner.run(Graph([fetch_profile]), {"user_id": "u-42"})
+# ConnectionError: connection reset by peer
+```
+
+After — the node declares which failures may repeat:
+
+```python
+from hypergraph import Graph, RetryPolicy, SyncRunner, node
+
+@node(
+    output_name="profile",
+    retry=RetryPolicy(
+        max_attempts=3,                    # includes the first invocation
+        retry_on=(ConnectionError,),       # ONLY these exceptions retry
+    ),
+)
+def fetch_profile(user_id: str) -> dict:
+    return api.get_profile(user_id)
+
+runner = SyncRunner()
+result = runner.run(Graph([fetch_profile]), {"user_id": "u-42"})
+# attempt 1 · ConnectionError → wait → attempt 2 · succeeded
+result["profile"]
+```
+
+The graph still sees **one** `fetch_profile` step. Downstream nodes run once, after the final success. If all three attempts fail, the exact final `ConnectionError` is re-raised — never a wrapper.
+
+## Runnable example
+
+```python
+from hypergraph import Graph, RetryPolicy, SyncRunner, node
+
+attempts = []
+
+@node(
+    output_name="fetched",
+    retry=RetryPolicy(
+        max_attempts=3,
+        retry_on=(ConnectionError,),
+        initial_delay=0.01,   # keep the example fast
+    ),
+)
+def flaky(x: int) -> int:
+    attempts.append(x)
+    if len(attempts) < 2:
+        raise ConnectionError("transient")
+    return x * 10
+
+@node(output_name="done")
+def downstream(fetched: int) -> int:
+    return fetched + 1
+
+result = SyncRunner().run(Graph([flaky, downstream]), {"x": 4})
+print(result["done"])     # 41
+print(len(attempts))      # 2 — one failure, one success, one logical step
+```
+
+## Only listed failures retry
+
+`retry_on` is a required, explicit allowlist. A `KeyError` from broken parsing is a bug, not a transient condition — it fails once, immediately:
+
+```python
+@node(
+    output_name="fetched",
+    retry=RetryPolicy(max_attempts=3, retry_on=(ConnectionError,)),
+)
+def parse_response(raw: str) -> dict:
+    return {"value": raw["field"]}   # TypeError — NOT in retry_on
+
+# → exactly one invocation; the TypeError escapes unchanged.
+```
+
+There is no `retry=True` shorthand and no retry-all default. `KeyboardInterrupt`, cancellation, and other `BaseException` control flow are never eligible, even if you try to list them — the policy rejects them at construction, before anything runs.
+
+## Backoff
+
+Delays grow exponentially and are jittered by default:
+
+```python
+RetryPolicy(
+    max_attempts=5,
+    retry_on=(ConnectionError,),
+    initial_delay=1.0,        # nominal delay after the 1st failure
+    backoff_multiplier=2.0,   # 1s, 2s, 4s, ... nominal
+    max_delay=60.0,           # nominal never exceeds this
+    jitter="full",            # sleep uniform in [0, nominal]; "none" = exact nominal
+)
+```
+
+## Bound the whole series with `retry_window`
+
+`retry_window` (seconds) caps one attempt series with a single absolute deadline, fixed when the series opens. Backoff waits, persistence overhead, and even process downtime consume it. It combines with `max_attempts` as independent OR limits — whichever ends first, ends the series:
+
+```python
+RetryPolicy(
+    max_attempts=5,
+    retry_on=(ConnectionError,),
+    retry_window=45,   # no attempt may start 45s after the series opened
+)
+```
+
+## Honor a server's Retry-After
+
+When a response tells you exactly how long to wait, raise `RetryAfterError` around the real failure instead of sleeping inside your node:
+
+```python
+from hypergraph import RetryAfterError
+
+@node(
+    output_name="response",
+    retry=RetryPolicy(max_attempts=5, retry_on=(RateLimited,)),
+)
+def send(message: str) -> str:
+    try:
+        return client.send(message)
+    except RateLimited as error:
+        raise RetryAfterError(error, retry_after=30) from error
+```
+
+The carrier never authorizes anything: eligibility is still decided by `retry_on` against the underlying `RateLimited`. When a retry may start, the 30s is honored exactly (no jitter, no `max_delay` cap). When it may not — ineligible type, exhausted budget, or a wait that cannot end before the `retry_window` deadline — the exact underlying exception is re-raised without sleeping.
+
+## Durable budgets across restarts
+
+Budget durability follows your checkpointer:
+
+```python
+from hypergraph import SyncRunner
+from hypergraph.checkpointers import SqliteCheckpointer
+
+runner = SyncRunner(checkpointer=SqliteCheckpointer("runs.db"))
+runner.run(graph, {"user_id": "u-42"}, workflow_id="onboard-u-42")
+```
+
+| Setup | `max_attempts` promise |
+|-------|------------------------|
+| No checkpointer | Process-local: each run gets a fresh budget |
+| `MemoryCheckpointer` | Survives in-process resume, not process exit |
+| `SqliteCheckpointer` + `workflow_id` | Hard cap across crash and restart |
+
+With persistence, every attempt is durably reserved **before** your code runs, and each failure persists its sampled backoff plus the absolute wake-up time. Re-running the same `workflow_id` after a crash continues the same series: consumed attempts stay consumed, and a pending backoff wait resumes from the persisted wake time — it is never redrawn and never restarted. Attempt history is inspectable per step in the checkpointer's attempt ledger.
+
+This is an at-most-N-invocations guarantee, not exactly-once side effects: a crash mid-attempt cannot know whether the external call landed (the attempt is recorded as outcome-unknown). Payment-style APIs still need idempotency keys.
+
+## What retry does NOT change
+
+- **Cache**: one lookup before any attempt; a hit invokes nothing and consumes no budget; one write after final success. Changing the policy never invalidates cached results.
+- **Events and progress**: one `NodeStartEvent` and one `NodeEndEvent`/`NodeErrorEvent` per logical node, regardless of attempts.
+- **Direct calls**: `fetch_profile("u-42")` and `fetch_profile.func("u-42")` invoke exactly once — retry runs only inside a runner.
+- **Map fan-out**: each `.map()` item owns its own series and budget; one item's failures never consume another's.
+- **Other node types**: gates, interrupts, and nested-graph (GraphNode) boundaries are not retryable; a FunctionNode inside a nested graph carries its own declaration.
+
+## API reference
+
+See [RetryPolicy](../06-api-reference/nodes.md#retrypolicy) and [RetryAfterError](../06-api-reference/nodes.md#retryaftererror).

--- a/docs/06-api-reference/checkpointers.md
+++ b/docs/06-api-reference/checkpointers.md
@@ -199,6 +199,8 @@ CheckpointPolicy()
 | `window` | `int \| None` | Required when `retention="windowed"`. |
 | `ttl` | `timedelta \| None` | Auto-expire completed runs after this duration. |
 
+**Retry evidence writes through under every durability mode.** For a node with a [RetryPolicy](nodes.md#retrypolicy), attempt reservations/outcomes and the series-closing StepRecord are persisted immediately even under `durability="async"` or `"exit"`: the final attempt outcome, its linked StepRecord, and the series closure must commit atomically, and that invariant takes precedence over buffering. Non-retrying nodes buffer normally.
+
 **Async durability is best-effort.** With `durability="async"` (the default), step writes happen in background tasks: a failed write does not fail the run — the run still returns `COMPLETED`, and the failure is reported on the result instead. Check `result.checkpoint_ok` (and `result.checkpoint_errors`, a tuple of error strings) to detect gaps in the persisted history:
 
 ```python

--- a/docs/06-api-reference/nodes.md
+++ b/docs/06-api-reference/nodes.md
@@ -161,6 +161,7 @@ def __init__(
     hide: bool = False,
     emit: str | tuple[str, ...] | None = None,
     wait_for: str | tuple[str, ...] | None = None,
+    retry: RetryPolicy | None = None,
 ) -> None: ...
 ```
 
@@ -177,6 +178,7 @@ def __init__(
 - `hide`: Whether to hide this node from visualization (default: False)
 - `emit`: Ordering-only local output name(s). Auto-produced when the node runs
 - `wait_for`: Ordering-only graph-scope output/emit address(es). Node waits until these values exist and are fresh
+- `retry`: Optional [RetryPolicy](#retrypolicy). Node-owned only — there is no runner, graph, or per-call retry default, and no `retry=True` shorthand. Direct calls stay raw single-shot invocations
 
 **Returns:** FunctionNode instance
 
@@ -498,6 +500,7 @@ def node(
     hide: bool = False,
     emit: str | tuple[str, ...] | None = None,
     wait_for: str | tuple[str, ...] | None = None,
+    retry: RetryPolicy | None = None,
 ) -> FunctionNode | Callable[[Callable], FunctionNode]: ...
 ```
 
@@ -509,6 +512,7 @@ def node(
 - `hide`: Whether to hide this node from visualization (default: False)
 - `emit`: Ordering-only local output name(s). Auto-produced when the node runs. Used with `wait_for` to enforce execution order without data dependency. See [Ordering](../03-patterns/03-agentic-loops.md#ordering-with-emitwait_for)
 - `wait_for`: Ordering-only graph-scope output/emit address(es). Node won't run until these values exist and are fresh. Must reference an `emit` or `output_name` of another node at the current graph scope
+- `retry`: Optional [RetryPolicy](#retrypolicy) declaring which failures are safe to repeat and with what budget/backoff. See [How to Retry Transient Failures](../05-how-to/retry-transient-failures.md)
 
 **Returns:**
 - FunctionNode if source provided (decorator without parens)
@@ -581,6 +585,96 @@ def log(msg: str) -> None:  # Explicitly None → no warning
 def log(msg: str):  # No return annotation → no warning
     print(msg)
 ```
+
+---
+
+## RetryPolicy
+
+Frozen, node-owned retry declaration with capped-exponential backoff. Passed to `@node(retry=...)` or `FunctionNode(retry=...)`.
+
+```python
+from hypergraph import RetryPolicy, node
+
+@node(
+    output_name="response",
+    retry=RetryPolicy(
+        max_attempts=3,
+        retry_on=(ConnectionError, TimeoutError),
+    ),
+)
+def call_model(prompt: str) -> str:
+    return client.generate(prompt)
+```
+
+### Signature
+
+```python
+@dataclass(frozen=True)
+class RetryPolicy:
+    max_attempts: int
+    retry_on: tuple[type[Exception], ...]
+    retry_window: float | None = None
+    initial_delay: float = 1.0
+    backoff_multiplier: float = 2.0
+    max_delay: float = 60.0
+    jitter: Literal["full", "none"] = "full"
+```
+
+**Args:**
+
+- `max_attempts`: Total callable invocations **including the first**. `max_attempts=3` means at most three calls
+- `retry_on` (required): Explicit allowlist of `Exception` subclasses that may retry. There is no retry-all default and no `retry=True` shorthand. `BaseException` control flow (KeyboardInterrupt, cancellation, pause/stop) is never eligible and is rejected at construction
+- `retry_window`: Optional bound in seconds on one attempt series. The absolute deadline is fixed once when the series opens; attempt execution, backoff, persistence overhead, and process downtime all consume it. Independent OR-limit with `max_attempts`
+- `initial_delay`: Base delay in seconds before the second attempt (default: 1.0)
+- `backoff_multiplier`: Exponential growth factor; `1.0` expresses constant delay (default: 2.0)
+- `max_delay`: Cap on the nominal delay in seconds (default: 60.0)
+- `jitter`: `"full"` samples uniformly from `[0, nominal]`; `"none"` uses the nominal delay directly (default: `"full"`)
+
+After failed one-based attempt `n`, the nominal delay is `min(max_delay, initial_delay * backoff_multiplier ** (n - 1))`.
+
+**Raises:** `ValueError` / `TypeError` at construction — before any execution — for a missing or empty `retry_on`, `BaseException`-family entries, non-positive or non-finite timing fields, `max_attempts < 1`, or an unknown jitter mode.
+
+### Semantics
+
+- **Node-owned only.** Only the node declaration can make its callable repeat. Runners, graphs, and `run()`/`map()` calls have no retry defaults or overrides.
+- **One logical step.** A retrying node stays a single graph step: downstream scheduling, state application, and the cache write happen once, after the final success. Intermediate attempts never fold state or emit node events.
+- **Exact exception, no wrapper.** After exhaustion or an ineligible failure, the exact final underlying exception is re-raised — never a generic retry-exhausted wrapper.
+- **Durable budget.** With a persistent checkpointer (e.g. `SqliteCheckpointer`) and a `workflow_id`, every attempt is reserved write-through in the durable attempt ledger before user code runs: `max_attempts` is a hard cap across crash and resume, and the sampled backoff plus its absolute wake time are persisted so a restart neither redraws jitter nor restarts the wait. With `MemoryCheckpointer` the budget survives in-process resume only; without a checkpointer it is process-local.
+- **Cache first.** A cache hit invokes nothing, consumes zero attempts, and opens no series. Changing a retry policy does not invalidate cached results.
+- **Composition.** The declaration travels with the node through nested graphs and background execution; each `.map()` item owns its own attempt series and budget. Gates, interrupts, and the GraphNode boundary are not retryable.
+- **Direct calls stay raw.** `node(...)` and `node.func(...)` invoke exactly once regardless of policy.
+
+## RetryAfterError
+
+Typed carrier for a server-supplied retry delay (e.g. an HTTP `Retry-After` header). It never authorizes a retry by itself.
+
+```python
+from hypergraph import RetryAfterError
+
+@node(
+    output_name="response",
+    retry=RetryPolicy(max_attempts=5, retry_on=(RateLimited,)),
+)
+def send(message: str) -> str:
+    try:
+        return client.send(message)
+    except RateLimited as error:
+        raise RetryAfterError(error, retry_after=30) from error
+```
+
+### Signature
+
+```python
+class RetryAfterError(Exception):
+    def __init__(self, error: Exception, *, retry_after: float) -> None: ...
+```
+
+**Args:**
+
+- `error`: The exact underlying exception. Eligibility is checked against the node's `retry_on` allowlist using this object's type — the carrier never makes an ineligible error retryable
+- `retry_after`: Finite delay in seconds, `>= 0`. When a retry may start, this delay is honored **exactly** — no jitter and no `max_delay` cap — but it remains bounded by `max_attempts` and `retry_window`. If the wait cannot end before the series deadline, hypergraph skips the pointless sleep and re-raises the exact underlying exception (never the carrier)
+
+**Raises:** `TypeError` for a non-`Exception` or nested-carrier `error`; `ValueError` for a negative or non-finite `retry_after`.
 
 ---
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -41,6 +41,7 @@
 * [Nodes from Component Methods](05-how-to/nodes-from-component-methods.md)
 * [Rename and Adapt](05-how-to/rename-and-adapt.md)
 * [Integrate with LLMs](05-how-to/integrate-with-llms.md)
+* [Retry Transient Failures](05-how-to/retry-transient-failures.md)
 * [Use Hypergraph with Daft](05-how-to/daft-workflows.md)
 * [Test Without Framework](05-how-to/test-without-framework.md)
 * [Debug Workflows](05-how-to/debug-workflows.md)

--- a/src/hypergraph/__init__.py
+++ b/src/hypergraph/__init__.py
@@ -53,6 +53,8 @@ from hypergraph.nodes import (
     IfElseNode,
     InterruptNode,
     RenameError,
+    RetryAfterError,
+    RetryPolicy,
     RouteNode,
     ifelse,
     interrupt,
@@ -96,6 +98,8 @@ __all__ = [
     "InterruptNode",
     "HyperNode",
     "END",
+    "RetryPolicy",
+    "RetryAfterError",
     # Graph
     "Graph",
     "InputSpec",

--- a/src/hypergraph/checkpointers/base.py
+++ b/src/hypergraph/checkpointers/base.py
@@ -104,6 +104,44 @@ def _require_started(record: AttemptRecord | None, series_id: str, attempt_numbe
     return record
 
 
+#: Settled statuses over which a close may still link its StepRecord (resume
+#: dead ends). SUCCEEDED is deliberately absent: a success must be witnessed
+#: by a live reservation, never reconstructed over settled evidence.
+_LINK_CLOSABLE_STATUSES = frozenset({AttemptStatus.FAILED, AttemptStatus.OUTCOME_UNKNOWN})
+
+
+def _check_closable(
+    record: AttemptRecord | None,
+    series_id: str,
+    attempt_number: int,
+    status: AttemptStatus,
+    last_attempt_number: int,
+) -> bool:
+    """Validate a close target. True → settle the STARTED row; False → link only.
+
+    The ordinary close settles a live ``STARTED`` reservation with any
+    terminal status. A resume dead end (budget exhausted, window expired,
+    ``OUTCOME_UNKNOWN`` evidence) has no live reservation left, yet the
+    atomic outcome/link/close invariant still requires the failed logical
+    StepRecord to link its series and the series to close — so a close is
+    also accepted when the LAST record is already terminal ``FAILED`` /
+    ``OUTCOME_UNKNOWN``. In that link-only mode the requested status must
+    equal the record's settled status: evidence is never rewritten.
+    """
+    if record is None:
+        raise AttemptLedgerError(f"Unknown attempt #{attempt_number} in series {series_id!r}")
+    if record.status is AttemptStatus.STARTED:
+        return True
+    if record.status in _LINK_CLOSABLE_STATUSES and attempt_number == last_attempt_number:
+        if status is not record.status:
+            raise AttemptLedgerError(
+                f"Attempt #{attempt_number} in series {series_id!r} is already settled as "
+                f"{record.status.value!r}; a terminal close must carry that same status, got {status.value!r}."
+            )
+        return False
+    raise AttemptLedgerError(f"Attempt #{attempt_number} in series {series_id!r} is already settled as {record.status.value!r}.")
+
+
 def _check_close_request(series: AttemptSeries, status: AttemptStatus, step_record: StepRecord) -> None:
     if not series.is_open:
         raise AttemptLedgerError(f"Attempt series {series.id!r} is already closed.")
@@ -156,6 +194,14 @@ class CheckpointPolicy:
             "windowed" — keep last N supersteps.
         window: Supersteps to keep (required if retention="windowed").
         ttl: Auto-expire completed runs after this duration.
+
+    Note:
+        Retry evidence overrides durability timing: for a node with a
+        ``RetryPolicy``, attempt reservations/outcomes AND the series-closing
+        StepRecord write through immediately under every durability mode —
+        the final attempt outcome, its linked StepRecord, and series closure
+        must commit atomically, and that invariant takes precedence over
+        "async"/"exit" buffering. Non-retrying nodes buffer normally.
     """
 
     durability: Literal["sync", "async", "exit"] = "async"
@@ -460,6 +506,13 @@ class Checkpointer(ABC):
         The final outcome, the linked StepRecord (which must carry
         ``attempt_series_id``), series closure, and retention effects commit
         as one unit — either all are durable or none are.
+
+        Two accepted shapes: the ordinary close settles a live ``STARTED``
+        reservation with ``status``; a resume dead end may instead close over
+        a LAST record that is already terminal ``FAILED``/``OUTCOME_UNKNOWN``
+        — ``status`` must then equal the settled status (evidence is never
+        rewritten) and only the StepRecord link, closure, and retention
+        commit. ``SUCCEEDED`` always requires a live reservation.
         """
         raise self._attempt_ledger_unsupported()
 

--- a/src/hypergraph/checkpointers/memory.py
+++ b/src/hypergraph/checkpointers/memory.py
@@ -9,6 +9,7 @@ from typing import Any
 from hypergraph.checkpointers.base import (
     _UNSET,
     Checkpointer,
+    _check_closable,
     _check_close_request,
     _check_no_live_reservation,
     _check_no_open_series,
@@ -292,7 +293,8 @@ class MemoryCheckpointer(Checkpointer):
         series = _require_series(self._attempt_series.get(series_id), series_id)
         _check_close_request(series, status, step_record)
         records = self._attempt_records[series_id]
-        record = _require_started(records.get(attempt_number), series_id, attempt_number)
+        record = records.get(attempt_number)
+        settle = _check_closable(record, series_id, attempt_number, status, max(records, default=0))
         now = datetime.now(timezone.utc)
         # The step store happens first: it is the only in-principle fallible
         # write here. The attempt settle and series close below are pure dict
@@ -300,7 +302,8 @@ class MemoryCheckpointer(Checkpointer):
         # attempt unsettled — the atomic-close outcome.
         run_steps = self._steps.setdefault(step_record.run_id, {})
         run_steps[(step_record.superstep, step_record.node_name)] = step_record
-        records[attempt_number] = replace(record, status=status, completed_at=now, error=error)
+        if settle:
+            records[attempt_number] = replace(record, status=status, completed_at=now, error=error)
         self._attempt_series[series_id] = replace(series, closed_at=now, committed_superstep=step_record.superstep)
         self._apply_retention_policy(step_record.run_id)
 

--- a/src/hypergraph/checkpointers/sqlite.py
+++ b/src/hypergraph/checkpointers/sqlite.py
@@ -18,6 +18,7 @@ from hypergraph.checkpointers.base import (
     _UNSET,
     Checkpointer,
     CheckpointPolicy,
+    _check_closable,
     _check_close_request,
     _check_no_live_reservation,
     _check_no_open_series,
@@ -1030,19 +1031,23 @@ class SqliteCheckpointer(Checkpointer):
                 await self._db.execute("BEGIN IMMEDIATE")
                 series = _require_series(await self._fetch_attempt_series(series_id), series_id)
                 _check_close_request(series, status, step_record)
-                _require_started(await self._fetch_attempt_record(series_id, attempt_number), series_id, attempt_number)
-                cursor = await self._db.execute(
-                    _ATTEMPT_FINAL_SQL,
-                    (
-                        status.value,
-                        now.isoformat(),
-                        error.type_name if error else None,
-                        error.message if error else None,
-                        series_id,
-                        attempt_number,
-                    ),
-                )
-                self._check_settled_exactly_one(cursor.rowcount, f"Attempt #{attempt_number} in series {series_id!r}")
+                record = await self._fetch_attempt_record(series_id, attempt_number)
+                cursor = await self._db.execute(_ATTEMPT_MAX_NUMBER_SQL, (series_id,))
+                (max_number,) = await cursor.fetchone()
+                settle = _check_closable(record, series_id, attempt_number, status, int(max_number))
+                if settle:
+                    cursor = await self._db.execute(
+                        _ATTEMPT_FINAL_SQL,
+                        (
+                            status.value,
+                            now.isoformat(),
+                            error.type_name if error else None,
+                            error.message if error else None,
+                            series_id,
+                            attempt_number,
+                        ),
+                    )
+                    self._check_settled_exactly_one(cursor.rowcount, f"Attempt #{attempt_number} in series {series_id!r}")
                 await self._db.execute(_STEP_UPSERT_SQL, self._step_upsert_params(step_record))
                 cursor = await self._db.execute(_ATTEMPT_SERIES_CLOSE_SQL, (now.isoformat(), step_record.superstep, series_id))
                 self._check_settled_exactly_one(cursor.rowcount, f"Attempt series {series_id!r}")
@@ -1914,19 +1919,22 @@ class SqliteCheckpointer(Checkpointer):
                 db.execute("BEGIN IMMEDIATE")
                 series = _require_series(self._fetch_attempt_series_sync(db, series_id), series_id)
                 _check_close_request(series, status, step_record)
-                _require_started(self._fetch_attempt_record_sync(db, series_id, attempt_number), series_id, attempt_number)
-                cursor = db.execute(
-                    _ATTEMPT_FINAL_SQL,
-                    (
-                        status.value,
-                        now.isoformat(),
-                        error.type_name if error else None,
-                        error.message if error else None,
-                        series_id,
-                        attempt_number,
-                    ),
-                )
-                self._check_settled_exactly_one(cursor.rowcount, f"Attempt #{attempt_number} in series {series_id!r}")
+                record = self._fetch_attempt_record_sync(db, series_id, attempt_number)
+                (max_number,) = db.execute(_ATTEMPT_MAX_NUMBER_SQL, (series_id,)).fetchone()
+                settle = _check_closable(record, series_id, attempt_number, status, int(max_number))
+                if settle:
+                    cursor = db.execute(
+                        _ATTEMPT_FINAL_SQL,
+                        (
+                            status.value,
+                            now.isoformat(),
+                            error.type_name if error else None,
+                            error.message if error else None,
+                            series_id,
+                            attempt_number,
+                        ),
+                    )
+                    self._check_settled_exactly_one(cursor.rowcount, f"Attempt #{attempt_number} in series {series_id!r}")
                 db.execute(_STEP_UPSERT_SQL, self._step_upsert_params(step_record))
                 cursor = db.execute(_ATTEMPT_SERIES_CLOSE_SQL, (now.isoformat(), step_record.superstep, series_id))
                 self._check_settled_exactly_one(cursor.rowcount, f"Attempt series {series_id!r}")

--- a/src/hypergraph/nodes/__init__.py
+++ b/src/hypergraph/nodes/__init__.py
@@ -6,12 +6,15 @@ from hypergraph.nodes.function import FunctionNode, node
 from hypergraph.nodes.gate import END, GateNode, IfElseNode, RouteNode, ifelse, route
 from hypergraph.nodes.graph_node import GraphNode, GraphNodeMapExecutionConfig
 from hypergraph.nodes.interrupt import InterruptNode, interrupt
+from hypergraph.nodes.retry import RetryAfterError, RetryPolicy
 
 __all__ = [
     "HyperNode",
     "_EMIT_SENTINEL",
     "RenameEntry",
     "RenameError",
+    "RetryAfterError",
+    "RetryPolicy",
     "FunctionNode",
     "GraphNode",
     "GraphNodeMapExecutionConfig",

--- a/src/hypergraph/nodes/function.py
+++ b/src/hypergraph/nodes/function.py
@@ -12,6 +12,7 @@ from hypergraph.nodes._callable import CallableMixin
 from hypergraph.nodes._input_extraction import extract_inputs
 from hypergraph.nodes._rename import _apply_renames
 from hypergraph.nodes.base import HyperNode, _validate_emit_wait_for
+from hypergraph.nodes.retry import RetryPolicy
 
 
 def _resolve_outputs(
@@ -101,6 +102,7 @@ class FunctionNode(CallableMixin, HyperNode):
     _is_generator: bool
     _wait_for: tuple[str, ...]
     _emit: tuple[str, ...]
+    _retry: RetryPolicy | None
 
     def __init__(
         self,
@@ -113,6 +115,7 @@ class FunctionNode(CallableMixin, HyperNode):
         hide: bool = False,
         emit: str | tuple[str, ...] | None = None,
         wait_for: str | tuple[str, ...] | None = None,
+        retry: RetryPolicy | None = None,
     ) -> None:
         """Wrap a function as a node.
 
@@ -128,6 +131,9 @@ class FunctionNode(CallableMixin, HyperNode):
                   when node runs. Participates in edge inference like output_name.
             wait_for: Ordering-only graph-scope output/emit address(es). Node
                       won't run until these values exist and are fresh.
+            retry: Optional :class:`RetryPolicy`. Only a node declaration can
+                   make its callable repeat; runners execute the attempt loop.
+                   Direct calls stay raw single-shot invocations.
         Warning:
             If the function has a return type annotation but no output_name
             is provided, a warning is emitted. This helps catch cases where
@@ -142,9 +148,18 @@ class FunctionNode(CallableMixin, HyperNode):
         # Extract func if source is FunctionNode
         func = source.func if isinstance(source, FunctionNode) else source
 
+        if retry is not None and not isinstance(retry, RetryPolicy):
+            raise TypeError(
+                f"retry must be a RetryPolicy (or None), got {retry!r}.\n\n"
+                "How to fix:\n"
+                "  There is no retry=True shorthand. Declare the failure classes that\n"
+                "  are safe to repeat: retry=RetryPolicy(max_attempts=3, retry_on=(TimeoutError,))."
+            )
+
         self.func = func
         self._cache = cache
         self._hide = hide
+        self._retry = retry
         self._definition_hash = hash_definition(func)
         self._emit = ensure_tuple(emit) if emit else ()
         self._wait_for = ensure_tuple(wait_for) if wait_for else ()
@@ -183,6 +198,11 @@ class FunctionNode(CallableMixin, HyperNode):
     def cache(self) -> bool:
         """Whether results should be cached."""
         return self._cache
+
+    @property
+    def retry(self) -> RetryPolicy | None:
+        """The node-owned retry declaration, or None (no retry)."""
+        return self._retry
 
     @property
     def hide(self) -> bool:
@@ -297,6 +317,7 @@ def node(
     hide: bool = False,
     emit: str | tuple[str, ...] | None = None,
     wait_for: str | tuple[str, ...] | None = None,
+    retry: RetryPolicy | None = None,
 ) -> FunctionNode | Callable[[Callable], FunctionNode]:
     """Decorator to wrap a function as a FunctionNode.
 
@@ -319,6 +340,10 @@ def node(
               when node runs. Participates in edge inference like output_name.
         wait_for: Ordering-only graph-scope output/emit address(es). Node
                   won't run until these values exist and are fresh.
+        retry: Optional RetryPolicy declaring which failures are safe to
+               repeat and with what budget/backoff. Node-owned only: there is
+               no runner, graph, or per-call retry default, and no retry=True
+               shorthand. Direct calls stay raw single-shot invocations.
     Returns:
         FunctionNode if source provided, else decorator function.
 
@@ -342,6 +367,7 @@ def node(
             hide=hide,
             emit=emit,
             wait_for=wait_for,
+            retry=retry,
         )
         fn_node.__wrapped__ = func
         return fn_node

--- a/src/hypergraph/nodes/retry.py
+++ b/src/hypergraph/nodes/retry.py
@@ -1,0 +1,164 @@
+"""Node-owned retry declarations: RetryPolicy and RetryAfterError.
+
+The locked #187 contract makes retry a node declaration: only the node that
+owns a side effect may make its callable repeat. The policy is a frozen value
+object; the retry loop itself lives in the runner execution layer
+(``hypergraph.runners._shared.attempts``). Direct ``FunctionNode`` calls stay
+raw single-shot invocations regardless of policy.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Literal
+
+#: Fingerprint schema/algorithm tag. The random jitter sample is attempt
+#: state, not policy identity, so it never enters the fingerprint.
+_FINGERPRINT_SCHEMA = "hypergraph.retry/v1|capped-exponential"
+
+_JITTER_MODES = ("full", "none")
+
+
+def _qualified_type_name(exc_type: type[BaseException]) -> str:
+    """Canonical module-qualified exception name (builtins stay bare)."""
+    if exc_type.__module__ in ("builtins", "__main__"):
+        return exc_type.__qualname__
+    return f"{exc_type.__module__}.{exc_type.__qualname__}"
+
+
+def _normalize_retry_on(retry_on: object) -> tuple[type[Exception], ...]:
+    """Validate and normalize the eligibility allowlist to a tuple of types."""
+    if isinstance(retry_on, type):
+        entries: tuple[object, ...] = (retry_on,)
+    elif isinstance(retry_on, Iterable) and not isinstance(retry_on, (str, bytes)):
+        entries = tuple(retry_on)
+    else:
+        raise TypeError(f"retry_on must be an exception type or an iterable of exception types, got {retry_on!r}.")
+
+    if not entries:
+        raise ValueError(
+            "retry_on must name at least one exception type.\n\n"
+            "How to fix:\n"
+            "  Declare exactly which transient failures are safe to repeat, e.g.\n"
+            "  RetryPolicy(max_attempts=3, retry_on=(httpx.ReadTimeout,)).\n"
+            "  There is no retry-all default and no retry=True shorthand."
+        )
+
+    for entry in entries:
+        if not isinstance(entry, type) or not issubclass(entry, BaseException):
+            raise TypeError(f"retry_on entries must be exception types, got {entry!r}.")
+        if not issubclass(entry, Exception):
+            raise ValueError(
+                f"retry_on must not contain BaseException-family control flow: {_qualified_type_name(entry)}.\n\n"
+                "How to fix:\n"
+                "  KeyboardInterrupt, SystemExit, cancellation, and other BaseException\n"
+                "  control flow are never retryable. List Exception subclasses only."
+            )
+    return entries  # type: ignore[return-value]
+
+
+def _require_positive_finite(name: str, value: float) -> float:
+    number = float(value)
+    if not math.isfinite(number) or number <= 0:
+        raise ValueError(f"{name} must be a positive finite number, got {value!r}.")
+    return number
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    """Frozen, node-owned retry declaration with capped-exponential backoff.
+
+    ``max_attempts`` counts the initial invocation: ``max_attempts=3`` means at
+    most three callable invocations. ``retry_on`` is a required, explicit
+    allowlist of ``Exception`` subclasses — only listed failures may repeat,
+    and ``BaseException`` control flow is never eligible.
+
+    After failed one-based attempt ``n`` the nominal delay is
+    ``min(max_delay, initial_delay * backoff_multiplier ** (n - 1))``;
+    ``jitter="full"`` samples uniformly from ``[0, nominal]`` while
+    ``jitter="none"`` uses the nominal delay directly. A
+    ``backoff_multiplier`` of ``1.0`` expresses constant delay.
+
+    ``retry_window`` (seconds) bounds one attempt series with a single
+    immutable absolute deadline fixed when the series opens. Attempt
+    execution, backoff, persistence overhead, and process downtime all
+    consume it; it OR-combines with ``max_attempts``.
+
+    Example:
+        >>> policy = RetryPolicy(max_attempts=3, retry_on=(ConnectionError,))
+        >>> policy.max_attempts
+        3
+    """
+
+    max_attempts: int
+    retry_on: tuple[type[Exception], ...]
+    retry_window: float | None = None
+    initial_delay: float = 1.0
+    backoff_multiplier: float = 2.0
+    max_delay: float = 60.0
+    jitter: Literal["full", "none"] = "full"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "retry_on", _normalize_retry_on(self.retry_on))
+        if not isinstance(self.max_attempts, int) or isinstance(self.max_attempts, bool) or self.max_attempts < 1:
+            raise ValueError(f"max_attempts must be an integer >= 1 (it counts the initial invocation), got {self.max_attempts!r}.")
+        object.__setattr__(self, "initial_delay", _require_positive_finite("initial_delay", self.initial_delay))
+        object.__setattr__(self, "backoff_multiplier", _require_positive_finite("backoff_multiplier", self.backoff_multiplier))
+        object.__setattr__(self, "max_delay", _require_positive_finite("max_delay", self.max_delay))
+        if self.retry_window is not None:
+            object.__setattr__(self, "retry_window", _require_positive_finite("retry_window", self.retry_window))
+        if self.jitter not in _JITTER_MODES:
+            raise ValueError(f'jitter must be "full" or "none", got {self.jitter!r}.')
+
+    @property
+    def fingerprint(self) -> str:
+        """Canonical policy identity for the durable attempt ledger.
+
+        Normalized timing fields plus a schema/algorithm tag; exception types
+        as sorted module-qualified names. Equal policies share a fingerprint
+        regardless of ``retry_on`` ordering.
+        """
+        names = ",".join(sorted(_qualified_type_name(entry) for entry in self.retry_on))
+        return (
+            f"{_FINGERPRINT_SCHEMA}"
+            f"|max_attempts={self.max_attempts}"
+            f"|retry_on={names}"
+            f"|retry_window={self.retry_window!r}"
+            f"|initial_delay={self.initial_delay!r}"
+            f"|backoff_multiplier={self.backoff_multiplier!r}"
+            f"|max_delay={self.max_delay!r}"
+            f"|jitter={self.jitter}"
+        )
+
+
+class RetryAfterError(Exception):
+    """Typed carrier for a server-supplied retry delay. Never authorizes a retry.
+
+    Raise it around the real failure when a response carries an exact
+    ``Retry-After`` delay::
+
+        try:
+            return await client.send(message)
+        except RateLimited as error:
+            raise RetryAfterError(error, retry_after=30) from error
+
+    Eligibility is still decided by the node's ``retry_on`` allowlist against
+    the exact underlying ``error``. When a retry may start, the server delay
+    is honored exactly — no jitter, no ``max_delay`` cap — but stays bounded
+    by ``max_attempts`` and ``retry_window``. When no retry may start, the
+    exact underlying exception is re-raised, never this carrier.
+    """
+
+    def __init__(self, error: Exception, *, retry_after: float) -> None:
+        if isinstance(error, RetryAfterError):
+            raise TypeError("RetryAfterError cannot wrap another RetryAfterError; pass the underlying exception.")
+        if not isinstance(error, Exception):
+            raise TypeError(f"error must be an Exception instance (the real underlying failure), got {error!r}.")
+        delay = float(retry_after)
+        if not math.isfinite(delay) or delay < 0:
+            raise ValueError(f"retry_after must be a finite delay >= 0 seconds, got {retry_after!r}.")
+        self.error = error
+        self.retry_after = delay
+        super().__init__(f"retry after {delay}s: {error!r}")

--- a/src/hypergraph/runners/_shared/attempts.py
+++ b/src/hypergraph/runners/_shared/attempts.py
@@ -41,6 +41,7 @@ import asyncio
 import random
 import time
 from collections.abc import Awaitable, Callable
+from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass, replace
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
@@ -80,11 +81,16 @@ async def _sleep_async(seconds: float) -> None:
 
 
 def nominal_delay(policy: RetryPolicy, failed_attempt_number: int) -> float:
-    """Nominal backoff cap after failed one-based attempt ``n``."""
-    return min(
-        policy.max_delay,
-        policy.initial_delay * policy.backoff_multiplier ** (failed_attempt_number - 1),
-    )
+    """Nominal backoff cap after failed one-based attempt ``n``.
+
+    Valid extreme policies (huge multipliers, deep attempt numbers) overflow
+    float exponentiation; the nominal delay is then simply the cap.
+    """
+    try:
+        grown = policy.initial_delay * policy.backoff_multiplier ** (failed_attempt_number - 1)
+    except OverflowError:
+        return policy.max_delay
+    return min(policy.max_delay, grown)
 
 
 @dataclass(frozen=True)
@@ -424,6 +430,12 @@ def run_attempts_sync(
             _sleep_sync(step.decision.sampled_delay)
         # BaseException control flow is deliberately not caught: it passes
         # through untouched and the reservation stays for resume semantics.
+        if deadline_at is not None and _utcnow() >= deadline_at:
+            # Post-sleep freshness: the wait itself may have outlived the
+            # window. In-process the exact last underlying exception is
+            # re-raised; the ledger's begin_attempt re-verifies atomically as
+            # the durable backstop.
+            raise step.underlying
 
 
 async def run_attempts_async(
@@ -434,8 +446,14 @@ async def run_attempts_async(
     checkpointer: Any | None,
     run_id: str | None,
     scheduled_superstep: int,
+    attempt_scope: Callable[[], AbstractAsyncContextManager[Any]] | None = None,
 ) -> Any:
-    """Drive one logical node execution as a series of attempts (async)."""
+    """Drive one logical node execution as a series of attempts (async).
+
+    ``attempt_scope`` scopes ONE in-flight invocation (the concurrency
+    permit, per #218): it is entered before and exited after each attempt,
+    so backoff sleeps never hold a permit.
+    """
     now = _utcnow()
     if checkpointer is not None and run_id:
         ledger: Checkpointer | None = checkpointer
@@ -459,7 +477,10 @@ async def run_attempts_async(
         else:
             attempt_number += 1
         try:
-            return await invoke()
+            if attempt_scope is None:
+                return await invoke()
+            async with attempt_scope():
+                return await invoke()
         except Exception as error:
             # Terminal paths raise the exact underlying exception from here.
             # The reservation intentionally stays STARTED: the step-save site
@@ -477,6 +498,12 @@ async def run_attempts_async(
             await _sleep_async(step.decision.sampled_delay)
         # BaseException control flow is deliberately not caught: it passes
         # through untouched and the reservation stays for resume semantics.
+        if deadline_at is not None and _utcnow() >= deadline_at:
+            # Post-sleep freshness: the wait itself may have outlived the
+            # window. In-process the exact last underlying exception is
+            # re-raised; the ledger's begin_attempt re-verifies atomically as
+            # the durable backstop.
+            raise step.underlying
 
 
 # === Atomic close at the step-save boundary ===
@@ -494,6 +521,9 @@ def _retrying_function_node(graph: Graph, node_name: str) -> bool:
     return isinstance(node, FunctionNode) and node.retry is not None
 
 
+_LINKABLE_TERMINAL = frozenset({AttemptStatus.FAILED, AttemptStatus.OUTCOME_UNKNOWN})
+
+
 def _close_args(
     record: StepRecord,
     series: AttemptSeries,
@@ -502,18 +532,24 @@ def _close_args(
 ) -> tuple[int, AttemptStatus, AttemptError | None, StepRecord] | None:
     """Pure close decision: (attempt_number, status, error, linked record)."""
     status = _CLOSE_STATUS.get(record.status)
-    if status is None:
+    if status is None or not records:
         return None
-    if not records or records[-1].status is not AttemptStatus.STARTED:
-        # No live reservation to settle (crash edges resolve on resume).
-        return None
-    error = None
-    if status is AttemptStatus.FAILED:
-        raw = (node_errors or {}).get(record.node_name)
-        if isinstance(raw, Exception):
-            error = AttemptError.from_exception(raw)
+    last = records[-1]
     linked = replace(record, attempt_series_id=series.id)
-    return records[-1].attempt_number, status, error, linked
+    if last.status is AttemptStatus.STARTED:
+        # Ordinary close: settle the live reservation with this step's outcome.
+        error = None
+        if status is AttemptStatus.FAILED:
+            raw = (node_errors or {}).get(record.node_name)
+            if isinstance(raw, Exception):
+                error = AttemptError.from_exception(raw)
+        return last.attempt_number, status, error, linked
+    if status is AttemptStatus.FAILED and last.status in _LINKABLE_TERMINAL:
+        # Resume dead end (budget exhausted, window expired, OUTCOME_UNKNOWN
+        # evidence): the logical step failed FROM already-terminal durable
+        # evidence — link it and close without rewriting that evidence.
+        return last.attempt_number, last.status, None, linked
+    return None
 
 
 def maybe_close_attempt_series_sync(

--- a/src/hypergraph/runners/_shared/attempts.py
+++ b/src/hypergraph/runners/_shared/attempts.py
@@ -1,0 +1,565 @@
+"""Shared retry attempt coordinator for the FunctionNode executor path (#230).
+
+The runner execution layer owns retry orchestration: the coordinator sits
+inside the sync/async FunctionNode executors — below the superstep's cache
+lookup, above state application — so a cache hit consumes zero attempts and
+intermediate attempts never fold state, bump versions, emit node events, or
+schedule downstream work.
+
+Semantics live in small pure helpers shared by both drivers; the sync/async
+drivers differ only in how they sleep and how they call the ledger. All
+decisions come from the locked #187 contract:
+
+- Eligibility is an isinstance check of the exact underlying ``Exception``
+  against the node's ``retry_on`` allowlist. ``BaseException`` control flow
+  (pause, stop, cancellation, KeyboardInterrupt) passes through untouched
+  and never settles a reservation as FAILED.
+- Backoff is drawn once per failed attempt — nominal
+  ``min(max_delay, initial_delay * multiplier ** (n - 1))``, full jitter
+  uniform in ``[0, nominal]`` — and persisted with the failed attempt as
+  ``sampled_delay`` + absolute ``retry_not_before``. A resume honors the
+  persisted wake time; it never redraws or restarts a wait.
+- ``RetryAfterError`` is a non-authorizing carrier: its server delay is
+  honored exactly (no jitter, no ``max_delay`` cap) but stays bounded by the
+  budget and the series window; when no retry may start the exact underlying
+  exception is re-raised, never the carrier.
+- Budget durability follows the checkpointer: a run with persistence gets the
+  durable attempt ledger (write-through reservations); otherwise the budget
+  is process-local and no ledger call is made.
+- The FINAL attempt (success or terminal failure) intentionally stays
+  ``STARTED``: :func:`maybe_close_attempt_series_sync` /
+  :func:`maybe_close_attempt_series_async` settle it atomically with the
+  linked StepRecord at the runner's step-save site, per the atomic-close
+  invariant of the ledger. Series-closing records always persist write-through
+  (a deferred close could collide with a cyclic re-execution opening the next
+  series).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, replace
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+from hypergraph.checkpointers.types import (
+    AttemptError,
+    AttemptLedgerError,
+    AttemptRecord,
+    AttemptSeries,
+    AttemptStatus,
+    StepStatus,
+)
+from hypergraph.nodes.retry import RetryAfterError, RetryPolicy
+
+if TYPE_CHECKING:
+    from hypergraph.checkpointers.base import Checkpointer
+    from hypergraph.checkpointers.types import StepRecord
+    from hypergraph.graph import Graph
+
+
+def _utcnow() -> datetime:
+    """Coordinator clock (module-level so tests can pin time deterministically)."""
+    return datetime.now(timezone.utc)
+
+
+def _sleep_sync(seconds: float) -> None:
+    """Sync backoff wait (module-level seam for deterministic tests)."""
+    time.sleep(seconds)
+
+
+async def _sleep_async(seconds: float) -> None:
+    """Async backoff wait (module-level seam for deterministic tests)."""
+    await asyncio.sleep(seconds)
+
+
+# === Pure decision helpers (single source of truth for both drivers) ===
+
+
+def nominal_delay(policy: RetryPolicy, failed_attempt_number: int) -> float:
+    """Nominal backoff cap after failed one-based attempt ``n``."""
+    return min(
+        policy.max_delay,
+        policy.initial_delay * policy.backoff_multiplier ** (failed_attempt_number - 1),
+    )
+
+
+@dataclass(frozen=True)
+class BackoffDecision:
+    """One drawn backoff: what is slept now and persisted with the failure.
+
+    ``nominal_delay`` is None for a server-supplied ``RetryAfterError`` delay,
+    which is honored exactly (no jitter, no cap). ``sampled_delay`` is also
+    the effective wait; ``retry_not_before`` is the absolute wake time.
+    """
+
+    nominal_delay: float | None
+    sampled_delay: float
+    retry_not_before: datetime
+
+    @property
+    def effective_delay(self) -> float:
+        """The wait actually enforced (the ticket's third delay fact).
+
+        Always equals ``sampled_delay``: the persisted shape stores the
+        irreducible state (sampled draw + absolute wake time) and nominal is
+        recomputable from the fingerprinted policy.
+        """
+        return self.sampled_delay
+
+
+def draw_backoff(
+    policy: RetryPolicy,
+    failed_attempt_number: int,
+    *,
+    now: datetime,
+    retry_after: float | None = None,
+) -> BackoffDecision:
+    """Draw the wait before the next attempt. Sampled exactly once."""
+    if retry_after is not None:
+        sampled = float(retry_after)
+        nominal: float | None = None
+    else:
+        nominal = nominal_delay(policy, failed_attempt_number)
+        sampled = random.uniform(0.0, nominal) if policy.jitter == "full" else nominal
+    return BackoffDecision(
+        nominal_delay=nominal,
+        sampled_delay=sampled,
+        retry_not_before=now + timedelta(seconds=sampled),
+    )
+
+
+@dataclass(frozen=True)
+class _FailureDisposition:
+    """An attempt failure, unwrapped: the exact underlying exception object."""
+
+    underlying: Exception
+    retry_after: float | None
+    eligible: bool
+
+
+def classify_failure(error: Exception, policy: RetryPolicy) -> _FailureDisposition:
+    """Unwrap a RetryAfterError carrier and check the retry_on allowlist."""
+    if isinstance(error, RetryAfterError):
+        underlying: Exception = error.error
+        retry_after: float | None = error.retry_after
+    else:
+        underlying, retry_after = error, None
+    return _FailureDisposition(
+        underlying=underlying,
+        retry_after=retry_after,
+        eligible=isinstance(underlying, policy.retry_on),
+    )
+
+
+@dataclass(frozen=True)
+class RetryStep:
+    """A granted retry: the unwrapped failure and the backoff to persist/sleep."""
+
+    underlying: Exception
+    decision: BackoffDecision
+
+
+def plan_after_failure(
+    error: Exception,
+    policy: RetryPolicy,
+    attempt_number: int,
+    deadline_at: datetime | None,
+    *,
+    now: datetime,
+) -> RetryStep:
+    """Decide what follows a failed attempt.
+
+    Returns the backoff to persist and sleep when another attempt may start.
+    Raises the exact underlying exception (never a wrapper, never the
+    RetryAfterError carrier) when the failure is ineligible, the budget is
+    exhausted, or the wait cannot end before the series deadline — the
+    deadline case deliberately skips the pointless sleep.
+    """
+    disposition = classify_failure(error, policy)
+    if not disposition.eligible or attempt_number >= policy.max_attempts:
+        raise disposition.underlying
+    decision = draw_backoff(policy, attempt_number, now=now, retry_after=disposition.retry_after)
+    if deadline_at is not None and decision.retry_not_before >= deadline_at:
+        raise disposition.underlying
+    return RetryStep(underlying=disposition.underlying, decision=decision)
+
+
+def _series_deadline(policy: RetryPolicy, now: datetime) -> datetime | None:
+    """The immutable absolute deadline fixed when a series opens."""
+    if policy.retry_window is None:
+        return None
+    return now + timedelta(seconds=policy.retry_window)
+
+
+@dataclass(frozen=True)
+class _SeriesPlan:
+    """A ledger series ready to continue: consumed budget and pending wake."""
+
+    series_id: str
+    deadline_at: datetime | None
+    consumed: int
+    pending_wake_at: datetime | None
+    last_evidence: AttemptError | None
+
+
+def _plan_resumed_series(series: AttemptSeries, records: list[AttemptRecord]) -> _SeriesPlan:
+    """Continue an open series from its durable evidence (stranded rows already settled)."""
+    last = records[-1] if records else None
+    return _SeriesPlan(
+        series_id=series.id,
+        deadline_at=series.deadline_at,
+        consumed=len(records),
+        pending_wake_at=last.retry_not_before if last is not None else None,
+        last_evidence=last.error if last is not None else None,
+    )
+
+
+def _evidence_suffix(evidence: AttemptError | None) -> str:
+    if evidence is None:
+        return ""
+    return f" Last recorded failure: {evidence.type_name}: {evidence.message}"
+
+
+def _pre_loop_wait(plan: _SeriesPlan, policy: RetryPolicy, now: datetime) -> float | None:
+    """Seconds to wait before the next resumed reservation, honoring evidence.
+
+    Raises from durable evidence — without sleeping — when no retry may start:
+    the persisted budget is exhausted, or the persisted wake time lies at or
+    beyond the immutable series deadline. In a fresh process there is no live
+    exception object to re-raise, so the typed ledger error carries the
+    evidence instead.
+    """
+    if plan.consumed >= policy.max_attempts:
+        raise AttemptLedgerError(
+            f"Attempt budget exhausted for series {plan.series_id!r}: "
+            f"{plan.consumed} of max_attempts={policy.max_attempts} consumed across resume."
+            f"{_evidence_suffix(plan.last_evidence)}\n\n"
+            "How to fix:\n"
+            "  Fork or start a new workflow to grant a fresh retry budget."
+        )
+    if plan.pending_wake_at is None:
+        return None
+    if plan.deadline_at is not None and plan.pending_wake_at >= plan.deadline_at:
+        raise AttemptLedgerError(
+            f"Persisted retry_not_before {plan.pending_wake_at.isoformat()} lies at or beyond "
+            f"deadline_at {plan.deadline_at.isoformat()} for series {plan.series_id!r}; "
+            f"no further attempt may start.{_evidence_suffix(plan.last_evidence)}\n\n"
+            "How to fix:\n"
+            "  Fork or start a new workflow to grant a fresh retry window."
+        )
+    remaining = (plan.pending_wake_at - now).total_seconds()
+    return remaining if remaining > 0 else None
+
+
+# === Ledger surfaces ===
+
+
+@runtime_checkable
+class SyncAttemptLedger(Protocol):
+    """Sync flavor of the #229 attempt-ledger seam (structural).
+
+    SqliteCheckpointer satisfies this via its ``*_sync`` methods. Defined here
+    because the checkpointer protocol surface belongs to #229 and is not
+    extended by this module.
+    """
+
+    def open_attempt_series_sync(
+        self,
+        run_id: str,
+        node_name: str,
+        *,
+        policy_fingerprint: str,
+        max_attempts: int,
+        deadline_at: datetime | None = None,
+    ) -> AttemptSeries: ...
+
+    def get_open_attempt_series_sync(self, run_id: str, node_name: str) -> AttemptSeries | None: ...
+
+    def get_attempt_records_sync(self, series_id: str) -> list[AttemptRecord]: ...
+
+    def begin_attempt_sync(
+        self,
+        series_id: str,
+        *,
+        policy_fingerprint: str,
+        scheduled_superstep: int,
+    ) -> AttemptRecord: ...
+
+    def record_attempt_outcome_sync(
+        self,
+        series_id: str,
+        attempt_number: int,
+        status: AttemptStatus,
+        *,
+        error: AttemptError | None = None,
+        retry_not_before: datetime | None = None,
+        sampled_delay: float | None = None,
+    ) -> AttemptRecord: ...
+
+    def close_attempt_series_sync(
+        self,
+        series_id: str,
+        attempt_number: int,
+        status: AttemptStatus,
+        *,
+        step_record: StepRecord,
+        error: AttemptError | None = None,
+    ) -> None: ...
+
+    def resolve_stranded_attempts_sync(self, series_id: str) -> list[AttemptRecord]: ...
+
+
+def _require_sync_ledger(checkpointer: Any) -> SyncAttemptLedger:
+    if isinstance(checkpointer, SyncAttemptLedger):
+        return checkpointer
+    raise NotImplementedError(
+        f"{type(checkpointer).__name__} does not support the durable attempt ledger for SyncRunner.\n\n"
+        "How to fix:\n"
+        "  Use a checkpointer with the sync attempt-series operations (SqliteCheckpointer),\n"
+        "  or implement the *_sync attempt-ledger methods on your backend."
+    )
+
+
+def _open_or_resume_sync(
+    ledger: SyncAttemptLedger,
+    run_id: str,
+    node_name: str,
+    policy: RetryPolicy,
+    now: datetime,
+) -> _SeriesPlan:
+    series = ledger.get_open_attempt_series_sync(run_id, node_name)
+    if series is None:
+        series = ledger.open_attempt_series_sync(
+            run_id,
+            node_name,
+            policy_fingerprint=policy.fingerprint,
+            max_attempts=policy.max_attempts,
+            deadline_at=_series_deadline(policy, now),
+        )
+        return _SeriesPlan(series.id, series.deadline_at, 0, None, None)
+    # Resume: under the workflow reservation no other process can still be
+    # running these attempts, so stranded STARTED rows are settled explicitly
+    # BEFORE any new reservation.
+    records = ledger.resolve_stranded_attempts_sync(series.id)
+    return _plan_resumed_series(series, records)
+
+
+async def _open_or_resume_async(
+    ledger: Checkpointer,
+    run_id: str,
+    node_name: str,
+    policy: RetryPolicy,
+    now: datetime,
+) -> _SeriesPlan:
+    series = await ledger.get_open_attempt_series(run_id, node_name)
+    if series is None:
+        series = await ledger.open_attempt_series(
+            run_id,
+            node_name,
+            policy_fingerprint=policy.fingerprint,
+            max_attempts=policy.max_attempts,
+            deadline_at=_series_deadline(policy, now),
+        )
+        return _SeriesPlan(series.id, series.deadline_at, 0, None, None)
+    # Resume: settle stranded rows explicitly before any new reservation.
+    records = await ledger.resolve_stranded_attempts(series.id)
+    return _plan_resumed_series(series, records)
+
+
+# === Attempt-loop drivers (keep these two structurally parallel) ===
+
+
+def run_attempts_sync(
+    invoke: Callable[[], Any],
+    *,
+    node_name: str,
+    policy: RetryPolicy,
+    checkpointer: Any | None,
+    run_id: str | None,
+    scheduled_superstep: int,
+) -> Any:
+    """Drive one logical node execution as a series of attempts (sync)."""
+    now = _utcnow()
+    if checkpointer is not None and run_id:
+        ledger = _require_sync_ledger(checkpointer)
+        plan = _open_or_resume_sync(ledger, run_id, node_name, policy, now)
+        wait = _pre_loop_wait(plan, policy, now)
+        if wait is not None:
+            _sleep_sync(wait)
+        series_id, deadline_at, attempt_number = plan.series_id, plan.deadline_at, plan.consumed
+    else:
+        ledger, series_id = None, None
+        deadline_at, attempt_number = _series_deadline(policy, now), 0
+
+    while True:
+        if ledger is not None:
+            record = ledger.begin_attempt_sync(
+                series_id,
+                policy_fingerprint=policy.fingerprint,
+                scheduled_superstep=scheduled_superstep,
+            )
+            attempt_number = record.attempt_number
+        else:
+            attempt_number += 1
+        try:
+            return invoke()
+        except Exception as error:
+            # Terminal paths raise the exact underlying exception from here.
+            # The reservation intentionally stays STARTED: the step-save site
+            # settles it atomically with the linked StepRecord.
+            step = plan_after_failure(error, policy, attempt_number, deadline_at, now=_utcnow())
+            if ledger is not None:
+                ledger.record_attempt_outcome_sync(
+                    series_id,
+                    attempt_number,
+                    AttemptStatus.FAILED,
+                    error=AttemptError.from_exception(step.underlying),
+                    retry_not_before=step.decision.retry_not_before,
+                    sampled_delay=step.decision.sampled_delay,
+                )
+            _sleep_sync(step.decision.sampled_delay)
+        # BaseException control flow is deliberately not caught: it passes
+        # through untouched and the reservation stays for resume semantics.
+
+
+async def run_attempts_async(
+    invoke: Callable[[], Awaitable[Any]],
+    *,
+    node_name: str,
+    policy: RetryPolicy,
+    checkpointer: Any | None,
+    run_id: str | None,
+    scheduled_superstep: int,
+) -> Any:
+    """Drive one logical node execution as a series of attempts (async)."""
+    now = _utcnow()
+    if checkpointer is not None and run_id:
+        ledger: Checkpointer | None = checkpointer
+        plan = await _open_or_resume_async(ledger, run_id, node_name, policy, now)
+        wait = _pre_loop_wait(plan, policy, now)
+        if wait is not None:
+            await _sleep_async(wait)
+        series_id, deadline_at, attempt_number = plan.series_id, plan.deadline_at, plan.consumed
+    else:
+        ledger, series_id = None, None
+        deadline_at, attempt_number = _series_deadline(policy, now), 0
+
+    while True:
+        if ledger is not None:
+            record = await ledger.begin_attempt(
+                series_id,
+                policy_fingerprint=policy.fingerprint,
+                scheduled_superstep=scheduled_superstep,
+            )
+            attempt_number = record.attempt_number
+        else:
+            attempt_number += 1
+        try:
+            return await invoke()
+        except Exception as error:
+            # Terminal paths raise the exact underlying exception from here.
+            # The reservation intentionally stays STARTED: the step-save site
+            # settles it atomically with the linked StepRecord.
+            step = plan_after_failure(error, policy, attempt_number, deadline_at, now=_utcnow())
+            if ledger is not None:
+                await ledger.record_attempt_outcome(
+                    series_id,
+                    attempt_number,
+                    AttemptStatus.FAILED,
+                    error=AttemptError.from_exception(step.underlying),
+                    retry_not_before=step.decision.retry_not_before,
+                    sampled_delay=step.decision.sampled_delay,
+                )
+            await _sleep_async(step.decision.sampled_delay)
+        # BaseException control flow is deliberately not caught: it passes
+        # through untouched and the reservation stays for resume semantics.
+
+
+# === Atomic close at the step-save boundary ===
+
+_CLOSE_STATUS: dict[StepStatus, AttemptStatus] = {
+    StepStatus.COMPLETED: AttemptStatus.SUCCEEDED,
+    StepStatus.FAILED: AttemptStatus.FAILED,
+}
+
+
+def _retrying_function_node(graph: Graph, node_name: str) -> bool:
+    from hypergraph.nodes.function import FunctionNode
+
+    node = graph._nodes.get(node_name)
+    return isinstance(node, FunctionNode) and node.retry is not None
+
+
+def _close_args(
+    record: StepRecord,
+    series: AttemptSeries,
+    records: list[AttemptRecord],
+    node_errors: dict[str, BaseException] | None,
+) -> tuple[int, AttemptStatus, AttemptError | None, StepRecord] | None:
+    """Pure close decision: (attempt_number, status, error, linked record)."""
+    status = _CLOSE_STATUS.get(record.status)
+    if status is None:
+        return None
+    if not records or records[-1].status is not AttemptStatus.STARTED:
+        # No live reservation to settle (crash edges resolve on resume).
+        return None
+    error = None
+    if status is AttemptStatus.FAILED:
+        raw = (node_errors or {}).get(record.node_name)
+        if isinstance(raw, Exception):
+            error = AttemptError.from_exception(raw)
+    linked = replace(record, attempt_series_id=series.id)
+    return records[-1].attempt_number, status, error, linked
+
+
+def maybe_close_attempt_series_sync(
+    checkpointer: Any,
+    graph: Graph,
+    record: StepRecord,
+    node_errors: dict[str, BaseException] | None = None,
+) -> bool:
+    """Close the node's open attempt series atomically with this StepRecord.
+
+    Returns True when the record was persisted BY the close (the caller must
+    not save it again); False when the record is not series-linked and should
+    follow the ordinary durability dispatch.
+    """
+    if not _retrying_function_node(graph, record.node_name):
+        return False
+    if not isinstance(checkpointer, SyncAttemptLedger):
+        return False
+    series = checkpointer.get_open_attempt_series_sync(record.run_id, record.node_name)
+    if series is None:
+        return False
+    records = checkpointer.get_attempt_records_sync(series.id)
+    args = _close_args(record, series, records, node_errors)
+    if args is None:
+        return False
+    attempt_number, status, error, linked = args
+    checkpointer.close_attempt_series_sync(series.id, attempt_number, status, step_record=linked, error=error)
+    return True
+
+
+async def maybe_close_attempt_series_async(
+    checkpointer: Checkpointer,
+    graph: Graph,
+    record: StepRecord,
+    node_errors: dict[str, BaseException] | None = None,
+) -> bool:
+    """Async twin of :func:`maybe_close_attempt_series_sync`."""
+    if not _retrying_function_node(graph, record.node_name):
+        return False
+    series = await checkpointer.get_open_attempt_series(record.run_id, record.node_name)
+    if series is None:
+        return False
+    records = await checkpointer.get_attempt_records(series.id)
+    args = _close_args(record, series, records, node_errors)
+    if args is None:
+        return False
+    attempt_number, status, error, linked = args
+    await checkpointer.close_attempt_series(series.id, attempt_number, status, step_record=linked, error=error)
+    return True

--- a/src/hypergraph/runners/_shared/state.py
+++ b/src/hypergraph/runners/_shared/state.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 from hypergraph.runners._shared.results import PauseInfo, RunLog
 
 if TYPE_CHECKING:
+    from hypergraph.checkpointers.base import Checkpointer
     from hypergraph.events.processor import EventProcessor
 
 CheckpointErrorSink = Callable[[str], None]
@@ -87,6 +88,13 @@ class ExecutionContext:
     Note:
         ``provided_values`` intentionally remains a shared mutable dict so
         interrupt resume payloads can be consumed across supersteps.
+
+    Attempt-ledger fields (#230): ``checkpointer`` is the active persistence
+    for THIS run — set only when a checkpointer and workflow_id are both
+    present, so the retry coordinator can tell ledger-backed budgets from
+    process-local ones. ``superstep_offset`` (per-run resume offset) plus
+    ``superstep`` (current index, set per superstep) give attempt reservations
+    the same superstep numbering StepRecords use.
     """
 
     event_processors: list[EventProcessor] | None = None
@@ -101,6 +109,9 @@ class ExecutionContext:
     on_inner_log: Callable[[RunLog], None] | None = None
     checkpoint_error_sink: CheckpointErrorSink | None = None
     emit_fn: Callable[[Any], None] | None = None
+    checkpointer: Checkpointer | None = None
+    superstep_offset: int = 0
+    superstep: int = 0
 
 
 @dataclass

--- a/src/hypergraph/runners/async_/executors/function_node.py
+++ b/src/hypergraph/runners/async_/executors/function_node.py
@@ -89,17 +89,38 @@ class AsyncFunctionNodeExecutor:
             graph_name=ctx.graph_name,
             node_span_id=ctx.parent_span_id or "",
         ):
-            result = node.func(**func_inputs)
 
-            # Await if coroutine
-            if inspect.iscoroutine(result):
-                result = await result
+            async def invoke() -> Any:
+                result = node.func(**func_inputs)
 
-            # Handle async generators
-            if inspect.isasyncgen(result):
-                result = [item async for item in result]
-            # Handle sync generators
-            elif inspect.isgenerator(result):
-                result = list(result)
+                # Await if coroutine
+                if inspect.iscoroutine(result):
+                    result = await result
+
+                # Generators are consumed inside the observer scope (and
+                # inside the attempt, so a failing generator body counts as a
+                # failed attempt) to preserve inner-cache telemetry.
+                if inspect.isasyncgen(result):
+                    return [item async for item in result]
+                if inspect.isgenerator(result):
+                    return list(result)
+                return result
+
+            if node.retry is None:
+                result = await invoke()
+            else:
+                # The attempt coordinator sits here: below the superstep's
+                # cache lookup, above state application. The ledger keys off
+                # the workflow_id (StepRecords use it as run_id).
+                from hypergraph.runners._shared.attempts import run_attempts_async
+
+                result = await run_attempts_async(
+                    invoke,
+                    node_name=node.name,
+                    policy=node.retry,
+                    checkpointer=ctx.checkpointer,
+                    run_id=ctx.workflow_id,
+                    scheduled_superstep=ctx.superstep_offset + ctx.superstep,
+                )
 
         return wrap_outputs(node, result)

--- a/src/hypergraph/runners/async_/executors/function_node.py
+++ b/src/hypergraph/runners/async_/executors/function_node.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import inspect
+from contextlib import AbstractAsyncContextManager, nullcontext
 from typing import TYPE_CHECKING, Any
 
 from hypergraph.runners._shared.cache_observer import node_cache_observer
@@ -12,6 +13,12 @@ from hypergraph.runners.async_.superstep import get_concurrency_limiter
 if TYPE_CHECKING:
     from hypergraph.nodes.function import FunctionNode
     from hypergraph.runners._shared.state import ExecutionContext, GraphState
+
+
+def _attempt_concurrency_scope() -> AbstractAsyncContextManager[Any]:
+    """One in-flight-invocation permit (#218); no limiter means no gate."""
+    semaphore = get_concurrency_limiter()
+    return semaphore if semaphore is not None else nullcontext()
 
 
 class AsyncFunctionNodeExecutor:
@@ -49,6 +56,13 @@ class AsyncFunctionNodeExecutor:
         Returns:
             Dict mapping output names to their values
         """
+        if node.retry is not None:
+            # Per-attempt permits (#218): the concurrency budget covers
+            # in-flight callable invocations only, so backoff sleeps must not
+            # hold a permit. The attempt coordinator acquires the limiter
+            # around each attempt via _attempt_concurrency_scope.
+            return await self._execute(node, inputs, ctx)
+
         semaphore = get_concurrency_limiter()
 
         if semaphore:
@@ -121,6 +135,7 @@ class AsyncFunctionNodeExecutor:
                     checkpointer=ctx.checkpointer,
                     run_id=ctx.workflow_id,
                     scheduled_superstep=ctx.superstep_offset + ctx.superstep,
+                    attempt_scope=_attempt_concurrency_scope,
                 )
 
         return wrap_outputs(node, result)

--- a/src/hypergraph/runners/async_/runner.py
+++ b/src/hypergraph/runners/async_/runner.py
@@ -431,6 +431,8 @@ class AsyncRunner(AsyncRunnerTemplate):
                 is_resuming=(checkpoint is not None if self._checkpointer_instance is not None else True),
                 checkpoint_error_sink=checkpoint_save_errors.append if checkpoint_save_errors is not None else None,
                 emit_fn=dispatcher.emit if dispatcher.active else None,
+                checkpointer=checkpointer if has_checkpointer else None,
+                superstep_offset=superstep_offset,
             )
 
             while frontier.has_pending_components():
@@ -618,6 +620,7 @@ class AsyncRunner(AsyncRunnerTemplate):
         node_errors: dict[str, BaseException] | None = None,
     ) -> int:
         """Build StepRecords and dispatch to the appropriate durability mode."""
+        from hypergraph.runners._shared.attempts import maybe_close_attempt_series_async
         from hypergraph.runners._shared.checkpoint_helpers import build_superstep_records
 
         records, step_counter = build_superstep_records(
@@ -639,6 +642,12 @@ class AsyncRunner(AsyncRunnerTemplate):
 
         durability = checkpointer.policy.durability
         for record in records:
+            # A record that closes an attempt series persists write-through
+            # inside the atomic close (awaited, never a background task) —
+            # a deferred close would leave the series open against a later
+            # re-execution of the same node.
+            if await maybe_close_attempt_series_async(checkpointer, graph, record, node_errors):
+                continue
             if durability == "sync":
                 await checkpointer.save_step(record)
             elif durability == "async":

--- a/src/hypergraph/runners/async_/superstep.py
+++ b/src/hypergraph/runners/async_/superstep.py
@@ -238,6 +238,7 @@ async def run_superstep_async(
                 graph_name=graph.name,
                 provided_values=provided_values,
                 on_inner_log=inner_logs.append,
+                superstep=superstep_idx if superstep_idx is not None else 0,
             )
 
             # Publish the node span so in-node telemetry (LLM clients, stores)

--- a/src/hypergraph/runners/sync/executors/function_node.py
+++ b/src/hypergraph/runners/sync/executors/function_node.py
@@ -64,11 +64,32 @@ class SyncFunctionNodeExecutor:
             graph_name=ctx.graph_name,
             node_span_id=ctx.parent_span_id or "",
         ):
-            result = node.func(**func_inputs)
 
-            # Sync generator bodies execute lazily during iteration, so consume
-            # them inside the observer scope to preserve inner-cache telemetry.
-            if node.is_generator:
-                result = list(result)
+            def invoke() -> Any:
+                result = node.func(**func_inputs)
+                # Sync generator bodies execute lazily during iteration, so
+                # consume them inside the observer scope (and inside the
+                # attempt, so a failing generator body counts as a failed
+                # attempt) to preserve inner-cache telemetry.
+                if node.is_generator:
+                    return list(result)
+                return result
+
+            if node.retry is None:
+                result = invoke()
+            else:
+                # The attempt coordinator sits here: below the superstep's
+                # cache lookup, above state application. The ledger keys off
+                # the workflow_id (StepRecords use it as run_id).
+                from hypergraph.runners._shared.attempts import run_attempts_sync
+
+                result = run_attempts_sync(
+                    invoke,
+                    node_name=node.name,
+                    policy=node.retry,
+                    checkpointer=ctx.checkpointer,
+                    run_id=ctx.workflow_id,
+                    scheduled_superstep=ctx.superstep_offset + ctx.superstep,
+                )
 
         return wrap_outputs(node, result)

--- a/src/hypergraph/runners/sync/runner.py
+++ b/src/hypergraph/runners/sync/runner.py
@@ -375,6 +375,8 @@ class SyncRunner(SyncRunnerTemplate):
             run_id=run_id,
             provided_values=values,
             emit_fn=dispatcher.emit if dispatcher.active else None,
+            checkpointer=sync_cp,
+            superstep_offset=superstep_offset,
         )
 
         try:
@@ -570,6 +572,7 @@ def _save_superstep_sync(
     node_errors: dict[str, BaseException] | None = None,
 ) -> int:
     """Build StepRecords and dispatch to sync durability mode."""
+    from hypergraph.runners._shared.attempts import maybe_close_attempt_series_sync
     from hypergraph.runners._shared.checkpoint_helpers import build_superstep_records
 
     records, step_counter = build_superstep_records(
@@ -592,6 +595,11 @@ def _save_superstep_sync(
     # "exit" buffers for flushing after run completes.
     durability = sync_cp.policy.durability
     for record in records:
+        # A record that closes an attempt series persists write-through inside
+        # the atomic close, whatever the durability mode — a deferred close
+        # would leave the series open against a later re-execution.
+        if maybe_close_attempt_series_sync(sync_cp, graph, record, node_errors):
+            continue
         if durability == "exit" and step_buffer is not None:
             step_buffer.append(record)
         else:

--- a/src/hypergraph/runners/sync/superstep.py
+++ b/src/hypergraph/runners/sync/superstep.py
@@ -219,6 +219,7 @@ def run_superstep_sync(
                     graph_name=graph.name,
                     provided_values=provided_values,
                     on_inner_log=inner_logs.append,
+                    superstep=superstep_idx if superstep_idx is not None else 0,
                 )
 
                 # Publish the node span so in-node telemetry (LLM clients, stores)

--- a/tests/test_checkpointer/test_attempt_ledger_terminal_close.py
+++ b/tests/test_checkpointer/test_attempt_ledger_terminal_close.py
@@ -1,0 +1,250 @@
+"""Terminal-close seam contract (#230 F1) — memory/sqlite parity.
+
+A resume dead end (budget exhausted, window expired, OUTCOME_UNKNOWN evidence)
+has no live STARTED reservation left, yet the atomic outcome/link/close
+invariant still requires the failed logical StepRecord to link its series and
+the series to close. ``close_attempt_series`` therefore also accepts closing
+when the LAST record is already terminal FAILED/OUTCOME_UNKNOWN: the
+StepRecord is linked and the series closes atomically WITHOUT rewriting the
+settled evidence. SUCCEEDED still requires a live STARTED reservation.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+from hypergraph.checkpointers import (
+    AttemptError,
+    AttemptLedgerError,
+    AttemptStatus,
+    MemoryCheckpointer,
+    StepRecord,
+    StepStatus,
+)
+
+aiosqlite = pytest.importorskip("aiosqlite")
+
+from hypergraph.checkpointers import SqliteCheckpointer  # noqa: E402
+
+FP = "policy-fp-v1"
+RUN = "wf-1"
+NODE = "call_model"
+
+
+def _step(series_id: str, *, status: StepStatus = StepStatus.FAILED, superstep: int = 0) -> StepRecord:
+    return StepRecord(
+        run_id=RUN,
+        superstep=superstep,
+        node_name=NODE,
+        index=0,
+        status=status,
+        input_versions={},
+        error="boom" if status is StepStatus.FAILED else None,
+        attempt_series_id=series_id,
+    )
+
+
+class _MemoryBackend:
+    name = "memory"
+
+    async def make(self):
+        return MemoryCheckpointer()
+
+    async def close_all(self) -> None:
+        pass
+
+
+class _SqliteBackend:
+    name = "sqlite"
+
+    def __init__(self, tmp_path):
+        self._tmp_path = tmp_path
+        self._open: list[SqliteCheckpointer] = []
+
+    async def make(self):
+        cp = SqliteCheckpointer(str(self._tmp_path / f"terminal-close-{len(self._open)}.db"))
+        self._open.append(cp)
+        return cp
+
+    async def close_all(self) -> None:
+        for cp in self._open:
+            await cp.close()
+        self._open.clear()
+
+
+@pytest_asyncio.fixture(params=["memory", "sqlite"])
+async def backend(request, tmp_path):
+    b = _MemoryBackend() if request.param == "memory" else _SqliteBackend(tmp_path)
+    yield b
+    await b.close_all()
+
+
+async def _series_with_settled_failure(cp, *, max_attempts: int = 1):
+    await cp.create_run(RUN, graph_name="g")
+    series = await cp.open_attempt_series(RUN, NODE, policy_fingerprint=FP, max_attempts=max_attempts)
+    record = await cp.begin_attempt(series.id, policy_fingerprint=FP, scheduled_superstep=0)
+    settled = await cp.record_attempt_outcome(
+        series.id,
+        record.attempt_number,
+        AttemptStatus.FAILED,
+        error=AttemptError.from_exception(ConnectionError("boom")),
+        sampled_delay=0.5,
+    )
+    return series, settled
+
+
+async def _series_with_outcome_unknown(cp, *, max_attempts: int = 1):
+    await cp.create_run(RUN, graph_name="g")
+    series = await cp.open_attempt_series(RUN, NODE, policy_fingerprint=FP, max_attempts=max_attempts)
+    await cp.begin_attempt(series.id, policy_fingerprint=FP, scheduled_superstep=0)
+    records = await cp.resolve_stranded_attempts(series.id)
+    assert [r.status for r in records] == [AttemptStatus.OUTCOME_UNKNOWN]
+    return series, records[0]
+
+
+async def test_close_links_step_over_settled_failed(backend):
+    cp = await backend.make()
+    series, settled = await _series_with_settled_failure(cp)
+
+    await cp.close_attempt_series(series.id, settled.attempt_number, AttemptStatus.FAILED, step_record=_step(series.id))
+
+    closed = await cp.get_attempt_series(series.id)
+    assert closed is not None and not closed.is_open
+    assert closed.committed_superstep == 0
+    steps = await cp.get_steps(RUN)
+    assert len(steps) == 1
+    assert steps[0].attempt_series_id == series.id
+
+    # The settled evidence is linked, never rewritten.
+    records = await cp.get_attempt_records(series.id)
+    assert [r.status for r in records] == [AttemptStatus.FAILED]
+    assert records[0].error is not None and records[0].error.type_name == "ConnectionError"
+    assert records[0].sampled_delay == 0.5
+    assert records[0].completed_at == settled.completed_at
+
+
+async def test_close_links_step_over_outcome_unknown(backend):
+    cp = await backend.make()
+    series, stranded = await _series_with_outcome_unknown(cp)
+
+    await cp.close_attempt_series(
+        series.id,
+        stranded.attempt_number,
+        AttemptStatus.OUTCOME_UNKNOWN,
+        step_record=_step(series.id),
+    )
+
+    closed = await cp.get_attempt_series(series.id)
+    assert closed is not None and not closed.is_open
+    steps = await cp.get_steps(RUN)
+    assert steps[0].attempt_series_id == series.id
+    records = await cp.get_attempt_records(series.id)
+    assert [r.status for r in records] == [AttemptStatus.OUTCOME_UNKNOWN]
+    assert await cp.get_open_attempt_series(RUN, NODE) is None
+
+
+async def test_terminal_close_requires_matching_status(backend):
+    cp = await backend.make()
+    series, settled = await _series_with_settled_failure(cp)
+
+    with pytest.raises(AttemptLedgerError, match="same status"):
+        await cp.close_attempt_series(
+            series.id,
+            settled.attempt_number,
+            AttemptStatus.OUTCOME_UNKNOWN,
+            step_record=_step(series.id),
+        )
+
+    still_open = await cp.get_attempt_series(series.id)
+    assert still_open is not None and still_open.is_open
+    assert await cp.get_steps(RUN) == []
+
+
+async def test_succeeded_close_still_requires_live_reservation(backend):
+    cp = await backend.make()
+    series, settled = await _series_with_settled_failure(cp)
+
+    with pytest.raises(AttemptLedgerError, match="already settled"):
+        await cp.close_attempt_series(
+            series.id,
+            settled.attempt_number,
+            AttemptStatus.SUCCEEDED,
+            step_record=_step(series.id, status=StepStatus.COMPLETED),
+        )
+    assert (await cp.get_attempt_series(series.id)).is_open
+
+
+async def test_terminal_close_targets_only_the_last_record(backend):
+    cp = await backend.make()
+    await cp.create_run(RUN, graph_name="g")
+    series = await cp.open_attempt_series(RUN, NODE, policy_fingerprint=FP, max_attempts=3)
+    first = await cp.begin_attempt(series.id, policy_fingerprint=FP, scheduled_superstep=0)
+    await cp.record_attempt_outcome(
+        series.id,
+        first.attempt_number,
+        AttemptStatus.FAILED,
+        error=AttemptError.from_exception(ConnectionError("boom")),
+    )
+    await cp.begin_attempt(series.id, policy_fingerprint=FP, scheduled_superstep=0)
+
+    # Attempt 1 is settled but NOT last — a live reservation exists after it.
+    with pytest.raises(AttemptLedgerError, match="already settled"):
+        await cp.close_attempt_series(series.id, first.attempt_number, AttemptStatus.FAILED, step_record=_step(series.id))
+    assert (await cp.get_attempt_series(series.id)).is_open
+
+
+async def test_sqlite_sync_mirror_links_over_terminal_records(tmp_path):
+    cp = SqliteCheckpointer(str(tmp_path / "terminal-close-sync.db"))
+    try:
+        cp.create_run_sync(RUN, graph_name="g")
+
+        # Settled FAILED evidence.
+        series = cp.open_attempt_series_sync(RUN, NODE, policy_fingerprint=FP, max_attempts=1)
+        record = cp.begin_attempt_sync(series.id, policy_fingerprint=FP, scheduled_superstep=0)
+        cp.record_attempt_outcome_sync(
+            series.id,
+            record.attempt_number,
+            AttemptStatus.FAILED,
+            error=AttemptError.from_exception(ConnectionError("boom")),
+        )
+        cp.close_attempt_series_sync(series.id, record.attempt_number, AttemptStatus.FAILED, step_record=_step(series.id))
+        assert not cp.get_attempt_series_sync(series.id).is_open
+        assert [r.status for r in cp.get_attempt_records_sync(series.id)] == [AttemptStatus.FAILED]
+
+        # OUTCOME_UNKNOWN evidence (fresh node name → fresh series).
+        series2 = cp.open_attempt_series_sync(RUN, "other_node", policy_fingerprint=FP, max_attempts=1)
+        stranded = cp.begin_attempt_sync(series2.id, policy_fingerprint=FP, scheduled_superstep=0)
+        cp.resolve_stranded_attempts_sync(series2.id)
+        step2 = StepRecord(
+            run_id=RUN,
+            superstep=1,
+            node_name="other_node",
+            index=1,
+            status=StepStatus.FAILED,
+            input_versions={},
+            error="unknown",
+            attempt_series_id=series2.id,
+        )
+        cp.close_attempt_series_sync(series2.id, stranded.attempt_number, AttemptStatus.OUTCOME_UNKNOWN, step_record=step2)
+        assert not cp.get_attempt_series_sync(series2.id).is_open
+        assert [r.status for r in cp.get_attempt_records_sync(series2.id)] == [AttemptStatus.OUTCOME_UNKNOWN]
+
+        # Mismatched status is rejected without closing.
+        series3 = cp.open_attempt_series_sync(RUN, "third_node", policy_fingerprint=FP, max_attempts=1)
+        third = cp.begin_attempt_sync(series3.id, policy_fingerprint=FP, scheduled_superstep=0)
+        cp.record_attempt_outcome_sync(series3.id, third.attempt_number, AttemptStatus.FAILED)
+        step3 = StepRecord(
+            run_id=RUN,
+            superstep=2,
+            node_name="third_node",
+            index=2,
+            status=StepStatus.FAILED,
+            input_versions={},
+            attempt_series_id=series3.id,
+        )
+        with pytest.raises(AttemptLedgerError, match="same status"):
+            cp.close_attempt_series_sync(series3.id, third.attempt_number, AttemptStatus.OUTCOME_UNKNOWN, step_record=step3)
+        assert cp.get_attempt_series_sync(series3.id).is_open
+    finally:
+        await cp.close()

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -795,3 +795,63 @@ def test_inspect_docs_pin_exception_labels_and_recovery_runner_truth() -> None:
     assert "After (truthful async recovery)" in debug
     assert "Before (a boundary retry can raise or print `None`)" in debug
     assert "After (the assignment and evidence read are both guarded)" in debug
+
+
+def test_retry_docs_pin_public_contract() -> None:
+    import dataclasses
+
+    from hypergraph import RetryPolicy
+    from hypergraph import node as node_decorator
+
+    nodes_api = _read("docs/06-api-reference/nodes.md")
+    how_to = _read("docs/05-how-to/retry-transient-failures.md")
+    summary = _read("docs/SUMMARY.md")
+
+    assert "05-how-to/retry-transient-failures.md" in summary
+
+    # The decorator surface exposes retry= and the docs track it.
+    assert "retry" in inspect.signature(node_decorator).parameters
+    node_section = _scoped_section(nodes_api, "## @node Decorator")
+    assert "retry: RetryPolicy | None = None" in node_section
+
+    # RetryPolicy fields match the documented signature block, in order.
+    policy_fields = tuple(field.name for field in dataclasses.fields(RetryPolicy))
+    assert policy_fields == (
+        "max_attempts",
+        "retry_on",
+        "retry_window",
+        "initial_delay",
+        "backoff_multiplier",
+        "max_delay",
+        "jitter",
+    )
+    policy_section = _scoped_section(nodes_api, "## RetryPolicy")
+    for name in policy_fields:
+        assert name in policy_section
+    assert "including the first" in policy_section
+    assert "no `retry=True` shorthand" in policy_section
+    assert "min(max_delay, initial_delay * backoff_multiplier ** (n - 1))" in policy_section
+    assert "exact final underlying exception" in policy_section
+
+    # Documented defaults are the real defaults.
+    defaults = RetryPolicy(max_attempts=1, retry_on=(ValueError,))
+    assert defaults.retry_window is None
+    assert defaults.initial_delay == 1.0
+    assert defaults.backoff_multiplier == 2.0
+    assert defaults.max_delay == 60.0
+    assert defaults.jitter == "full"
+    for pinned in ("initial_delay: float = 1.0", "backoff_multiplier: float = 2.0", "max_delay: float = 60.0"):
+        assert pinned in policy_section
+
+    carrier_section = _scoped_section(nodes_api, "## RetryAfterError")
+    assert "never authorizes" in carrier_section
+    assert "no jitter" in carrier_section
+    assert "retry_after: float" in carrier_section
+
+    # The how-to's example is actually runnable, with the documented outputs.
+    assert "## Before / After" in how_to
+    example = how_to.split("## Runnable example", 1)[1].split("```python\n", 1)[1].split("\n```", 1)[0]
+    namespace: dict = {}
+    exec(example, namespace)  # noqa: S102
+    assert namespace["result"]["done"] == 41
+    assert len(namespace["attempts"]) == 2

--- a/tests/test_retry_loop.py
+++ b/tests/test_retry_loop.py
@@ -299,7 +299,9 @@ async def test_kill_resume_honors_persisted_backoff(family, make_sqlite, monkeyp
 
     # Resume in a "new process": later clock, recording sleep. The wait must be
     # derived from the PERSISTED wake time — never redrawn, never restarted.
-    resumed_now = frozen_now + timedelta(seconds=1)
+    # The offset derives from the persisted sample (full jitter can draw
+    # arbitrarily small delays, so a fixed offset could overshoot the wake).
+    resumed_now = frozen_now + timedelta(seconds=first.sampled_delay / 2)
     monkeypatch.setattr(attempts_module, "_utcnow", lambda: resumed_now)
     resumed_sleeps: list[float] = []
 
@@ -317,7 +319,8 @@ async def test_kill_resume_honors_persisted_backoff(family, make_sqlite, monkeyp
 
     assert result["fetched"] == 10
     assert calls == [1, 1], "resume continues the same budget with attempt 2"
-    assert resumed_sleeps == [(persisted_wake - resumed_now).total_seconds()]
+    remaining = (persisted_wake - resumed_now).total_seconds()
+    assert resumed_sleeps == ([remaining] if remaining > 0 else []), "the resumed wait derives from the persisted wake time"
 
     records_after = await cp.get_attempt_records(series.id)
     assert records_after[0].retry_not_before == persisted_wake, "persisted wake time must not be redrawn"
@@ -776,6 +779,213 @@ async def test_cycle_reexecution_gets_fresh_series(make_sqlite, recorded_sleeps)
         assert [r.status for r in records] == [AttemptStatus.FAILED, AttemptStatus.SUCCEEDED]
 
 
+# === F1: resume dead ends terminalize the series (link + close) ===
+
+
+async def test_resume_dead_end_over_outcome_unknown_links_and_closes(family, make_sqlite):
+    """Reviewer repro: max_attempts=1, crash-stranded STARTED, resume.
+
+    The dead end must emit a FAILED StepRecord that carries the series id and
+    must close the series — never leave it open with an unlinked step.
+    """
+    cp = make_sqlite()
+    policy = _policy(max_attempts=1)
+    calls: list[int] = []
+
+    @node(output_name="fetched", retry=policy)
+    def flaky(x: int = 1) -> int:
+        calls.append(x)
+        return x
+
+    # Seed the crash: a durably reserved attempt whose process died.
+    await cp.create_run("wf-deadend", graph_name="g")
+    series = await cp.open_attempt_series(
+        "wf-deadend",
+        "flaky",
+        policy_fingerprint=policy.fingerprint,
+        max_attempts=policy.max_attempts,
+    )
+    await cp.begin_attempt(series.id, policy_fingerprint=policy.fingerprint, scheduled_superstep=0)
+
+    from hypergraph.checkpointers import AttemptLedgerError
+
+    runner = _make_runner(family, checkpointer=cp)
+    with pytest.raises(AttemptLedgerError, match="budget exhausted"):
+        await _run(runner, Graph([flaky]), workflow_id="wf-deadend")
+
+    assert calls == [], "no budget remains: user code must not run"
+    closed = await cp.get_attempt_series(series.id)
+    assert closed is not None and not closed.is_open, "the dead end must close the series"
+    records = await cp.get_attempt_records(series.id)
+    assert [r.status for r in records] == [AttemptStatus.OUTCOME_UNKNOWN], "evidence is never rewritten"
+    steps = [s for s in await cp.get_steps("wf-deadend") if s.node_name == "flaky"]
+    assert len(steps) == 1
+    assert steps[0].status is StepStatus.FAILED
+    assert steps[0].attempt_series_id == series.id, "the failed step must link the series"
+    assert await cp.get_open_attempt_series("wf-deadend", "flaky") is None
+
+
+async def test_resume_dead_end_over_expired_window_links_and_closes(family, make_sqlite):
+    """Persisted wake at/beyond deadline_at: end from evidence, link, close."""
+    cp = make_sqlite()
+    policy = _policy(max_attempts=5, retry_window=10.0)
+    calls: list[int] = []
+
+    @node(output_name="fetched", retry=policy)
+    def flaky(x: int = 1) -> int:
+        calls.append(x)
+        return x
+
+    now = datetime.now(timezone.utc)
+    await cp.create_run("wf-window-dead", graph_name="g")
+    series = await cp.open_attempt_series(
+        "wf-window-dead",
+        "flaky",
+        policy_fingerprint=policy.fingerprint,
+        max_attempts=policy.max_attempts,
+        deadline_at=now + timedelta(seconds=10),
+    )
+    reserved = await cp.begin_attempt(series.id, policy_fingerprint=policy.fingerprint, scheduled_superstep=0)
+    from hypergraph.checkpointers import AttemptError, AttemptLedgerError
+
+    await cp.record_attempt_outcome(
+        series.id,
+        reserved.attempt_number,
+        AttemptStatus.FAILED,
+        error=AttemptError.from_exception(ConnectionError("rate limited")),
+        retry_not_before=now + timedelta(seconds=30),  # beyond the deadline
+        sampled_delay=30.0,
+    )
+
+    runner = _make_runner(family, checkpointer=cp)
+    with pytest.raises(AttemptLedgerError, match="deadline"):
+        await _run(runner, Graph([flaky]), workflow_id="wf-window-dead")
+
+    assert calls == [], "the expired window must not admit another invocation"
+    closed = await cp.get_attempt_series(series.id)
+    assert closed is not None and not closed.is_open
+    records = await cp.get_attempt_records(series.id)
+    assert [r.status for r in records] == [AttemptStatus.FAILED]
+    assert records[0].error is not None and records[0].error.type_name == "ConnectionError"
+    steps = [s for s in await cp.get_steps("wf-window-dead") if s.node_name == "flaky"]
+    assert len(steps) == 1 and steps[0].attempt_series_id == series.id
+
+
+# === F3b: the retry window is re-checked AFTER sleeping ===
+
+
+async def test_window_rechecked_after_sleep_before_invoking(family, monkeypatch):
+    """Process-local parity with the persistent path's atomic reservation check."""
+    start = datetime(2026, 7, 17, 12, 0, 0, tzinfo=timezone.utc)
+    clock = {"now": start}
+    monkeypatch.setattr(attempts_module, "_utcnow", lambda: clock["now"])
+
+    def sleeping_advances_past_deadline(seconds: float) -> None:
+        clock["now"] = start + timedelta(seconds=60)
+
+    async def sleeping_advances_past_deadline_async(seconds: float) -> None:
+        clock["now"] = start + timedelta(seconds=60)
+
+    monkeypatch.setattr(attempts_module, "_sleep_sync", sleeping_advances_past_deadline)
+    monkeypatch.setattr(attempts_module, "_sleep_async", sleeping_advances_past_deadline_async)
+
+    calls: list[int] = []
+    underlying = ConnectionError("transient")
+
+    @node(output_name="fetched", retry=_policy(max_attempts=5, retry_window=30.0))
+    def flaky(x: int) -> int:
+        calls.append(x)
+        raise underlying
+
+    runner = _make_runner(family)
+    with pytest.raises(ConnectionError) as exc_info:
+        await _run(runner, Graph([flaky]), {"x": 1})
+
+    assert exc_info.value is underlying
+    assert calls == [1], "a wait that outlived the window must not invoke again"
+
+
+# === F4: the concurrency permit covers in-flight invocations, not backoff ===
+
+
+async def test_attempt_scope_wraps_each_invocation_not_backoff(monkeypatch):
+    """The injected per-attempt scope enters/exits around each invocation;
+    backoff sleeps happen outside it (#218: budget covers in-flight callables)."""
+    from contextlib import asynccontextmanager
+
+    events: list[str] = []
+
+    async def recording_sleep(seconds: float) -> None:
+        events.append("sleep")
+
+    monkeypatch.setattr(attempts_module, "_sleep_async", recording_sleep)
+
+    @asynccontextmanager
+    async def scope():
+        events.append("enter")
+        try:
+            yield
+        finally:
+            events.append("exit")
+
+    calls: list[int] = []
+
+    async def invoke():
+        calls.append(1)
+        if len(calls) == 1:
+            raise ConnectionError("transient")
+        return {"fetched": 1}
+
+    result = await attempts_module.run_attempts_async(
+        invoke,
+        node_name="flaky",
+        policy=_policy(),
+        checkpointer=None,
+        run_id=None,
+        scheduled_superstep=0,
+        attempt_scope=scope,
+    )
+
+    assert result == {"fetched": 1}
+    assert events == ["enter", "exit", "sleep", "enter", "exit"], "backoff must not hold the permit"
+
+
+async def test_backoff_releases_concurrency_permit(monkeypatch):
+    """With max_concurrency=1, node B must run while node A sleeps in backoff."""
+    b_ran = asyncio.Event()
+
+    async def blocking_sleep(seconds: float) -> None:
+        # A's backoff completes only once B has run — impossible if the
+        # permit is held across the sleep.
+        await asyncio.wait_for(b_ran.wait(), timeout=5)
+
+    monkeypatch.setattr(attempts_module, "_sleep_async", blocking_sleep)
+
+    a_calls: list[int] = []
+    b_calls: list[int] = []
+
+    @node(output_name="a_out", retry=_policy())
+    async def worker_a(x: int) -> int:
+        a_calls.append(x)
+        if len(a_calls) == 1:
+            raise ConnectionError("transient")
+        return x + 1
+
+    @node(output_name="b_out")
+    async def worker_b(x: int) -> int:
+        b_calls.append(x)
+        b_ran.set()
+        return x + 2
+
+    runner = AsyncRunner()
+    result = await runner.run(Graph([worker_a, worker_b]), {"x": 1}, max_concurrency=1)
+
+    assert result["a_out"] == 2
+    assert result["b_out"] == 3
+    assert a_calls == [1, 1]
+    assert b_calls == [1]
+
+
 # === Backoff math (pure helpers) ===
 
 
@@ -815,3 +1025,22 @@ class TestBackoffMath:
         assert decision.sampled_delay == 30.0
         assert decision.effective_delay == 30.0
         assert decision.retry_not_before == now + timedelta(seconds=30.0)
+
+    @pytest.mark.parametrize(
+        ("multiplier", "initial", "attempt"),
+        [
+            (1e308, 1.0, 2),  # exponential base overflow
+            (2.0, 1.0, 1100),  # deep-attempt exponent overflow
+            (10.0, 1e308, 5),  # product overflow
+            (1e308, 1e308, 1099),  # both extremes
+        ],
+    )
+    def test_extreme_policies_cap_at_max_delay_without_overflow(self, multiplier, initial, attempt):
+        # F3a: valid extreme policies must yield max_delay, never OverflowError.
+        policy = _policy(initial_delay=initial, backoff_multiplier=multiplier, max_delay=60.0)
+        assert attempts_module.nominal_delay(policy, attempt) == 60.0
+        now = datetime.now(timezone.utc)
+        decision = attempts_module.draw_backoff(
+            _policy(initial_delay=initial, backoff_multiplier=multiplier, max_delay=60.0, jitter="none"), attempt, now=now
+        )
+        assert decision.sampled_delay == 60.0

--- a/tests/test_retry_loop.py
+++ b/tests/test_retry_loop.py
@@ -272,8 +272,10 @@ async def test_kill_resume_honors_persisted_backoff(family, make_sqlite, monkeyp
     monkeypatch.setattr(attempts_module, "_sleep_sync", dying_sleep)
     monkeypatch.setattr(attempts_module, "_sleep_async", dying_sleep_async)
 
+    # x has a default so the "new process" can resume the SAME workflow_id
+    # bare — the resume contract rejects re-supplying input values.
     @node(output_name="fetched", retry=_policy(max_attempts=3, initial_delay=3600.0, jitter="full"))
-    def flaky(x: int) -> int:
+    def flaky(x: int = 1) -> int:
         calls.append(x)
         if len(calls) == 1:
             raise ConnectionError("transient")
@@ -282,7 +284,7 @@ async def test_kill_resume_honors_persisted_backoff(family, make_sqlite, monkeyp
     graph = Graph([flaky])
     runner = _make_runner(family, checkpointer=cp)
     with pytest.raises(_SimulatedProcessDeath):
-        await _run(runner, graph, {"x": 1}, workflow_id="wf-crash")
+        await _run(runner, graph, workflow_id="wf-crash")
 
     assert calls == [1]
     series = await cp.get_open_attempt_series("wf-crash", "flaky")
@@ -311,7 +313,7 @@ async def test_kill_resume_honors_persisted_backoff(family, make_sqlite, monkeyp
     monkeypatch.setattr(attempts_module, "_sleep_async", recording_sleep_async)
 
     resumed_runner = _make_runner(family, checkpointer=make_sqlite())
-    result = await _run(resumed_runner, graph, {"x": 1}, workflow_id="wf-crash")
+    result = await _run(resumed_runner, graph, workflow_id="wf-crash")
 
     assert result["fetched"] == 10
     assert calls == [1, 1], "resume continues the same budget with attempt 2"

--- a/tests/test_retry_loop.py
+++ b/tests/test_retry_loop.py
@@ -1,0 +1,815 @@
+"""Contract tests for the retry attempt coordinator (#230).
+
+Assertion map (ticket red-green items + wave-A2 sharpened falsifiers):
+    1   exhaustion truth                 test_exhaustion_reraises_exact_exception_and_ledger_truth
+    2   ineligible = one invocation      test_eligibility_flip_controls_invocations
+    3   failure then success             test_failure_then_success_runs_downstream_once
+    4   persisted backoff, no redraw     test_kill_resume_honors_persisted_backoff (S3)
+    5   RetryAfterError vs deadline      test_retry_after_beyond_window_ends_without_sleeping
+    6   sync/async parity                every runner-driven test parametrizes both families
+    7   cache hit consumes nothing       test_cache_hit_consumes_no_attempts
+    8   -W error CI-equivalent           the full suite run (no test-local assertion)
+    S1  fresh world                      test_fresh_world_sqlite_end_to_end
+    S2  eligibility flip                 test_eligibility_flip_controls_invocations
+    S4  concurrent series isolation      test_concurrent_nodes_have_isolated_series
+    S5  control-flow immunity            test_keyboard_interrupt_passes_through_untouched,
+                                         test_pause_execution_passes_through_untouched,
+                                         test_stop_signal_does_not_consume_attempts,
+                                         test_cancelled_error_passes_through_untouched
+    S7  no-checkpointer truth            test_no_checkpointer_budget_is_process_local,
+                                         test_no_checkpointer_backoff_still_honored
+    S8  direct call raw                  lives in test_retry_policy.py
+
+Repo flaky rule: no wall-clock assertions. Sleeps are intercepted via the
+coordinator's _sleep_sync/_sleep_async seams; time is fixed via _utcnow.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+
+from hypergraph import (
+    END,
+    AsyncRunner,
+    Graph,
+    InMemoryCache,
+    RetryAfterError,
+    RetryPolicy,
+    RunStatus,
+    SyncRunner,
+    node,
+    route,
+)
+from hypergraph.checkpointers import AttemptStatus, MemoryCheckpointer, SqliteCheckpointer, StepStatus
+from hypergraph.events import NodeEndEvent, NodeErrorEvent, NodeStartEvent
+from hypergraph.events.processor import EventProcessor
+from hypergraph.runners._shared import attempts as attempts_module
+
+aiosqlite = pytest.importorskip("aiosqlite")
+
+
+# === Helpers ===
+
+
+def _policy(**overrides) -> RetryPolicy:
+    kwargs = {
+        "max_attempts": 3,
+        "retry_on": (ConnectionError,),
+        "initial_delay": 0.001,
+        "jitter": "none",
+    }
+    kwargs.update(overrides)
+    return RetryPolicy(**kwargs)
+
+
+def _make_runner(family: str, **kwargs):
+    return SyncRunner(**kwargs) if family == "sync" else AsyncRunner(**kwargs)
+
+
+async def _run(runner, *args, **kwargs):
+    result = runner.run(*args, **kwargs)
+    if inspect.iscoroutine(result):
+        result = await result
+    return result
+
+
+@pytest.fixture(params=["sync", "async"])
+def family(request) -> str:
+    return request.param
+
+
+@pytest_asyncio.fixture
+async def make_sqlite(tmp_path):
+    created = []
+
+    def factory(name: str = "retry.db") -> SqliteCheckpointer:
+        cp = SqliteCheckpointer(str(tmp_path / name))
+        created.append(cp)
+        return cp
+
+    yield factory
+    for cp in created:
+        await cp.close()
+
+
+@pytest.fixture
+def recorded_sleeps(monkeypatch):
+    sleeps: list[float] = []
+
+    def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    async def fake_sleep_async(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(attempts_module, "_sleep_sync", fake_sleep)
+    monkeypatch.setattr(attempts_module, "_sleep_async", fake_sleep_async)
+    return sleeps
+
+
+class _Recorder(EventProcessor):
+    def __init__(self) -> None:
+        self.events: list = []
+
+    def on_event(self, event) -> None:
+        self.events.append(event)
+
+
+class _CountingCache(InMemoryCache):
+    def __init__(self) -> None:
+        super().__init__()
+        self.set_calls = 0
+
+    def set(self, key, value) -> None:
+        self.set_calls += 1
+        super().set(key, value)
+
+
+def _series_rows(db_path, run_id: str) -> list[tuple]:
+    with sqlite3.connect(str(db_path)) as db:
+        return db.execute(
+            "SELECT id, closed_at FROM attempt_series WHERE run_id = ?",
+            (run_id,),
+        ).fetchall()
+
+
+async def _closed_series_for_step(cp, run_id: str, node_name: str):
+    """Return (series, records) linked from the node's StepRecord."""
+    steps = [s for s in await cp.get_steps(run_id) if s.node_name == node_name]
+    assert len(steps) == 1, f"expected ONE logical step for {node_name}, got {len(steps)}"
+    step = steps[0]
+    assert step.attempt_series_id is not None, "StepRecord must link its attempt series"
+    series = await cp.get_attempt_series(step.attempt_series_id)
+    records = await cp.get_attempt_records(step.attempt_series_id)
+    return step, series, records
+
+
+# === Ticket 1: exhaustion truth ===
+
+
+async def test_exhaustion_reraises_exact_exception_and_ledger_truth(family, make_sqlite, recorded_sleeps):
+    cp = make_sqlite()
+    calls: list[int] = []
+    downstream_calls: list[int] = []
+    final_error = ConnectionError("always down")
+
+    @node(output_name="fetched", retry=_policy(max_attempts=3))
+    def flaky(x: int) -> int:
+        calls.append(x)
+        raise final_error
+
+    @node(output_name="done")
+    def downstream(fetched: int) -> int:
+        downstream_calls.append(fetched)
+        return fetched
+
+    runner = _make_runner(family, checkpointer=cp)
+    with pytest.raises(ConnectionError) as exc_info:
+        await _run(runner, Graph([flaky, downstream]), {"x": 1}, workflow_id="wf-exhaust")
+
+    assert exc_info.value is final_error, "the exact final underlying exception must escape, unwrapped"
+    assert calls == [1, 1, 1], "max_attempts=3 means exactly three invocations"
+    assert downstream_calls == [], "downstream must never run"
+
+    step, series, records = await _closed_series_for_step(cp, "wf-exhaust", "flaky")
+    assert step.status is StepStatus.FAILED
+    assert series is not None and not series.is_open, "the series must close with the failed step"
+    assert [r.status for r in records] == [
+        AttemptStatus.FAILED,
+        AttemptStatus.FAILED,
+        AttemptStatus.FAILED,
+    ]
+    assert records[0].retry_not_before is not None
+    assert records[1].retry_not_before is not None
+    assert records[2].retry_not_before is None, "no backoff is drawn for the final attempt"
+    assert records[2].error is not None and records[2].error.type_name == "ConnectionError"
+    # Two backoffs slept, none for the terminal attempt.
+    assert len(recorded_sleeps) == 2
+
+
+# === Ticket 2 + S2: eligibility flip ===
+
+
+@pytest.mark.parametrize("eligible", [True, False])
+async def test_eligibility_flip_controls_invocations(family, make_sqlite, recorded_sleeps, eligible):
+    cp = make_sqlite()
+    calls: list[int] = []
+    retry_on = (KeyError,) if eligible else (ConnectionError,)
+
+    @node(output_name="fetched", retry=_policy(max_attempts=3, retry_on=retry_on))
+    def flaky(x: int) -> int:
+        calls.append(x)
+        raise KeyError("missing")
+
+    runner = _make_runner(family, checkpointer=cp)
+    with pytest.raises(KeyError):
+        await _run(runner, Graph([flaky]), {"x": 1}, workflow_id="wf-flip")
+
+    assert len(calls) == (3 if eligible else 1), "flipping retry_on must flip the invocation count"
+
+    _, series, records = await _closed_series_for_step(cp, "wf-flip", "flaky")
+    assert not series.is_open
+    assert len(records) == (3 if eligible else 1)
+
+
+# === Ticket 3: failure then success ===
+
+
+async def test_failure_then_success_runs_downstream_once(family, make_sqlite, recorded_sleeps):
+    cp = make_sqlite()
+    calls: list[int] = []
+    downstream_calls: list[int] = []
+
+    @node(output_name="fetched", retry=_policy())
+    def flaky(x: int) -> int:
+        calls.append(x)
+        if len(calls) == 1:
+            raise ConnectionError("transient")
+        return x * 10
+
+    @node(output_name="done")
+    def downstream(fetched: int) -> int:
+        downstream_calls.append(fetched)
+        return fetched + 1
+
+    runner = _make_runner(family, checkpointer=cp)
+    result = await _run(runner, Graph([flaky, downstream]), {"x": 1}, workflow_id="wf-recover")
+
+    assert result["done"] == 11
+    assert calls == [1, 1]
+    assert downstream_calls == [10], "downstream runs exactly once, after final success"
+
+    step, series, records = await _closed_series_for_step(cp, "wf-recover", "flaky")
+    assert step.status is StepStatus.COMPLETED
+    assert not series.is_open
+    assert [r.status for r in records] == [AttemptStatus.FAILED, AttemptStatus.SUCCEEDED]
+
+
+# === Ticket 4 + S3: kill/resume honors persisted backoff, no redraw ===
+
+
+async def test_kill_resume_honors_persisted_backoff(family, make_sqlite, monkeypatch):
+    class _SimulatedProcessDeath(BaseException):
+        pass
+
+    cp = make_sqlite()
+    calls: list[int] = []
+    frozen_now = datetime(2026, 7, 17, 12, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(attempts_module, "_utcnow", lambda: frozen_now)
+
+    def dying_sleep(seconds: float) -> None:
+        raise _SimulatedProcessDeath
+
+    async def dying_sleep_async(seconds: float) -> None:
+        raise _SimulatedProcessDeath
+
+    monkeypatch.setattr(attempts_module, "_sleep_sync", dying_sleep)
+    monkeypatch.setattr(attempts_module, "_sleep_async", dying_sleep_async)
+
+    @node(output_name="fetched", retry=_policy(max_attempts=3, initial_delay=3600.0, jitter="full"))
+    def flaky(x: int) -> int:
+        calls.append(x)
+        if len(calls) == 1:
+            raise ConnectionError("transient")
+        return x * 10
+
+    graph = Graph([flaky])
+    runner = _make_runner(family, checkpointer=cp)
+    with pytest.raises(_SimulatedProcessDeath):
+        await _run(runner, graph, {"x": 1}, workflow_id="wf-crash")
+
+    assert calls == [1]
+    series = await cp.get_open_attempt_series("wf-crash", "flaky")
+    assert series is not None, "the series must survive the crash open"
+    records_before = await cp.get_attempt_records(series.id)
+    assert len(records_before) == 1
+    first = records_before[0]
+    assert first.status is AttemptStatus.FAILED
+    assert first.sampled_delay is not None and 0.0 <= first.sampled_delay <= 3600.0
+    persisted_wake = first.retry_not_before
+    assert persisted_wake == frozen_now + timedelta(seconds=first.sampled_delay)
+
+    # Resume in a "new process": later clock, recording sleep. The wait must be
+    # derived from the PERSISTED wake time — never redrawn, never restarted.
+    resumed_now = frozen_now + timedelta(seconds=1)
+    monkeypatch.setattr(attempts_module, "_utcnow", lambda: resumed_now)
+    resumed_sleeps: list[float] = []
+
+    def recording_sleep(seconds: float) -> None:
+        resumed_sleeps.append(seconds)
+
+    async def recording_sleep_async(seconds: float) -> None:
+        resumed_sleeps.append(seconds)
+
+    monkeypatch.setattr(attempts_module, "_sleep_sync", recording_sleep)
+    monkeypatch.setattr(attempts_module, "_sleep_async", recording_sleep_async)
+
+    resumed_runner = _make_runner(family, checkpointer=make_sqlite())
+    result = await _run(resumed_runner, graph, {"x": 1}, workflow_id="wf-crash")
+
+    assert result["fetched"] == 10
+    assert calls == [1, 1], "resume continues the same budget with attempt 2"
+    assert resumed_sleeps == [(persisted_wake - resumed_now).total_seconds()]
+
+    records_after = await cp.get_attempt_records(series.id)
+    assert records_after[0].retry_not_before == persisted_wake, "persisted wake time must not be redrawn"
+    assert records_after[0].sampled_delay == first.sampled_delay
+    assert [r.status for r in records_after] == [AttemptStatus.FAILED, AttemptStatus.SUCCEEDED]
+    assert (await cp.get_open_attempt_series("wf-crash", "flaky")) is None
+
+
+# === Ticket 5: RetryAfterError bounded by the series window ===
+
+
+async def test_retry_after_beyond_window_ends_without_sleeping(family, make_sqlite, recorded_sleeps):
+    cp = make_sqlite()
+    calls: list[int] = []
+    underlying = ConnectionError("rate limited")
+
+    @node(output_name="fetched", retry=_policy(max_attempts=5, retry_window=10.0))
+    def flaky(x: int) -> int:
+        calls.append(x)
+        raise RetryAfterError(underlying, retry_after=30)
+
+    runner = _make_runner(family, checkpointer=cp)
+    with pytest.raises(ConnectionError) as exc_info:
+        await _run(runner, Graph([flaky]), {"x": 1}, workflow_id="wf-window")
+
+    assert exc_info.value is underlying, "the carrier must unwrap to the exact underlying exception"
+    assert calls == [1]
+    assert recorded_sleeps == [], "a wait that cannot fit before deadline_at must not sleep"
+
+    _, series, records = await _closed_series_for_step(cp, "wf-window", "flaky")
+    assert not series.is_open
+    assert len(records) == 1
+    assert records[0].status is AttemptStatus.FAILED
+    assert records[0].error is not None and records[0].error.type_name == "ConnectionError"
+
+
+async def test_retry_after_delay_is_persisted_exactly(family, make_sqlite, recorded_sleeps):
+    cp = make_sqlite()
+    calls: list[int] = []
+
+    # max_delay far below the server delay: the server delay must NOT be capped or jittered.
+    @node(output_name="fetched", retry=_policy(max_attempts=3, max_delay=0.001, jitter="full"))
+    def flaky(x: int) -> int:
+        calls.append(x)
+        if len(calls) == 1:
+            raise RetryAfterError(ConnectionError("rate limited"), retry_after=5)
+        return x
+
+    runner = _make_runner(family, checkpointer=cp)
+    result = await _run(runner, Graph([flaky]), {"x": 7}, workflow_id="wf-after")
+
+    assert result["fetched"] == 7
+    assert recorded_sleeps == [5.0], "the server-supplied delay is honored exactly"
+
+    _, _, records = await _closed_series_for_step(cp, "wf-after", "flaky")
+    assert records[0].sampled_delay == 5.0
+    assert records[0].retry_not_before is not None
+
+
+# === Ticket 7: cache hit consumes nothing ===
+
+
+async def test_cache_hit_consumes_no_attempts(family, make_sqlite, recorded_sleeps, tmp_path):
+    cp = make_sqlite()
+    cache = _CountingCache()
+    calls: list[int] = []
+
+    @node(output_name="fetched", cache=True, retry=_policy())
+    def flaky(x: int) -> int:
+        calls.append(x)
+        if len(calls) == 1:
+            raise ConnectionError("transient")
+        return x * 10
+
+    graph = Graph([flaky])
+    runner = _make_runner(family, checkpointer=cp, cache=cache)
+
+    first = await _run(runner, graph, {"x": 1}, workflow_id="wf-cache-1")
+    assert first["fetched"] == 10
+    assert calls == [1, 1]
+    assert cache.set_calls == 1, "cache write happens once, after final success"
+
+    second = await _run(runner, graph, {"x": 1}, workflow_id="wf-cache-2")
+    assert second["fetched"] == 10
+    assert calls == [1, 1], "a cache hit invokes nothing"
+    assert cache.set_calls == 1
+
+    assert _series_rows(tmp_path / "retry.db", "wf-cache-2") == [], "a cache hit opens no attempt series"
+    _, series, records = await _closed_series_for_step(cp, "wf-cache-1", "flaky")
+    assert not series.is_open
+    assert len(records) == 2
+
+
+# === S1: fresh world ===
+
+
+async def test_fresh_world_sqlite_end_to_end(tmp_path):
+    db_path = tmp_path / "fresh.db"
+    calls: list[int] = []
+
+    @node(output_name="fetched", retry=_policy(initial_delay=0.001, jitter="full"))
+    def flaky(x: int) -> int:
+        calls.append(x)
+        if len(calls) == 1:
+            raise ConnectionError("transient")
+        return x * 10
+
+    @node(output_name="done")
+    def downstream(fetched: int) -> int:
+        return fetched + 1
+
+    runner = SyncRunner(checkpointer=SqliteCheckpointer(str(db_path)))
+    result = runner.run(Graph([flaky, downstream]), {"x": 4}, workflow_id="wf-fresh")
+    assert result["done"] == 41
+
+    reopened = SqliteCheckpointer(str(db_path))
+    try:
+        step, series, records = await _closed_series_for_step(reopened, "wf-fresh", "flaky")
+        assert step.status is StepStatus.COMPLETED
+        assert series is not None and not series.is_open
+        assert series.max_attempts == 3
+        assert [r.status for r in records] == [AttemptStatus.FAILED, AttemptStatus.SUCCEEDED]
+        assert records[0].sampled_delay is not None
+        assert records[0].retry_not_before is not None
+        downstream_steps = [s for s in await reopened.get_steps("wf-fresh") if s.node_name == "downstream"]
+        assert len(downstream_steps) == 1
+        assert downstream_steps[0].attempt_series_id is None
+    finally:
+        await reopened.close()
+
+
+# === S4: concurrent nodes keep isolated series/budgets ===
+
+
+async def test_concurrent_nodes_have_isolated_series(recorded_sleeps):
+    cp = MemoryCheckpointer()
+    a_started = asyncio.Event()
+    b_started = asyncio.Event()
+    a_calls: list[int] = []
+    b_calls: list[int] = []
+
+    @node(output_name="a_out", retry=_policy())
+    async def worker_a(x: int) -> int:
+        a_calls.append(x)
+        a_started.set()
+        await asyncio.wait_for(b_started.wait(), timeout=5)
+        if len(a_calls) == 1:
+            raise ConnectionError("a transient")
+        return x + 1
+
+    @node(output_name="b_out", retry=_policy())
+    async def worker_b(x: int) -> int:
+        b_calls.append(x)
+        b_started.set()
+        await asyncio.wait_for(a_started.wait(), timeout=5)
+        if len(b_calls) == 1:
+            raise ConnectionError("b transient")
+        return x + 2
+
+    runner = AsyncRunner(checkpointer=cp)
+    result = await runner.run(Graph([worker_a, worker_b]), {"x": 1}, workflow_id="wf-pair")
+
+    assert result["a_out"] == 2
+    assert result["b_out"] == 3
+    assert len(a_calls) == 2
+    assert len(b_calls) == 2
+
+    _, series_a, records_a = await _closed_series_for_step(cp, "wf-pair", "worker_a")
+    _, series_b, records_b = await _closed_series_for_step(cp, "wf-pair", "worker_b")
+    assert series_a.id != series_b.id
+    assert [r.status for r in records_a] == [AttemptStatus.FAILED, AttemptStatus.SUCCEEDED]
+    assert [r.status for r in records_b] == [AttemptStatus.FAILED, AttemptStatus.SUCCEEDED]
+    assert [r.series_id for r in records_a] == [series_a.id, series_a.id]
+    assert [r.series_id for r in records_b] == [series_b.id, series_b.id]
+
+
+# === S5: control-flow immunity ===
+
+
+async def test_keyboard_interrupt_passes_through_untouched(make_sqlite):
+    cp = make_sqlite()
+    calls: list[int] = []
+
+    @node(output_name="fetched", retry=_policy(max_attempts=5))
+    def flaky(x: int) -> int:
+        calls.append(x)
+        raise KeyboardInterrupt
+
+    runner = SyncRunner(checkpointer=cp)
+    with pytest.raises(KeyboardInterrupt):
+        runner.run(Graph([flaky]), {"x": 1}, workflow_id="wf-kbd")
+
+    assert calls == [1], "BaseException control flow is never retried"
+    series = await cp.get_open_attempt_series("wf-kbd", "flaky")
+    assert series is not None, "the series stays open for resume semantics"
+    records = await cp.get_attempt_records(series.id)
+    assert [r.status for r in records] == [AttemptStatus.STARTED], "no FAILED outcome is invented for control flow"
+
+
+def test_pause_execution_passes_through_untouched():
+    from hypergraph.runners._shared.results import PauseInfo
+    from hypergraph.runners._shared.state import PauseExecution
+
+    calls: list[int] = []
+    policy = _policy(max_attempts=5)
+
+    def invoke():
+        calls.append(1)
+        raise PauseExecution(PauseInfo(node_name="flaky", value="q", response_key="answer"))
+
+    with pytest.raises(PauseExecution):
+        attempts_module.run_attempts_sync(
+            invoke,
+            node_name="flaky",
+            policy=policy,
+            checkpointer=None,
+            run_id=None,
+            scheduled_superstep=0,
+        )
+    assert calls == [1], "PauseExecution must pass through without consuming attempts"
+
+
+async def test_cancelled_error_passes_through_untouched():
+    cp = MemoryCheckpointer()
+    calls: list[int] = []
+    second_attempt_running = asyncio.Event()
+    release = asyncio.Event()
+
+    @node(output_name="fetched", retry=_policy(max_attempts=3))
+    async def flaky(x: int) -> int:
+        calls.append(x)
+        if len(calls) == 1:
+            raise ConnectionError("transient")
+        second_attempt_running.set()
+        await release.wait()
+        return x
+
+    runner = AsyncRunner(checkpointer=cp)
+    task = asyncio.create_task(runner.run(Graph([flaky]), {"x": 1}, workflow_id="wf-cancel"))
+    await asyncio.wait_for(second_attempt_running.wait(), timeout=5)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert calls == [1, 1]
+    series = await cp.get_open_attempt_series("wf-cancel", "flaky")
+    assert series is not None
+    records = await cp.get_attempt_records(series.id)
+    assert [r.status for r in records] == [
+        AttemptStatus.FAILED,
+        AttemptStatus.STARTED,
+    ], "cancellation must not settle the running attempt as FAILED"
+
+
+async def test_stop_signal_does_not_consume_attempts(recorded_sleeps):
+    cp = MemoryCheckpointer()
+    calls: list[int] = []
+    first_failure_recorded = asyncio.Event()
+    stop_requested = asyncio.Event()
+
+    @node(output_name="fetched", retry=_policy(max_attempts=3))
+    async def flaky(x: int) -> int:
+        calls.append(x)
+        if len(calls) == 1:
+            first_failure_recorded.set()
+            raise ConnectionError("transient")
+        await asyncio.wait_for(stop_requested.wait(), timeout=5)
+        return x * 10
+
+    runner = AsyncRunner(checkpointer=cp)
+    task = asyncio.create_task(runner.run(Graph([flaky]), {"x": 1}, workflow_id="wf-stop"))
+    await asyncio.wait_for(first_failure_recorded.wait(), timeout=5)
+    runner.stop("wf-stop")
+    stop_requested.set()
+    result = await task
+
+    # Cooperative stop: the in-flight retry series completes its attempt.
+    assert result.status is RunStatus.STOPPED
+    assert calls == [1, 1], "stop consumed no extra attempts"
+    _, series, records = await _closed_series_for_step(cp, "wf-stop", "flaky")
+    assert not series.is_open
+    assert [r.status for r in records] == [AttemptStatus.FAILED, AttemptStatus.SUCCEEDED]
+
+
+# === S7: no-checkpointer truth ===
+
+
+async def test_no_checkpointer_budget_is_process_local(family, recorded_sleeps):
+    calls: list[int] = []
+    final_error = ConnectionError("always down")
+
+    @node(output_name="fetched", retry=_policy(max_attempts=3))
+    def flaky(x: int) -> int:
+        calls.append(x)
+        raise final_error
+
+    runner = _make_runner(family)
+    with pytest.raises(ConnectionError) as exc_info:
+        await _run(runner, Graph([flaky]), {"x": 1})
+
+    assert exc_info.value is final_error
+    assert calls == [1, 1, 1]
+    assert len(recorded_sleeps) == 2
+
+
+async def test_no_checkpointer_backoff_still_honored(family, recorded_sleeps):
+    calls: list[int] = []
+
+    @node(
+        output_name="fetched",
+        retry=_policy(max_attempts=4, initial_delay=1.0, backoff_multiplier=2.0, max_delay=60.0, jitter="full"),
+    )
+    def flaky(x: int) -> int:
+        calls.append(x)
+        if len(calls) < 3:
+            raise ConnectionError("transient")
+        return x
+
+    runner = _make_runner(family)
+    result = await _run(runner, Graph([flaky]), {"x": 1})
+
+    assert result["fetched"] == 1
+    assert calls == [1, 1, 1]
+    assert len(recorded_sleeps) == 2
+    # Full jitter samples uniformly in [0, nominal]; nominal doubles per attempt.
+    assert 0.0 <= recorded_sleeps[0] <= 1.0
+    assert 0.0 <= recorded_sleeps[1] <= 2.0
+
+
+# === Events: intermediate attempts never disturb the logical node shape ===
+
+
+@pytest.mark.parametrize("outcome", ["success", "exhausted"])
+async def test_intermediate_attempts_do_not_disturb_event_shape(family, recorded_sleeps, outcome):
+    calls: list[int] = []
+
+    @node(output_name="fetched", retry=_policy(max_attempts=3))
+    def flaky(x: int) -> int:
+        calls.append(x)
+        if outcome == "exhausted" or len(calls) == 1:
+            raise ConnectionError("boom")
+        return x
+
+    recorder = _Recorder()
+    runner = _make_runner(family)
+    if outcome == "success":
+        await _run(runner, Graph([flaky]), {"x": 1}, event_processors=[recorder])
+    else:
+        with pytest.raises(ConnectionError):
+            await _run(runner, Graph([flaky]), {"x": 1}, event_processors=[recorder])
+
+    starts = [e for e in recorder.events if isinstance(e, NodeStartEvent) and e.node_name == "flaky"]
+    ends = [e for e in recorder.events if isinstance(e, NodeEndEvent) and e.node_name == "flaky"]
+    errors = [e for e in recorder.events if isinstance(e, NodeErrorEvent) and e.node_name == "flaky"]
+    assert len(starts) == 1, "one logical NodeStartEvent regardless of attempts"
+    if outcome == "success":
+        assert len(ends) == 1 and len(errors) == 0
+    else:
+        assert len(ends) == 0 and len(errors) == 1, "intermediate failures emit no NodeErrorEvent"
+    assert not any(type(e).__name__.startswith("NodeAttempt") for e in recorder.events), "attempt events belong to a later ticket"
+
+
+# === Composition: map items and nested graphs ===
+
+
+async def test_map_items_own_separate_series(make_sqlite, recorded_sleeps):
+    cp = make_sqlite()
+    failed_once: set[int] = set()
+    calls: list[int] = []
+
+    @node(output_name="fetched", retry=_policy())
+    def flaky(x: int) -> int:
+        calls.append(x)
+        if x not in failed_once:
+            failed_once.add(x)
+            raise ConnectionError("transient")
+        return x * 10
+
+    runner = SyncRunner(checkpointer=cp)
+    result = runner.map(Graph([flaky]), {"x": [1, 2, 3]}, map_over="x", workflow_id="wf-map")
+
+    assert [item["fetched"] for item in result] == [10, 20, 30]
+    assert sorted(calls) == [1, 1, 2, 2, 3, 3], "each item retried independently"
+
+    child_runs = await cp.list_runs(parent_run_id="wf-map")
+    assert len(child_runs) == 3
+    seen_series = set()
+    for child in child_runs:
+        _, series, records = await _closed_series_for_step(cp, child.id, "flaky")
+        assert not series.is_open
+        assert [r.status for r in records] == [AttemptStatus.FAILED, AttemptStatus.SUCCEEDED]
+        seen_series.add(series.id)
+    assert len(seen_series) == 3, "map items own separate attempt series"
+
+
+async def test_nested_function_node_carries_policy(family, recorded_sleeps):
+    calls: list[int] = []
+
+    @node(output_name="fetched", retry=_policy())
+    def flaky(x: int) -> int:
+        calls.append(x)
+        if len(calls) == 1:
+            raise ConnectionError("transient")
+        return x * 10
+
+    inner = Graph([flaky], name="inner")
+    outer = Graph([inner.as_node()])
+
+    runner = _make_runner(family)
+    result = await _run(runner, outer, {"x": 1})
+
+    assert result["fetched"] == 10
+    assert calls == [1, 1], "a nested FunctionNode carries its retry declaration"
+
+
+# === Cycles: each logical execution owns a fresh series ===
+
+
+async def test_cycle_reexecution_gets_fresh_series(make_sqlite, recorded_sleeps):
+    cp = make_sqlite()
+    calls: list[int] = []
+    failed_for: set[int] = set()
+
+    @node(output_name="count", retry=_policy())
+    def worker(count: int) -> int:
+        calls.append(count)
+        if count not in failed_for:
+            failed_for.add(count)
+            raise ConnectionError("transient")
+        return count + 1
+
+    @route(targets=["worker", END])
+    def keep_going(count: int) -> str:
+        return END if count >= 2 else "worker"
+
+    runner = SyncRunner(checkpointer=cp)
+    result = runner.run(
+        Graph([worker, keep_going], entrypoint="worker"),
+        {"count": 0},
+        workflow_id="wf-cycle",
+    )
+
+    assert result["count"] == 2
+    # Two logical executions (0 -> 1 -> 2), each failing once then succeeding.
+    assert calls == [0, 0, 1, 1]
+
+    steps = [s for s in await cp.get_steps("wf-cycle") if s.node_name == "worker"]
+    assert len(steps) == 2
+    series_ids = {s.attempt_series_id for s in steps}
+    assert None not in series_ids
+    assert len(series_ids) == 2, "each logical execution owns its own closed series"
+    for series_id in series_ids:
+        series = await cp.get_attempt_series(series_id)
+        assert series is not None and not series.is_open
+        records = await cp.get_attempt_records(series_id)
+        assert [r.status for r in records] == [AttemptStatus.FAILED, AttemptStatus.SUCCEEDED]
+
+
+# === Backoff math (pure helpers) ===
+
+
+class TestBackoffMath:
+    def test_nominal_delay_formula(self):
+        policy = _policy(initial_delay=1.0, backoff_multiplier=2.0, max_delay=60.0)
+        assert attempts_module.nominal_delay(policy, 1) == 1.0
+        assert attempts_module.nominal_delay(policy, 2) == 2.0
+        assert attempts_module.nominal_delay(policy, 3) == 4.0
+        assert attempts_module.nominal_delay(policy, 7) == 60.0, "nominal is capped by max_delay"
+
+    def test_constant_delay_with_multiplier_one(self):
+        policy = _policy(initial_delay=5.0, backoff_multiplier=1.0)
+        assert attempts_module.nominal_delay(policy, 1) == 5.0
+        assert attempts_module.nominal_delay(policy, 4) == 5.0
+
+    def test_jitter_none_uses_nominal(self):
+        policy = _policy(initial_delay=3.0, jitter="none")
+        now = datetime.now(timezone.utc)
+        decision = attempts_module.draw_backoff(policy, 1, now=now)
+        assert decision.sampled_delay == 3.0
+        assert decision.effective_delay == 3.0
+        assert decision.retry_not_before == now + timedelta(seconds=3.0)
+
+    def test_full_jitter_samples_within_nominal(self):
+        policy = _policy(initial_delay=10.0, jitter="full")
+        now = datetime.now(timezone.utc)
+        for _ in range(50):
+            decision = attempts_module.draw_backoff(policy, 1, now=now)
+            assert 0.0 <= decision.sampled_delay <= 10.0
+            assert decision.retry_not_before == now + timedelta(seconds=decision.sampled_delay)
+
+    def test_server_delay_is_neither_jittered_nor_capped(self):
+        policy = _policy(initial_delay=0.5, max_delay=1.0, jitter="full")
+        now = datetime.now(timezone.utc)
+        decision = attempts_module.draw_backoff(policy, 1, now=now, retry_after=30.0)
+        assert decision.sampled_delay == 30.0
+        assert decision.effective_delay == 30.0
+        assert decision.retry_not_before == now + timedelta(seconds=30.0)

--- a/tests/test_retry_policy.py
+++ b/tests/test_retry_policy.py
@@ -1,0 +1,238 @@
+"""Contract tests for the public RetryPolicy / RetryAfterError surface (#230).
+
+Assertion map (validation contract, wave A2):
+    S6  validation errors before execution   TestRetryPolicyValidation, TestRetryAfterErrorValidation
+    S8  direct calls stay raw                test_direct_function_call_is_single_shot,
+                                             test_node_call_is_single_shot
+    —   node-owned declaration + clones      TestNodeRetryParam
+    —   fingerprint canonicality             TestPolicyFingerprint
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+
+import pytest
+
+from hypergraph import FunctionNode, RetryAfterError, RetryPolicy, node
+
+
+class TestRetryPolicyValidation:
+    """S6 — every invalid policy is rejected at construction, before any execution."""
+
+    def test_retry_on_is_required(self):
+        with pytest.raises(TypeError):
+            RetryPolicy(max_attempts=3)  # type: ignore[call-arg]
+
+    def test_empty_retry_on_rejected(self):
+        with pytest.raises(ValueError, match="retry_on"):
+            RetryPolicy(max_attempts=3, retry_on=())
+
+    @pytest.mark.parametrize(
+        "bad_entry",
+        [KeyboardInterrupt, SystemExit, BaseException, asyncio.CancelledError, GeneratorExit],
+    )
+    def test_base_exception_family_rejected(self, bad_entry):
+        with pytest.raises(ValueError, match="BaseException"):
+            RetryPolicy(max_attempts=3, retry_on=(ValueError, bad_entry))
+
+    @pytest.mark.parametrize("bad_entry", ["timeout", ValueError("instance"), 42])
+    def test_non_class_entries_rejected(self, bad_entry):
+        with pytest.raises((TypeError, ValueError), match="retry_on"):
+            RetryPolicy(max_attempts=3, retry_on=(bad_entry,))
+
+    @pytest.mark.parametrize("bad", [0, -1])
+    def test_non_positive_max_attempts_rejected(self, bad):
+        with pytest.raises(ValueError, match="max_attempts"):
+            RetryPolicy(max_attempts=bad, retry_on=(ValueError,))
+
+    def test_bogus_jitter_rejected(self):
+        with pytest.raises(ValueError, match="jitter"):
+            RetryPolicy(max_attempts=3, retry_on=(ValueError,), jitter="bogus")
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("initial_delay", 0.0),
+            ("initial_delay", -1.0),
+            ("backoff_multiplier", 0.0),
+            ("backoff_multiplier", -2.0),
+            ("max_delay", 0.0),
+            ("max_delay", -5.0),
+            ("retry_window", 0.0),
+            ("retry_window", -10.0),
+            ("initial_delay", float("nan")),
+            ("max_delay", float("inf")),
+        ],
+    )
+    def test_non_positive_or_non_finite_timing_rejected(self, field, value):
+        kwargs = {"max_attempts": 3, "retry_on": (ValueError,), field: value}
+        with pytest.raises(ValueError, match=field):
+            RetryPolicy(**kwargs)
+
+    def test_policy_is_frozen(self):
+        policy = RetryPolicy(max_attempts=3, retry_on=(ValueError,))
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            policy.max_attempts = 5  # type: ignore[misc]
+
+    def test_single_exception_type_normalized_to_tuple(self):
+        policy = RetryPolicy(max_attempts=3, retry_on=ValueError)
+        assert policy.retry_on == (ValueError,)
+
+    def test_defaults_match_locked_contract(self):
+        policy = RetryPolicy(max_attempts=3, retry_on=(ValueError,))
+        assert policy.retry_window is None
+        assert policy.initial_delay == 1.0
+        assert policy.backoff_multiplier == 2.0
+        assert policy.max_delay == 60.0
+        assert policy.jitter == "full"
+
+    def test_exception_base_is_allowed(self):
+        # Only the BaseException family is rejected; a broad Exception entry is legal.
+        policy = RetryPolicy(max_attempts=2, retry_on=(Exception,))
+        assert policy.retry_on == (Exception,)
+
+
+class TestRetryAfterErrorValidation:
+    def test_carries_error_and_delay(self):
+        underlying = ConnectionError("rate limited")
+        carrier = RetryAfterError(underlying, retry_after=30)
+        assert carrier.error is underlying
+        assert carrier.retry_after == 30.0
+
+    @pytest.mark.parametrize("bad", [-1, float("inf"), float("nan")])
+    def test_invalid_delay_rejected(self, bad):
+        with pytest.raises(ValueError, match="retry_after"):
+            RetryAfterError(ConnectionError("x"), retry_after=bad)
+
+    def test_zero_delay_allowed(self):
+        assert RetryAfterError(ConnectionError("x"), retry_after=0).retry_after == 0.0
+
+    @pytest.mark.parametrize("bad", [KeyboardInterrupt(), ValueError, "boom"])
+    def test_error_must_be_exception_instance(self, bad):
+        with pytest.raises(TypeError, match="error"):
+            RetryAfterError(bad, retry_after=1)
+
+    def test_nested_carrier_rejected(self):
+        inner = RetryAfterError(ConnectionError("x"), retry_after=1)
+        with pytest.raises(TypeError, match="RetryAfterError"):
+            RetryAfterError(inner, retry_after=2)
+
+
+class TestNodeRetryParam:
+    def test_node_decorator_accepts_policy(self):
+        policy = RetryPolicy(max_attempts=3, retry_on=(ConnectionError,))
+
+        @node(output_name="out", retry=policy)
+        def fetch(x: int) -> int:
+            return x
+
+        assert fetch.retry is policy
+
+    def test_default_is_no_retry(self):
+        @node(output_name="out")
+        def fetch(x: int) -> int:
+            return x
+
+        assert fetch.retry is None
+
+    def test_retry_true_shorthand_rejected(self):
+        with pytest.raises(TypeError, match="RetryPolicy"):
+
+            @node(output_name="out", retry=True)
+            def fetch(x: int) -> int:
+                return x
+
+    def test_function_node_constructor_accepts_policy(self):
+        policy = RetryPolicy(max_attempts=2, retry_on=(ValueError,))
+
+        def fetch(x: int) -> int:
+            return x
+
+        fn = FunctionNode(fetch, output_name="out", retry=policy)
+        assert fn.retry is policy
+
+    def test_clones_carry_the_declaration(self):
+        policy = RetryPolicy(max_attempts=3, retry_on=(ConnectionError,))
+
+        @node(output_name="out", retry=policy)
+        def fetch(x: int) -> int:
+            return x
+
+        assert fetch.with_name("fetch2").retry is policy
+        assert fetch.rename_inputs({"x": "y"}).retry is policy
+        assert fetch.rename_outputs({"out": "value"}).retry is policy
+
+    def test_retry_does_not_change_cache_identity(self):
+        def fetch(x: int) -> int:
+            return x
+
+        plain = FunctionNode(fetch, output_name="out")
+        with_retry = FunctionNode(fetch, output_name="out", retry=RetryPolicy(max_attempts=5, retry_on=(ValueError,)))
+        assert plain.definition_hash == with_retry.definition_hash
+
+
+class TestPolicyFingerprint:
+    def test_equal_policies_share_a_fingerprint(self):
+        a = RetryPolicy(max_attempts=3, retry_on=(ConnectionError, TimeoutError))
+        b = RetryPolicy(max_attempts=3, retry_on=(ConnectionError, TimeoutError))
+        assert a.fingerprint == b.fingerprint
+
+    def test_retry_on_order_is_canonical(self):
+        a = RetryPolicy(max_attempts=3, retry_on=(ConnectionError, TimeoutError))
+        b = RetryPolicy(max_attempts=3, retry_on=(TimeoutError, ConnectionError))
+        assert a.fingerprint == b.fingerprint
+
+    @pytest.mark.parametrize(
+        "changed",
+        [
+            {"max_attempts": 4},
+            {"retry_on": (ValueError,)},
+            {"retry_window": 30.0},
+            {"initial_delay": 0.5},
+            {"backoff_multiplier": 3.0},
+            {"max_delay": 10.0},
+            {"jitter": "none"},
+        ],
+    )
+    def test_every_field_feeds_the_fingerprint(self, changed):
+        base_kwargs = {"max_attempts": 3, "retry_on": (ConnectionError,)}
+        base = RetryPolicy(**base_kwargs)
+        other = RetryPolicy(**{**base_kwargs, **changed})
+        assert base.fingerprint != other.fingerprint
+
+
+# === S8: direct calls stay raw ===
+
+
+def test_direct_function_call_is_single_shot():
+    calls: list[int] = []
+
+    @node(
+        output_name="out",
+        retry=RetryPolicy(max_attempts=5, retry_on=(ConnectionError,), initial_delay=0.001),
+    )
+    def fetch(x: int) -> int:
+        calls.append(x)
+        raise ConnectionError("boom")
+
+    with pytest.raises(ConnectionError):
+        fetch.func(1)
+    assert calls == [1]
+
+
+def test_node_call_is_single_shot():
+    calls: list[int] = []
+
+    @node(
+        output_name="out",
+        retry=RetryPolicy(max_attempts=5, retry_on=(ConnectionError,), initial_delay=0.001),
+    )
+    def fetch(x: int) -> int:
+        calls.append(x)
+        raise ConnectionError("boom")
+
+    with pytest.raises(ConnectionError):
+        fetch(1)
+    assert calls == [1]

--- a/tests/test_runners/test_type_ownership.py
+++ b/tests/test_runners/test_type_ownership.py
@@ -26,6 +26,8 @@ ROOT_EXPORTS = (
     "InterruptNode",
     "HyperNode",
     "END",
+    "RetryPolicy",
+    "RetryAfterError",
     "Graph",
     "InputSpec",
     "SyncHandle",


### PR DESCRIPTION
Closes #230. The user-facing core of the locked #187 retry contract, on top of the #229 attempt ledger.

## What this adds
```python
@node(retry=RetryPolicy(max_attempts=3, retry_on=(httpx.ReadTimeout,), retry_window=45))
async def call_model(prompt: str) -> str: ...
```
Node-owned only (no runner/graph/call overrides); explicit `retry_on` allowlist (no retry=True); `max_attempts` includes the first invocation; capped-exponential backoff with full jitter, sampled once and PERSISTED (`retry_not_before`/`sampled_delay`) so restart never redraws a wait; durable `retry_window` OR-limit; non-authorizing `RetryAfterError` carrier honoring server delays exactly; exhaustion re-raises the exact underlying exception. One shared coordinator (pure decision core + two ~40-line drivers whose normalized diff is the two intended deltas) sits inside the FunctionNode executors: cache-once boundary, no state folding or events from intermediate attempts, map items own separate series, direct calls stay raw.

## Review-hardened (2 adversarial rounds)
Resume dead ends now atomically link-and-close their series via a new terminal-close ledger primitive (status never rewritten; last-record-only; SUCCEEDED still requires live STARTED); post-sleep window re-check; OverflowError-proof backoff at valid extremes; the async concurrency permit is acquired per ATTEMPT and released during backoff (per the #218 in-flight wording); the retried-step durability write-through exception is disclosed in CheckpointPolicy docs.

## Test plan
6 commits (3 RED/GREEN rounds); 148 dedicated tests incl. kill/resume backoff persistence, control-flow immunity (KeyboardInterrupt/Pause/Stop/CancelledError), fresh-world sqlite end-to-end, concurrency isolation, 35 validation cases, event-shape preservation, terminal-close invariants on all three backends; docs how-to with an executed runnable example. Verifier probes: crash-at-step-save repro, no-mutation transactional attack, permit-release ordering (A1→backoff→B→A2). Full CI-equivalent: 3,851 passed / 0 failed / 0 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable node-level retries for transient failures.
  * Supports retry limits, exception eligibility, backoff, jitter, retry windows, and server-provided retry delays.
  * Added durable retry tracking across restarts when checkpointing is enabled.
  * Exposed `RetryPolicy` and `RetryAfterError` for public use.

* **Documentation**
  * Added a comprehensive retry guide and expanded API references.
  * Documented checkpoint durability guarantees and retry behavior limitations.

* **Tests**
  * Added extensive coverage for retry behavior, persistence, timing, concurrency, and public API contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->