### PR TITLE
fix(runners): repair four sync/async parity micro-bugs

### DIFF
--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -1403,6 +1403,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                         graph,
                         start_time,
                         _parent_span_id,
+                        context=RunContext(workflow_id=workflow_id, item_index=_item_index),
                         error=e,
                     )
                 # Mark parent batch run as failed

--- a/src/hypergraph/runners/_shared/template_sync.py
+++ b/src/hypergraph/runners/_shared/template_sync.py
@@ -932,6 +932,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
             validate_runner_compatibility(graph, self.capabilities)
             validate_node_types(graph, self.supported_node_types)
             validate_delegated_runners(graph, self.capabilities)
+            sync_cp = self._get_sync_checkpointer(workflow_id)
         except BaseException as error:
             if inspection_transport is not None:
                 inspection_transport.fail_to_start(error)
@@ -998,7 +999,6 @@ class SyncRunnerTemplate(BaseRunner, ABC):
             raise
         dispatcher = None
         signal_token = None
-        sync_cp = None
         parent_run_row_created = False
         claimed_indexes: set[int] = set()
         results: list[RunResult] = []
@@ -1039,7 +1039,6 @@ class SyncRunnerTemplate(BaseRunner, ABC):
             start_time = time.time()
 
             # Create parent batch run if checkpointing
-            sync_cp = self._get_sync_checkpointer(workflow_id)
             if sync_cp is not None:
                 sync_cp.create_run_sync(
                     workflow_id,
@@ -1261,6 +1260,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
                         graph,
                         start_time,
                         _parent_span_id,
+                        context=RunContext(workflow_id=workflow_id, item_index=_item_index),
                         error=e,
                     )
                 # Mark parent batch run as failed

--- a/src/hypergraph/runners/sync/runner.py
+++ b/src/hypergraph/runners/sync/runner.py
@@ -374,6 +374,8 @@ class SyncRunner(SyncRunnerTemplate):
             item_index=item_index,
             run_id=run_id,
             provided_values=values,
+            # Sync has no InterruptNode executor, but custom/nested executors still receive parity metadata.
+            is_resuming=(checkpoint is not None if self._checkpointer_instance is not None else True),
             emit_fn=dispatcher.emit if dispatcher.active else None,
             checkpointer=sync_cp,
             superstep_offset=superstep_offset,

--- a/src/hypergraph/runners/sync/superstep.py
+++ b/src/hypergraph/runners/sync/superstep.py
@@ -357,16 +357,21 @@ def run_superstep_sync(
                         )
                     )
 
-            except BaseException as e:
+            except PauseExecution as e:
+                e.span_id = node_span_id
+                raise
+            except _NodeExecutionError:
+                raise
+            except Exception as e:
                 duration_ms = (time.time() - node_start) * 1000
-                if inspection_session is not None and isinstance(e, Exception) and not isinstance(e, _NodeExecutionError):
+                if inspection_session is not None:
                     inspection_session.abort_node(
                         span_id=node_span_id,
                         error=e,
                         ended_at_ms=time.perf_counter() * 1000,
                         duration_ms=duration_ms,
                     )
-                if active and not node_error_event_attempted and not isinstance(e, _NodeExecutionError):
+                if active and not node_error_event_attempted:
                     dispatcher.emit(
                         build_node_error_event(
                             run_id,
@@ -379,31 +384,21 @@ def run_superstep_sync(
                             superstep=superstep_idx,
                         )
                     )
-                # Re-raise PauseExecution unwrapped (needed for InterruptNode)
-                if isinstance(e, PauseExecution):
-                    e.span_id = node_span_id
-                    raise
-                if isinstance(e, _NodeExecutionError):
-                    raise
-                # Wrap only Exception subclasses
-                if isinstance(e, Exception):
-                    if isinstance(e, ExecutionError):
-                        error = ExecutionError(
-                            e,
-                            e.partial_state,
-                            attempted_node_names=e.attempted_node_names,
-                            node_errors=e.node_errors,
-                        )
-                        raise error from e
+                if isinstance(e, ExecutionError):
                     error = ExecutionError(
                         e,
-                        new_state,
-                        attempted_node_names=tuple(attempted_node_names),
-                        node_errors={node.name: e},
+                        e.partial_state,
+                        attempted_node_names=e.attempted_node_names,
+                        node_errors=e.node_errors,
                     )
                     raise error from e
-                # Re-raise other BaseExceptions (KeyboardInterrupt, SystemExit, etc.)
-                raise
+                error = ExecutionError(
+                    e,
+                    new_state,
+                    attempted_node_names=tuple(attempted_node_names),
+                    node_errors={node.name: e},
+                )
+                raise error from e
 
         # Record wait_for versions
         wait_for_versions = {name: state.get_version(name) for name in node.wait_for}

--- a/tests/events/test_async_events.py
+++ b/tests/events/test_async_events.py
@@ -467,6 +467,29 @@ class TestMapEvents:
         # 1 map-level RunEnd + 2 individual RunEnds
         assert len(run_ends) == 3
 
+    @pytest.mark.asyncio
+    async def test_failed_map_run_end_preserves_workflow_context(self):
+        @node(output_name="out")
+        def failing(x: int) -> int:
+            raise ValueError(f"boom: {x}")
+
+        runner = AsyncRunner()
+        lp = ListProcessor()
+
+        with pytest.raises(ValueError, match="boom: 1"):
+            await runner.map(
+                Graph([failing]),
+                {"x": [1]},
+                map_over="x",
+                workflow_id="failed-async-map",
+                event_processors=[lp],
+            )
+
+        map_start = next(event for event in lp.of_type(RunStartEvent) if event.is_map)
+        map_end = next(event for event in lp.of_type(RunEndEvent) if event.run_id == map_start.run_id)
+        assert map_end.workflow_id == "failed-async-map"
+        assert map_end.item_index is None
+
 
 # ---------------------------------------------------------------------------
 # Shutdown

--- a/tests/events/test_sync_events.py
+++ b/tests/events/test_sync_events.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from hypergraph import END, Graph, SyncRunner, node, route
 from hypergraph.events import EventProcessor, TypedEventProcessor
 from hypergraph.events.types import (
@@ -187,6 +189,18 @@ class TestErrorEvents:
         assert run_end.status == RunStatus.FAILED
         assert "boom" in run_end.error
 
+    def test_keyboard_interrupt_does_not_emit_node_error(self):
+        @node(output_name="out")
+        def interrupted(x: int) -> int:
+            raise KeyboardInterrupt
+
+        lp = ListProcessor()
+
+        with pytest.raises(KeyboardInterrupt):
+            SyncRunner().run(Graph([interrupted]), {"x": 1}, event_processors=[lp])
+
+        assert lp.of_type(NodeErrorEvent) == []
+
     def test_processor_failure_does_not_break_execution(self):
         class BadProcessor(EventProcessor):
             def on_event(self, event):
@@ -365,6 +379,28 @@ class TestMapEvents:
         run_ends = lp.of_type(RunEndEvent)
         # 1 map-level RunEnd + 2 individual RunEnds
         assert len(run_ends) == 3
+
+    def test_failed_map_run_end_preserves_workflow_context(self):
+        @node(output_name="out")
+        def failing(x: int) -> int:
+            raise ValueError(f"boom: {x}")
+
+        runner = SyncRunner()
+        lp = ListProcessor()
+
+        with pytest.raises(ValueError, match="boom: 1"):
+            runner.map(
+                Graph([failing]),
+                {"x": [1]},
+                map_over="x",
+                workflow_id="failed-sync-map",
+                event_processors=[lp],
+            )
+
+        map_start = next(event for event in lp.of_type(RunStartEvent) if event.is_map)
+        map_end = next(event for event in lp.of_type(RunEndEvent) if event.run_id == map_start.run_id)
+        assert map_end.workflow_id == "failed-sync-map"
+        assert map_end.item_index is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_checkpointer/test_sync_runner_checkpointing.py
+++ b/tests/test_checkpointer/test_sync_runner_checkpointing.py
@@ -5,8 +5,10 @@ import pytest
 from hypergraph import Graph, SyncRunner, node
 from hypergraph.checkpointers import (
     CheckpointPolicy,
+    MemoryCheckpointer,
     SqliteCheckpointer,
 )
+from hypergraph.events import EventProcessor
 
 aiosqlite = pytest.importorskip("aiosqlite")
 
@@ -151,6 +153,28 @@ class TestSyncRunnerCheckpointing:
 
         with pytest.raises(TypeError, match="does not support sync writes"):
             runner.run(graph, {"x": 1}, workflow_id="wf-proto")
+
+    def test_map_protocol_mismatch_fails_before_emitting_events(self):
+        class Recorder(EventProcessor):
+            def __init__(self) -> None:
+                self.events: list[object] = []
+
+            def on_event(self, event) -> None:
+                self.events.append(event)
+
+        recorder = Recorder()
+        runner = SyncRunner(checkpointer=MemoryCheckpointer())
+
+        with pytest.raises(TypeError, match="does not support sync writes"):
+            runner.map(
+                Graph([double]),
+                {"x": [1]},
+                map_over="x",
+                workflow_id="batch-proto",
+                event_processors=[recorder],
+            )
+
+        assert recorder.events == []
 
     def test_workflow_id_with_slash_rejected(self):
         """User-provided workflow_id containing '/' is rejected."""

--- a/tests/test_runners/test_execution.py
+++ b/tests/test_runners/test_execution.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 
 import pytest
 
-from hypergraph import Graph, node
+from hypergraph import Graph, SyncRunner, node
 from hypergraph.nodes.gate import END, route
 from hypergraph.runners._shared.map_inputs import generate_map_inputs
 from hypergraph.runners._shared.outputs import filter_outputs
@@ -426,6 +426,25 @@ class TestSyncFunctionNodeExecutor:
         self.executor = SyncFunctionNodeExecutor()
         self.state = GraphState()
         self.ctx = ExecutionContext()
+
+    def test_runner_marks_stateless_execution_context_as_resuming(self):
+        @node(output_name="out")
+        def step(x: int) -> int:
+            return x
+
+        runner = SyncRunner()
+        observed: list[bool] = []
+        executor = runner._executors[type(step)]
+
+        def recording_executor(node, state, inputs, ctx):
+            observed.append(ctx.is_resuming)
+            return executor(node, state, inputs, ctx)
+
+        runner._executors[type(step)] = recording_executor
+
+        runner.run(Graph([step]), {"x": 1})
+
+        assert observed == [True]
 
     def test_executes_function_rename_inputs(self):
         """Function is called with provided inputs."""


### PR DESCRIPTION
Closes #241.

## Before / after
```text
Failed map() RunEndEvent workflow_id: None      → caller's workflow_id preserved (both runners)
KeyboardInterrupt NodeErrorEvents (sync): 1     → 0 (matches async: BaseException never emits)
Stateless sync is_resuming: False               → True (parity with async ExecutionContext)
Invalid map checkpointer: RunStartEvent emitted → 0 events (pre-flight validation, parity with run())
```

All four located by the 2026-07-17 deep review; each fixed red-first with a pinning regression test.

## Test plan
Red/green per fix; full CI-equivalent 3,775 passed, 15 skipped; pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failure events from synchronous and asynchronous map runs now retain workflow context.
  * Improved handling of pauses, interruptions, and node execution errors during synchronous runs.
  * Prevented events from being emitted when map execution fails validation before starting.
  * Checkpoint-based resume status is now reported consistently during synchronous execution.

* **Tests**
  * Added coverage for failure events, interruptions, checkpointing, and resume behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->