### PR TITLE
refactor(graph): move structural signatures into nodes; unify gate init

### DIFF
--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -1329,64 +1329,11 @@ class Graph:
         """Compute hash for resume compatibility checks.
 
         Includes node identity/topology and declared interfaces, but excludes
-        function source code so bug-fix edits do not force forking.
+        function source code so bug-fix edits do not force forking. Each node
+        reports its own ``structural_signature``; this method only composes
+        those with the edge topology.
         """
-        from hypergraph.nodes.gate import END, GateNode
-        from hypergraph.nodes.graph_node import GraphNode
-
-        node_signatures: list[str] = []
-        for node in sorted(self._nodes.values(), key=lambda n: n.name):
-            parts = [
-                node.__class__.__name__,
-                node.name,
-                ",".join(node.inputs),
-                ",".join(node.outputs),
-                ",".join(getattr(node, "wait_for", ())),
-            ]
-            if isinstance(node, GateNode):
-                targets = [t if t is not END else "END" for t in node.targets]
-                parts.extend(
-                    [
-                        "targets=" + ",".join(targets),
-                        f"default_open={getattr(node, 'default_open', True)}",
-                    ]
-                )
-                if hasattr(node, "multi_target"):
-                    parts.append(f"multi_target={node.multi_target}")
-                if hasattr(node, "fallback"):
-                    fb = node.fallback
-                    fb_str = "None" if fb is None else "END" if fb is END else fb
-                    parts.append(f"fallback={fb_str}")
-                if hasattr(node, "when_true") and hasattr(node, "when_false"):
-                    wt = node.when_true
-                    wf = node.when_false
-                    parts.append(f"when_true={wt if wt is not END else 'END'}")
-                    parts.append(f"when_false={wf if wf is not END else 'END'}")
-            if isinstance(node, GraphNode):
-                parts.append(f"nested_struct={node.graph.structural_hash}")
-                parts.append(f"namespaced={node.namespaced}")
-                parts.append("local_inputs=" + ",".join(node.local_inputs))
-                parts.append("local_outputs=" + ",".join(node.local_outputs))
-                parts.append("data_outputs=" + ",".join(node.data_outputs))
-                exposed = getattr(node, "_exposed", {})
-                if exposed:
-                    exposed_str = ",".join(f"{local}->{address}" for local, address in sorted(exposed.items()))
-                    parts.append(f"exposed={exposed_str}")
-                if getattr(node, "_complete_on_stop", False):
-                    parts.append("complete_on_stop=True")
-                map_config = node.map_config
-                if map_config is not None:
-                    map_params, map_mode, error_handling = map_config
-                    parts.append("map_over=" + ",".join(map_params))
-                    parts.append(f"map_mode={map_mode}")
-                    parts.append(f"map_error_handling={error_handling}")
-                    clone_cfg = getattr(node, "_clone", False)
-                    if isinstance(clone_cfg, list):
-                        parts.append("map_clone=" + ",".join(clone_cfg))
-                    else:
-                        parts.append(f"map_clone={clone_cfg}")
-            node_signatures.append("|".join(parts))
-
+        node_signatures = [node.structural_signature for node in sorted(self._nodes.values(), key=lambda n: n.name)]
         edges = sorted((u, v, ",".join(data.get("value_names", []))) for u, v, data in self._nx_graph.edges(data=True))
         edge_str = str(edges)
         return hashlib.sha256(("|".join(node_signatures) + "|" + edge_str).encode()).hexdigest()

--- a/src/hypergraph/nodes/base.py
+++ b/src/hypergraph/nodes/base.py
@@ -115,6 +115,31 @@ class HyperNode(ABC):
         return hashlib.sha256(content.encode()).hexdigest()
 
     @property
+    def structural_signature(self) -> str:
+        """Code-insensitive identity string used by ``Graph.structural_hash``.
+
+        Joined from :meth:`_structural_signature_parts`. These bytes feed
+        checkpoint resume-compatibility checks, so the layout is frozen:
+        subclasses append parts via ``super()``, never reorder or reformat
+        existing entries.
+        """
+        return "|".join(self._structural_signature_parts())
+
+    def _structural_signature_parts(self) -> list[str]:
+        """Ordered structural-signature fields every node contributes.
+
+        Subclasses with extra declared interface (gate targets, nested-graph
+        boundaries) extend the list returned by ``super()``.
+        """
+        return [
+            type(self).__name__,
+            self.name,
+            ",".join(self.inputs),
+            ",".join(self.outputs),
+            ",".join(self.wait_for),
+        ]
+
+    @property
     def is_async(self) -> bool:
         """Does this node require async execution?
 

--- a/src/hypergraph/nodes/gate.py
+++ b/src/hypergraph/nodes/gate.py
@@ -111,6 +111,53 @@ class GateNode(CallableMixin, HyperNode):
     _emit: tuple[str, ...]
     default_open: bool
 
+    def __init__(
+        self,
+        func: Callable,
+        *,
+        cache: bool,
+        hide: bool,
+        default_open: bool,
+        name: str | None,
+        rename_inputs: dict[str, str] | None,
+        emit: str | tuple[str, ...] | None,
+        wait_for: str | tuple[str, ...] | None,
+    ) -> None:
+        """Shared gate initialization tail.
+
+        Subclasses validate and assign their routing-specific attributes
+        (targets/fallback vs when_true/when_false) BEFORE delegating here,
+        so construction error ordering matches the historical per-subclass
+        constructors.
+        """
+        self.name = name or func.__name__
+        self.func = func
+        self._cache = cache
+        self._hide = hide
+        self._emit = ensure_tuple(emit) if emit else ()
+        self._wait_for = ensure_tuple(wait_for) if wait_for else ()
+        self.default_open = default_open
+        self._definition_hash = hash_definition(func)
+
+        # `outputs` is a derived property on GateNode — no stored copy here.
+        inputs, self._context_param = extract_inputs(func)
+        self.inputs, self._rename_history = _apply_renames(inputs, rename_inputs, "inputs")
+
+        _validate_emit_wait_for(
+            self.name,
+            self._emit,
+            self._wait_for,
+            (),
+            self.inputs,
+        )
+
+    def _structural_signature_parts(self) -> list[str]:
+        """Add the routing interface every gate declares."""
+        parts = super()._structural_signature_parts()
+        parts.append("targets=" + ",".join(t if t is not END else "END" for t in self.targets))
+        parts.append(f"default_open={self.default_open}")
+        return parts
+
     @property
     def cache(self) -> bool:
         """Whether routing function results should be cached."""
@@ -301,31 +348,28 @@ class RouteNode(GateNode):
             if fallback not in target_list:
                 target_list.append(fallback)
 
-        resolved_name = name or func.__name__
-        self.name = resolved_name
-        self.func = func
         self.targets = target_list
         self.descriptions = descriptions  # type: ignore[assignment]
         self.fallback = fallback
         self.multi_target = multi_target
-        self._cache = cache
-        self._hide = hide
-        self._emit = ensure_tuple(emit) if emit else ()
-        self._wait_for = ensure_tuple(wait_for) if wait_for else ()
-        self.default_open = default_open
-        self._definition_hash = hash_definition(func)
-
-        # `outputs` is a derived property on GateNode — no stored copy here.
-        inputs, self._context_param = extract_inputs(func)
-        self.inputs, self._rename_history = _apply_renames(inputs, rename_inputs, "inputs")
-
-        _validate_emit_wait_for(
-            self.name,
-            self._emit,
-            self._wait_for,
-            (),
-            self.inputs,
+        super().__init__(
+            func,
+            cache=cache,
+            hide=hide,
+            default_open=default_open,
+            name=name,
+            rename_inputs=rename_inputs,
+            emit=emit,
+            wait_for=wait_for,
         )
+
+    def _structural_signature_parts(self) -> list[str]:
+        """Add multi-target and fallback routing configuration."""
+        parts = super()._structural_signature_parts()
+        parts.append(f"multi_target={self.multi_target}")
+        fallback = self.fallback
+        parts.append(f"fallback={'None' if fallback is None else 'END' if fallback is END else fallback}")
+        return parts
 
     def __call__(self, *args: Any, **kwargs: Any) -> str | list | None:
         """Call the routing function directly."""
@@ -512,31 +556,27 @@ class IfElseNode(GateNode):
                 f"or use a regular FunctionNode if no branching is needed"
             )
 
-        resolved_name = name or func.__name__
-        self.name = resolved_name
-        self.func = func
         self.when_true = when_true
         self.when_false = when_false
         self.targets = [when_true, when_false]
         self.descriptions = {True: "True", False: "False"}
-        self._cache = cache
-        self._hide = hide
-        self._emit = ensure_tuple(emit) if emit else ()
-        self._wait_for = ensure_tuple(wait_for) if wait_for else ()
-        self.default_open = default_open
-        self._definition_hash = hash_definition(func)
-
-        # `outputs` is a derived property on GateNode — no stored copy here.
-        inputs, self._context_param = extract_inputs(func)
-        self.inputs, self._rename_history = _apply_renames(inputs, rename_inputs, "inputs")
-
-        _validate_emit_wait_for(
-            self.name,
-            self._emit,
-            self._wait_for,
-            (),
-            self.inputs,
+        super().__init__(
+            func,
+            cache=cache,
+            hide=hide,
+            default_open=default_open,
+            name=name,
+            rename_inputs=rename_inputs,
+            emit=emit,
+            wait_for=wait_for,
         )
+
+    def _structural_signature_parts(self) -> list[str]:
+        """Add the binary branch targets."""
+        parts = super()._structural_signature_parts()
+        parts.append(f"when_true={self.when_true if self.when_true is not END else 'END'}")
+        parts.append(f"when_false={self.when_false if self.when_false is not END else 'END'}")
+        return parts
 
     def __call__(self, *args: Any, **kwargs: Any) -> bool:
         """Call the routing function directly."""

--- a/src/hypergraph/nodes/graph_node.py
+++ b/src/hypergraph/nodes/graph_node.py
@@ -147,6 +147,30 @@ class GraphNode(HyperNode):
         )
         return hashlib.sha256(content.encode()).hexdigest()
 
+    def _structural_signature_parts(self) -> list[str]:
+        """Add the nested-graph boundary: nested hash, projection, map config."""
+        parts = super()._structural_signature_parts()
+        parts.append(f"nested_struct={self._graph.structural_hash}")
+        parts.append(f"namespaced={self._namespaced}")
+        parts.append("local_inputs=" + ",".join(self._local_inputs))
+        parts.append("local_outputs=" + ",".join(self._local_outputs))
+        parts.append("data_outputs=" + ",".join(self.data_outputs))
+        if self._exposed:
+            parts.append("exposed=" + ",".join(f"{local}->{address}" for local, address in sorted(self._exposed.items())))
+        if self._complete_on_stop:
+            parts.append("complete_on_stop=True")
+        map_config = self.map_config
+        if map_config is not None:
+            map_params, map_mode, error_handling = map_config
+            parts.append("map_over=" + ",".join(map_params))
+            parts.append(f"map_mode={map_mode}")
+            parts.append(f"map_error_handling={error_handling}")
+            if isinstance(self._clone, list):
+                parts.append("map_clone=" + ",".join(self._clone))
+            else:
+                parts.append(f"map_clone={self._clone}")
+        return parts
+
     @property
     def is_async(self) -> bool:
         """Does this nested graph contain any async nodes?


### PR DESCRIPTION
Slice 1 of #208 (slice 2 — the _build_graph construction-mode switches — follows separately; keep #208 open).

## Before / after
```text
before: Graph._compute_structural_hash probes subtypes (hasattr/isinstance, 11 probing lines)
        to reconstruct each node's identity; Route/IfElse repeat the same init tail
after:  HyperNode.structural_signature is the one polymorphic interface — a
        _structural_signature_parts() template hook that Gate/Route/IfElse/GraphNode extend
        via super(); graph core only composes per-node signatures with edge topology;
        GateNode.__init__ owns the shared tail (subclass error ordering preserved exactly)
```

## Byte-stability proof
The #263 frozen baselines pass with ZERO fixture edits, plus two independent extended batteries: the builder's 11-graph branch-coverage set and the reviewer's 12 novel shapes (3-level nesting with renames, gates inside nested graphs, map+namespaced+expose, RetryPolicy, bind/entrypoint variants, emit/wait_for chains) — structural and definition hashes byte-identical vs master in every case. Cross-version probe: a checkpoint written by master code resumes to COMPLETED under this branch with the same stored hash, and a tampered graph still raises GraphChangedError.

## Test plan
CI-equivalent 3841 passed post-rebase; 23 invalid-construction probes raise identical exception types/messages; repr/nx_attrs/branch_data snapshots byte-identical; mypy clean (touched modules NOT in the override baseline); pre-commit green. Adversarial review verdict: SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive structural signatures for graph nodes, gates, routes, and conditional nodes.
  * Structural compatibility checks now account for node configuration, graph boundaries, routing behavior, and mapping settings.

* **Refactor**
  * Standardized gate and route initialization to improve consistency while preserving existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->