### PR TITLE
fix(runners): satisfy typecheck gate for async run event iterator

### DIFF
--- a/src/hypergraph/runners/_shared/handles.py
+++ b/src/hypergraph/runners/_shared/handles.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import threading
 from collections import deque
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Coroutine
 from concurrent.futures import Future
 from typing import Any, Generic, TypeVar
 
@@ -72,7 +72,7 @@ class AsyncRunEventHandle(AsyncEventProcessor):
 
     def __init__(
         self,
-        operation: Callable[[], Awaitable[RunResult]],
+        operation: Callable[[], Coroutine[Any, Any, RunResult]],
         live_tasks: set[asyncio.Task[Any]],
         *,
         buffer_size: int,


### PR DESCRIPTION
Master's `typecheck` job (new in #299) is red on `df40d7ac` (async run event iterator, direct push): `loop.create_task()` stubs require a `Coroutine`, but `AsyncRunEventHandle.operation` was typed `Callable[[], Awaitable[RunResult]]`. The only caller passes an `async def` closure, so the tighter `Coroutine[Any, Any, RunResult]` type is simply accurate. Annotation-only — no behavior change; iterator tests green.

Unblocks CI for every queued PR (they all run the typecheck job against the merge ref).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type definitions for asynchronous run operations, providing clearer validation and more precise developer feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->