### PR TITLE
fix(materialization): journal every union producer

### DIFF
--- a/src/hypergraph/materialization/_writes.py
+++ b/src/hypergraph/materialization/_writes.py
@@ -186,15 +186,15 @@ class WritePlanner:
             self._journal.record(entry.hash, entry.kind, entry.payload)
         return entries[0].hash
 
-    def _provenance_node(self, name: str) -> Any:
+    def _provenance_nodes(self, name: str) -> tuple[Any, ...]:
         for column in self._spec.columns:
             if column.role in ("derived", "answer") and column.name == name:
-                producer = column.produced_by
-                return producer[0] if isinstance(producer, tuple) else producer
+                return self._provenance.column_producers(column)
         for child_spec in self._spec.children:
             if child_spec.map_input == name:
-                return self._provenance.boundary_node(child_spec)
-        return None
+                boundary = self._provenance.boundary_node(child_spec)
+                return (boundary,) if boundary is not None else ()
+        return ()
 
     def _build_parent_row(
         self,
@@ -243,8 +243,7 @@ class WritePlanner:
                         )
             for name, provenance in provenances.items():
                 row[f"_provenance_{name}"] = provenance
-                node = self._provenance_node(name)
-                if node is not None:
+                for node in self._provenance_nodes(name):
                     self._record_node_recipe(node)
 
         row["_status"] = mode
@@ -287,7 +286,8 @@ class WritePlanner:
             row[f"_provenance_{name}"] = provenance
             for column in spec.columns:
                 if column.role == "derived" and column.name == name:
-                    self._record_node_recipe(column.produced_by)
+                    for node in self._provenance.column_producers(column):
+                        self._record_node_recipe(node)
                     break
         return row
 

--- a/tests/test_hypertable_recipe_journal.py
+++ b/tests/test_hypertable_recipe_journal.py
@@ -170,7 +170,12 @@ def test_explain_labels_every_producer_of_a_union_column(store):
 
     explained = table.explain("i1")["label"]
 
-    assert set(explained["producers"]) == {"positive", "negative"}
-    for entry in explained["producers"].values():
+    producers = explained["producers"]
+    assert set(producers) == {"positive", "negative"}
+    for producer_name, entry in producers.items():
         assert entry["provenance"]
-        assert "source" in entry
+        assert entry["source"] is not None
+        assert f"def {producer_name}" in entry["source"]
+
+    journal_keys = {entry["hash"] for entry in table.journal_rows()}
+    assert {entry["provenance"] for entry in producers.values()} <= journal_keys


### PR DESCRIPTION
Closes #275.

`_record_node_recipe` journaled only `producer[0]` of a union column, so `explain()`'s labeled multi-producer output (from #247) resolved `source=None` for every non-first producer. Now a RecipeEntry per producer, keyed by each node's hash. Red-first; full CI-equivalent: 3,880 passed, 0 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)