### PR TITLE
fix(runners): synthesize default progress after processor merge

### DIFF
--- a/docs/06-api-reference/runners.md
+++ b/docs/06-api-reference/runners.md
@@ -63,7 +63,7 @@ class SyncRunner:
 **Args:**
 - `cache` — Optional [cache backend](../03-patterns/08-caching.md) for node result caching. Nodes opt in with `@node(..., cache=True)`. Supports `InMemoryCache`, `DiskCache`, or any `CacheBackend` implementation.
 - `checkpointer` — Optional [checkpointer](../05-how-to/batch-processing.md#checkpointing-with-map) for persistent run history. For `run()`, enables strict lineage semantics, generic IDs for fresh/retry runs, and source-derived IDs for `fork_from`. For `map()`, persistence is enabled when `workflow_id` is provided. Requires `SqliteCheckpointer` or any `SyncCheckpointerProtocol` implementation.
-- `show_progress` — If `True`, automatically attaches a Rich progress processor to `run()` and `map()` calls. Per-call `show_progress` overrides this default.
+- `show_progress` — If `True`, automatically attaches a Rich progress processor to `run()` and `map()` calls — unless a `RichProgressProcessor` is already carried by the graph or passed via `event_processors`. Per-call `show_progress` overrides this default.
 
 ### run()
 
@@ -766,7 +766,7 @@ class AsyncRunner:
 **Args:**
 - `cache` — Optional [cache backend](../03-patterns/08-caching.md) for node result caching. Nodes opt in with `@node(..., cache=True)`.
 - `checkpointer` — Optional checkpointer for persistent run history. For `run()`, enables strict lineage semantics, generic IDs for fresh/retry runs, and source-derived IDs for `fork_from`. For `map()`, persistence is enabled when `workflow_id` is provided. Requires `SqliteCheckpointer` or any `Checkpointer` implementation.
-- `show_progress` — If `True`, automatically attaches a Rich progress processor to `run()` and `map()` calls. Per-call `show_progress` overrides this default.
+- `show_progress` — If `True`, automatically attaches a Rich progress processor to `run()` and `map()` calls — unless a `RichProgressProcessor` is already carried by the graph or passed via `event_processors`. Per-call `show_progress` overrides this default.
 
 ### run()
 

--- a/src/hypergraph/runners/_shared/scheduling.py
+++ b/src/hypergraph/runners/_shared/scheduling.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -324,15 +325,25 @@ def plan_interrupt_batch(ready_nodes: list[HyperNode]) -> list[HyperNode]:
 
 def ensure_progress_processor(
     event_processors: list[Any] | None,
+    *,
+    carried: Sequence[Any] = (),
 ) -> list[Any]:
-    """Ensure at least one RichProgressProcessor is in the list.
+    """Ensure at least one RichProgressProcessor across the merged sequence.
 
-    Returns a new list. If a RichProgressProcessor is already present,
-    the list is returned as-is (copied). Otherwise a default one is prepended.
+    ``carried`` is the graph-carried processor tuple that the caller merges in
+    front of the call-site list afterwards. The presence check inspects the
+    merged view ``[*carried, *event_processors]`` so an explicit Rich processor
+    anywhere in it suppresses the auto-synthesized default (issue #207).
+
+    Returns a new call-site list: unchanged (copied) when a Rich processor is
+    already present, otherwise with one default prepended. ``carried``
+    processors are only inspected, never included in the returned list — the
+    caller owns that merge (and map templates must forward only the call-site
+    list into per-item runs).
     """
     from hypergraph.events.rich_progress import RichProgressProcessor
 
     processors = list(event_processors) if event_processors else []
-    if not any(isinstance(p, RichProgressProcessor) for p in processors):
+    if not any(isinstance(p, RichProgressProcessor) for p in (*carried, *processors)):
         processors.insert(0, RichProgressProcessor())
     return processors

--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -460,12 +460,14 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
             if effective_show_progress:
                 from hypergraph.runners._shared.scheduling import ensure_progress_processor
 
-                event_processors = ensure_progress_processor(event_processors)
+                # The auto default inspects the merged carried + call-site view:
+                # an explicit Rich processor anywhere suppresses it (issue #207).
+                event_processors = ensure_progress_processor(event_processors, carried=graph.default_event_processors)
             if graph.default_event_processors:
                 # Graph-carried processors merge in front of call-site ones — never
-                # replace, never dedup. Reassigning event_processors also forwards
-                # them into nested GraphNode sub-runs, exactly like call-site
-                # processors.
+                # replace, and user-declared processors are never deduped.
+                # Reassigning event_processors also forwards them into nested
+                # GraphNode sub-runs, exactly like call-site processors.
                 event_processors = [*graph.default_event_processors, *(event_processors or [])]
         except BaseException as error:
             if owns_inspection and inspection_session is not None:
@@ -994,7 +996,10 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
             if effective_show_progress:
                 from hypergraph.runners._shared.scheduling import ensure_progress_processor
 
-                event_processors = ensure_progress_processor(event_processors)
+                # Inspect the merged carried + call-site view before synthesizing
+                # a default; only the call-site list is returned — the map
+                # dispatcher below merges carried processors itself (issue #207).
+                event_processors = ensure_progress_processor(event_processors, carried=graph.default_event_processors)
 
             # One-time graph-structural validation
             validate_runner_compatibility(graph, self.capabilities)

--- a/src/hypergraph/runners/_shared/template_sync.py
+++ b/src/hypergraph/runners/_shared/template_sync.py
@@ -444,12 +444,14 @@ class SyncRunnerTemplate(BaseRunner, ABC):
             if effective_show_progress:
                 from hypergraph.runners._shared.scheduling import ensure_progress_processor
 
-                event_processors = ensure_progress_processor(event_processors)
+                # The auto default inspects the merged carried + call-site view:
+                # an explicit Rich processor anywhere suppresses it (issue #207).
+                event_processors = ensure_progress_processor(event_processors, carried=graph.default_event_processors)
             if graph.default_event_processors:
                 # Graph-carried processors merge in front of call-site ones — never
-                # replace, never dedup. Reassigning event_processors also forwards
-                # them into nested GraphNode sub-runs, exactly like call-site
-                # processors.
+                # replace, and user-declared processors are never deduped.
+                # Reassigning event_processors also forwards them into nested
+                # GraphNode sub-runs, exactly like call-site processors.
                 event_processors = [*graph.default_event_processors, *(event_processors or [])]
         except BaseException as error:
             if owns_inspection and inspection_session is not None:
@@ -933,7 +935,10 @@ class SyncRunnerTemplate(BaseRunner, ABC):
             if effective_show_progress:
                 from hypergraph.runners._shared.scheduling import ensure_progress_processor
 
-                event_processors = ensure_progress_processor(event_processors)
+                # Inspect the merged carried + call-site view before synthesizing
+                # a default; only the call-site list is returned — the map
+                # dispatcher below merges carried processors itself (issue #207).
+                event_processors = ensure_progress_processor(event_processors, carried=graph.default_event_processors)
 
             # One-time graph-structural validation
             validate_runner_compatibility(graph, self.capabilities)

--- a/src/hypergraph/runners/async_/runner.py
+++ b/src/hypergraph/runners/async_/runner.py
@@ -106,7 +106,9 @@ class AsyncRunner(AsyncRunnerTemplate):
                 Enables save/resume, crash recovery, and cross-process queries.
                 Pass a workflow_id to run() to activate persistence.
             show_progress: If True, automatically add a RichProgressProcessor
-                to every run() and map() call. Can be overridden per-call.
+                to every run() and map() call — unless one is already carried
+                by the graph or passed via event_processors. Can be
+                overridden per-call.
         """
         self._cache = cache
         self._checkpointer_instance = checkpointer

--- a/src/hypergraph/runners/sync/runner.py
+++ b/src/hypergraph/runners/sync/runner.py
@@ -85,7 +85,9 @@ class SyncRunner(SyncRunnerTemplate):
                 Must implement SyncCheckpointerProtocol (e.g. SqliteCheckpointer).
                 Pass a workflow_id to run() to activate persistence.
             show_progress: If True, automatically add a RichProgressProcessor
-                to every run() and map() call. Can be overridden per-call.
+                to every run() and map() call — unless one is already carried
+                by the graph or passed via event_processors. Can be
+                overridden per-call.
         """
         self._cache = cache
         self._checkpointer_instance = checkpointer

--- a/tests/events/test_progress_dedupe.py
+++ b/tests/events/test_progress_dedupe.py
@@ -1,0 +1,254 @@
+"""Issue #207: ``show_progress=True`` must not double-render progress.
+
+The auto-synthesized default ``RichProgressProcessor`` must inspect the MERGED
+processor sequence — ``[*graph.default_event_processors, *event_processors]`` —
+and only be added when no Rich processor exists anywhere in it. Explicit
+user-supplied duplicates are always preserved; only the auto default is
+suppressed.
+
+Every witness compares against a call-site control transcript (same graph, one
+explicit non-TTY Rich processor, no auto progress) — counting transcript lines,
+never wall-clock.
+"""
+
+from __future__ import annotations
+
+import re
+
+from hypergraph import AsyncRunner, Graph, SyncRunner, node
+from hypergraph.events import EventProcessor
+from hypergraph.events.rich_progress import RichProgressProcessor
+from hypergraph.events.types import RunStartEvent
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_TS = re.compile(r"\[\d{2}:\d{2}:\d{2}\]")
+
+
+def _transcript(capsys) -> list[str]:
+    """Read captured stdout as timestamp-normalized non-empty lines."""
+    out = capsys.readouterr().out
+    return [_TS.sub("[TS]", line) for line in out.splitlines() if line.strip()]
+
+
+def _rich() -> RichProgressProcessor:
+    return RichProgressProcessor(force_mode="non-tty")
+
+
+class Recorder(EventProcessor):
+    """Non-Rich processor; optionally journals (label, event) into a shared list."""
+
+    def __init__(self, label: str = "", journal: list | None = None) -> None:
+        self.label = label
+        self.events: list = []
+        self._journal = journal
+
+    def on_event(self, event) -> None:
+        self.events.append(event)
+        if self._journal is not None:
+            self._journal.append((self.label, event))
+
+
+@node(output_name="doubled")
+def double(x: int) -> int:
+    return x * 2
+
+
+@node(output_name="tripled")
+def triple(doubled: int) -> int:
+    return doubled * 3
+
+
+def _flat_graph() -> Graph:
+    return Graph([double], name="wf")
+
+
+def _nested_graph() -> Graph:
+    inner = Graph([double], name="inner")
+    return Graph([inner.as_node(), triple], name="outer")
+
+
+# ---------------------------------------------------------------------------
+# Sync
+# ---------------------------------------------------------------------------
+
+
+class TestSyncProgressDedupe:
+    def test_run_carried_rich_with_show_progress_renders_once(self, capsys):
+        """The #207 witness: carried Rich + show_progress=True → one transcript."""
+        control_result = SyncRunner().run(_flat_graph(), {"x": 3}, event_processors=[_rich()])
+        control = _transcript(capsys)
+        assert control_result["doubled"] == 6
+        assert len(control) == 3  # node start, node end, run end
+
+        graph = _flat_graph().with_processors(_rich())
+        result = SyncRunner(show_progress=True).run(graph, {"x": 3})
+
+        assert result["doubled"] == 6
+        assert _transcript(capsys) == control
+
+    def test_run_callsite_rich_with_show_progress_renders_once(self, capsys):
+        control_result = SyncRunner().run(_flat_graph(), {"x": 3}, event_processors=[_rich()])
+        control = _transcript(capsys)
+        assert control_result.completed
+
+        result = SyncRunner(show_progress=True).run(_flat_graph(), {"x": 3}, event_processors=[_rich()])
+
+        assert result["doubled"] == 6
+        assert _transcript(capsys) == control
+
+    def test_run_explicit_duplicate_rich_processors_are_kept(self, capsys):
+        """Two DISTINCT user-supplied Rich processors are never deduplicated."""
+        SyncRunner().run(_flat_graph(), {"x": 3}, event_processors=[_rich()])
+        control = _transcript(capsys)
+
+        graph = _flat_graph().with_processors(_rich())
+        result = SyncRunner(show_progress=True).run(graph, {"x": 3}, event_processors=[_rich()])
+
+        assert result["doubled"] == 6
+        lines = _transcript(capsys)
+        # Both explicit processors render (2x control) — and no third auto default.
+        assert len(lines) == 2 * len(control)
+        for line in control:
+            assert lines.count(line) == 2
+
+    def test_run_carried_non_rich_still_synthesizes_default(self, capsys):
+        """A carried non-Rich processor must not suppress the auto default."""
+        SyncRunner().run(_flat_graph(), {"x": 3}, event_processors=[_rich()])
+        control = _transcript(capsys)
+
+        recorder = Recorder("carried")
+        graph = _flat_graph().with_processors(recorder)
+        result = SyncRunner(show_progress=True).run(graph, {"x": 3})
+
+        assert result["doubled"] == 6
+        assert _transcript(capsys) == control
+        assert any(isinstance(e, RunStartEvent) for e in recorder.events)
+
+    def test_run_show_progress_preserves_carried_before_callsite_order(self, capsys):
+        journal: list = []
+        carried = Recorder("carried", journal)
+        callsite = Recorder("callsite", journal)
+        graph = _flat_graph().with_processors(carried)
+
+        result = SyncRunner(show_progress=True).run(graph, {"x": 3}, event_processors=[callsite])
+
+        assert result["doubled"] == 6
+        run_start_labels = [label for label, e in journal if isinstance(e, RunStartEvent)]
+        assert run_start_labels == ["carried", "callsite"]
+        capsys.readouterr()  # drain synthesized-progress output
+
+    def test_map_carried_rich_with_show_progress_renders_once(self, capsys):
+        control_results = SyncRunner().map(_flat_graph(), {"x": [1, 2, 3]}, map_over="x", event_processors=[_rich()])
+        control = _transcript(capsys)
+        assert control_results["doubled"] == [2, 4, 6]
+        assert len(control) > 0
+
+        graph = _flat_graph().with_processors(_rich())
+        results = SyncRunner(show_progress=True).map(graph, {"x": [1, 2, 3]}, map_over="x")
+
+        assert results["doubled"] == [2, 4, 6]
+        assert _transcript(capsys) == control
+
+    def test_nested_graphnode_carried_rich_renders_once(self, capsys):
+        control_result = SyncRunner().run(_nested_graph(), {"x": 2}, event_processors=[_rich()])
+        control = _transcript(capsys)
+        assert control_result["tripled"] == 12
+
+        graph = _nested_graph().with_processors(_rich())
+        result = SyncRunner(show_progress=True).run(graph, {"x": 2})
+
+        assert result["tripled"] == 12
+        assert _transcript(capsys) == control
+
+
+# ---------------------------------------------------------------------------
+# Async
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncProgressDedupe:
+    async def test_run_carried_rich_with_show_progress_renders_once(self, capsys):
+        control_result = await AsyncRunner().run(_flat_graph(), {"x": 3}, event_processors=[_rich()])
+        control = _transcript(capsys)
+        assert control_result["doubled"] == 6
+        assert len(control) == 3
+
+        graph = _flat_graph().with_processors(_rich())
+        result = await AsyncRunner(show_progress=True).run(graph, {"x": 3})
+
+        assert result["doubled"] == 6
+        assert _transcript(capsys) == control
+
+    async def test_run_callsite_rich_with_show_progress_renders_once(self, capsys):
+        control_result = await AsyncRunner().run(_flat_graph(), {"x": 3}, event_processors=[_rich()])
+        control = _transcript(capsys)
+        assert control_result.completed
+
+        result = await AsyncRunner(show_progress=True).run(_flat_graph(), {"x": 3}, event_processors=[_rich()])
+
+        assert result["doubled"] == 6
+        assert _transcript(capsys) == control
+
+    async def test_run_explicit_duplicate_rich_processors_are_kept(self, capsys):
+        await AsyncRunner().run(_flat_graph(), {"x": 3}, event_processors=[_rich()])
+        control = _transcript(capsys)
+
+        graph = _flat_graph().with_processors(_rich())
+        result = await AsyncRunner(show_progress=True).run(graph, {"x": 3}, event_processors=[_rich()])
+
+        assert result["doubled"] == 6
+        lines = _transcript(capsys)
+        assert len(lines) == 2 * len(control)
+        for line in control:
+            assert lines.count(line) == 2
+
+    async def test_run_carried_non_rich_still_synthesizes_default(self, capsys):
+        await AsyncRunner().run(_flat_graph(), {"x": 3}, event_processors=[_rich()])
+        control = _transcript(capsys)
+
+        recorder = Recorder("carried")
+        graph = _flat_graph().with_processors(recorder)
+        result = await AsyncRunner(show_progress=True).run(graph, {"x": 3})
+
+        assert result["doubled"] == 6
+        assert _transcript(capsys) == control
+        assert any(isinstance(e, RunStartEvent) for e in recorder.events)
+
+    async def test_run_show_progress_preserves_carried_before_callsite_order(self, capsys):
+        journal: list = []
+        carried = Recorder("carried", journal)
+        callsite = Recorder("callsite", journal)
+        graph = _flat_graph().with_processors(carried)
+
+        result = await AsyncRunner(show_progress=True).run(graph, {"x": 3}, event_processors=[callsite])
+
+        assert result["doubled"] == 6
+        run_start_labels = [label for label, e in journal if isinstance(e, RunStartEvent)]
+        assert run_start_labels == ["carried", "callsite"]
+        capsys.readouterr()  # drain synthesized-progress output
+
+    async def test_map_carried_rich_with_show_progress_renders_once(self, capsys):
+        control_results = await AsyncRunner().map(_flat_graph(), {"x": [1, 2, 3]}, map_over="x", event_processors=[_rich()])
+        control = _transcript(capsys)
+        assert control_results["doubled"] == [2, 4, 6]
+        assert len(control) > 0
+
+        graph = _flat_graph().with_processors(_rich())
+        results = await AsyncRunner(show_progress=True).map(graph, {"x": [1, 2, 3]}, map_over="x")
+
+        assert results["doubled"] == [2, 4, 6]
+        assert _transcript(capsys) == control
+
+    async def test_nested_graphnode_carried_rich_renders_once(self, capsys):
+        control_result = await AsyncRunner().run(_nested_graph(), {"x": 2}, event_processors=[_rich()])
+        control = _transcript(capsys)
+        assert control_result["tripled"] == 12
+
+        graph = _nested_graph().with_processors(_rich())
+        result = await AsyncRunner(show_progress=True).run(graph, {"x": 2})
+
+        assert result["tripled"] == 12
+        assert _transcript(capsys) == control

--- a/tests/inspect/test_transport_integration.py
+++ b/tests/inspect/test_transport_integration.py
@@ -2106,7 +2106,7 @@ async def test_direct_lineage_and_progress_setup_failures_settle_exact_shells(
 
     error = RuntimeError("PROGRESS-SETUP-BOOM")
 
-    def fail_progress(_processors: object) -> None:
+    def fail_progress(_processors: object, *, carried: object = ()) -> None:
         raise error
 
     monkeypatch.setattr(


### PR DESCRIPTION
Closes #207.

## Before / after
```python
graph = base.with_event_processors(RichProgressProcessor(force_mode="non-tty"))
SyncRunner(show_progress=True).run(graph, ...)
# before: 6 transcript lines — the auto default was synthesized BEFORE the carried list merged
# after:  3 lines — synthesis inspects the merged carried + call-site view first
```
`ensure_progress_processor` gains keyword-only `carried=` (internal, exported nowhere); all four synthesis sites (sync/async × run/map) pass the graph-carried list; explicit user-supplied duplicates are never deduplicated; declared order (carried before call-site) and per-item single-delivery preserved.

## Test plan
Red-first: 6 witness tests (run/map/nested × sync/async) fail on master, pass after; 14 new tests total (explicit-duplicate guard, carried-non-Rich guard, dispatch order). Adversarial review SHIP: witness independently reproduced via PYTHONPATH shadow; iter()/start_run/start_map/map_iter/nested paths probed clean; sync/async hunks byte-identical; exactly-once delivery probed per event. CI-equivalent 3814 passed (3833 post-rebase); mypy clean; pre-commit green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)