### PR TITLE
fix(runners): align MapResult.failed with aggregate status; add any_failed

### DIFF
--- a/docs/05-how-to/batch-processing.md
+++ b/docs/05-how-to/batch-processing.md
@@ -234,8 +234,8 @@ results = runner.map(
     error_handling="continue",
 )
 
-# Aggregate status
-if results.failed:
+# Any-item failure check (status-independent)
+if results.any_failed:
     print(f"{len(results.failures)} items failed out of {len(results)}")
 
 # Collect values with None for failures
@@ -305,9 +305,11 @@ print(batch.unstarted_item_indexes)  # sorted original indexes never claimed
 ```
 
 A curtailed batch has `status == RunStatus.STOPPED` even when a real attempted
-item failed. In that case `batch.stopped` and `batch.failed` are both true, and
-`batch.failures` preserves the failure. A stop received only after every input
-settles does not rewrite the ordinary completed/partial/failed aggregation.
+item failed. In that case `batch.stopped` is true and `batch.failed` is false
+(it mirrors the aggregate status), while `batch.any_failed` and
+`batch.failures` preserve the attempted-item failures. A stop received only
+after every input settles does not rewrite the ordinary
+completed/partial/failed aggregation.
 
 See [Control Work After It Starts](control-background-execution.md) for sync
 and async submission, cancellation isolation, duplicate workflow IDs, and

--- a/docs/05-how-to/control-background-execution.md
+++ b/docs/05-how-to/control-background-execution.md
@@ -284,8 +284,9 @@ After:  10 requested inputs -> 4 real outcomes + 6 unstarted indexes
 
 `results`, iteration, indexing, logs, child run IDs, child events, and child
 checkpoint rows contain only claimed work, in original input order. A stopped
-batch may also have real failures: `batch.stopped` and `batch.failed` can both
-be true, while `batch.failures` retains those attempted-item failures. Default
+batch may also have real failures: `batch.stopped` and `batch.any_failed` can
+both be true (`batch.failed` stays false — it mirrors the aggregate status),
+while `batch.failures` retains those attempted-item failures. Default
 retrieval still raises the first real failed item; non-raising retrieval gives
 the settled stopped batch.
 

--- a/docs/05-how-to/debug-workflows.md
+++ b/docs/05-how-to/debug-workflows.md
@@ -681,7 +681,7 @@ for i, r in enumerate(results):
     print(f"Item {i}: {r.log.summary()}")
 
 # Failed items
-if results.failed:
+if results.any_failed:
     for f in results.failures:
         print(f"Failed: {f.error}")
 ```

--- a/docs/06-api-reference/runners.md
+++ b/docs/06-api-reference/runners.md
@@ -274,7 +274,7 @@ results = runner.map(
     inspect=True,
     error_handling="continue",
 )
-if results.failed:
+if results.any_failed:
     print(f"{len(results.failures)} items failed")
 
 results.inspect()
@@ -1489,9 +1489,10 @@ results.get("doubled", 0)   # [2, 4, 6] (with default for missing)
 
 # Aggregate status
 results.status       # RunStatus.COMPLETED, PARTIAL, FAILED, PAUSED, or STOPPED
-results.completed    # True if all completed
-results.failed       # True if any failed
-results.partial      # True if some items completed and some failed
+results.completed    # True if status is COMPLETED (all completed, or empty)
+results.failed       # True if status is FAILED (some failed, none completed)
+results.any_failed   # True if at least one item failed, whatever the status
+results.partial      # True if status is PARTIAL (some completed, some failed)
 results.stopped      # True if status is STOPPED, including curtailed scope
 results.failures     # List of failed RunResult items
 results.requested_count          # Real outcomes + inputs never started

--- a/docs/adr/0004-background-handles-control-live-work.md
+++ b/docs/adr/0004-background-handles-control-live-work.md
@@ -2,6 +2,8 @@
 
 **Status:** Accepted on 2026-07-13 and implemented by the change set tracked in [issue #155](https://github.com/gilad-rubin/hypergraph/issues/155). This ADR supersedes ADR 0003 only where ADR 0003 proposed `wait()`; its background-map collection and retrieval policy remains accepted.
 
+**Amended 2026-07-18** by [issue #296](https://github.com/gilad-rubin/hypergraph/issues/296) (decision [#251](https://github.com/gilad-rubin/hypergraph/issues/251)): `MapResult.failed` now mirrors the batch aggregate (`status == FAILED`) instead of "any item failed", so a stopped batch is no longer both `stopped` and `failed`. Item-level failures on a stopped or partial batch are exposed by `any_failed` and `failures`. Where the text below says `failed` exposes failures on a stopped batch (Decision bullet on curtailed stop; first Consequences bullet), read `any_failed`/`failures`.
+
 A background handle exists to let one Python process control a live Hypergraph execution without turning the handle into a second result model or a durable job reference. We keep the control surface minimal and preserve execution truth on `RunResult` and `MapResult`.
 
 ## Decision

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -233,6 +233,17 @@
 
 ### Changed
 
+- **`MapResult.failed` now mirrors the aggregate status (alpha breaking
+  change)** — `batch.failed` is True only when `status == RunStatus.FAILED`
+  (at least one item failed and none completed), matching `RunResult.failed`.
+  Use the new `batch.any_failed` (`bool(batch.failures)`) for "did anything
+  fail" regardless of status. Consequences: a 99/100-success batch is
+  `partial`, not `failed`, and `batch.stopped` and `batch.failed` can no
+  longer both be True — a curtailed stopped batch with real attempted-item
+  failures reports `stopped=True, failed=False, any_failed=True`.
+  ([#296](https://github.com/gilad-rubin/hypergraph/issues/296), decision
+  [#251](https://github.com/gilad-rubin/hypergraph/issues/251))
+
 - **Active workflow identity covers every execution shape** — a runner permits
   only one active execution per `workflow_id`; duplicate blocking/background
   starts fail before a second handle is returned. Different IDs are

--- a/examples/generate_playground.py
+++ b/examples/generate_playground.py
@@ -571,8 +571,8 @@ results = runner_sync.map(
 >>> results.summary()
 '{results_map.summary()}'
 
->>> results.failed
-{results_map.failed}
+>>> results.any_failed
+{results_map.any_failed}
 
 >>> [f.error for f in results.failures]
 {failure_errors}

--- a/notebooks/llm_batch.ipynb
+++ b/notebooks/llm_batch.ipynb
@@ -199,7 +199,7 @@
    "outputs": [],
    "source": [
     "# Which items failed?\n",
-    "if results.failed:\n",
+    "if results.any_failed:\n",
     "    for i, r in enumerate(results):\n",
     "        if r.failed:\n",
     "            print(f\"  Item {i}: {r.error}\")\n",

--- a/src/hypergraph/runners/_shared/results.py
+++ b/src/hypergraph/runners/_shared/results.py
@@ -128,22 +128,22 @@ class RunResult:
 
     @property
     def stopped(self) -> bool:
-        """Whether execution was stopped via runner.stop()."""
+        """True when ``status == RunStatus.STOPPED`` (stopped via runner.stop())."""
         return self.status == RunStatus.STOPPED
 
     @property
     def paused(self) -> bool:
-        """Whether execution is paused at an InterruptNode."""
+        """True when ``status == RunStatus.PAUSED`` (paused at an InterruptNode)."""
         return self.status == RunStatus.PAUSED
 
     @property
     def completed(self) -> bool:
-        """Whether execution completed successfully."""
+        """True when ``status == RunStatus.COMPLETED``."""
         return self.status == RunStatus.COMPLETED
 
     @property
     def failed(self) -> bool:
-        """Whether execution failed."""
+        """True when ``status == RunStatus.FAILED``."""
         return self.status == RunStatus.FAILED
 
     @property
@@ -451,27 +451,41 @@ class MapResult:
 
     @property
     def completed(self) -> bool:
-        """Whether the batch aggregate completed (including an empty map)."""
+        """True when ``status == RunStatus.COMPLETED`` (including an empty map)."""
         return self.status == RunStatus.COMPLETED
 
     @property
     def paused(self) -> bool:
-        """Whether the batch aggregate paused."""
+        """True when ``status == RunStatus.PAUSED``."""
         return self.status == RunStatus.PAUSED
 
     @property
     def stopped(self) -> bool:
-        """Whether the batch aggregate stopped."""
+        """True when ``status == RunStatus.STOPPED``."""
         return self.status == RunStatus.STOPPED
 
     @property
     def failed(self) -> bool:
-        """True if any item failed (FAILED or PARTIAL)."""
-        return any(r.status == RunStatus.FAILED for r in self.results)
+        """True when ``status == RunStatus.FAILED``.
+
+        Mirrors the aggregate exactly (parity with ``RunResult.failed``): at
+        least one item failed and none completed. Use ``any_failed`` for
+        "did anything fail" regardless of the aggregate status.
+        """
+        return self.status == RunStatus.FAILED
+
+    @property
+    def any_failed(self) -> bool:
+        """True when ``bool(self.failures)`` — at least one item failed.
+
+        Independent of the aggregate status: also True for PARTIAL batches
+        and for STOPPED batches that carry real attempted-item failures.
+        """
+        return bool(self.failures)
 
     @property
     def partial(self) -> bool:
-        """True if some items completed and some failed."""
+        """True when ``status == RunStatus.PARTIAL`` — some items completed and some failed."""
         return self.status == RunStatus.PARTIAL
 
     @property

--- a/tests/test_background_handles.py
+++ b/tests/test_background_handles.py
@@ -337,7 +337,8 @@ def test_sync_stopped_map_contains_only_claimed_results() -> None:
     assert early_batch.unstarted_item_indexes == (2, 3, 4)
     assert early_batch.status is RunStatus.STOPPED
     assert early_batch.stopped is True
-    assert early_batch.failed is True
+    assert early_batch.failed is False
+    assert early_batch.any_failed is True
     assert early_batch.partial is False
     assert early_batch.failures == [early_batch[0]]
     assert evidence.item_index == 0
@@ -416,7 +417,8 @@ async def test_bounded_async_stopped_map_is_sparse_and_input_ordered() -> None:
     assert batch.unstarted_item_indexes == (2, 3, 4)
     assert batch.status is RunStatus.STOPPED
     assert batch.stopped is True
-    assert batch.failed is True
+    assert batch.failed is False
+    assert batch.any_failed is True
     assert batch.partial is False
     assert batch.failures == [batch[1]]
     assert evidence.item_index == 1

--- a/tests/test_map_result.py
+++ b/tests/test_map_result.py
@@ -323,7 +323,8 @@ class TestMapResultAggregateStatus:
         mr = _make_map_result(items)
         assert mr.status == RunStatus.PARTIAL
         assert mr.partial is True
-        assert mr.failed is True  # .failed checks any(), not .status
+        assert mr.failed is False  # .failed mirrors status == FAILED
+        assert mr.any_failed is True  # any-item check lives on .any_failed
         assert mr.completed is False
 
     def test_all_failed_is_failed(self):
@@ -370,6 +371,60 @@ class TestMapResultAggregateStatus:
         assert mr.failures == []
 
 
+class TestMapResultFailedMirrorsAggregate:
+    """`failed` mirrors `status == FAILED`; `any_failed` is the any-item check.
+
+    Locked semantics from decision #251 (issue #296): every boolean helper
+    mirrors exactly one aggregate status value, and `any_failed` is the
+    detailed-path convenience for "did anything fail".
+    """
+
+    def test_completed_plus_failed_is_partial_not_failed(self):
+        items = [
+            _make_result(),
+            _make_result(status=RunStatus.FAILED, error=ValueError("x")),
+        ]
+        mr = _make_map_result(items)
+        assert mr.partial is True
+        assert mr.failed is False
+        assert mr.any_failed is True
+
+    def test_all_failed_is_failed(self):
+        items = [
+            _make_result(status=RunStatus.FAILED, error=ValueError("a")),
+            _make_result(status=RunStatus.FAILED, error=ValueError("b")),
+        ]
+        mr = _make_map_result(items)
+        assert mr.failed is True
+        assert mr.any_failed is True
+        assert mr.partial is False
+
+    def test_stopped_with_some_failures_is_stopped_not_failed(self):
+        items = [
+            _make_result(status=RunStatus.FAILED, error=ValueError("x")),
+            _make_result(status=RunStatus.STOPPED),
+        ]
+        mr = _make_map_result(items, unstarted_item_indexes=(2, 3))
+        assert mr.stopped is True
+        assert mr.failed is False
+        assert mr.any_failed is True
+
+    def test_all_completed_only_completed_is_true(self):
+        mr = _make_map_result([_make_result(), _make_result()])
+        assert mr.completed is True
+        assert mr.failed is False
+        assert mr.any_failed is False
+        assert mr.partial is False
+        assert mr.stopped is False
+        assert mr.paused is False
+
+    def test_empty_batch_is_completed_with_no_failures(self):
+        mr = _make_map_result([])
+        assert mr.completed is True
+        assert mr.any_failed is False
+        assert mr.failed is False
+
+
 class TestMapResultRequestedScope:
     def test_full_batch_defaults_to_no_unstarted_items(self):
         mapped = _make_map_result([_make_result(), _make_result()])
@@ -392,7 +447,8 @@ class TestMapResultRequestedScope:
         assert mapped.unstarted_item_indexes == (2, 3, 4)
         assert mapped.status == RunStatus.STOPPED
         assert mapped.stopped is True
-        assert mapped.failed is True
+        assert mapped.failed is False  # aggregate is STOPPED, not FAILED
+        assert mapped.any_failed is True
         assert mapped.partial is False
         assert mapped.failures == [failure]
 
@@ -854,7 +910,8 @@ class TestSyncRunnerMapResult:
         )
 
         assert len(results) == 3
-        assert results.failed is True
+        assert results.any_failed is True
+        assert results.failed is False  # 2 of 3 completed, so PARTIAL
         assert len(results.failures) == 1
         assert results["result"] == [4, None, 8]
 

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -558,7 +558,8 @@ class TestPartialStatus:
         )
         assert mr.status == RunStatus.PARTIAL
         assert mr.partial is True
-        assert mr.failed is True  # any() check
+        assert mr.failed is False  # mirrors status == FAILED
+        assert mr.any_failed is True  # any-item check
 
     def test_all_failed(self):
         mr = MapResult(


### PR DESCRIPTION
Closes #296. Implements decision [#251 item 1](https://github.com/gilad-rubin/hypergraph/issues/251#issuecomment-5007269226).

## Before / after
```python
r = runner.map(graph, values, map_over="x", error_handling="continue")  # 99 ok, 1 failed
r.failed      # before: True ("any item failed")   after: False — batch aggregate is PARTIAL
r.partial     # True either way
r.any_failed  # after: True — the explicit "did anything fail" helper (new)
# stopped batch with a failed item: before stopped=True AND failed=True; after stopped=True, any_failed=True
```
Every boolean helper docstring now states the exact aggregate it mirrors (runners/CLAUDE.md rule). Alpha breaking change — changelog entry included.

Full consumer sweep (~60 `.failed` sites classified; 15 switched to `any_failed`, docs/API-reference/notebook updated in-commit; ADR 0004 amended under its Status line rather than silently edited).

## Test plan
Red-first 5-case mixed-outcome matrix (fails on parent commit, reproduced independently by the reviewer via PYTHONPATH shadow). Adversarial review: FIX(1) on an ADR sweep miss → amended; independent re-sweep incl. all 6 notebooks found nothing else; 11-case semantics probe exact; DaftRunner/background-handle paths verified twin-free. CI-equivalent 3824 passed; mypy clean; pre-commit green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)