### PR TITLE
test(inspect): harden script-tag extraction regex

### DIFF
--- a/tests/inspect/test_transport_browser.py
+++ b/tests/inspect/test_transport_browser.py
@@ -309,7 +309,7 @@ def _defer_child_ready(shell: str) -> str:
 
 
 def _append_notebook_shell(page: Page, shell: str) -> None:
-    scripts = re.findall(r"<script(?: [^>]*)?>(.*?)</script>", shell, flags=re.DOTALL)
+    scripts = re.findall(r"<script\b[^>]*>(.*?)</script\b[^>]*>", shell, flags=re.DOTALL | re.IGNORECASE)
     assert len(scripts) == 2
     page.evaluate(
         """markup => {


### PR DESCRIPTION
Part of #271 (alert clearance; do not auto-close).

Fixes the one real CodeQL finding (`py/bad-tag-filter`, tests/inspect/test_transport_browser.py:312): the `</script>` close-tag pattern now tolerates whitespace and matches case-insensitively.

## Test plan
Inspect browser suite (35 passed) + full CI-equivalent green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)