### PR TITLE
fix(runners): preserve seeds across nested resume; surface original child failures

### DIFF
--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -250,6 +250,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
         _parent_run_id: str | None = None,
         _validation_ctx: _InputValidationContext | None = None,
         _run_config: dict[str, Any] | None = None,
+        _resume_seed_values: dict[str, Any] | None = None,
         _complete_on_stop: bool = False,
         _item_index: int | None = None,
         _checkpoint_error_sink: CheckpointErrorSink | None = None,
@@ -380,6 +381,12 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
             if inspection_transport is not None:
                 inspection_transport.fail_to_start(error)
             raise
+
+        if resume_checkpoint is not None and _resume_seed_values:
+            # GraphNode may recover parent-owned seeds when a child paused or
+            # failed before producing any durable value. Keep them out of the
+            # runtime payload so strict resume/interrupt lineage stays intact.
+            resume_checkpoint.values = {**_resume_seed_values, **resume_checkpoint.values}
 
         has_checkpointer = checkpointer is not None and workflow_id is not None
         run_context = RunContext(workflow_id=workflow_id, item_index=_item_index)

--- a/src/hypergraph/runners/_shared/template_sync.py
+++ b/src/hypergraph/runners/_shared/template_sync.py
@@ -235,6 +235,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
         _parent_run_id: str | None = None,
         _validation_ctx: _InputValidationContext | None = None,
         _run_config: dict[str, Any] | None = None,
+        _resume_seed_values: dict[str, Any] | None = None,
         _complete_on_stop: bool = False,
         _item_index: int | None = None,
         _reservation: _WorkflowReservation | None = None,
@@ -365,6 +366,12 @@ class SyncRunnerTemplate(BaseRunner, ABC):
             if inspection_transport is not None:
                 inspection_transport.fail_to_start(error)
             raise
+
+        if resume_checkpoint is not None and _resume_seed_values:
+            # GraphNode may recover parent-owned seeds when a child paused or
+            # failed before producing any durable value. Keep them out of the
+            # runtime payload so strict resume/interrupt lineage stays intact.
+            resume_checkpoint.values = {**_resume_seed_values, **resume_checkpoint.values}
 
         run_context = RunContext(workflow_id=workflow_id, item_index=_item_index)
         run_lineage = plan_lineage(

--- a/src/hypergraph/runners/async_/executors/graph_node.py
+++ b/src/hypergraph/runners/async_/executors/graph_node.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import inspect
 from typing import TYPE_CHECKING, Any
 
-from hypergraph.checkpointers.types import WorkflowStatus
+from hypergraph.checkpointers.types import StepStatus, WorkflowStatus
 from hypergraph.exceptions import IncompatibleRunnerError
 from hypergraph.runners._shared._inspect import current_inspection
 from hypergraph.runners._shared.outputs import collect_as_lists
@@ -72,6 +72,7 @@ class AsyncGraphNodeExecutor:
         runner = node.runner_override or self.runner
         parent_cp = self.runner._checkpointer
         child_cp = getattr(runner, "_checkpointer", None)
+        child_resume_seed_values: dict[str, Any] | None = None
 
         # Route interrupt resume values into the inner graph. The parent sees
         # the GraphNode's resolved output address ("decision", "review.verdict",
@@ -142,10 +143,20 @@ class AsyncGraphNodeExecutor:
                                 # In-flight iteration (paused/failed/stopped):
                                 # resume it from its own checkpoint.
                                 child_workflow_id = candidate
+                                child_steps = await child_cp.get_steps(candidate, show_internal=True)
+                                if not any(step.status is StepStatus.COMPLETED for step in child_steps):
+                                    child_resume_seed_values = inner_inputs
                                 inner_inputs = {}
                                 break
                             index += 1
                     else:
+                        child_steps = await child_cp.get_steps(child_workflow_id, show_internal=True)
+                        if not any(step.status is StepStatus.COMPLETED for step in child_steps):
+                            # A child that failed or paused before its first
+                            # completed step has no folded checkpoint values.
+                            # Carry its parent-owned seeds in the in-memory
+                            # checkpoint, not as runtime overrides.
+                            child_resume_seed_values = inner_inputs
                         inner_inputs = {}
                 elif resume_values:
                     current_parent_run = await parent_cp.get_run_async(ctx.workflow_id) if ctx.workflow_id else None
@@ -244,6 +255,8 @@ class AsyncGraphNodeExecutor:
         if runner.capabilities.supports_checkpointing:
             run_kwargs["fork_from"] = child_fork_from
             run_kwargs["retry_from"] = child_retry_from
+        if child_resume_seed_values is not None:
+            run_kwargs["_resume_seed_values"] = child_resume_seed_values
         if getattr(node, "_complete_on_stop", False):
             run_kwargs["_complete_on_stop"] = True
         if ctx.checkpoint_error_sink is not None and accepts_checkpoint_error_sink:

--- a/src/hypergraph/runners/sync/executors/graph_node.py
+++ b/src/hypergraph/runners/sync/executors/graph_node.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from hypergraph.checkpointers.types import WorkflowStatus
+from hypergraph.checkpointers.types import StepStatus, WorkflowStatus
 from hypergraph.runners._shared._inspect import current_inspection
 from hypergraph.runners._shared.outputs import collect_as_lists
 from hypergraph.runners._shared.state_restore import (
@@ -62,6 +62,7 @@ class SyncGraphNodeExecutor:
         runner = node.runner_override or self.runner
         parent_cp = self.runner._get_sync_checkpointer(ctx.workflow_id)
         child_cp = runner._get_sync_checkpointer(child_workflow_id) if hasattr(runner, "_get_sync_checkpointer") else None
+        child_resume_seed_values: dict[str, Any] | None = None
 
         # Route interrupt resume values into the inner graph. The parent sees
         # the GraphNode's resolved output address ("decision", "review.verdict",
@@ -131,10 +132,20 @@ class SyncGraphNodeExecutor:
                                 # In-flight iteration (paused/failed/stopped):
                                 # resume it from its own checkpoint.
                                 child_workflow_id = candidate
+                                child_steps = child_cp.steps(candidate, show_internal=True)
+                                if not any(step.status is StepStatus.COMPLETED for step in child_steps):
+                                    child_resume_seed_values = inner_inputs
                                 inner_inputs = {}
                                 break
                             index += 1
                     else:
+                        child_steps = child_cp.steps(child_workflow_id, show_internal=True)
+                        if not any(step.status is StepStatus.COMPLETED for step in child_steps):
+                            # A child that failed or paused before its first
+                            # completed step has no folded checkpoint values.
+                            # Carry its parent-owned seeds in the in-memory
+                            # checkpoint, not as runtime overrides.
+                            child_resume_seed_values = inner_inputs
                         inner_inputs = {}
                 elif resume_values:
                     current_parent_run = parent_cp.get_run(ctx.workflow_id) if ctx.workflow_id else None
@@ -210,6 +221,8 @@ class SyncGraphNodeExecutor:
         if runner.capabilities.supports_checkpointing:
             run_kwargs["fork_from"] = child_fork_from
             run_kwargs["retry_from"] = child_retry_from
+        if child_resume_seed_values is not None:
+            run_kwargs["_resume_seed_values"] = child_resume_seed_values
         if getattr(node, "_complete_on_stop", False):
             run_kwargs["_complete_on_stop"] = True
 

--- a/tests/test_checkpointer/test_nested_crash_resume.py
+++ b/tests/test_checkpointer/test_nested_crash_resume.py
@@ -204,6 +204,24 @@ def build_failing_child_graph():
     return parent, counters
 
 
+def build_zero_step_failing_child_graph():
+    """Parent whose child fails before persisting any completed step."""
+    counters = {"boom": 0}
+
+    @node(output_name="prepared")
+    def prepare(x: int) -> int:
+        return x + 100
+
+    @node(output_name="doubled")
+    def boom(prepared: int) -> int:
+        counters["boom"] += 1
+        raise ValueError("first child step exploded")
+
+    child = Graph(nodes=[boom], name="child")
+    parent = Graph(nodes=[prepare, child.as_node(name="child_wf")], name="parent")
+    return parent, counters
+
+
 class TestAsyncNestedCrashResume:
     async def test_resume_restores_completed_child_after_parent_step_crash(self, tmp_path):
         """B1/B2/B3: resume restores the child's outputs instead of re-invoking."""
@@ -396,6 +414,86 @@ class TestAsyncNestedCrashResume:
         finally:
             await cp.close()
 
+    @pytest.mark.parametrize("error_handling", ["raise", "continue"])
+    async def test_resume_replays_failed_child_with_no_completed_steps(self, tmp_path, error_handling):
+        """#270: child seeds survive resume when its first step failed."""
+        parent, counters = build_zero_step_failing_child_graph()
+        cp = SqliteCheckpointer(str(tmp_path / "test.db"), durability="sync")
+        try:
+            runner = AsyncRunner(checkpointer=cp)
+            if error_handling == "raise":
+                with pytest.raises(ValueError, match="first child step exploded"):
+                    await runner.run(parent, {"x": 5}, workflow_id="wf", error_handling=error_handling)
+            else:
+                first = await runner.run(parent, {"x": 5}, workflow_id="wf", error_handling=error_handling)
+                assert first.status is RunStatus.FAILED
+                assert isinstance(first.error, ValueError)
+
+            child_steps = await cp.get_steps("wf/child_wf")
+            assert not any(step.status is StepStatus.COMPLETED for step in child_steps)
+
+            if error_handling == "raise":
+                with pytest.raises(ValueError, match="first child step exploded"):
+                    await runner.run(parent, workflow_id="wf", error_handling=error_handling)
+            else:
+                resumed = await runner.run(parent, workflow_id="wf", error_handling=error_handling)
+                assert resumed.status is RunStatus.FAILED
+                assert isinstance(resumed.error, ValueError)
+                assert str(resumed.error) == "first child step exploded"
+
+            assert counters["boom"] == 2
+        finally:
+            await cp.close()
+
+    async def test_paused_child_persists_runtime_answer_before_parent_step(self, tmp_path):
+        """#278: a terminal child durably folds its consumed interrupt answer."""
+
+        @node(output_name="draft")
+        def prepare(query: str) -> str:
+            return f"Draft for: {query}"
+
+        @interrupt(answer_name="decision")
+        def approval(draft: str) -> StringQuestion:
+            return StringQuestion(prompt="Approve?", evidence=(draft,))
+
+        @node(output_name="result")
+        def finalize(decision: str) -> str:
+            return f"Final: {decision}"
+
+        child = Graph([approval], name="review")
+        parent = Graph([prepare, child.as_node(name="child_wf"), finalize], name="parent")
+        cp = CrashingStepCheckpointer(str(tmp_path / "test.db"), {("wf", "child_wf")})
+        cp.armed = False
+        try:
+            runner = AsyncRunner(checkpointer=cp)
+            paused = await runner.run(parent, {"query": "hello"}, workflow_id="wf")
+            assert paused.status is RunStatus.PAUSED
+            assert await cp.get_state("wf/child_wf") == {}
+
+            cp.armed = True
+            with pytest.raises(RuntimeError, match=CRASH_MESSAGE):
+                await runner.run(parent, {"decision": "approved"}, workflow_id="wf")
+
+            child_run = await cp.get_run_async("wf/child_wf")
+            assert child_run is not None
+            assert child_run.status is WorkflowStatus.COMPLETED
+            assert await cp.get_state("wf/child_wf") == {"decision": "approved"}
+            child_steps = await cp.get_steps("wf/child_wf")
+            assert any(
+                step.node_name == "approval" and step.status is StepStatus.COMPLETED and step.values == {"decision": "approved"}
+                for step in child_steps
+            )
+
+            cp.armed = False
+            restored = await runner.run(parent, workflow_id="wf")
+            assert restored.values == {
+                "draft": "Draft for: hello",
+                "decision": "approved",
+                "result": "Final: approved",
+            }
+        finally:
+            await cp.close()
+
 
 class TestSyncNestedCrashResume:
     """B4: sync-runner parity for the crash-window restore."""
@@ -527,6 +625,39 @@ class TestSyncNestedCrashResume:
             child_run = cp.get_run("wf/child_wf")
             assert child_run is not None
             assert child_run.status is WorkflowStatus.FAILED
+        finally:
+            if cp._sync_conn:
+                cp._sync_conn.close()
+
+    @pytest.mark.parametrize("error_handling", ["raise", "continue"])
+    def test_resume_replays_failed_child_with_no_completed_steps(self, tmp_path, error_handling):
+        """#270: child seeds survive resume when its first step failed."""
+        parent, counters = build_zero_step_failing_child_graph()
+        cp = SqliteCheckpointer(str(tmp_path / "test.db"), durability="sync")
+        cp._sync_db()
+        try:
+            runner = SyncRunner(checkpointer=cp)
+            if error_handling == "raise":
+                with pytest.raises(ValueError, match="first child step exploded"):
+                    runner.run(parent, {"x": 5}, workflow_id="wf", error_handling=error_handling)
+            else:
+                first = runner.run(parent, {"x": 5}, workflow_id="wf", error_handling=error_handling)
+                assert first.status is RunStatus.FAILED
+                assert isinstance(first.error, ValueError)
+
+            child_steps = cp.steps("wf/child_wf")
+            assert not any(step.status is StepStatus.COMPLETED for step in child_steps)
+
+            if error_handling == "raise":
+                with pytest.raises(ValueError, match="first child step exploded"):
+                    runner.run(parent, workflow_id="wf", error_handling=error_handling)
+            else:
+                resumed = runner.run(parent, workflow_id="wf", error_handling=error_handling)
+                assert resumed.status is RunStatus.FAILED
+                assert isinstance(resumed.error, ValueError)
+                assert str(resumed.error) == "first child step exploded"
+
+            assert counters["boom"] == 2
         finally:
             if cp._sync_conn:
                 cp._sync_conn.close()


### PR DESCRIPTION
Closes #270. Closes #278.

## Before / after
```text
FAILED child with zero completed steps + resume → MissingInputError naming the child's seeds (masked the real error)
                                               → child re-executes from its seeds; original failure resurfaces per error_handling

COMPLETED interrupt child whose answer was runtime-only + crash-window restore → missing values in parent output
                                               → truthful restore (seeds preserved through nested resume)
```
Sync/async parity; red-first regression tests (131 new test lines). Full CI-equivalent green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)