### PR TITLE
feat(runners): cooperative async per-attempt timeout

### DIFF
--- a/docs/05-how-to/retry-transient-failures.md
+++ b/docs/05-how-to/retry-transient-failures.md
@@ -115,6 +115,64 @@ RetryPolicy(
 )
 ```
 
+## Bound one async attempt with `timeout`
+
+Before, a framework deadline around synchronous Python could return while the
+function kept running and producing side effects. Hypergraph rejects that
+configuration instead of calling it a timeout.
+
+After, `timeout=` is a cooperative deadline for an async function or async
+generator under `AsyncRunner`:
+
+```python
+from hypergraph import AsyncRunner, AttemptTimeoutError, Graph, RetryPolicy, node
+
+@node(
+    output_name="response",
+    timeout=10,
+    retry=RetryPolicy(
+        max_attempts=3,
+        retry_on=(AttemptTimeoutError,),  # timeout retries only when listed
+    ),
+)
+async def call_model(prompt: str) -> str:
+    return await client.generate(prompt)  # cancellation-aware async I/O
+
+result = await AsyncRunner().run(Graph([call_model]), {"prompt": "hello"})
+```
+
+When the ten-second deadline wins, Hypergraph requests cancellation and waits
+for the callable to settle. Only then does that attempt finish or the next
+attempt start. Cleanup may make the surfaced result arrive after ten seconds.
+
+Keep these four facts separate:
+
+| Fact | What Hypergraph can say |
+|---|---|
+| **Deadline elapsed** | Recorded as `deadline_elapsed=True` on the attempt. |
+| **Cancellation requested** | Recorded as `cancellation_requested=True`. |
+| **Work stopped** | Never claimed as a field. A settled coroutine does not prove that an external side effect was stopped. |
+| **Cleanup completed** | Hypergraph waits for settlement. A cleanup exception is preserved exactly; cleanup that suppresses cancellation may return a late value. |
+
+Settlement decides the outcome:
+
+- settled cancelled → `AttemptTimeoutError` and `TIMED_OUT` attempt evidence;
+- cancellation suppressed and a real value returned → accept the late success;
+- cancellation cleanup raised another exception → preserve that exact
+  exception, and judge retry eligibility by its type.
+
+The series-level `retry_window` uses the same cooperative settlement rule when
+it expires during active async work, but raises
+`RetryWindowExpiredError`. See [Errors](../06-api-reference/errors.md#attempttimeouterror)
+for both public exceptions.
+
+Framework `timeout=` is rejected before execution for `SyncRunner`, for sync
+functions/generators under `AsyncRunner`, and for delegated backends without a
+native cooperative capability. Make the node async and await
+cancellation-aware I/O, or use the client library's own request timeout. A
+direct `call_model(...)` / `call_model.func(...)` call stays raw and does not
+apply runner timeout or retry behavior.
+
 ## Honor a server's Retry-After
 
 When a response tells you exactly how long to wait, raise `RetryAfterError` around the real failure instead of sleeping inside your node:
@@ -157,7 +215,7 @@ With persistence, every attempt is durably reserved **before** your code runs, a
 
 This is an at-most-N-invocations guarantee, not exactly-once side effects: a crash mid-attempt cannot know whether the external call landed (the attempt is recorded as outcome-unknown). Payment-style APIs still need idempotency keys.
 
-Retry evidence deliberately overrides `CheckpointPolicy` durability timing: a retrying node's attempt records AND its series-closing StepRecord write through immediately under every durability mode (including `"async"` and `"exit"`), because the final outcome, its linked step, and the series closure must commit atomically. Non-retrying nodes buffer according to the configured durability as usual.
+Retry/timeout evidence deliberately overrides `CheckpointPolicy` durability timing: an attempt-managed node's records AND its series-closing StepRecord write through immediately under every durability mode (including `"async"` and `"exit"`), because the final outcome, its linked step, and the series closure must commit atomically. Nodes without retry or timeout buffer according to the configured durability as usual.
 
 ## What retry does NOT change
 
@@ -169,4 +227,4 @@ Retry evidence deliberately overrides `CheckpointPolicy` durability timing: a re
 
 ## API reference
 
-See [RetryPolicy](../06-api-reference/nodes.md#retrypolicy) and [RetryAfterError](../06-api-reference/nodes.md#retryaftererror).
+See [RetryPolicy](../06-api-reference/nodes.md#retrypolicy), [RetryAfterError](../06-api-reference/nodes.md#retryaftererror), and [Errors](../06-api-reference/errors.md#retry-and-timeout-errors).

--- a/docs/06-api-reference/checkpointers.md
+++ b/docs/06-api-reference/checkpointers.md
@@ -199,7 +199,7 @@ CheckpointPolicy()
 | `window` | `int \| None` | Required when `retention="windowed"`. |
 | `ttl` | `timedelta \| None` | Auto-expire completed runs after this duration. |
 
-**Retry evidence writes through under every durability mode.** For a node with a [RetryPolicy](nodes.md#retrypolicy), attempt reservations/outcomes and the series-closing StepRecord are persisted immediately even under `durability="async"` or `"exit"`: the final attempt outcome, its linked StepRecord, and the series closure must commit atomically, and that invariant takes precedence over buffering. Non-retrying nodes buffer normally.
+**Retry/timeout evidence writes through under every durability mode.** For a node with a [RetryPolicy](nodes.md#retrypolicy) or `timeout=`, attempt reservations/outcomes and the series-closing StepRecord are persisted immediately even under `durability="async"` or `"exit"`: the final attempt outcome, its linked StepRecord, and the series closure must commit atomically, and that invariant takes precedence over buffering. Nodes without retry or timeout buffer normally.
 
 **Async durability is best-effort.** With `durability="async"` (the default), step writes happen in background tasks: a failed write does not fail the run — the run still returns `COMPLETED`, and the failure is reported on the result instead. Check `result.checkpoint_ok` (and `result.checkpoint_errors`, a tuple of error strings) to detect gaps in the persisted history:
 
@@ -326,10 +326,10 @@ run.status == WorkflowStatus.COMPLETED  # True
 ## Attempt Ledger (Internal)
 
 {% hint style="warning" %}
-Internal attempt-ledger persistence. These records back the retry/timeout contract; the runtime that writes them (retry loops, `@node` retry parameters) ships separately. The shapes below are stable for inspection but the write seam is not a public API.
+Internal attempt-ledger persistence. These records back retry and cooperative `@node(timeout=...)`. The shapes below are stable for inspection but the write seam is not a public API.
 {% endhint %}
 
-A retrying node stays **one logical graph step**; each callable invocation is a separately durable attempt. The evidence lives next to the steps:
+An attempt-managed node stays **one logical graph step**; each callable invocation is a separately durable attempt. The evidence lives next to the steps:
 
 ```text
 step 4 = call_model                       # one StepRecord, one state application
@@ -339,7 +339,7 @@ attempts = #1 failed, #2 timed out, #3 succeeded   # the attempt ledger
 | Type | Fields | Notes |
 |---|---|---|
 | `AttemptSeries` | `id`, `run_id`, `node_name`, `policy_fingerprint`, `max_attempts`, `opened_at`, `deadline_at`, `committed_superstep`, `closed_at` | One durable retry budget per logical node execution. The id stays stable across superstep drift; open (`closed_at is None`) series are never pruned. |
-| `AttemptRecord` | `series_id`, `attempt_number`, `scheduled_superstep`, `status`, `started_at`, `completed_at`, `error`, `retry_not_before`, `sampled_delay` | One-based `attempt_number`. Backoff is sampled once and persisted as data. |
+| `AttemptRecord` | `series_id`, `attempt_number`, `scheduled_superstep`, `status`, `started_at`, `completed_at`, `error`, `retry_not_before`, `sampled_delay`, `deadline_elapsed`, `cancellation_requested` | One-based `attempt_number`. Backoff is sampled once and persisted as data. Deadline and cancellation are independent facts; there is deliberately no `work_stopped` field. |
 | `AttemptStatus` | `STARTED`, `FAILED`, `TIMED_OUT`, `SUCCEEDED`, `CANCELLED`, `OUTCOME_UNKNOWN` | Enum. `STARTED` is a durable reservation that consumes budget; crash-stranded reservations settle as `OUTCOME_UNKNOWN` on resume. |
 | `AttemptError` | `type_name`, `message` | Bounded error projection (type name + capped message text). No args, no stack traces, no `repr` of user values — but the capped message is stored verbatim; message-content redaction is #233's diagnostics scope. |
 

--- a/docs/06-api-reference/errors.md
+++ b/docs/06-api-reference/errors.md
@@ -1,0 +1,71 @@
+# Errors
+
+Hypergraph rejects unsupported execution promises before user code runs and
+preserves the exact exception that actually settled an attempt. This page
+covers the retry/timeout exceptions; runner and graph APIs document their
+other validation errors next to each operation.
+
+## Retry and timeout errors
+
+### AttemptTimeoutError
+
+```python
+from hypergraph import AttemptTimeoutError
+```
+
+Raised when an async attempt crosses its `@node(timeout=...)` deadline,
+Hypergraph requests cancellation, and the callable settles cancelled.
+
+```python
+class AttemptTimeoutError(TimeoutError):
+    node_name: str
+    timeout_seconds: float
+```
+
+The exception means cancellation was requested and awaited. It does not claim
+that external work or side effects stopped at the deadline. It enters the
+retry loop only when its type (or an intentional superclass) is listed in the
+node's `RetryPolicy.retry_on` allowlist.
+
+If the callable suppresses cancellation and returns a value, Hypergraph accepts
+that late success instead. If cancellation cleanup raises another exception,
+that exact exception replaces `AttemptTimeoutError` and its own type decides
+retry eligibility.
+
+### RetryWindowExpiredError
+
+```python
+from hypergraph import RetryWindowExpiredError
+```
+
+Raised when `RetryPolicy.retry_window` expires during active async work,
+Hypergraph requests cancellation, and the callable settles cancelled.
+
+```python
+class RetryWindowExpiredError(TimeoutError):
+    node_name: str
+    retry_window_seconds: float
+```
+
+The same late-value and cleanup-exception precedence as
+`AttemptTimeoutError` applies. The retry window is a whole-series deadline;
+attempt execution, backoff, persistence overhead, cancellation settlement,
+and process downtime all consume it.
+
+### IncompatibleRunnerError for timeout
+
+Framework `timeout=` is rejected before execution when Hypergraph cannot make
+the cooperative promise: under `SyncRunner`, on a sync function/generator
+under `AsyncRunner`, or through a delegated/backend runner without native
+capability.
+
+```python
+class IncompatibleRunnerError(Exception):
+    node_name: str | None
+    capability: str | None
+```
+
+For timeout rejection, `capability == "supports_cooperative_timeout"`. The
+error states that Hypergraph did not run the node and gives both fixes: make
+the node async with cancellation-aware I/O, or configure the client library's
+own timeout.

--- a/docs/06-api-reference/nodes.md
+++ b/docs/06-api-reference/nodes.md
@@ -162,6 +162,7 @@ def __init__(
     emit: str | tuple[str, ...] | None = None,
     wait_for: str | tuple[str, ...] | None = None,
     retry: RetryPolicy | None = None,
+    timeout: float | None = None,
 ) -> None: ...
 ```
 
@@ -179,12 +180,14 @@ def __init__(
 - `emit`: Ordering-only local output name(s). Auto-produced when the node runs
 - `wait_for`: Ordering-only graph-scope output/emit address(es). Node waits until these values exist and are fresh
 - `retry`: Optional [RetryPolicy](#retrypolicy). Node-owned only — there is no runner, graph, or per-call retry default, and no `retry=True` shorthand. Direct calls stay raw single-shot invocations
+- `timeout`: Optional positive, finite seconds for cooperative cancellation of async functions/generators under `AsyncRunner`. Unsupported runner/callable combinations are rejected before execution. Direct calls stay raw
 
 **Returns:** FunctionNode instance
 
 **Raises:**
 - `ValueError` - If function source cannot be retrieved (for definition_hash)
 - `TypeError` - If the signature contains a positional-only, `*args`, or `**kwargs` parameter (see [Supported Parameter Kinds](#supported-parameter-kinds))
+- `TypeError` / `ValueError` - If `timeout` is not a positive finite number or `None`
 - `UserWarning` - If function has return annotation but no output_name provided
 
 ### Supported Parameter Kinds
@@ -501,6 +504,7 @@ def node(
     emit: str | tuple[str, ...] | None = None,
     wait_for: str | tuple[str, ...] | None = None,
     retry: RetryPolicy | None = None,
+    timeout: float | None = None,
 ) -> FunctionNode | Callable[[Callable], FunctionNode]: ...
 ```
 
@@ -513,6 +517,7 @@ def node(
 - `emit`: Ordering-only local output name(s). Auto-produced when the node runs. Used with `wait_for` to enforce execution order without data dependency. See [Ordering](../03-patterns/03-agentic-loops.md#ordering-with-emitwait_for)
 - `wait_for`: Ordering-only graph-scope output/emit address(es). Node won't run until these values exist and are fresh. Must reference an `emit` or `output_name` of another node at the current graph scope
 - `retry`: Optional [RetryPolicy](#retrypolicy) declaring which failures are safe to repeat and with what budget/backoff. See [How to Retry Transient Failures](../05-how-to/retry-transient-failures.md)
+- `timeout`: Optional positive, finite seconds for cooperative per-attempt cancellation of async functions/generators under `AsyncRunner`. See [Bound one async attempt with timeout](../05-how-to/retry-transient-failures.md#bound-one-async-attempt-with-timeout)
 
 **Returns:**
 - FunctionNode if source provided (decorator without parens)
@@ -637,7 +642,7 @@ After failed one-based attempt `n`, the nominal delay is `min(max_delay, initial
 ### Semantics
 
 - **Node-owned only.** Only the node declaration can make its callable repeat. Runners, graphs, and `run()`/`map()` calls have no retry defaults or overrides.
-- **One logical step.** A retrying node stays a single graph step: downstream scheduling, state application, and the cache write happen once, after the final success. Intermediate attempts never fold state or emit node events.
+- **One logical step.** A retrying or timed node stays a single graph step: downstream scheduling, state application, and the cache write happen once, after the final success. Intermediate attempts never fold state or emit node events.
 - **Exact exception, no wrapper.** After exhaustion or an ineligible failure, the exact final underlying exception is re-raised — never a generic retry-exhausted wrapper.
 - **Durable budget.** With a persistent checkpointer (e.g. `SqliteCheckpointer`) and a `workflow_id`, every attempt is reserved write-through in the durable attempt ledger before user code runs: `max_attempts` is a hard cap across crash and resume, and the sampled backoff plus its absolute wake time are persisted so a restart neither redraws jitter nor restarts the wait. With `MemoryCheckpointer` the budget survives in-process resume only; without a checkpointer it is process-local.
 - **Cache first.** A cache hit invokes nothing, consumes zero attempts, and opens no series. Changing a retry policy does not invalidate cached results.

--- a/docs/06-api-reference/runners.md
+++ b/docs/06-api-reference/runners.md
@@ -363,6 +363,7 @@ caps.supports_async_nodes  # False
 caps.supports_streaming    # True (map_iter + ctx.stream chunks)
 caps.returns_coroutine     # False
 caps.supports_interrupts   # False
+caps.supports_cooperative_timeout  # False
 ```
 
 ---
@@ -631,6 +632,7 @@ caps.supports_interrupts      # False
 caps.supports_events          # False
 caps.supports_distributed     # True
 caps.supports_checkpointing   # False
+caps.supports_cooperative_timeout  # False
 ```
 
 `DaftRunner` does not implement `start_run()` or `start_map()`. It translates
@@ -1019,6 +1021,7 @@ caps.supports_async_nodes  # True
 caps.supports_streaming    # True (map_iter + ctx.stream chunks)
 caps.returns_coroutine     # True
 caps.supports_interrupts   # True
+caps.supports_cooperative_timeout  # True
 ```
 
 ---

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -57,6 +57,7 @@
 * [Events](06-api-reference/events.md)
 * [InputSpec](06-api-reference/inputspec.md)
 * [Checkpointers](06-api-reference/checkpointers.md)
+* [Errors](06-api-reference/errors.md)
 
 ## HyperTable (Incremental Tables)
 

--- a/src/hypergraph/__init__.py
+++ b/src/hypergraph/__init__.py
@@ -29,6 +29,7 @@ from hypergraph.events import (
 )
 from hypergraph.events.rich_progress import RichProgressProcessor
 from hypergraph.exceptions import (
+    AttemptTimeoutError,
     CompactedRetentionError,
     ExecutionError,
     GraphChangedError,
@@ -36,6 +37,7 @@ from hypergraph.exceptions import (
     InfiniteLoopError,
     InputOverrideRequiresForkError,
     MissingInputError,
+    RetryWindowExpiredError,
     WorkflowAlreadyCompletedError,
     WorkflowAlreadyRunningError,
     WorkflowForkError,
@@ -120,6 +122,8 @@ __all__ = [
     # Errors
     "RenameError",
     "GraphConfigError",
+    "AttemptTimeoutError",
+    "RetryWindowExpiredError",
     "CompactedRetentionError",
     "MissingInputError",
     "InfiniteLoopError",

--- a/src/hypergraph/checkpointers/_migrate.py
+++ b/src/hypergraph/checkpointers/_migrate.py
@@ -131,6 +131,8 @@ CREATE TABLE IF NOT EXISTS attempt_records (
     error_message TEXT,
     retry_not_before TEXT,
     sampled_delay REAL,
+    deadline_elapsed INTEGER NOT NULL DEFAULT 0,
+    cancellation_requested INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (series_id, attempt_number)
 )
 """
@@ -192,6 +194,12 @@ def _ensure_v4_objects(conn: Any) -> None:
     existing_steps = {row[1] for row in conn.execute("PRAGMA table_info(steps)").fetchall()}
     if "attempt_series_id" not in existing_steps:
         conn.execute("ALTER TABLE steps ADD COLUMN attempt_series_id TEXT REFERENCES attempt_series(id)")
+
+    existing_attempt_records = {row[1] for row in conn.execute("PRAGMA table_info(attempt_records)").fetchall()}
+    if "deadline_elapsed" not in existing_attempt_records:
+        conn.execute("ALTER TABLE attempt_records ADD COLUMN deadline_elapsed INTEGER NOT NULL DEFAULT 0")
+    if "cancellation_requested" not in existing_attempt_records:
+        conn.execute("ALTER TABLE attempt_records ADD COLUMN cancellation_requested INTEGER NOT NULL DEFAULT 0")
 
     _create_attempt_indexes(conn)
     conn.commit()

--- a/src/hypergraph/checkpointers/base.py
+++ b/src/hypergraph/checkpointers/base.py
@@ -107,7 +107,13 @@ def _require_started(record: AttemptRecord | None, series_id: str, attempt_numbe
 #: Settled statuses over which a close may still link its StepRecord (resume
 #: dead ends). SUCCEEDED is deliberately absent: a success must be witnessed
 #: by a live reservation, never reconstructed over settled evidence.
-_LINK_CLOSABLE_STATUSES = frozenset({AttemptStatus.FAILED, AttemptStatus.OUTCOME_UNKNOWN})
+_LINK_CLOSABLE_STATUSES = frozenset(
+    {
+        AttemptStatus.FAILED,
+        AttemptStatus.TIMED_OUT,
+        AttemptStatus.OUTCOME_UNKNOWN,
+    }
+)
 
 
 def _check_closable(
@@ -196,12 +202,12 @@ class CheckpointPolicy:
         ttl: Auto-expire completed runs after this duration.
 
     Note:
-        Retry evidence overrides durability timing: for a node with a
-        ``RetryPolicy``, attempt reservations/outcomes AND the series-closing
-        StepRecord write through immediately under every durability mode —
-        the final attempt outcome, its linked StepRecord, and series closure
-        must commit atomically, and that invariant takes precedence over
-        "async"/"exit" buffering. Non-retrying nodes buffer normally.
+        Retry/timeout evidence overrides durability timing: attempt
+        reservations/outcomes AND the series-closing StepRecord write through
+        immediately under every durability mode. The final attempt outcome,
+        its linked StepRecord, and series closure must commit atomically, and
+        that invariant takes precedence over "async"/"exit" buffering. Nodes
+        without retry or timeout buffer normally.
     """
 
     durability: Literal["sync", "async", "exit"] = "async"
@@ -405,7 +411,7 @@ class Checkpointer(ABC):
     #
     # Durable retry/timeout persistence (#229). Backends that support the
     # ledger override every method below; the defaults fail loudly so an
-    # unsupported backend can never silently drop retry evidence.
+    # unsupported backend can never silently drop attempt evidence.
 
     def _attempt_ledger_unsupported(self) -> NotImplementedError:
         return NotImplementedError(
@@ -492,6 +498,20 @@ class Checkpointer(ABC):
         """
         raise self._attempt_ledger_unsupported()
 
+    async def record_attempt_deadline(
+        self,
+        series_id: str,
+        attempt_number: int,
+    ) -> AttemptRecord:
+        """Record that a live attempt crossed a deadline and was cancelled.
+
+        This updates evidence on the still-``STARTED`` reservation without
+        settling it. Hypergraph then waits for the callable to settle: a late
+        value can still close as ``SUCCEEDED`` and a cleanup exception can
+        still close as ``FAILED``.
+        """
+        raise self._attempt_ledger_unsupported()
+
     async def close_attempt_series(
         self,
         series_id: str,
@@ -509,7 +529,8 @@ class Checkpointer(ABC):
 
         Two accepted shapes: the ordinary close settles a live ``STARTED``
         reservation with ``status``; a resume dead end may instead close over
-        a LAST record that is already terminal ``FAILED``/``OUTCOME_UNKNOWN``
+        a LAST record that is already terminal
+        ``FAILED``/``TIMED_OUT``/``OUTCOME_UNKNOWN``
         — ``status`` must then equal the settled status (evidence is never
         rewritten) and only the StepRecord link, closure, and retention
         commit. ``SUCCEEDED`` always requires a live reservation.

--- a/src/hypergraph/checkpointers/memory.py
+++ b/src/hypergraph/checkpointers/memory.py
@@ -281,6 +281,22 @@ class MemoryCheckpointer(Checkpointer):
         records[attempt_number] = updated
         return updated
 
+    async def record_attempt_deadline(
+        self,
+        series_id: str,
+        attempt_number: int,
+    ) -> AttemptRecord:
+        _require_series(self._attempt_series.get(series_id), series_id)
+        records = self._attempt_records[series_id]
+        record = _require_started(records.get(attempt_number), series_id, attempt_number)
+        updated = replace(
+            record,
+            deadline_elapsed=True,
+            cancellation_requested=True,
+        )
+        records[attempt_number] = updated
+        return updated
+
     async def close_attempt_series(
         self,
         series_id: str,

--- a/src/hypergraph/checkpointers/sqlite.py
+++ b/src/hypergraph/checkpointers/sqlite.py
@@ -93,10 +93,11 @@ _STEP_UPSERT_SQL = """
 # === Attempt-ledger SQL (shared by async and sync paths) ===
 _ATTEMPT_SERIES_COLS = "id, run_id, node_name, policy_fingerprint, max_attempts, opened_at, deadline_at, committed_superstep, closed_at"
 _ATTEMPT_RECORD_COLS = (
-    "series_id, attempt_number, scheduled_superstep, status, started_at, completed_at, error_type, error_message, retry_not_before, sampled_delay"
+    "series_id, attempt_number, scheduled_superstep, status, started_at, completed_at, error_type, error_message, "
+    "retry_not_before, sampled_delay, deadline_elapsed, cancellation_requested"
 )
 _ATTEMPT_SERIES_INSERT_SQL = f"INSERT INTO attempt_series ({_ATTEMPT_SERIES_COLS}) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
-_ATTEMPT_RECORD_INSERT_SQL = f"INSERT INTO attempt_records ({_ATTEMPT_RECORD_COLS}) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+_ATTEMPT_RECORD_INSERT_SQL = f"INSERT INTO attempt_records ({_ATTEMPT_RECORD_COLS}) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
 _ATTEMPT_SERIES_BY_ID_SQL = f"SELECT {_ATTEMPT_SERIES_COLS} FROM attempt_series WHERE id = ?"
 _ATTEMPT_SERIES_OPEN_SQL = f"SELECT {_ATTEMPT_SERIES_COLS} FROM attempt_series WHERE run_id = ? AND node_name = ? AND closed_at IS NULL"
 _ATTEMPT_RECORDS_SQL = f"SELECT {_ATTEMPT_RECORD_COLS} FROM attempt_records WHERE series_id = ? ORDER BY attempt_number"
@@ -109,6 +110,9 @@ _ATTEMPT_SETTLE_STRANDED_SQL = "UPDATE attempt_records SET status = ?, completed
 _ATTEMPT_OUTCOME_SQL = (
     "UPDATE attempt_records SET status = ?, completed_at = ?, error_type = ?, error_message = ?, "
     "retry_not_before = ?, sampled_delay = ? WHERE series_id = ? AND attempt_number = ? AND status = 'started'"
+)
+_ATTEMPT_DEADLINE_SQL = (
+    "UPDATE attempt_records SET deadline_elapsed = 1, cancellation_requested = 1 WHERE series_id = ? AND attempt_number = ? AND status = 'started'"
 )
 _ATTEMPT_FINAL_SQL = (
     "UPDATE attempt_records SET status = ?, completed_at = ?, error_type = ?, error_message = ? "
@@ -184,6 +188,8 @@ def _row_to_attempt_record(row: tuple[Any, ...]) -> AttemptRecord:
         error=error,
         retry_not_before=_parse_dt(row[8]),
         sampled_delay=row[9],
+        deadline_elapsed=bool(row[10]),
+        cancellation_requested=bool(row[11]),
     )
 
 
@@ -203,6 +209,8 @@ def _attempt_record_insert_params(record: AttemptRecord) -> tuple[Any, ...]:
         record.error.message if record.error else None,
         _iso_or_none(record.retry_not_before),
         record.sampled_delay,
+        int(record.deadline_elapsed),
+        int(record.cancellation_requested),
     )
 
 
@@ -1010,6 +1018,39 @@ class SqliteCheckpointer(Checkpointer):
                     error=error,
                     retry_not_before=retry_not_before,
                     sampled_delay=sampled_delay,
+                )
+            except BaseException:
+                await self._rollback_async()
+                raise
+
+    async def record_attempt_deadline(
+        self,
+        series_id: str,
+        attempt_number: int,
+    ) -> AttemptRecord:
+        await self._ensure_db()
+        async with self._txn_lock():
+            try:
+                await self._db.execute("BEGIN IMMEDIATE")
+                _require_series(await self._fetch_attempt_series(series_id), series_id)
+                record = _require_started(
+                    await self._fetch_attempt_record(series_id, attempt_number),
+                    series_id,
+                    attempt_number,
+                )
+                cursor = await self._db.execute(
+                    _ATTEMPT_DEADLINE_SQL,
+                    (series_id, attempt_number),
+                )
+                self._check_settled_exactly_one(
+                    cursor.rowcount,
+                    f"Attempt #{attempt_number} in series {series_id!r}",
+                )
+                await self._db.commit()
+                return replace(
+                    record,
+                    deadline_elapsed=True,
+                    cancellation_requested=True,
                 )
             except BaseException:
                 await self._rollback_async()

--- a/src/hypergraph/checkpointers/types.py
+++ b/src/hypergraph/checkpointers/types.py
@@ -128,6 +128,10 @@ class AttemptRecord:
     ``attempt_number`` is one-based. ``retry_not_before`` and
     ``sampled_delay`` persist a once-sampled backoff decision as data so a
     restart neither redraws jitter nor restarts the full delay.
+
+    ``deadline_elapsed`` and ``cancellation_requested`` are independent,
+    witnessed facts. The settled ``status`` supplies the third fact; no field
+    claims that arbitrary user work or external side effects stopped.
     """
 
     series_id: str
@@ -139,6 +143,8 @@ class AttemptRecord:
     error: AttemptError | None = None
     retry_not_before: datetime | None = None
     sampled_delay: float | None = None
+    deadline_elapsed: bool = False
+    cancellation_requested: bool = False
 
     def __repr__(self) -> str:
         parts = [f"Attempt #{self.attempt_number}", self.status.value, f"superstep {self.scheduled_superstep}"]

--- a/src/hypergraph/exceptions.py
+++ b/src/hypergraph/exceptions.py
@@ -106,6 +106,41 @@ class IncompatibleRunnerError(Exception):
         super().__init__(message)
 
 
+class AttemptTimeoutError(TimeoutError):
+    """An async attempt settled cancelled after its deadline elapsed.
+
+    The deadline is cooperative: Hypergraph requested cancellation and waited
+    for the callable to settle before raising this exception. The exception is
+    therefore evidence of a cancelled settlement, not a claim that arbitrary
+    external work or side effects stopped at the deadline.
+    """
+
+    def __init__(self, node_name: str, timeout_seconds: float) -> None:
+        self.node_name = node_name
+        self.timeout_seconds = timeout_seconds
+        super().__init__(
+            f"Node {node_name!r} exceeded its {timeout_seconds:g}s attempt timeout; "
+            "Hypergraph requested cancellation and the async callable settled cancelled."
+        )
+
+
+class RetryWindowExpiredError(TimeoutError):
+    """A retry-series window elapsed during active async work.
+
+    Hypergraph requested cooperative cancellation and waited for settlement.
+    A late real value or a cancellation-cleanup exception takes precedence and
+    this exception is not raised in those cases.
+    """
+
+    def __init__(self, node_name: str, retry_window_seconds: float) -> None:
+        self.node_name = node_name
+        self.retry_window_seconds = retry_window_seconds
+        super().__init__(
+            f"Node {node_name!r} exceeded its {retry_window_seconds:g}s retry window during active work; "
+            "Hypergraph requested cancellation and the async callable settled cancelled."
+        )
+
+
 class ExecutionError(Exception):
     """Wraps an exception that occurred during graph execution.
 

--- a/src/hypergraph/nodes/function.py
+++ b/src/hypergraph/nodes/function.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import inspect
+import math
 import warnings
 from collections.abc import Callable
 from typing import Any, get_type_hints
@@ -103,6 +104,7 @@ class FunctionNode(CallableMixin, HyperNode):
     _wait_for: tuple[str, ...]
     _emit: tuple[str, ...]
     _retry: RetryPolicy | None
+    _timeout: float | None
 
     def __init__(
         self,
@@ -116,6 +118,7 @@ class FunctionNode(CallableMixin, HyperNode):
         emit: str | tuple[str, ...] | None = None,
         wait_for: str | tuple[str, ...] | None = None,
         retry: RetryPolicy | None = None,
+        timeout: float | None = None,
     ) -> None:
         """Wrap a function as a node.
 
@@ -134,6 +137,8 @@ class FunctionNode(CallableMixin, HyperNode):
             retry: Optional :class:`RetryPolicy`. Only a node declaration can
                    make its callable repeat; runners execute the attempt loop.
                    Direct calls stay raw single-shot invocations.
+            timeout: Optional positive number of seconds for cooperative
+                     cancellation of an async callable under AsyncRunner.
         Warning:
             If the function has a return type annotation but no output_name
             is provided, a warning is emitted. This helps catch cases where
@@ -156,10 +161,21 @@ class FunctionNode(CallableMixin, HyperNode):
                 "  are safe to repeat: retry=RetryPolicy(max_attempts=3, retry_on=(TimeoutError,))."
             )
 
+        if isinstance(timeout, bool):
+            raise TypeError(f"timeout must be a positive finite number of seconds (or None), got {timeout!r}.")
+        if timeout is not None:
+            try:
+                timeout = float(timeout)
+            except (TypeError, ValueError):
+                raise TypeError(f"timeout must be a positive finite number of seconds (or None), got {timeout!r}.") from None
+            if not math.isfinite(timeout) or timeout <= 0:
+                raise ValueError(f"timeout must be a positive finite number of seconds, got {timeout!r}.")
+
         self.func = func
         self._cache = cache
         self._hide = hide
         self._retry = retry
+        self._timeout = timeout
         self._definition_hash = hash_definition(func)
         self._emit = ensure_tuple(emit) if emit else ()
         self._wait_for = ensure_tuple(wait_for) if wait_for else ()
@@ -203,6 +219,11 @@ class FunctionNode(CallableMixin, HyperNode):
     def retry(self) -> RetryPolicy | None:
         """The node-owned retry declaration, or None (no retry)."""
         return self._retry
+
+    @property
+    def timeout(self) -> float | None:
+        """Cooperative per-attempt timeout in seconds, or None."""
+        return self._timeout
 
     @property
     def hide(self) -> bool:
@@ -318,6 +339,7 @@ def node(
     emit: str | tuple[str, ...] | None = None,
     wait_for: str | tuple[str, ...] | None = None,
     retry: RetryPolicy | None = None,
+    timeout: float | None = None,
 ) -> FunctionNode | Callable[[Callable], FunctionNode]:
     """Decorator to wrap a function as a FunctionNode.
 
@@ -344,6 +366,9 @@ def node(
                repeat and with what budget/backoff. Node-owned only: there is
                no runner, graph, or per-call retry default, and no retry=True
                shorthand. Direct calls stay raw single-shot invocations.
+        timeout: Optional positive number of seconds for cooperative
+                 cancellation of async callables under AsyncRunner. Direct
+                 calls stay raw and do not apply the timeout.
     Returns:
         FunctionNode if source provided, else decorator function.
 
@@ -368,6 +393,7 @@ def node(
             emit=emit,
             wait_for=wait_for,
             retry=retry,
+            timeout=timeout,
         )
         fn_node.__wrapped__ = func
         return fn_node

--- a/src/hypergraph/runners/_shared/attempts.py
+++ b/src/hypergraph/runners/_shared/attempts.py
@@ -1,4 +1,4 @@
-"""Shared retry attempt coordinator for the FunctionNode executor path (#230).
+"""Shared retry/timeout attempt coordinator for FunctionNode execution.
 
 The runner execution layer owns retry orchestration: the coordinator sits
 inside the sync/async FunctionNode executors — below the superstep's cache
@@ -41,10 +41,10 @@ import asyncio
 import random
 import time
 from collections.abc import Awaitable, Callable
-from contextlib import AbstractAsyncContextManager
+from contextlib import AbstractAsyncContextManager, suppress
 from dataclasses import dataclass, replace
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
 from hypergraph.checkpointers.types import (
     AttemptError,
@@ -54,6 +54,7 @@ from hypergraph.checkpointers.types import (
     AttemptStatus,
     StepStatus,
 )
+from hypergraph.exceptions import AttemptTimeoutError, RetryWindowExpiredError
 from hypergraph.nodes.retry import RetryAfterError, RetryPolicy
 
 if TYPE_CHECKING:
@@ -75,6 +76,12 @@ def _sleep_sync(seconds: float) -> None:
 async def _sleep_async(seconds: float) -> None:
     """Async backoff wait (module-level seam for deterministic tests)."""
     await asyncio.sleep(seconds)
+
+
+_TIMEOUT_ONLY_POLICY = RetryPolicy(
+    max_attempts=1,
+    retry_on=(AttemptTimeoutError,),
+)
 
 
 # === Pure decision helpers (single source of truth for both drivers) ===
@@ -199,6 +206,98 @@ def _series_deadline(policy: RetryPolicy, now: datetime) -> datetime | None:
     if policy.retry_window is None:
         return None
     return now + timedelta(seconds=policy.retry_window)
+
+
+@dataclass(frozen=True)
+class _ActiveDeadline:
+    """The next cooperative deadline for one in-flight invocation."""
+
+    seconds: float
+    scope: Literal["attempt", "retry_window"]
+    configured_seconds: float
+
+
+def _active_deadline(
+    timeout: float | None,
+    policy: RetryPolicy,
+    deadline_at: datetime | None,
+    *,
+    now: datetime,
+) -> _ActiveDeadline | None:
+    """Choose the earlier of the per-attempt and retry-window deadlines."""
+    window_remaining = None if deadline_at is None else max(0.0, (deadline_at - now).total_seconds())
+    if window_remaining is not None and (timeout is None or window_remaining <= timeout):
+        assert policy.retry_window is not None
+        return _ActiveDeadline(
+            seconds=window_remaining,
+            scope="retry_window",
+            configured_seconds=policy.retry_window,
+        )
+    if timeout is not None:
+        return _ActiveDeadline(
+            seconds=timeout,
+            scope="attempt",
+            configured_seconds=timeout,
+        )
+    return None
+
+
+async def _invoke_with_deadline(
+    invoke: Callable[[], Awaitable[Any]],
+    *,
+    node_name: str,
+    deadline: _ActiveDeadline | None,
+    record_deadline: Callable[[], Awaitable[None]] | None,
+) -> Any:
+    """Invoke once, requesting cancellation at a cooperative deadline.
+
+    ``asyncio.wait`` supplies the Python-3.10-compatible wait-for shape while
+    leaving cancellation and settlement explicit: after the deadline wins we
+    call ``Task.cancel()`` and await the task before deciding which terminal
+    condition was actually witnessed.
+    """
+    if deadline is None:
+        return await invoke()
+
+    task = asyncio.create_task(invoke())
+    try:
+        done, _ = await asyncio.wait((task,), timeout=deadline.seconds)
+    except BaseException:
+        # External cancellation/control flow remains the terminal cause, but
+        # do not leak the child invocation. This mirrors direct-await cleanup.
+        if not task.done():
+            task.cancel()
+        with suppress(BaseException):
+            await task
+        raise
+
+    if task in done:
+        return await task
+
+    # Deadline elapsed. Cancellation is only a request; the task may settle
+    # cancelled, raise during cleanup, or suppress cancellation and return.
+    task.cancel()
+
+    async def persist_deadline_evidence() -> None:
+        if record_deadline is not None:
+            await record_deadline()
+
+    try:
+        result = await task
+    except asyncio.CancelledError:
+        await persist_deadline_evidence()
+        if deadline.scope == "retry_window":
+            raise RetryWindowExpiredError(node_name, deadline.configured_seconds) from None
+        raise AttemptTimeoutError(node_name, deadline.configured_seconds) from None
+    except BaseException:
+        # A cleanup exception is the exact terminal cause. Record that the
+        # deadline/cancellation happened, then preserve the object and trace.
+        await persist_deadline_evidence()
+        raise
+    else:
+        # Suppressed cancellation produced a real witnessed value. Keep it.
+        await persist_deadline_evidence()
+        return result
 
 
 @dataclass(frozen=True)
@@ -442,7 +541,8 @@ async def run_attempts_async(
     invoke: Callable[[], Awaitable[Any]],
     *,
     node_name: str,
-    policy: RetryPolicy,
+    policy: RetryPolicy | None,
+    timeout: float | None = None,
     checkpointer: Any | None,
     run_id: str | None,
     scheduled_superstep: int,
@@ -454,6 +554,7 @@ async def run_attempts_async(
     permit, per #218): it is entered before and exited after each attempt,
     so backoff sleeps never hold a permit.
     """
+    policy = policy or _TIMEOUT_ONLY_POLICY
     now = _utcnow()
     if checkpointer is not None and run_id:
         ledger: Checkpointer | None = checkpointer
@@ -476,21 +577,47 @@ async def run_attempts_async(
             attempt_number = record.attempt_number
         else:
             attempt_number += 1
+
+        deadline = _active_deadline(
+            timeout,
+            policy,
+            deadline_at,
+            now=_utcnow(),
+        )
+
+        async def record_deadline(
+            current_attempt_number: int = attempt_number,
+        ) -> None:
+            if ledger is not None:
+                assert series_id is not None
+                await ledger.record_attempt_deadline(series_id, current_attempt_number)
+
+        async def invoke_attempt(
+            current_deadline: _ActiveDeadline | None = deadline,
+        ) -> Any:
+            return await _invoke_with_deadline(
+                invoke,
+                node_name=node_name,
+                deadline=current_deadline,
+                record_deadline=record_deadline if ledger is not None else None,
+            )
+
         try:
             if attempt_scope is None:
-                return await invoke()
+                return await invoke_attempt()
             async with attempt_scope():
-                return await invoke()
+                return await invoke_attempt()
         except Exception as error:
             # Terminal paths raise the exact underlying exception from here.
             # The reservation intentionally stays STARTED: the step-save site
             # settles it atomically with the linked StepRecord.
             step = plan_after_failure(error, policy, attempt_number, deadline_at, now=_utcnow())
             if ledger is not None:
+                status = AttemptStatus.TIMED_OUT if isinstance(error, (AttemptTimeoutError, RetryWindowExpiredError)) else AttemptStatus.FAILED
                 await ledger.record_attempt_outcome(
                     series_id,
                     attempt_number,
-                    AttemptStatus.FAILED,
+                    status,
                     error=AttemptError.from_exception(step.underlying),
                     retry_not_before=step.decision.retry_not_before,
                     sampled_delay=step.decision.sampled_delay,
@@ -514,14 +641,20 @@ _CLOSE_STATUS: dict[StepStatus, AttemptStatus] = {
 }
 
 
-def _retrying_function_node(graph: Graph, node_name: str) -> bool:
+def _attempt_managed_function_node(graph: Graph, node_name: str) -> bool:
     from hypergraph.nodes.function import FunctionNode
 
     node = graph._nodes.get(node_name)
-    return isinstance(node, FunctionNode) and node.retry is not None
+    return isinstance(node, FunctionNode) and (node.retry is not None or node.timeout is not None)
 
 
-_LINKABLE_TERMINAL = frozenset({AttemptStatus.FAILED, AttemptStatus.OUTCOME_UNKNOWN})
+_LINKABLE_TERMINAL = frozenset(
+    {
+        AttemptStatus.FAILED,
+        AttemptStatus.TIMED_OUT,
+        AttemptStatus.OUTCOME_UNKNOWN,
+    }
+)
 
 
 def _close_args(
@@ -539,10 +672,14 @@ def _close_args(
     if last.status is AttemptStatus.STARTED:
         # Ordinary close: settle the live reservation with this step's outcome.
         error = None
-        if status is AttemptStatus.FAILED:
-            raw = (node_errors or {}).get(record.node_name)
-            if isinstance(raw, Exception):
-                error = AttemptError.from_exception(raw)
+        raw = (node_errors or {}).get(record.node_name)
+        if status is AttemptStatus.FAILED and isinstance(
+            raw,
+            (AttemptTimeoutError, RetryWindowExpiredError),
+        ):
+            status = AttemptStatus.TIMED_OUT
+        if status in (AttemptStatus.FAILED, AttemptStatus.TIMED_OUT) and isinstance(raw, Exception):
+            error = AttemptError.from_exception(raw)
         return last.attempt_number, status, error, linked
     if status is AttemptStatus.FAILED and last.status in _LINKABLE_TERMINAL:
         # Resume dead end (budget exhausted, window expired, OUTCOME_UNKNOWN
@@ -564,7 +701,7 @@ def maybe_close_attempt_series_sync(
     not save it again); False when the record is not series-linked and should
     follow the ordinary durability dispatch.
     """
-    if not _retrying_function_node(graph, record.node_name):
+    if not _attempt_managed_function_node(graph, record.node_name):
         return False
     if not isinstance(checkpointer, SyncAttemptLedger):
         return False
@@ -587,7 +724,7 @@ async def maybe_close_attempt_series_async(
     node_errors: dict[str, BaseException] | None = None,
 ) -> bool:
     """Async twin of :func:`maybe_close_attempt_series_sync`."""
-    if not _retrying_function_node(graph, record.node_name):
+    if not _attempt_managed_function_node(graph, record.node_name):
         return False
     series = await checkpointer.get_open_attempt_series(record.run_id, record.node_name)
     if series is None:

--- a/src/hypergraph/runners/_shared/state.py
+++ b/src/hypergraph/runners/_shared/state.py
@@ -65,6 +65,8 @@ class RunnerCapabilities:
         supports_events: Supports event processors (default: True)
         supports_distributed: Can distribute across workers (default: False)
         returns_coroutine: run() returns a coroutine (default: False)
+        supports_cooperative_timeout: Can request cancellation of async
+            callables and await settlement (default: False)
     """
 
     supports_cycles: bool = True
@@ -76,6 +78,7 @@ class RunnerCapabilities:
     returns_coroutine: bool = False
     supports_interrupts: bool = False
     supports_checkpointing: bool = False
+    supports_cooperative_timeout: bool = False
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/hypergraph/runners/_shared/validation.py
+++ b/src/hypergraph/runners/_shared/validation.py
@@ -306,6 +306,25 @@ def validate_runner_compatibility(
     Raises:
         IncompatibleRunnerError: If runner can't handle graph features
     """
+    # Timeout is a narrower capability than general async-node support. Check
+    # it first so SyncRunner/DaftRunner and sync callables under AsyncRunner
+    # all receive the locked actionable did-not-run error.
+    from hypergraph.nodes.function import FunctionNode
+
+    for node in graph._nodes.values():
+        if not isinstance(node, FunctionNode) or node.timeout is None:
+            continue
+        if not capabilities.supports_cooperative_timeout or not node.is_async:
+            raise IncompatibleRunnerError(
+                f"Node {node.name!r} declares timeout={node.timeout:g}, but this runner/callable "
+                "cannot provide cooperative async timeout. Hypergraph did not run the node.\n\n"
+                "How to fix:\n"
+                "  - make the node async and await cancellation-aware I/O, or\n"
+                "  - use the client library's own timeout.",
+                node_name=node.name,
+                capability="supports_cooperative_timeout",
+            )
+
     # Check async nodes
     if graph.has_async_nodes and not capabilities.supports_async_nodes:
         # Find the async node(s) for a helpful error message

--- a/src/hypergraph/runners/async_/executors/function_node.py
+++ b/src/hypergraph/runners/async_/executors/function_node.py
@@ -56,11 +56,11 @@ class AsyncFunctionNodeExecutor:
         Returns:
             Dict mapping output names to their values
         """
-        if node.retry is not None:
+        if node.retry is not None or node.timeout is not None:
             # Per-attempt permits (#218): the concurrency budget covers
-            # in-flight callable invocations only, so backoff sleeps must not
-            # hold a permit. The attempt coordinator acquires the limiter
-            # around each attempt via _attempt_concurrency_scope.
+            # in-flight callable invocation through timeout settlement, while
+            # backoff sleeps hold no permit. The attempt coordinator acquires
+            # the limiter around each attempt via _attempt_concurrency_scope.
             return await self._execute(node, inputs, ctx)
 
         semaphore = get_concurrency_limiter()
@@ -120,18 +120,20 @@ class AsyncFunctionNodeExecutor:
                     return list(result)
                 return result
 
-            if node.retry is None:
+            if node.retry is None and node.timeout is None:
                 result = await invoke()
             else:
                 # The attempt coordinator sits here: below the superstep's
-                # cache lookup, above state application. The ledger keys off
-                # the workflow_id (StepRecords use it as run_id).
+                # cache lookup, above state application. Timeout wraps only
+                # the callable invocation inside an attempt. The ledger keys
+                # off workflow_id (StepRecords use it as run_id).
                 from hypergraph.runners._shared.attempts import run_attempts_async
 
                 result = await run_attempts_async(
                     invoke,
                     node_name=node.name,
                     policy=node.retry,
+                    timeout=node.timeout,
                     checkpointer=ctx.checkpointer,
                     run_id=ctx.workflow_id,
                     scheduled_superstep=ctx.superstep_offset + ctx.superstep,

--- a/src/hypergraph/runners/async_/runner.py
+++ b/src/hypergraph/runners/async_/runner.py
@@ -355,6 +355,7 @@ class AsyncRunner(AsyncRunnerTemplate):
             returns_coroutine=True,
             supports_interrupts=True,
             supports_checkpointing=self._checkpointer_instance is not None,
+            supports_cooperative_timeout=True,
         )
 
     @property

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -800,19 +800,23 @@ def test_inspect_docs_pin_exception_labels_and_recovery_runner_truth() -> None:
 def test_retry_docs_pin_public_contract() -> None:
     import dataclasses
 
-    from hypergraph import RetryPolicy
+    from hypergraph import AttemptTimeoutError, RetryPolicy, RetryWindowExpiredError
     from hypergraph import node as node_decorator
 
     nodes_api = _read("docs/06-api-reference/nodes.md")
     how_to = _read("docs/05-how-to/retry-transient-failures.md")
+    errors_api = _read("docs/06-api-reference/errors.md")
     summary = _read("docs/SUMMARY.md")
 
     assert "05-how-to/retry-transient-failures.md" in summary
+    assert "06-api-reference/errors.md" in summary
 
-    # The decorator surface exposes retry= and the docs track it.
+    # The decorator surface exposes retry=/timeout= and the docs track both.
     assert "retry" in inspect.signature(node_decorator).parameters
+    assert "timeout" in inspect.signature(node_decorator).parameters
     node_section = _scoped_section(nodes_api, "## @node Decorator")
     assert "retry: RetryPolicy | None = None" in node_section
+    assert "timeout: float | None = None" in node_section
 
     # RetryPolicy fields match the documented signature block, in order.
     policy_fields = tuple(field.name for field in dataclasses.fields(RetryPolicy))
@@ -855,3 +859,12 @@ def test_retry_docs_pin_public_contract() -> None:
     exec(example, namespace)  # noqa: S102
     assert namespace["result"]["done"] == 41
     assert len(namespace["attempts"]) == 2
+
+    timeout_section = _scoped_section(how_to, "## Bound one async attempt with `timeout`")
+    for fact in ("Deadline elapsed", "Cancellation requested", "Work stopped", "Cleanup completed"):
+        assert fact in timeout_section
+    assert "there is deliberately no `work_stopped` field" in _read("docs/06-api-reference/checkpointers.md")
+    assert "AttemptTimeoutError" in errors_api
+    assert "RetryWindowExpiredError" in errors_api
+    assert issubclass(AttemptTimeoutError, TimeoutError)
+    assert issubclass(RetryWindowExpiredError, TimeoutError)

--- a/tests/test_runners/test_async_runner.py
+++ b/tests/test_runners/test_async_runner.py
@@ -81,6 +81,10 @@ class TestAsyncRunnerCapabilities:
         runner = AsyncRunner()
         assert runner.capabilities.returns_coroutine is True
 
+    def test_supports_cooperative_timeout_true(self):
+        runner = AsyncRunner()
+        assert runner.capabilities.supports_cooperative_timeout is True
+
 
 class TestAsyncRunnerRun:
     """Tests for AsyncRunner.run()."""

--- a/tests/test_runners/test_daft_infrastructure.py
+++ b/tests/test_runners/test_daft_infrastructure.py
@@ -86,6 +86,7 @@ class TestRunnerCapabilitiesNewFields:
         assert cap.returns_coroutine is False
         assert cap.supports_interrupts is False
         assert cap.supports_checkpointing is False
+        assert cap.supports_cooperative_timeout is False
 
     def test_all_fields_overridable(self):
         cap = RunnerCapabilities(

--- a/tests/test_runners/test_sync_runner.py
+++ b/tests/test_runners/test_sync_runner.py
@@ -84,6 +84,10 @@ class TestSyncRunnerCapabilities:
         runner = SyncRunner()
         assert runner.capabilities.returns_coroutine is False
 
+    def test_supports_cooperative_timeout_false(self):
+        runner = SyncRunner()
+        assert runner.capabilities.supports_cooperative_timeout is False
+
 
 class TestSyncRunnerRun:
     """Tests for SyncRunner.run()."""

--- a/tests/test_runners/test_type_ownership.py
+++ b/tests/test_runners/test_type_ownership.py
@@ -45,6 +45,8 @@ ROOT_EXPORTS = (
     "RunStatus",
     "RenameError",
     "GraphConfigError",
+    "AttemptTimeoutError",
+    "RetryWindowExpiredError",
     "CompactedRetentionError",
     "MissingInputError",
     "InfiniteLoopError",

--- a/tests/test_runners/test_types.py
+++ b/tests/test_runners/test_types.py
@@ -199,6 +199,7 @@ class TestRunnerCapabilities:
         assert caps.supports_async_nodes is False
         assert caps.supports_streaming is False
         assert caps.returns_coroutine is False
+        assert caps.supports_cooperative_timeout is False
 
     def test_supports_cycles_default_true(self):
         caps = RunnerCapabilities()
@@ -218,11 +219,13 @@ class TestRunnerCapabilities:
             supports_async_nodes=True,
             supports_streaming=True,
             returns_coroutine=True,
+            supports_cooperative_timeout=True,
         )
         assert caps.supports_cycles is False
         assert caps.supports_async_nodes is True
         assert caps.supports_streaming is True
         assert caps.returns_coroutine is True
+        assert caps.supports_cooperative_timeout is True
 
 
 class TestNodeExecution:

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -1,0 +1,443 @@
+"""Contract tests for cooperative async per-attempt timeout (#231).
+
+Assertion map (ticket red-green items + locked #187 precedence):
+    1  cancellation settles before timeout escapes
+       test_attempt_timeout_waits_for_cleanup_and_records_truth
+    2  retry never overlaps settling work
+       test_timeout_retry_starts_only_after_prior_attempt_settles
+    3  unsupported work is rejected before execution
+       test_sync_runner_rejects_timeout_before_execution
+       test_async_runner_rejects_sync_callable_timeout_before_execution
+       test_async_runner_rejects_sync_generator_timeout_before_execution
+       test_daft_runner_rejects_timeout_before_execution
+    4  suppressed cancellation returns a witnessed value
+       test_suppressed_cancellation_accepts_late_success_with_evidence
+    5  cleanup exception replaces timeout
+       test_cleanup_exception_is_preserved_exactly
+       test_cleanup_exception_retry_eligibility_uses_its_own_type
+    6  no wall-clock assertions
+       Event/barrier ordering only; tiny deadlines merely trigger cancellation
+    7  series deadline during active work
+       test_retry_window_expiry_during_active_work_has_distinct_error
+    8  async generators are supported; sync generators are rejected
+       test_async_generator_timeout_waits_for_cleanup
+    9  external cancellation remains BaseException control flow
+       test_external_cancellation_is_not_converted_to_timeout
+
+The tests deliberately assert public runner behavior and public checkpoint
+evidence. ``asyncio.wait_for(..., timeout=5)`` calls are deadlock guards, not
+elapsed-time assertions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import math
+
+import pytest
+
+from hypergraph import (
+    AsyncRunner,
+    AttemptTimeoutError,
+    DaftRunner,
+    Graph,
+    IncompatibleRunnerError,
+    RetryPolicy,
+    RetryWindowExpiredError,
+    SyncRunner,
+    node,
+)
+from hypergraph.checkpointers import AttemptStatus, MemoryCheckpointer, SqliteCheckpointer, StepStatus
+
+TIMEOUT = 0.01
+
+
+async def _closed_attempts(checkpointer, workflow_id: str, node_name: str):
+    steps = [step for step in await checkpointer.get_steps(workflow_id) if step.node_name == node_name]
+    assert len(steps) == 1, f"expected one logical step for {node_name}, got {len(steps)}"
+    step = steps[0]
+    assert step.attempt_series_id is not None
+    series = await checkpointer.get_attempt_series(step.attempt_series_id)
+    records = await checkpointer.get_attempt_records(step.attempt_series_id)
+    assert series is not None and not series.is_open
+    return step, records
+
+
+def _assert_actionable_timeout_rejection(error: IncompatibleRunnerError, node_name: str) -> None:
+    message = str(error)
+    assert error.node_name == node_name
+    assert "did not run" in message
+    assert "make the node async" in message
+    assert "cancellation-aware I/O" in message
+    assert "client library's own timeout" in message
+
+
+async def test_attempt_timeout_waits_for_cleanup_and_records_truth(tmp_path) -> None:
+    cleanup_completed = asyncio.Event()
+    never_finishes = asyncio.Event()
+    checkpointer = SqliteCheckpointer(str(tmp_path / "timeout.db"))
+
+    @node(output_name="response", timeout=TIMEOUT)
+    async def call_model(prompt: str) -> str:
+        try:
+            await never_finishes.wait()
+        finally:
+            cleanup_completed.set()
+
+    try:
+        with pytest.raises(AttemptTimeoutError):
+            await AsyncRunner(checkpointer=checkpointer).run(
+                Graph([call_model]),
+                {"prompt": "hello"},
+                workflow_id="wf-timeout",
+            )
+
+        assert cleanup_completed.is_set(), "timeout must not escape before cancellation cleanup settles"
+        step, records = await _closed_attempts(checkpointer, "wf-timeout", "call_model")
+        assert step.status is StepStatus.FAILED
+        assert len(records) == 1
+        assert records[0].status is AttemptStatus.TIMED_OUT
+        assert records[0].deadline_elapsed is True
+        assert records[0].cancellation_requested is True
+        assert not hasattr(records[0], "work_stopped")
+    finally:
+        await checkpointer.close()
+
+
+async def test_timeout_retry_starts_only_after_prior_attempt_settles() -> None:
+    checkpointer = MemoryCheckpointer()
+    cleanup_started = asyncio.Event()
+    allow_cleanup_to_finish = asyncio.Event()
+    order: list[str] = []
+    calls = 0
+
+    @node(
+        output_name="response",
+        timeout=TIMEOUT,
+        retry=RetryPolicy(
+            max_attempts=2,
+            retry_on=(AttemptTimeoutError,),
+            initial_delay=0.001,
+            jitter="none",
+        ),
+    )
+    async def call_model(prompt: str) -> str:
+        nonlocal calls
+        calls += 1
+        order.append(f"attempt-{calls}-started")
+        if calls == 2:
+            return "recovered"
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            order.append("cleanup-started")
+            cleanup_started.set()
+            await allow_cleanup_to_finish.wait()
+            order.append("cleanup-finished")
+            raise
+
+    task = asyncio.create_task(
+        AsyncRunner(checkpointer=checkpointer).run(
+            Graph([call_model]),
+            {"prompt": "hello"},
+            workflow_id="wf-retry-timeout",
+        )
+    )
+    await asyncio.wait_for(cleanup_started.wait(), timeout=5)
+    assert order == ["attempt-1-started", "cleanup-started"]
+    allow_cleanup_to_finish.set()
+    result = await asyncio.wait_for(task, timeout=5)
+
+    assert result["response"] == "recovered"
+    assert order == [
+        "attempt-1-started",
+        "cleanup-started",
+        "cleanup-finished",
+        "attempt-2-started",
+    ]
+    step, records = await _closed_attempts(checkpointer, "wf-retry-timeout", "call_model")
+    assert step.status is StepStatus.COMPLETED
+    assert [record.status for record in records] == [AttemptStatus.TIMED_OUT, AttemptStatus.SUCCEEDED]
+    assert records[0].deadline_elapsed is True
+    assert records[0].cancellation_requested is True
+    assert records[1].deadline_elapsed is False
+    assert records[1].cancellation_requested is False
+
+
+def test_sync_runner_rejects_timeout_before_execution() -> None:
+    calls: list[str] = []
+
+    @node(output_name="response", timeout=1)
+    def charge_card(prompt: str) -> str:
+        calls.append(prompt)
+        return "charged"
+
+    with pytest.raises(IncompatibleRunnerError) as exc_info:
+        SyncRunner().run(Graph([charge_card]), {"prompt": "hello"})
+
+    _assert_actionable_timeout_rejection(exc_info.value, "charge_card")
+    assert calls == []
+
+
+async def test_async_runner_rejects_sync_callable_timeout_before_execution() -> None:
+    calls: list[str] = []
+
+    @node(output_name="response", timeout=1)
+    def charge_card(prompt: str) -> str:
+        calls.append(prompt)
+        return "charged"
+
+    with pytest.raises(IncompatibleRunnerError) as exc_info:
+        await AsyncRunner().run(Graph([charge_card]), {"prompt": "hello"})
+
+    _assert_actionable_timeout_rejection(exc_info.value, "charge_card")
+    assert calls == []
+
+
+async def test_async_runner_rejects_sync_generator_timeout_before_execution() -> None:
+    calls: list[str] = []
+
+    @node(output_name="chunks", timeout=1)
+    def stream_chunks(prompt: str):
+        calls.append(prompt)
+        yield "chunk"
+
+    with pytest.raises(IncompatibleRunnerError) as exc_info:
+        await AsyncRunner().run(Graph([stream_chunks]), {"prompt": "hello"})
+
+    _assert_actionable_timeout_rejection(exc_info.value, "stream_chunks")
+    assert calls == []
+
+
+def test_daft_runner_rejects_timeout_before_execution() -> None:
+    calls: list[str] = []
+
+    @node(output_name="response", timeout=1)
+    async def call_model(prompt: str) -> str:
+        calls.append(prompt)
+        return "ok"
+
+    # Compatibility validation runs before Daft plan construction. Bypassing
+    # optional-dependency initialization keeps this contract test available in
+    # the core test environment while still exercising DaftRunner.run().
+    runner = DaftRunner.__new__(DaftRunner)
+    runner._cache = None
+    with pytest.raises(IncompatibleRunnerError) as exc_info:
+        runner.run(Graph([call_model]), {"prompt": "hello"})
+
+    _assert_actionable_timeout_rejection(exc_info.value, "call_model")
+    assert calls == []
+
+
+async def test_suppressed_cancellation_accepts_late_success_with_evidence() -> None:
+    checkpointer = MemoryCheckpointer()
+    cleanup_completed = asyncio.Event()
+
+    @node(output_name="response", timeout=TIMEOUT)
+    async def call_model(prompt: str) -> str:
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cleanup_completed.set()
+            return f"late:{prompt}"
+
+    result = await AsyncRunner(checkpointer=checkpointer).run(
+        Graph([call_model]),
+        {"prompt": "hello"},
+        workflow_id="wf-late-success",
+    )
+
+    assert result["response"] == "late:hello", "a witnessed value must never be discarded"
+    assert cleanup_completed.is_set()
+    step, records = await _closed_attempts(checkpointer, "wf-late-success", "call_model")
+    assert step.status is StepStatus.COMPLETED
+    assert [record.status for record in records] == [AttemptStatus.SUCCEEDED]
+    assert records[0].deadline_elapsed is True
+    assert records[0].cancellation_requested is True
+
+
+async def test_cleanup_exception_is_preserved_exactly() -> None:
+    checkpointer = MemoryCheckpointer()
+    cleanup_error = ValueError("cleanup failed")
+    calls = 0
+
+    @node(
+        output_name="response",
+        timeout=TIMEOUT,
+        retry=RetryPolicy(
+            max_attempts=2,
+            retry_on=(AttemptTimeoutError,),
+            initial_delay=0.001,
+            jitter="none",
+        ),
+    )
+    async def call_model(prompt: str) -> str:
+        nonlocal calls
+        calls += 1
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            raise cleanup_error from None
+
+    with pytest.raises(ValueError) as exc_info:
+        await AsyncRunner(checkpointer=checkpointer).run(
+            Graph([call_model]),
+            {"prompt": "hello"},
+            workflow_id="wf-cleanup-error",
+        )
+
+    assert exc_info.value is cleanup_error
+    assert calls == 1, "AttemptTimeoutError eligibility must not authorize a cleanup ValueError"
+    step, records = await _closed_attempts(checkpointer, "wf-cleanup-error", "call_model")
+    assert step.status is StepStatus.FAILED
+    assert [record.status for record in records] == [AttemptStatus.FAILED]
+    assert records[0].error is not None and records[0].error.type_name == "ValueError"
+    assert records[0].deadline_elapsed is True
+    assert records[0].cancellation_requested is True
+
+
+async def test_cleanup_exception_retry_eligibility_uses_its_own_type() -> None:
+    calls = 0
+
+    @node(
+        output_name="response",
+        timeout=TIMEOUT,
+        retry=RetryPolicy(
+            max_attempts=2,
+            retry_on=(ValueError,),
+            initial_delay=0.001,
+            jitter="none",
+        ),
+    )
+    async def call_model(prompt: str) -> str:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            return "recovered"
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            raise ValueError("cleanup failed") from None
+
+    result = await AsyncRunner().run(Graph([call_model]), {"prompt": "hello"})
+
+    assert result["response"] == "recovered"
+    assert calls == 2
+
+
+async def test_retry_window_expiry_during_active_work_has_distinct_error() -> None:
+    checkpointer = MemoryCheckpointer()
+    cleanup_completed = asyncio.Event()
+
+    @node(
+        output_name="response",
+        retry=RetryPolicy(
+            max_attempts=1,
+            retry_on=(RetryWindowExpiredError,),
+            retry_window=TIMEOUT,
+        ),
+    )
+    async def call_model(prompt: str) -> str:
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cleanup_completed.set()
+
+    with pytest.raises(RetryWindowExpiredError):
+        await AsyncRunner(checkpointer=checkpointer).run(
+            Graph([call_model]),
+            {"prompt": "hello"},
+            workflow_id="wf-window-active",
+        )
+
+    assert cleanup_completed.is_set()
+    step, records = await _closed_attempts(checkpointer, "wf-window-active", "call_model")
+    assert step.status is StepStatus.FAILED
+    assert [record.status for record in records] == [AttemptStatus.TIMED_OUT]
+    assert records[0].deadline_elapsed is True
+    assert records[0].cancellation_requested is True
+
+
+async def test_async_generator_timeout_waits_for_cleanup() -> None:
+    cleanup_completed = asyncio.Event()
+
+    @node(output_name="chunks", timeout=TIMEOUT)
+    async def stream_chunks(prompt: str):
+        try:
+            yield prompt
+            await asyncio.Event().wait()
+        finally:
+            cleanup_completed.set()
+
+    with pytest.raises(AttemptTimeoutError):
+        await AsyncRunner().run(Graph([stream_chunks]), {"prompt": "hello"})
+
+    assert cleanup_completed.is_set()
+
+
+async def test_external_cancellation_is_not_converted_to_timeout() -> None:
+    checkpointer = MemoryCheckpointer()
+    started = asyncio.Event()
+    cleanup_completed = asyncio.Event()
+
+    @node(output_name="response", timeout=60)
+    async def call_model(prompt: str) -> str:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cleanup_completed.set()
+
+    task = asyncio.create_task(
+        AsyncRunner(checkpointer=checkpointer).run(
+            Graph([call_model]),
+            {"prompt": "hello"},
+            workflow_id="wf-external-cancel",
+        )
+    )
+    await asyncio.wait_for(started.wait(), timeout=5)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert cleanup_completed.is_set()
+    series = await checkpointer.get_open_attempt_series("wf-external-cancel", "call_model")
+    assert series is not None
+    records = await checkpointer.get_attempt_records(series.id)
+    assert [record.status for record in records] == [AttemptStatus.STARTED]
+    assert records[0].deadline_elapsed is False
+    assert records[0].cancellation_requested is False
+
+
+async def test_timeout_declaration_does_not_change_direct_calls() -> None:
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    @node(output_name="response", timeout=TIMEOUT)
+    async def call_model(prompt: str) -> str:
+        started.set()
+        await release.wait()
+        return prompt
+
+    task = asyncio.create_task(call_model("raw"))
+    await asyncio.wait_for(started.wait(), timeout=5)
+    assert not task.done(), "direct FunctionNode calls stay raw; runner policy is not applied"
+    release.set()
+    assert await task == "raw"
+
+
+@pytest.mark.parametrize("bad_timeout", [0, -1, math.inf, -math.inf, math.nan, True])
+def test_timeout_must_be_a_positive_finite_number(bad_timeout: float) -> None:
+    with pytest.raises((TypeError, ValueError), match="timeout"):
+
+        @node(timeout=bad_timeout)
+        async def call_model() -> None:
+            pass
+
+
+def test_timeout_is_exposed_on_function_node() -> None:
+    @node(timeout=1.5)
+    async def call_model() -> None:
+        pass
+
+    assert call_model.timeout == 1.5

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -7,8 +7,10 @@ Assertion map (ticket red-green items + locked #187 precedence):
        test_timeout_retry_starts_only_after_prior_attempt_settles
     3  unsupported work is rejected before execution
        test_sync_runner_rejects_timeout_before_execution
+       test_sync_runner_rejects_async_timeout_before_execution
        test_async_runner_rejects_sync_callable_timeout_before_execution
        test_async_runner_rejects_sync_generator_timeout_before_execution
+       test_delegated_runner_rejects_timeout_before_execution
        test_daft_runner_rejects_timeout_before_execution
     4  suppressed cancellation returns a witnessed value
        test_suppressed_cancellation_accepts_late_success_with_evidence
@@ -179,6 +181,21 @@ def test_sync_runner_rejects_timeout_before_execution() -> None:
     assert calls == []
 
 
+def test_sync_runner_rejects_async_timeout_before_execution() -> None:
+    calls: list[str] = []
+
+    @node(output_name="response", timeout=1)
+    async def call_model(prompt: str) -> str:
+        calls.append(prompt)
+        return "ok"
+
+    with pytest.raises(IncompatibleRunnerError) as exc_info:
+        SyncRunner().run(Graph([call_model]), {"prompt": "hello"})
+
+    _assert_actionable_timeout_rejection(exc_info.value, "call_model")
+    assert calls == []
+
+
 async def test_async_runner_rejects_sync_callable_timeout_before_execution() -> None:
     calls: list[str] = []
 
@@ -206,6 +223,22 @@ async def test_async_runner_rejects_sync_generator_timeout_before_execution() ->
         await AsyncRunner().run(Graph([stream_chunks]), {"prompt": "hello"})
 
     _assert_actionable_timeout_rejection(exc_info.value, "stream_chunks")
+    assert calls == []
+
+
+async def test_delegated_runner_rejects_timeout_before_execution() -> None:
+    calls: list[str] = []
+
+    @node(output_name="response", timeout=1)
+    async def call_model(prompt: str) -> str:
+        calls.append(prompt)
+        return "ok"
+
+    delegated = Graph([call_model], name="delegated").as_node().with_runner(SyncRunner())
+    with pytest.raises(IncompatibleRunnerError) as exc_info:
+        await AsyncRunner().run(Graph([delegated]), {"prompt": "hello"})
+
+    _assert_actionable_timeout_rejection(exc_info.value, "call_model")
     assert calls == []
 
 


### PR DESCRIPTION
Closes #231. Completes the user-facing #187 retry/timeout surface.

## What this adds
```python
@node(timeout=30, retry=RetryPolicy(max_attempts=3, retry_on=(AttemptTimeoutError,)))
async def call_model(prompt: str) -> str: ...
```
Cooperative async-only, exactly per the locked contract: deadline elapsed → cancellation requested → Hypergraph waits for settlement → only then the attempt finishes or retries. Python 3.10-compatible. New public `AttemptTimeoutError` (retryable only when listed in `retry_on`) and `RetryWindowExpiredError`. TIMED_OUT ledger evidence carries `deadline_elapsed`/`cancellation_requested` — deliberately no `work_stopped` field. Suppressed cancellation returning a real value is accepted as a late success with deadline evidence; cleanup exceptions replace the timeout as the terminal cause with their own eligibility.

Truthful rejection BEFORE user code (with the two fixes in the message): SyncRunner graphs, sync callables/generators under AsyncRunner, delegated runners, DaftRunner.

## Test plan
Red-green (`879df5fd` → `8278b2b9`); 22 dedicated tests at public seams (decorator/runner/exceptions/ledger) incl. settlement-before-retry ordering, late-success acceptance, cleanup-exception precedence, pre-execution rejection matrix; no wall-clock asserts. Foreman falsifier: async twin runs (y=2), sync twin rejected pre-execution (`IncompatibleRunnerError`, user code never ran). Full CI-equivalent: 3,770 passed, 15 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)