### PR TITLE
fix(runners): signature-authoritative map-resume child restoration

### DIFF
--- a/docs/05-how-to/batch-processing.md
+++ b/docs/05-how-to/batch-processing.md
@@ -515,6 +515,8 @@ assert results[0].log.steps[0].status == "restored"
 
 Restored items remain included in completed counts, but are also reported as a separate subset in `MapResult`, `MapLog`, parent events, and telemetry. Average item duration uses only freshly executed completed items with real logs, so a fully restored batch omits the average instead of displaying fake `0ms` work. This makes it safe to retry large batches — you only pay for the items that actually need re-processing, and the result shows which items were skipped.
 
+**Compatibility.** Each completed item is matched by a persisted signature of its inputs, and that signature is authoritative: an item is restored only when its current inputs match, even if the item sits at the same position as before — changed or unmatched inputs re-execute fresh (never an error, never a stale result). Children persisted by pre-signature versions of hypergraph carry no signature, and only those legacy children keep the old position-based fallback: they are restored by their numeric index. Each stored child is restored at most once per resume, so duplicate inputs claim their matching runs one-for-one (in stable run-id order) and any extra duplicates execute fresh.
+
 ## When to Use Map vs Loop
 
 | Use `runner.map()` or `map_over` | Use a Python loop |

--- a/src/hypergraph/runners/_shared/map_resume.py
+++ b/src/hypergraph/runners/_shared/map_resume.py
@@ -48,27 +48,39 @@ def index_completed_child_runs(
     child_runs: list[Run],
     workflow_id: str | None,
 ) -> tuple[dict[str, list[str]], dict[int, list[str]]]:
-    """Index completed child runs by signature and by legacy index suffix."""
+    """Index completed child runs into disjoint signed and legacy pools.
+
+    Persisted signatures are authoritative (#199): a child with a valid
+    signature enters ONLY the signature pool, so a signed child whose inputs
+    changed can never be restored through the numeric index fallback. A child
+    whose config lacks the signature key entirely (persisted before signatures
+    existed) enters ONLY the legacy index pool. A child with
+    present-but-invalid signature metadata enters neither pool and is
+    therefore re-executed fresh rather than restored or erroring.
+    """
     by_signature: dict[str, list[str]] = defaultdict(list)
-    by_index: dict[int, list[str]] = defaultdict(list)
+    legacy_by_index: dict[int, list[str]] = defaultdict(list)
 
     for run in child_runs:
-        if isinstance(run.config, dict):
-            signature = run.config.get(MAP_SIGNATURE_CONFIG_KEY)
-            if isinstance(signature, str):
+        config = run.config if isinstance(run.config, dict) else {}
+        if MAP_SIGNATURE_CONFIG_KEY in config:
+            signature = config[MAP_SIGNATURE_CONFIG_KEY]
+            if isinstance(signature, str) and signature:
                 by_signature[signature].append(run.id)
+            # Present-but-invalid metadata: neither pool -> fresh execution.
+            continue
 
         if workflow_id is None:
             continue
         suffix = run.id.removeprefix(f"{workflow_id}/")
         if suffix.isdigit():
-            by_index[int(suffix)].append(run.id)
+            legacy_by_index[int(suffix)].append(run.id)
 
     for ids in by_signature.values():
         ids.sort()
-    for ids in by_index.values():
+    for ids in legacy_by_index.values():
         ids.sort()
-    return by_signature, by_index
+    return by_signature, legacy_by_index
 
 
 def claim_completed_child_run_id(
@@ -76,15 +88,23 @@ def claim_completed_child_run_id(
     idx: int,
     signature: str,
     by_signature: dict[str, list[str]],
-    by_index: dict[int, list[str]],
+    legacy_by_index: dict[int, list[str]],
 ) -> str | None:
-    """Claim a completed child run id, preferring input identity."""
-    by_sig = by_signature.get(signature)
-    if by_sig:
-        return by_sig.pop(0)
+    """Claim a completed child run id for one map item, or None for fresh.
 
-    by_idx = by_index.get(idx)
-    if by_idx:
-        return by_idx.pop(0)
+    Signed evidence is authoritative: a signature match claims the
+    lexicographically smallest unclaimed matching run id, so duplicate
+    signatures are claimed deterministically in ascending run-id order, one
+    child per claim. The numeric index fallback consults only legacy children
+    (signature key absent); signed children are never claimable by index.
+    Pools are disjoint and claims pop, so each child is claimed at most once.
+    """
+    signed = by_signature.get(signature)
+    if signed:
+        return signed.pop(0)
+
+    legacy = legacy_by_index.get(idx)
+    if legacy:
+        return legacy.pop(0)
 
     return None

--- a/src/hypergraph/runners/_shared/template_async.py
+++ b/src/hypergraph/runners/_shared/template_async.py
@@ -1148,7 +1148,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
 
             # Resume: find completed child runs to skip by stable input signature.
             completed_runs = await _get_completed_child_runs(checkpointer, workflow_id)
-            completed_by_signature, completed_by_index = index_completed_child_runs(completed_runs, workflow_id)
+            completed_by_signature, completed_legacy_by_index = index_completed_child_runs(completed_runs, workflow_id)
 
             existing_limiter = self._get_concurrency_limiter()
             token = self._set_concurrency_limiter(max_concurrency) if existing_limiter is None and max_concurrency is not None else None
@@ -1210,7 +1210,7 @@ class AsyncRunnerTemplate(BaseRunner, ABC):
                     idx=idx,
                     signature=item_signature,
                     by_signature=completed_by_signature,
-                    by_index=completed_by_index,
+                    legacy_by_index=completed_legacy_by_index,
                 )
                 if item_signature is not None
                 else None

--- a/src/hypergraph/runners/_shared/template_sync.py
+++ b/src/hypergraph/runners/_shared/template_sync.py
@@ -1068,7 +1068,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
 
             # Resume: find completed child runs to skip by stable input signature.
             completed_runs = _get_completed_child_runs_sync(sync_cp, workflow_id)
-            completed_by_signature, completed_by_index = index_completed_child_runs(completed_runs, workflow_id)
+            completed_by_signature, completed_legacy_by_index = index_completed_child_runs(completed_runs, workflow_id)
             map_stop_signal = get_stop_signal()
         except BaseException as error:
             try:
@@ -1128,7 +1128,7 @@ class SyncRunnerTemplate(BaseRunner, ABC):
                         idx=idx,
                         signature=item_signature,
                         by_signature=completed_by_signature,
-                        by_index=completed_by_index,
+                        legacy_by_index=completed_legacy_by_index,
                     )
                     if item_signature is not None
                     else None

--- a/tests/test_checkpointer/test_resume.py
+++ b/tests/test_checkpointer/test_resume.py
@@ -13,6 +13,7 @@ from hypergraph.exceptions import (
     MissingInputError,
     WorkflowAlreadyCompletedError,
 )
+from hypergraph.runners._shared.map_resume import MAP_SIGNATURE_CONFIG_KEY
 from hypergraph.runners._shared.results import RunStatus
 
 aiosqlite = pytest.importorskip("aiosqlite")
@@ -465,6 +466,93 @@ class TestAsyncMapResume:
         assert call_count == 0
         assert [r["doubled"] for r in result.results] == [60, 20, 40]
 
+    async def test_map_resume_changed_same_index_inputs_execute_fresh(self, checkpointer):
+        """Changed inputs at a completed index re-execute; the stale result is not restored."""
+        calls: list[int] = []
+
+        @node(output_name="doubled")
+        def counting_double(x: int) -> int:
+            calls.append(x)
+            return x * 2
+
+        runner = AsyncRunner(checkpointer=checkpointer)
+        graph = Graph([counting_double])
+
+        await runner.map(graph, {"x": [10, 20]}, map_over="x", workflow_id="changed-batch")
+        assert sorted(calls) == [10, 20]
+
+        calls.clear()
+        result = await runner.map(graph, {"x": [99, 20]}, map_over="x", workflow_id="changed-batch")
+
+        assert calls == [99]
+        assert [r["doubled"] for r in result.results] == [198, 40]
+        assert [r.restored for r in result.results] == [False, True]
+
+    async def test_map_resume_restores_unsigned_legacy_children_by_index(self, checkpointer):
+        """Pre-signature children (signature key absent from config) still restore by index."""
+        calls: list[int] = []
+
+        @node(output_name="doubled")
+        def counting_double(x: int) -> int:
+            calls.append(x)
+            return x * 2
+
+        runner = AsyncRunner(checkpointer=checkpointer)
+        graph = Graph([counting_double])
+
+        await runner.map(graph, {"x": [10, 20]}, map_over="x", workflow_id="legacy-batch")
+        assert sorted(calls) == [10, 20]
+
+        # Rewrite child rows as pre-signature legacy runs: no signature key at all.
+        for idx in (0, 1):
+            child_id = f"legacy-batch/{idx}"
+            await checkpointer.create_run(
+                child_id,
+                graph_name=graph.name,
+                parent_run_id="legacy-batch",
+                config={"graph_struct_hash": graph.structural_hash},
+            )
+            await checkpointer.update_run_status(child_id, WorkflowStatus.COMPLETED)
+
+        calls.clear()
+        result = await runner.map(graph, {"x": [10, 20]}, map_over="x", workflow_id="legacy-batch")
+
+        assert calls == []
+        assert [r["doubled"] for r in result.results] == [20, 40]
+        assert all(r.restored for r in result.results)
+
+    async def test_map_resume_invalid_signature_metadata_executes_fresh(self, checkpointer):
+        """Present-but-invalid signature metadata re-executes: no error, no restore."""
+        calls: list[int] = []
+
+        @node(output_name="doubled")
+        def counting_double(x: int) -> int:
+            calls.append(x)
+            return x * 2
+
+        runner = AsyncRunner(checkpointer=checkpointer)
+        graph = Graph([counting_double])
+
+        await runner.map(graph, {"x": [10, 20]}, map_over="x", workflow_id="invalid-sig-batch")
+        assert sorted(calls) == [10, 20]
+
+        for idx in (0, 1):
+            child_id = f"invalid-sig-batch/{idx}"
+            await checkpointer.create_run(
+                child_id,
+                graph_name=graph.name,
+                parent_run_id="invalid-sig-batch",
+                config={"graph_struct_hash": graph.structural_hash, MAP_SIGNATURE_CONFIG_KEY: 123},
+            )
+            await checkpointer.update_run_status(child_id, WorkflowStatus.COMPLETED)
+
+        calls.clear()
+        result = await runner.map(graph, {"x": [10, 20]}, map_over="x", workflow_id="invalid-sig-batch")
+
+        assert sorted(calls) == [10, 20]
+        assert [r["doubled"] for r in result.results] == [20, 40]
+        assert not any(r.restored for r in result.results)
+
     async def test_map_resume_reapplies_select_filter_when_restoring(self, checkpointer):
         """Restored map items should respect select filtering just like fresh runs."""
         runner = AsyncRunner(checkpointer=checkpointer)
@@ -742,6 +830,93 @@ class TestSyncMapResume:
         result = runner.map(graph, {"x": [30, 10, 20]}, map_over="x", workflow_id="sync-identity")
         assert call_count == 0
         assert [r["doubled"] for r in result.results] == [60, 20, 40]
+
+    def test_map_resume_changed_same_index_inputs_execute_fresh(self, sync_checkpointer):
+        """Sync mirror: changed inputs at a completed index re-execute, not restore stale."""
+        calls: list[int] = []
+
+        @node(output_name="doubled")
+        def counting_double(x: int) -> int:
+            calls.append(x)
+            return x * 2
+
+        runner = SyncRunner(checkpointer=sync_checkpointer)
+        graph = Graph([counting_double])
+
+        runner.map(graph, {"x": [10, 20]}, map_over="x", workflow_id="sync-changed-batch")
+        assert calls == [10, 20]
+
+        calls.clear()
+        result = runner.map(graph, {"x": [99, 20]}, map_over="x", workflow_id="sync-changed-batch")
+
+        assert calls == [99]
+        assert [r["doubled"] for r in result.results] == [198, 40]
+        assert [r.restored for r in result.results] == [False, True]
+
+    def test_map_resume_restores_unsigned_legacy_children_by_index(self, sync_checkpointer):
+        """Sync mirror: pre-signature children still restore by numeric index."""
+        calls: list[int] = []
+
+        @node(output_name="doubled")
+        def counting_double(x: int) -> int:
+            calls.append(x)
+            return x * 2
+
+        runner = SyncRunner(checkpointer=sync_checkpointer)
+        graph = Graph([counting_double])
+
+        runner.map(graph, {"x": [10, 20]}, map_over="x", workflow_id="sync-legacy-batch")
+        assert calls == [10, 20]
+
+        # Rewrite child rows as pre-signature legacy runs: no signature key at all.
+        for idx in (0, 1):
+            child_id = f"sync-legacy-batch/{idx}"
+            sync_checkpointer.create_run_sync(
+                child_id,
+                graph_name=graph.name,
+                parent_run_id="sync-legacy-batch",
+                config={"graph_struct_hash": graph.structural_hash},
+            )
+            sync_checkpointer.update_run_status_sync(child_id, WorkflowStatus.COMPLETED)
+
+        calls.clear()
+        result = runner.map(graph, {"x": [10, 20]}, map_over="x", workflow_id="sync-legacy-batch")
+
+        assert calls == []
+        assert [r["doubled"] for r in result.results] == [20, 40]
+        assert all(r.restored for r in result.results)
+
+    def test_map_resume_invalid_signature_metadata_executes_fresh(self, sync_checkpointer):
+        """Sync mirror: present-but-invalid signature metadata re-executes without error."""
+        calls: list[int] = []
+
+        @node(output_name="doubled")
+        def counting_double(x: int) -> int:
+            calls.append(x)
+            return x * 2
+
+        runner = SyncRunner(checkpointer=sync_checkpointer)
+        graph = Graph([counting_double])
+
+        runner.map(graph, {"x": [10, 20]}, map_over="x", workflow_id="sync-invalid-sig-batch")
+        assert calls == [10, 20]
+
+        for idx in (0, 1):
+            child_id = f"sync-invalid-sig-batch/{idx}"
+            sync_checkpointer.create_run_sync(
+                child_id,
+                graph_name=graph.name,
+                parent_run_id="sync-invalid-sig-batch",
+                config={"graph_struct_hash": graph.structural_hash, MAP_SIGNATURE_CONFIG_KEY: 123},
+            )
+            sync_checkpointer.update_run_status_sync(child_id, WorkflowStatus.COMPLETED)
+
+        calls.clear()
+        result = runner.map(graph, {"x": [10, 20]}, map_over="x", workflow_id="sync-invalid-sig-batch")
+
+        assert calls == [10, 20]
+        assert [r["doubled"] for r in result.results] == [20, 40]
+        assert not any(r.restored for r in result.results)
 
     def test_map_resume_reapplies_select_filter_when_restoring(self, sync_checkpointer):
         """Sync mirror: restored map items should preserve select filtering."""

--- a/tests/test_runners/test_shared_decisions.py
+++ b/tests/test_runners/test_shared_decisions.py
@@ -40,25 +40,84 @@ def test_map_signatures_normalize_mapping_and_set_order() -> None:
     assert len(first_signature) == 16
 
 
+def _signed_run(run_id: str, signature: object) -> Run:
+    return Run(id=run_id, status=WorkflowStatus.COMPLETED, config={MAP_SIGNATURE_CONFIG_KEY: signature})
+
+
+def _claim(pools: tuple[dict[str, list[str]], dict[int, list[str]]], *, idx: int, signature: str) -> str | None:
+    by_signature, legacy_by_index = pools
+    return claim_completed_child_run_id(idx=idx, signature=signature, by_signature=by_signature, legacy_by_index=legacy_by_index)
+
+
 def test_map_resume_claims_distinct_sorted_signatures_before_legacy_index() -> None:
     child_runs = [
-        Run(
-            id="batch/b",
-            status=WorkflowStatus.COMPLETED,
-            config={MAP_SIGNATURE_CONFIG_KEY: "same"},
-        ),
-        Run(
-            id="batch/a",
-            status=WorkflowStatus.COMPLETED,
-            config={MAP_SIGNATURE_CONFIG_KEY: "same"},
-        ),
+        _signed_run("batch/b", "same"),
+        _signed_run("batch/a", "same"),
         Run(id="batch/3", status=WorkflowStatus.COMPLETED),
     ]
-    by_signature, by_index = index_completed_child_runs(child_runs, "batch")
+    pools = index_completed_child_runs(child_runs, "batch")
 
-    assert claim_completed_child_run_id(idx=3, signature="same", by_signature=by_signature, by_index=by_index) == "batch/a"
-    assert claim_completed_child_run_id(idx=3, signature="same", by_signature=by_signature, by_index=by_index) == "batch/b"
-    assert claim_completed_child_run_id(idx=3, signature="missing", by_signature=by_signature, by_index=by_index) == "batch/3"
+    assert _claim(pools, idx=3, signature="same") == "batch/a"
+    assert _claim(pools, idx=3, signature="same") == "batch/b"
+    assert _claim(pools, idx=3, signature="missing") == "batch/3"
+
+
+def test_map_resume_signed_mismatch_is_fresh_execution_not_index_restore() -> None:
+    """Matrix #1: a signed child with a stale signature is never restored by index."""
+    pools = index_completed_child_runs([_signed_run("batch/0", "old-sig")], "batch")
+
+    assert _claim(pools, idx=0, signature="new-sig") is None
+
+
+def test_map_resume_legacy_children_without_signature_key_restore_by_index() -> None:
+    """Matrix #2: pre-signature children (key absent, config None or partial) keep the index fallback."""
+    child_runs = [
+        Run(id="batch/0", status=WorkflowStatus.COMPLETED, config=None),
+        Run(id="batch/1", status=WorkflowStatus.COMPLETED, config={"graph_struct_hash": "h"}),
+    ]
+    pools = index_completed_child_runs(child_runs, "batch")
+
+    assert _claim(pools, idx=0, signature="sig-0") == "batch/0"
+    assert _claim(pools, idx=1, signature="sig-1") == "batch/1"
+
+
+def test_map_resume_signed_children_restore_by_signature_regardless_of_index() -> None:
+    """Matrix #3: reordered signed inputs restore by signature, not position."""
+    child_runs = [_signed_run("batch/0", "sig-first"), _signed_run("batch/1", "sig-second")]
+    pools = index_completed_child_runs(child_runs, "batch")
+
+    assert _claim(pools, idx=0, signature="sig-second") == "batch/1"
+    assert _claim(pools, idx=1, signature="sig-first") == "batch/0"
+
+
+def test_map_resume_duplicate_signatures_claim_once_in_run_id_order() -> None:
+    """Matrix #4: duplicate signatures claim ascending run ids; exhaustion means fresh."""
+    child_runs = [_signed_run("batch/1", "same"), _signed_run("batch/0", "same")]
+    pools = index_completed_child_runs(child_runs, "batch")
+
+    assert _claim(pools, idx=0, signature="same") == "batch/0"
+    assert _claim(pools, idx=1, signature="same") == "batch/1"
+    # A third identical item finds the pool exhausted and must execute fresh —
+    # never re-claim a signed child through the numeric index fallback.
+    assert _claim(pools, idx=0, signature="same") is None
+
+
+def test_map_resume_signed_child_claimed_once_across_pools() -> None:
+    """Matrix #5: a child claimed by signature is not claimable by index later."""
+    pools = index_completed_child_runs([_signed_run("batch/0", "sig-a")], "batch")
+
+    assert _claim(pools, idx=5, signature="sig-a") == "batch/0"
+    assert _claim(pools, idx=0, signature="other") is None
+
+
+@pytest.mark.parametrize("invalid", [None, 123, ["sig"], {"sig": "x"}, ""])
+def test_map_resume_invalid_signature_metadata_is_fresh_execution(invalid: object) -> None:
+    """Matrix #6: present-but-invalid signature metadata joins neither pool."""
+    pools = index_completed_child_runs([_signed_run("batch/0", invalid)], "batch")
+
+    assert pools[0] == {}
+    assert pools[1] == {}
+    assert _claim(pools, idx=0, signature="any") is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #237. Implements locked decision #199.

## Before / after
```text
before: resume a map after changing item 0's inputs → completed child batch/0 restores
        STALE results by numeric index (silent wrong output — the #199 witness)
after:  disjoint pools — valid signature → claimed by signature only; signature-key-absent
        (legacy) → index fallback only; present-but-invalid metadata → fresh execution,
        never an error, never a restore. Single-claim across pools; duplicate signatures
        claim in ascending run-id order, extras execute fresh (documented).
```

## Test plan
Red-first stale-restore witness on master (builder + reviewer with an independent scenario). All 8 ticket matrix items, sync/async mirrored. Adversarial review SHIP: 21 pool-boundary probes (malformed metadata types, signed-beats-legacy without consumption, orphan children, all-invalid batches), crash-resume + delegation suites (124 passed) with changed-item probes, tiebreak determinism under unlimited async concurrency, fallback proven against a DB built by genuinely pre-signature code, #232 policy-manifest interplay verified read-path-only. CI-equivalent 3904 passed; mypy clean; pre-commit green. Docs compatibility paragraph in batch-processing.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)