### PR TITLE
fix(runners): unify script-safe JSON escaping and sandboxed iframe skeletons

### DIFF
--- a/src/hypergraph/checkpointers/presenters.py
+++ b/src/hypergraph/checkpointers/presenters.py
@@ -3,18 +3,14 @@
 from __future__ import annotations
 
 import hashlib
-import json
 from collections.abc import Iterable
 from importlib.resources import files
 from typing import TYPE_CHECKING, Any
 
+from hypergraph.runners._shared._wire import script_safe_json
+
 if TYPE_CHECKING:
     from hypergraph.checkpointers.types import Run, StepRecord, WorkflowStatus
-
-
-def _safe_json_payload(payload: dict[str, Any]) -> str:
-    """Serialize JSON safely for embedding inside a script tag."""
-    return json.dumps(payload).replace("<", "\\u003c").replace(">", "\\u003e").replace("&", "\\u0026")
 
 
 _EXPLORER_ASSET_SHA256 = "9909428d38a1ec32738c16eb54d8a72f1f4bb6a38b03858709b86286c35b413d"
@@ -137,8 +133,8 @@ def render_checkpointer_explorer_html(
         f'<div data-hg-explorer-body style="{panel_style}"></div>'
         f"</section>"
         f"</div>"
-        f'<script type="application/json" data-hg-explorer-data>{_safe_json_payload(payload)}</script>'
-        f'<script type="application/json" data-hg-explorer-config>{_safe_json_payload(config)}</script>'
+        f'<script type="application/json" data-hg-explorer-data>{script_safe_json(payload)}</script>'
+        f'<script type="application/json" data-hg-explorer-config>{script_safe_json(config)}</script>'
         f"<script>{_read_explorer_asset()}</script>"
         f"</div>"
     )

--- a/src/hypergraph/runners/_shared/_inspect_html.py
+++ b/src/hypergraph/runners/_shared/_inspect_html.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import html
-import json
 from functools import lru_cache
 from importlib.resources import files
 from typing import Literal
@@ -13,6 +12,7 @@ from hypergraph.runners._shared._inspect_serialization import (
     serialize_value,
     serialized_value_to_wire,
 )
+from hypergraph.runners._shared._wire import sandboxed_child_document, script_safe_json
 from hypergraph.runners._shared.results import FailureEvidence
 from hypergraph.runners.inspection import InspectionDisplay as InspectionDisplay
 
@@ -289,16 +289,6 @@ def _map_wire(artifact: MapInspection) -> dict[str, object]:
     }
 
 
-def _script_safe_json(payload: dict[str, object]) -> str:
-    encoded = json.dumps(
-        payload,
-        ensure_ascii=True,
-        allow_nan=False,
-        separators=(",", ":"),
-    )
-    return encoded.replace("<", "\\u003c").replace(">", "\\u003e").replace("&", "\\u0026")
-
-
 @lru_cache(maxsize=2)
 def _read_asset(name: str) -> str:
     """Read one packaged renderer asset without a network or runtime dependency."""
@@ -376,7 +366,7 @@ def render_inspection_payload(payload: dict[str, object]) -> str:
         "<noscript>JavaScript is required for local drill-down; the semantic "
         "payload remains embedded in this saved output.</noscript>"
         f'<script type="application/json" data-hg-inspect-payload>'
-        f"{_script_safe_json(payload)}</script>"
+        f"{script_safe_json(payload)}</script>"
         f"<script data-hg-inspect-runtime>{_read_asset('inspect.js')}</script>"
         "</section>"
     )
@@ -428,13 +418,7 @@ def render_map_inspection(artifact: MapInspection) -> str:
 
 def render_inspection_frame(child_html: str) -> str:
     """Isolate one saved inspection renderer from its notebook host."""
-    child_document = (
-        '<!doctype html><html><head><meta charset="utf-8">'
-        '<meta name="viewport" content="width=device-width,initial-scale=1">'
-        '</head><body style="margin:0">'
-        f"{child_html}"
-        "</body></html>"
-    )
+    child_document = sandboxed_child_document(child_html)
     return (
         '<iframe title="Hypergraph execution inspection" sandbox="allow-scripts" '
         'style="display:block;box-sizing:border-box;width:100%;min-width:0;'

--- a/src/hypergraph/runners/_shared/_inspect_serialization.py
+++ b/src/hypergraph/runners/_shared/_inspect_serialization.py
@@ -28,6 +28,8 @@ from types import (
 )
 from typing import Any, Literal, TypeAlias
 
+from hypergraph.runners._shared._wire import script_safe_json
+
 SerializedKind: TypeAlias = Literal[
     "null",
     "boolean",
@@ -2136,11 +2138,4 @@ def serialized_value_to_wire(value: SerializedValue) -> dict[str, JSONValue]:
 
 def dump_serialized_value(value: SerializedValue) -> str:
     """Encode one typed value as script-safe strict JSON."""
-
-    encoded = json.dumps(
-        serialized_value_to_wire(value),
-        ensure_ascii=True,
-        allow_nan=False,
-        separators=(",", ":"),
-    )
-    return encoded.replace("<", "\\u003c").replace(">", "\\u003e").replace("&", "\\u0026").replace("\u2028", "\\u2028").replace("\u2029", "\\u2029")
+    return script_safe_json(serialized_value_to_wire(value))

--- a/src/hypergraph/runners/_shared/_inspect_transport.py
+++ b/src/hypergraph/runners/_shared/_inspect_transport.py
@@ -14,7 +14,6 @@ import asyncio
 import contextlib
 import html
 import importlib.metadata
-import json
 import secrets
 import threading
 import time
@@ -41,6 +40,7 @@ from hypergraph.runners._shared._inspect_serialization import (
     serialize_value,
     serialized_value_to_wire,
 )
+from hypergraph.runners._shared._wire import sandboxed_child_document, script_safe_json
 
 INSPECTION_PROTOCOL_VERSION = 1
 _UPDATE_MESSAGE = "hypergraph.inspect.update"
@@ -121,27 +121,9 @@ def inspection_envelope_to_wire(envelope: InspectionEnvelope) -> dict[str, objec
     }
 
 
-def _script_safe_json(value: object) -> str:
-    """Encode inert inline JSON, including closing tags and JS separators."""
-    encoded = json.dumps(
-        value,
-        ensure_ascii=True,
-        allow_nan=False,
-        separators=(",", ":"),
-    )
-    return encoded.replace("<", "\\u003c").replace(">", "\\u003e").replace("&", "\\u0026")
-
-
 @lru_cache(maxsize=1)
 def _bridge_asset() -> str:
     return files("hypergraph.runners._shared.assets").joinpath("inspect_transport.js").read_text(encoding="utf-8")
-
-
-_CHILD_CSP = (
-    "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; "
-    "img-src data:; font-src data:; connect-src 'none'; frame-src 'none'; "
-    "object-src 'none'; base-uri 'none'; form-action 'none'"
-)
 
 
 def _dom_id(widget_id: str, suffix: str) -> str:
@@ -174,32 +156,28 @@ def render_notebook_shell(
     wire = inspection_envelope_to_wire(shell_envelope)
     payload = cast(dict[str, object], wire["payload"])
     renderer = render_inspection_payload(payload)
-    child_config = _script_safe_json(
+    child_config = script_safe_json(
         {
             "widgetId": envelope.widget_id,
             "nonce": envelope.nonce,
         }
     )
     bridge = _bridge_asset()
-    child_document = (
-        '<!doctype html><html><head><meta charset="utf-8">'
-        '<meta name="viewport" content="width=device-width,initial-scale=1">'
-        '<meta http-equiv="Content-Security-Policy" '
-        f'content="{_CHILD_CSP}">'
+    child_document = sandboxed_child_document(
         "<style>html,body{margin:0;min-width:0;background:transparent}"
-        "body{overflow-x:hidden}</style></head><body>"
+        "body{overflow-x:hidden}</style>"
         f"{renderer}"
         f"<script>{bridge}</script>"
         "<script data-hg-inspect-child-bootstrap>"
         f"window.__hypergraphInspectTransport.installChild({child_config});"
-        "</script></body></html>"
+        "</script>"
     )
 
     frame_id = _dom_id(envelope.widget_id, "frame")
     host_id = _dom_id(envelope.widget_id, "host")
     status_id = _dom_id(envelope.widget_id, "host-status")
     display_id = _dom_id(envelope.widget_id, "payload")
-    parent_config = _script_safe_json(
+    parent_config = script_safe_json(
         {
             "widgetId": envelope.widget_id,
             "nonce": envelope.nonce,
@@ -764,15 +742,8 @@ def _portable_fallback_markup(
     message: dict[str, object],
 ) -> str:
     renderer = render_inspection_payload(payload)
-    child_document = (
-        '<!doctype html><html><head><meta charset="utf-8">'
-        '<meta name="viewport" content="width=device-width,initial-scale=1">'
-        '<meta http-equiv="Content-Security-Policy" '
-        f'content="{_CHILD_CSP}">'
-        "<style>html,body{margin:0;min-width:0;background:transparent}"
-        "body{overflow-x:hidden}</style></head><body>"
-        f"{renderer}"
-        "</body></html>"
+    child_document = sandboxed_child_document(
+        f"<style>html,body{{margin:0;min-width:0;background:transparent}}body{{overflow-x:hidden}}</style>{renderer}"
     )
     frame_name = _dom_id(
         envelope.widget_id,
@@ -809,9 +780,9 @@ def render_payload_channel(envelope: InspectionEnvelope) -> str:
     wire = inspection_envelope_to_wire(envelope)
     payload = cast(dict[str, object], wire["payload"])
     message = _wire_dict(wire.get("message"))
-    encoded = _script_safe_json(wire)
+    encoded = script_safe_json(wire)
     channel_dom_id = _dom_id(envelope.widget_id, f"payload-output-s{envelope.sequence}")
-    key = _script_safe_json(f"{envelope.widget_id}::{envelope.nonce}")
+    key = script_safe_json(f"{envelope.widget_id}::{envelope.nonce}")
     fallback_state = "waiting" if envelope.delivery.state == "live" else envelope.delivery.state
     portable = envelope.artifact.terminal or envelope.delivery.state == "stale"
     fallback = (

--- a/src/hypergraph/runners/_shared/_wire.py
+++ b/src/hypergraph/runners/_shared/_wire.py
@@ -1,0 +1,37 @@
+"""Shared safety helpers for Python-to-browser wire content."""
+
+from __future__ import annotations
+
+import html
+import json
+
+_DEFAULT_CHILD_CSP = (
+    "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; "
+    "img-src data:; font-src data:; connect-src 'none'; frame-src 'none'; "
+    "object-src 'none'; base-uri 'none'; form-action 'none'"
+)
+
+
+def script_safe_json(value: object) -> str:
+    """Encode strict JSON for embedding inside an inline script element."""
+    encoded = json.dumps(
+        value,
+        ensure_ascii=True,
+        allow_nan=False,
+        separators=(",", ":"),
+    )
+    return encoded.replace("<", "\\u003c").replace(">", "\\u003e").replace("&", "\\u0026").replace("\u2028", "\\u2028").replace("\u2029", "\\u2029")
+
+
+def sandboxed_child_document(body: str, *, csp: str = _DEFAULT_CHILD_CSP) -> str:
+    """Wrap trusted body markup in the isolated document used by sandboxed frames."""
+    escaped_csp = html.escape(csp, quote=False).replace('"', "&quot;")
+    return (
+        '<!doctype html><html><head><meta charset="utf-8">'
+        '<meta name="viewport" content="width=device-width,initial-scale=1">'
+        '<meta http-equiv="Content-Security-Policy" '
+        f'content="{escaped_csp}">'
+        '</head><body style="margin:0">'
+        f"{body}"
+        "</body></html>"
+    )

--- a/tests/inspect/test_serialization.py
+++ b/tests/inspect/test_serialization.py
@@ -2100,9 +2100,25 @@ def test_js_unsafe_size_metadata_crosses_the_wire_as_exact_decimal_strings() -> 
 
 
 def test_serializer_module_imports_without_optional_data_packages() -> None:
-    module_path = Path(__file__).parents[2] / "src/hypergraph/runners/_shared/_inspect_serialization.py"
+    source_root = Path(__file__).parents[2] / "src"
+    import_script = """
+import sys
+import types
+
+source_root = sys.argv[1]
+for name, path in (
+    ("hypergraph", f"{source_root}/hypergraph"),
+    ("hypergraph.runners", f"{source_root}/hypergraph/runners"),
+    ("hypergraph.runners._shared", f"{source_root}/hypergraph/runners/_shared"),
+):
+    package = types.ModuleType(name)
+    package.__path__ = [path]
+    sys.modules[name] = package
+
+import hypergraph.runners._shared._inspect_serialization
+"""
     completed = subprocess.run(
-        [sys.executable, "-S", "-c", "import runpy, sys; runpy.run_path(sys.argv[1])", str(module_path)],
+        [sys.executable, "-S", "-c", import_script, str(source_root)],
         check=False,
         capture_output=True,
         text=True,

--- a/tests/inspect/test_wire.py
+++ b/tests/inspect/test_wire.py
@@ -1,0 +1,36 @@
+"""Shared browser-wire safety contracts."""
+
+from __future__ import annotations
+
+import pytest
+
+from hypergraph.runners._shared._wire import sandboxed_child_document, script_safe_json
+
+_DEFAULT_CSP = (
+    "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; "
+    "img-src data:; font-src data:; connect-src 'none'; frame-src 'none'; "
+    "object-src 'none'; base-uri 'none'; form-action 'none'"
+)
+
+
+def test_script_safe_json_rejects_non_finite_numbers() -> None:
+    with pytest.raises(ValueError, match="Out of range float values are not JSON compliant"):
+        script_safe_json({"measurement": float("nan")})
+
+
+def test_script_safe_json_escapes_inline_script_boundaries_and_separators() -> None:
+    assert script_safe_json({"marker": "</script>&\u2028\u2029", "label": "caf\u00e9"}) == (
+        '{"marker":"\\u003c/script\\u003e\\u0026\\u2028\\u2029","label":"caf\\u00e9"}'
+    )
+
+
+def test_sandboxed_child_document_wraps_body_with_default_csp() -> None:
+    document = sandboxed_child_document("<main>Saved inspection</main>")
+
+    assert document == (
+        '<!doctype html><html><head><meta charset="utf-8">'
+        '<meta name="viewport" content="width=device-width,initial-scale=1">'
+        '<meta http-equiv="Content-Security-Policy" '
+        f'content="{_DEFAULT_CSP}">'
+        '</head><body style="margin:0"><main>Saved inspection</main></body></html>'
+    )


### PR DESCRIPTION
Closes #272.

Four drifted escaper copies and three iframe skeletons (one missing its CSP meta) collapse into shared `runners/_shared/_wire.py`; every consumer upgrades to the strongest variant (ensure_ascii + allow_nan=False + angle/ampersand + U+2028/U+2029), CSP restored in `render_inspection_frame`. Security-adjacent duplication where the weakest copy used to define the real guarantee. Full CI-equivalent: 3,778 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)