### PR TITLE
feat(release): prove beta release readiness as hypergraph-ai

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,86 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      publish_testpypi:
+        description: Publish the built distributions to TestPyPI
+        required: true
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate production release tag
+        if: github.event_name == 'release'
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
+            echo "Release tag must match vX.Y.Z or a prerelease suffix, got: $RELEASE_TAG" >&2
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build wheel and source distribution
+        run: uv build
+      - name: Verify distribution contents
+        run: uv run python scripts/verify_distribution.py dist/*.whl dist/*.tar.gz
+      - name: Store distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-pypi:
+    name: Publish to PyPI
+    if: github.event_name == 'release'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/hypergraph-ai
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distributions
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    if: github.event_name == 'workflow_dispatch' && inputs.publish_testpypi == true
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/hypergraph-ai
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distributions
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/README.md
+++ b/README.md
@@ -34,15 +34,16 @@ A unified framework for Python workflow orchestration. DAG pipelines, agentic wo
 </picture>
 
 ## Installation
-(Working on claiming the `hypergraph` name on PyPI from a dormant project.)
+
+The first beta publish is pending. Once it is available:
 
 ```bash
-uv add git+https://github.com/gilad-rubin/hypergraph.git
-# or
-pip install git+https://github.com/gilad-rubin/hypergraph.git
+pip install hypergraph-ai
 ```
 
-> **Alpha**: API may change between releases. Core features are stable — nodes, graphs, runners, routing, and cyclic graphs.
+The distribution is named `hypergraph-ai`; the Python import remains `hypergraph`.
+
+> **Beta**: Stable-beta APIs receive a deprecation warning and at least one minor release of grace before removal. Experimental surfaces are identified in the documentation and may change with changelog notes.
 
 ## Quick Start
 

--- a/docs/01-introduction/comparison.md
+++ b/docs/01-introduction/comparison.md
@@ -319,7 +319,7 @@ Hypergraph is younger than these alternatives. Tradeoffs to consider:
 
 | Area | Status |
 |------|--------|
-| Maturity | Alpha - API may change |
+| Maturity | Beta - stable-beta APIs follow the documented deprecation policy |
 | Production use | Limited testing at scale |
 | Ecosystem | Smaller community |
 | Integrations | Fewer pre-built connectors |

--- a/docs/01-introduction/quick-start.md
+++ b/docs/01-introduction/quick-start.md
@@ -5,10 +5,11 @@ Get up and running with hypergraph in 5 minutes.
 ## Installation
 
 ```bash
-uv add git+https://github.com/gilad-rubin/hypergraph.git
-# or
-pip install git+https://github.com/gilad-rubin/hypergraph.git
+pip install hypergraph-ai
 ```
+
+The first beta publish is pending. The distribution name is `hypergraph-ai`;
+the Python import remains `hypergraph`.
 
 ## Your First Graph
 

--- a/docs/03-patterns/08-caching.md
+++ b/docs/03-patterns/08-caching.md
@@ -60,7 +60,7 @@ cache = InMemoryCache(max_size=1000)
 Persistent across runs. Requires the optional cache dependencies:
 
 ```bash
-pip install 'hypergraph[cache]'
+pip install 'hypergraph-ai[cache]'
 ```
 
 This installs:
@@ -175,7 +175,7 @@ CacheHitEvent(node_name="embed", cache_key="abc123...")
 NodeEndEvent(node_name="embed", cached=True, duration_ms=0.0)
 ```
 
-If your node body uses `hypercache` internally, Hypergraph also emits `InnerCacheEvent` entries for those nested cache decisions. Installing `hypergraph[cache]` gives you both Hypergraph's disk backend and the Hypercache observer bridge:
+If your node body uses `hypercache` internally, Hypergraph also emits `InnerCacheEvent` entries for those nested cache decisions. Installing `hypergraph-ai[cache]` gives you both Hypergraph's disk backend and the Hypercache observer bridge:
 
 ```python
 from hypergraph import InnerCacheEvent, TypedEventProcessor

--- a/docs/05-how-to/debug-workflows.md
+++ b/docs/05-how-to/debug-workflows.md
@@ -718,7 +718,7 @@ starts a new execution under the existing resume rules.
 ### Quick Start
 
 ```bash
-pip install 'hypergraph[checkpoint]'
+pip install 'hypergraph-ai[checkpoint]'
 ```
 
 ```python

--- a/docs/05-how-to/observe-execution.md
+++ b/docs/05-how-to/observe-execution.md
@@ -24,7 +24,7 @@ sensitivity, degraded views, and map failure drill-down.
 The fastest way to observe execution — hierarchical progress bars powered by Rich.
 
 ```bash
-pip install 'hypergraph[progress]'
+pip install 'hypergraph-ai[progress]'
 ```
 
 ```python
@@ -88,7 +88,7 @@ Hypergraph's native `result.inspect()` view, failure evidence, and checkpoint
 tools remain the primary debugging experience; OTel is the export layer.
 
 ```bash
-pip install 'hypergraph[otel]'
+pip install 'hypergraph-ai[otel]'
 ```
 
 ```python

--- a/docs/06-api-reference/events.md
+++ b/docs/06-api-reference/events.md
@@ -243,7 +243,7 @@ class CacheHitEvent(BaseEvent):
 
 Emitted when a hypercache-decorated call happens inside a running node. This
 bridge activates when `hypercache` is installed, including via
-`pip install 'hypergraph[cache]'`. The event is emitted when the installed
+`pip install 'hypergraph-ai[cache]'`. The event is emitted when the installed
 Hypercache version exposes its public observer API.
 
 ```python
@@ -413,7 +413,7 @@ Graph: my_graph | 3 nodes | 2 edges | no cycles · 1 processor
 Hierarchical Rich progress bars for graph execution. Requires the `rich` package.
 
 ```bash
-pip install 'hypergraph[progress]'
+pip install 'hypergraph-ai[progress]'
 # or
 pip install rich
 ```

--- a/docs/06-api-reference/runners.md
+++ b/docs/06-api-reference/runners.md
@@ -401,7 +401,7 @@ class DaftRunner:
 - `cache` - Optional cache backend for node-level caching.
 
 **Raises:**
-- `ImportError` - If the `daft` dependency is not installed. Install with `pip install 'hypergraph[daft]'`.
+- `ImportError` - If the `daft` dependency is not installed. Install with `pip install 'hypergraph-ai[daft]'`.
 
 ### run()
 

--- a/docs/07-design/roadmap.md
+++ b/docs/07-design/roadmap.md
@@ -2,7 +2,7 @@
 
 What's implemented, what's coming, and the vision for hypergraph.
 
-## Current Status: Alpha
+## Current Status: Beta
 
 Core features are working and stable. API may still change before 1.0.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -91,6 +91,7 @@ understand planned work.
 | `../examples/` | Canonical runnable patterns; examples must match the real API |
 | `adr/` | Canonical durable decisions; later ADRs supersede earlier decisions explicitly |
 | `changelog.md` | Historical record of shipped change sets |
+| `release.md` | Canonical distribution identity, release trigger, tag, and yank contract |
 | `prd/` and `07-design/roadmap.md` | Intent and planning, not evidence of current behavior |
 | `research/` | Dated investigations and decision evidence; intent, not evidence of shipped behavior |
 
@@ -164,6 +165,7 @@ For native execution inspection, start with
 - [Philosophy](07-design/philosophy.md) - Why hypergraph exists and design principles
 - [Inspiration](07-design/inspiration.md) - Frameworks that influenced hypergraph's design
 - [Roadmap](07-design/roadmap.md) - What's implemented, what's coming next
+- [Release Contract](release.md) - Distribution identity, publication trigger, tags, and yanking
 - [Changelog](changelog.md) - Release history and changes
 
 ## Design Principles

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -73,4 +73,5 @@
 * [Philosophy](07-design/philosophy.md)
 * [Inspiration](07-design/inspiration.md)
 * [Roadmap](07-design/roadmap.md)
+* [Release Contract](release.md)
 * [Changelog](changelog.md)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,14 @@
 
 ### Added
 
+- **Beta distribution and human-gated release path** — the distribution is now
+  `hypergraph-ai` at `0.2.0b1` with a Beta classifier while the import remains
+  `hypergraph`. A GitHub Release is the only production trigger; separate
+  Trusted Publishing jobs upload prebuilt artifacts to PyPI or, after an
+  explicit manual dry-run input, TestPyPI. A distribution verifier checks the
+  wheel and source distribution package trees, viz/inspect assets, changelog,
+  and forbidden development directories before publication.
+
 - **Native execution inspect mode** — before, users correlated result status,
   logs, map indexes, values, and failures by hand. Now `SyncRunner` and
   `AsyncRunner` accept `inspect=True` on `run()`, `map()`, `start_run()`, and

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,82 @@
+# Release Contract
+
+Hypergraph's package release boundary is human-controlled. Automation builds
+and publishes artifacts, but it does not decide that a production release
+should exist.
+
+## Before and after
+
+Before:
+
+```bash
+pip install git+https://github.com/gilad-rubin/hypergraph.git
+```
+
+After the first beta is published:
+
+```bash
+pip install hypergraph-ai
+python -c 'import hypergraph; g = hypergraph.Graph([])'
+```
+
+`hypergraph-ai` is the distribution name. The import name remains
+`hypergraph`.
+
+## Versioning and maturity
+
+The first beta is `0.2.0b1` and carries the
+`Development Status :: 4 - Beta` classifier. Stable-beta APIs receive a
+`DeprecationWarning` and at least one minor release of grace before removal.
+Experimental surfaces may change without that grace period, with the change
+recorded in the changelog.
+
+Real package releases use tags shaped like `vX.Y.Z`, with an optional
+prerelease suffix such as `v0.2.0b1`. A patch component is mandatory. The
+historical `v1.0`, `v1.1`, and `v1.2` tags are milestones, not package
+versions, so the release workflow rejects them.
+
+## Human production trigger
+
+Production publication starts only when a maintainer publishes a GitHub
+Release whose tag matches `vX.Y.Z*`. A tag push by itself does not trigger the
+workflow. The workflow builds the wheel and source distribution in an
+unprivileged job, then the PyPI job downloads those exact artifacts and uses
+Trusted Publishing through GitHub OIDC. No PyPI token is stored as a secret.
+
+The maintainer must configure the `pypi` GitHub environment as a Trusted
+Publisher on PyPI before the first production release. Publishing the GitHub
+Release is explicit approval to upload that version.
+
+## TestPyPI dry run
+
+TestPyPI is separate from the production trigger. A maintainer manually runs
+the `Release` workflow and enables `publish_testpypi`. The `testpypi`
+environment must already be configured as a TestPyPI Trusted Publisher. A
+manual run can publish only to TestPyPI; the production job is gated on the
+`release.published` event.
+
+Before using either index, the same local artifact checks are available:
+
+```bash
+uv build --clear
+uv run python scripts/verify_distribution.py dist/*.whl dist/*.tar.gz
+```
+
+## Historical milestone tag migration
+
+Remote tag history is maintainer-owned. After reviewing the three targets, a
+maintainer can create annotated milestone tags and remove the old remote names
+with this single compound command:
+
+```bash
+git tag -a milestone/1.0 'v1.0^{}' -m 'v1.0 Type Validation' && git tag -a milestone/1.1 'v1.1^{}' -m 'v1.1 Documentation' && git tag -a milestone/1.2 'v1.2^{}' -m 'v1.2 Test Coverage' && git push origin refs/tags/milestone/1.0 refs/tags/milestone/1.1 refs/tags/milestone/1.2 && git push origin --delete v1.0 v1.1 v1.2
+```
+
+The release-readiness implementation does not run this command or otherwise
+rewrite remote tag history.
+
+## Bad releases
+
+Yank a bad release from the package index and publish a corrected version.
+Never delete a published release. Yanking keeps the historical record while
+preventing ordinary dependency resolution from selecting the bad artifact.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
-name = "hypergraph"
-version = "0.1.0"
+name = "hypergraph-ai"
+version = "0.2.0b1"
 description = "A hierarchical and modular graph workflow framework for AI & ML"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -13,7 +13,7 @@ authors = [
 license = {text = "MIT"}
 keywords = ["graph", "pipeline", "workflow", "ml", "ai", "dag", "machine-learning"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",

--- a/scripts/verify_distribution.py
+++ b/scripts/verify_distribution.py
@@ -1,0 +1,165 @@
+"""Verify that a built Hypergraph wheel satisfies the release contract."""
+
+from __future__ import annotations
+
+import sys
+from email.parser import BytesParser
+from pathlib import Path, PurePosixPath
+from tarfile import open as open_tar
+from zipfile import ZipFile
+
+EXPECTED_DISTRIBUTION = "hypergraph-ai"
+EXPECTED_VERSION = "0.2.0b1"
+EXPECTED_CLASSIFIER = "Development Status :: 4 - Beta"
+FORBIDDEN_DIRECTORIES = frozenset({"dev", "specs", "tests"})
+ASSET_DIRECTORIES = (
+    Path("checkpointers/_assets"),
+    Path("runners/_shared/assets"),
+    Path("viz/assets"),
+)
+REQUIRED_ASSETS = frozenset(
+    {
+        "hypergraph/checkpointers/_assets/explorer.js",
+        "hypergraph/runners/_shared/assets/inspect.css",
+        "hypergraph/runners/_shared/assets/inspect.js",
+        "hypergraph/runners/_shared/assets/inspect_transport.js",
+        "hypergraph/viz/assets/vendor/reactflow.css",
+        "hypergraph/viz/assets/vendor/reactflow.umd.js",
+        "hypergraph/viz/assets/viz.js",
+        "hypergraph/viz/assets/viz_runtime.js",
+    }
+)
+
+
+def _source_contract(repo_root: Path) -> tuple[set[str], set[str]]:
+    package_root = repo_root / "src" / "hypergraph"
+    packages = {init_file.parent.relative_to(repo_root / "src").as_posix() for init_file in package_root.rglob("__init__.py")}
+    assets = {
+        (Path("hypergraph") / asset.relative_to(package_root)).as_posix()
+        for directory in ASSET_DIRECTORIES
+        for asset in (package_root / directory).rglob("*")
+        if asset.is_file() and asset.suffix != ".py" and "__pycache__" not in asset.parts
+    }
+    return packages, assets | REQUIRED_ASSETS
+
+
+def _metadata(wheel: ZipFile, members: set[str]) -> tuple[str, str, set[str]]:
+    metadata_files = [name for name in members if name.endswith(".dist-info/METADATA")]
+    if len(metadata_files) != 1:
+        raise ValueError(f"expected one METADATA file, found {len(metadata_files)}")
+
+    message = BytesParser().parsebytes(wheel.read(metadata_files[0]))
+    return (
+        message.get("Name", ""),
+        message.get("Version", ""),
+        set(message.get_all("Classifier", [])),
+    )
+
+
+def verify_wheel(wheel_path: Path, repo_root: Path) -> list[str]:
+    expected_packages, expected_assets = _source_contract(repo_root)
+    errors: list[str] = []
+
+    with ZipFile(wheel_path) as wheel:
+        members = set(wheel.namelist())
+        distribution, version, classifiers = _metadata(wheel, members)
+
+    expected_package_files = {f"{package}/__init__.py" for package in expected_packages}
+    missing_packages = sorted(expected_package_files - members)
+    missing_assets = sorted(expected_assets - members)
+    forbidden_members = sorted(member for member in members if FORBIDDEN_DIRECTORIES.intersection(PurePosixPath(member).parts))
+
+    if distribution != EXPECTED_DISTRIBUTION:
+        errors.append(f"distribution is {distribution!r}, expected {EXPECTED_DISTRIBUTION!r}")
+    if version != EXPECTED_VERSION:
+        errors.append(f"version is {version!r}, expected {EXPECTED_VERSION!r}")
+    if EXPECTED_CLASSIFIER not in classifiers:
+        errors.append(f"missing classifier {EXPECTED_CLASSIFIER!r}")
+    if missing_packages:
+        errors.append(f"missing packages: {', '.join(missing_packages)}")
+    if missing_assets:
+        errors.append(f"missing assets: {', '.join(missing_assets)}")
+    if forbidden_members:
+        errors.append(f"forbidden members: {', '.join(forbidden_members)}")
+    if any(member.startswith("src/") for member in members):
+        errors.append("wheel contains the source-layout prefix src/")
+
+    print(f"wheel: {wheel_path.name}")
+    print(f"distribution: {distribution} {version}")
+    print(f"subpackages: {len(expected_packages) - len(missing_packages)}/{len(expected_packages)} present")
+    print(f"assets: {len(expected_assets) - len(missing_assets)}/{len(expected_assets)} present")
+    print(f"forbidden directories: {'present' if forbidden_members else 'absent'}")
+
+    return errors
+
+
+def verify_sdist(sdist_path: Path, repo_root: Path) -> list[str]:
+    expected_packages, expected_assets = _source_contract(repo_root)
+    errors: list[str] = []
+
+    with open_tar(sdist_path, "r:gz") as archive:
+        raw_members = {PurePosixPath(member.name) for member in archive.getmembers() if member.isfile()}
+
+    roots = {member.parts[0] for member in raw_members if member.parts}
+    if len(roots) != 1:
+        return [f"sdist should have one root directory, found {sorted(roots)}"]
+
+    members = {PurePosixPath(*member.parts[1:]).as_posix() for member in raw_members if len(member.parts) > 1}
+    expected_package_files = {f"src/{package}/__init__.py" for package in expected_packages}
+    expected_asset_files = {f"src/{asset}" for asset in expected_assets}
+    missing_packages = sorted(expected_package_files - members)
+    missing_assets = sorted(expected_asset_files - members)
+    forbidden_members = sorted(member for member in members if FORBIDDEN_DIRECTORIES.intersection(PurePosixPath(member).parts))
+
+    if "docs/changelog.md" not in members:
+        errors.append("sdist is missing docs/changelog.md")
+    if missing_packages:
+        errors.append(f"sdist missing packages: {', '.join(missing_packages)}")
+    if missing_assets:
+        errors.append(f"sdist missing assets: {', '.join(missing_assets)}")
+    if forbidden_members:
+        errors.append(f"sdist forbidden members: {', '.join(forbidden_members)}")
+
+    print(f"sdist: {sdist_path.name}")
+    print(f"sdist changelog: {'present' if 'docs/changelog.md' in members else 'missing'}")
+    print(f"sdist subpackages: {len(expected_package_files) - len(missing_packages)}/{len(expected_package_files)} present")
+    print(f"sdist assets: {len(expected_asset_files) - len(missing_assets)}/{len(expected_asset_files)} present")
+    print(f"sdist forbidden directories: {'present' if forbidden_members else 'absent'}")
+    return errors
+
+
+def main() -> int:
+    if len(sys.argv) not in {2, 3}:
+        print("usage: verify_distribution.py WHEEL [SDIST]", file=sys.stderr)
+        return 2
+
+    repo_root = Path(__file__).resolve().parents[1]
+    wheel_path = Path(sys.argv[1]).resolve()
+    if not wheel_path.is_file():
+        print(f"wheel does not exist: {wheel_path}", file=sys.stderr)
+        return 2
+
+    try:
+        errors = verify_wheel(wheel_path, repo_root)
+        if len(sys.argv) == 3:
+            sdist_path = Path(sys.argv[2]).resolve()
+            if not sdist_path.is_file():
+                print(f"sdist does not exist: {sdist_path}", file=sys.stderr)
+                return 2
+            errors.extend(verify_sdist(sdist_path, repo_root))
+    except (OSError, ValueError) as error:
+        print(f"distribution verification failed: {error}", file=sys.stderr)
+        return 1
+
+    if errors:
+        print("FAILED")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    print("PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/hypergraph/cache.py
+++ b/src/hypergraph/cache.py
@@ -143,7 +143,7 @@ def _compute_hmac_bytes(hmac_key: bytes, cache_key: str, raw_bytes: bytes) -> st
 class DiskCache:
     """Persistent disk-based cache using diskcache.
 
-    Requires ``pip install hypergraph[cache]``.
+    Requires ``pip install hypergraph-ai[cache]``.
 
     The ``cache`` extra installs both ``diskcache`` for Hypergraph's node-result
     cache backend and ``hypercache`` for optional nested cache observability.
@@ -171,7 +171,7 @@ class DiskCache:
         try:
             import diskcache
         except ImportError:
-            raise ImportError("diskcache is required for DiskCache. Install it with: pip install 'hypergraph[cache]'") from None
+            raise ImportError("diskcache is required for DiskCache. Install it with: pip install 'hypergraph-ai[cache]'") from None
 
         expanded = os.path.expanduser(cache_dir)
         self._cache = diskcache.Cache(expanded, **kwargs)

--- a/src/hypergraph/checkpointers/sqlite.py
+++ b/src/hypergraph/checkpointers/sqlite.py
@@ -286,7 +286,7 @@ def _require_aiosqlite() -> Any:
 
         return aiosqlite
     except ImportError:
-        raise ImportError("SqliteCheckpointer requires aiosqlite. Install it with: pip install hypergraph[checkpoint]") from None
+        raise ImportError("SqliteCheckpointer requires aiosqlite. Install it with: pip install hypergraph-ai[checkpoint]") from None
 
 
 class SqliteCheckpointer(Checkpointer):

--- a/src/hypergraph/events/_progress_renderers.py
+++ b/src/hypergraph/events/_progress_renderers.py
@@ -44,7 +44,7 @@ def _require_rich() -> None:
         import rich  # noqa: F401
     except ImportError:
         raise ImportError(
-            "The 'rich' package is required for RichProgressProcessor. Install it with: pip install 'hypergraph[progress]' or pip install rich"
+            "The 'rich' package is required for RichProgressProcessor. Install it with: pip install 'hypergraph-ai[progress]' or pip install rich"
         ) from None
 
 

--- a/src/hypergraph/events/otel.py
+++ b/src/hypergraph/events/otel.py
@@ -37,7 +37,7 @@ def _require_opentelemetry() -> None:
     except ImportError:
         raise ImportError(
             "The 'opentelemetry' package is required for OpenTelemetryProcessor. "
-            "Install with: pip install 'hypergraph[otel]' "
+            "Install with: pip install 'hypergraph-ai[otel]' "
             "or: pip install opentelemetry-api opentelemetry-sdk"
         ) from None
 

--- a/src/hypergraph/runners/daft/runner.py
+++ b/src/hypergraph/runners/daft/runner.py
@@ -76,7 +76,7 @@ class DaftRunner(BaseRunner):
         try:
             import daft
         except ImportError:
-            raise ImportError("DaftRunner requires daft. Install it with: pip install 'hypergraph[daft]'") from None
+            raise ImportError("DaftRunner requires daft. Install it with: pip install 'hypergraph-ai[daft]'") from None
         return daft
 
     @property

--- a/src/hypergraph/viz/html/generator.py
+++ b/src/hypergraph/viz/html/generator.py
@@ -108,7 +108,7 @@ def generate_widget_html(graph_data: dict[str, Any]) -> str:
         raise RuntimeError(
             f"Missing bundled visualization library assets: {missing}. "
             "The hypergraph package may be incorrectly installed. "
-            "Try reinstalling with: pip install --force-reinstall hypergraph"
+            "Try reinstalling with: pip install --force-reinstall hypergraph-ai"
         )
 
     missing_first_party = [name for name, asset in first_party_assets if not asset]
@@ -116,7 +116,7 @@ def generate_widget_html(graph_data: dict[str, Any]) -> str:
         raise RuntimeError(
             f"Missing bundled visualization module(s): {missing_first_party}. "
             "The hypergraph package may be incorrectly installed. "
-            "Try reinstalling with: pip install --force-reinstall hypergraph"
+            "Try reinstalling with: pip install --force-reinstall hypergraph-ai"
         )
     first_party_scripts = "\n    ".join(asset for _, asset in first_party_assets if asset)
 

--- a/tests/test_run_log/test_otel_processor.py
+++ b/tests/test_run_log/test_otel_processor.py
@@ -54,7 +54,7 @@ class TestImportGuard:
 
         from hypergraph.events.otel import _require_opentelemetry
 
-        with pytest.raises(ImportError, match="pip install 'hypergraph\\[otel\\]'"):
+        with pytest.raises(ImportError, match="pip install 'hypergraph-ai\\[otel\\]'"):
             _require_opentelemetry()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1398,8 +1398,8 @@ wheels = [
 ]
 
 [[package]]
-name = "hypergraph"
-version = "0.1.0"
+name = "hypergraph-ai"
+version = "0.2.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Closes #283. Implements the maintainer-approved #221 release contract (name locked live on 2026-07-17: **hypergraph-ai**).

## Before / after
```text
Before: hypergraph==0.1.0, Development Status :: 3 - Alpha, no release path, README says PyPI unavailable
After:  hypergraph-ai==0.2.0b1, Development Status :: 4 - Beta, import stays 'import hypergraph',
        human-gated Trusted Publishing workflow, automated distribution verification
```

- `.github/workflows/release.yml`: build → OIDC publish on a maintainer-created GitHub Release only (no long-lived secrets); TestPyPI dry-run job behind workflow_dispatch.
- `scripts/verify_distribution.py`: 23/23 subpackages, 21/21 packaged assets, changelog present, tests/specs/dev absent — run against both wheel and sdist.
- `docs/release.md`: the release contract (versioning, tag scheme, human trigger, yank-never-delete) + the exact one-command milestone-tag migration for v1.0/v1.1/v1.2 (left as a maintainer action — history mutation).
- README install language updated with a pending-first-publish note.

## Deliberately NOT done (maintainer-only)
TestPyPI/PyPI Trusted Publishing account configuration and the first actual publication; remote milestone-tag renames.

## Test plan
Distribution verifier PASSED on wheel+sdist; fresh py3.12 venv wheel-install witness (Graph + RetryPolicy + all subpackages import; py3.9 correctly REFUSED by requires-python). Full CI-equivalent after rebase onto current master: 3,746 passed, 15 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)