### PR TITLE
fix(materialization): heal missing child rows on unchanged-parent sync

### DIFF
--- a/docs/08-hypertable/api-reference.md
+++ b/docs/08-hypertable/api-reference.md
@@ -43,7 +43,12 @@ class WriteOutcome(Enum):
     INSERTED = "inserted"
     UPDATED = "updated"
     SKIPPED = "skipped"
+    HEALED = "healed"
 ```
+
+`HEALED` is reported by `sync()` when an unchanged parent row had physically
+missing child rows rebuilt. A receipt is never `SKIPPED` on a path that wrote
+rows.
 
 ### `RowReceipt`
 
@@ -85,6 +90,9 @@ class TableReceipt:
 
     @property
     def skipped(self) -> int: ...
+
+    @property
+    def healed(self) -> int: ...
 
     @property
     def waiting(self) -> tuple[RowReceipt, ...]: ...
@@ -134,6 +142,17 @@ provenance.
 
 Converge a complete collection: insert new identities, update changed ones,
 skip fresh ones, and delete missing ones.
+
+Unchanged parents are also self-repairing: a successful parent must not make
+child loss permanent, so `sync()` rebuilds physically missing child rows and
+reports the row as `HEALED`. To detect loss, `sync()` inspects each child
+table once per unchanged parent row — it compares the fan-out count recorded
+on the parent row against the deduplicated child rows physically present
+(one child-table read per parent; no writes). When every child row is
+present, the row is a zero-execution, zero-write `SKIPPED`; when rows are
+missing, the fan-out boundary re-runs once to regenerate the item list and
+only the missing children run the child graph — present children and parent
+derived columns are not re-derived.
 
 ### `delete(id) -> None`
 

--- a/docs/08-hypertable/getting-started.md
+++ b/docs/08-hypertable/getting-started.md
@@ -156,7 +156,11 @@ for row_receipt in receipt.errors:
 ```
 
 `sync()` inserts new identities, converges changed ones, skips fresh ones,
-and deletes identities absent from the incoming collection.
+and deletes identities absent from the incoming collection. An unchanged
+parent whose child rows were physically lost is self-repairing: `sync()`
+compares each child table's recorded fan-out count against the child rows
+physically present and rebuilds only the missing children, reporting the row
+as `healed` instead of `skipped`.
 
 ## Stored errors
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -58,6 +58,19 @@
 
 ### Fixed
 
+- **Unchanged-parent `sync()` heals physically missing child rows** — before,
+  the unchanged-parent fast path never inspected child tables, so a deleted
+  or lost child row stayed missing forever behind a `skipped` receipt. Now
+  `sync()` compares each child table's recorded fan-out count against the
+  physically present deduplicated child rows (one read-only child-table probe
+  per unchanged parent) and rebuilds only the missing children: the fan-out
+  boundary re-runs once to regenerate the item list, present children and
+  parent derived columns are not re-derived, and healed child writes allocate
+  generations strictly above every physical child row. The repair is reported
+  by the new `WriteOutcome.HEALED` / `TableReceipt.healed` — a receipt is
+  never `skipped` on a path that wrote rows. All children present remains a
+  zero-execution, zero-write skip.
+
 - **HyperTable definition fingerprints harden to construction-time
   `hash_definition`** — before, a derive node that was a bound method of a
   configured object (`summarizer.summarize` with `model="gpt-4"` vs

--- a/src/hypergraph/materialization/_hypertable.py
+++ b/src/hypergraph/materialization/_hypertable.py
@@ -789,7 +789,14 @@ class HyperTable:
         self._write_planner.delete(identity_value)
 
     def sync(self, items: list[dict[str, Any]]) -> TableReceipt | Awaitable[TableReceipt]:
-        """Reconcile: insert new, update changed, delete missing, skip unchanged."""
+        """Reconcile: insert new, update changed, delete missing, skip unchanged.
+
+        Unchanged parents self-repair child loss (#204): sync() inspects each
+        child table once per unchanged parent row — recorded fan-out count vs
+        physically present deduplicated child rows — and rebuilds only the
+        missing children, reporting the row as ``HEALED``. All children
+        present stays a zero-execution, zero-write ``SKIPPED``.
+        """
         self._ensure_analyzed()
         operation = self._write_planner.sync(items)
         if self._is_async_runner():

--- a/src/hypergraph/materialization/_types.py
+++ b/src/hypergraph/materialization/_types.py
@@ -24,6 +24,12 @@ class WriteOutcome(Enum):
     INSERTED = "inserted"
     UPDATED = "updated"
     SKIPPED = "skipped"
+    HEALED = "healed"
+    """An unchanged parent whose physically missing child rows were rebuilt.
+
+    ``sync()`` reports the repair distinctly: a receipt is never ``SKIPPED``
+    on a path that wrote rows (#204).
+    """
 
 
 @dataclass(frozen=True)
@@ -67,6 +73,10 @@ class TableReceipt:
     @property
     def skipped(self) -> int:
         return sum(receipt.outcome is WriteOutcome.SKIPPED for receipt in self.receipts)
+
+    @property
+    def healed(self) -> int:
+        return sum(receipt.outcome is WriteOutcome.HEALED for receipt in self.receipts)
 
     @property
     def waiting(self) -> tuple[RowReceipt, ...]:

--- a/src/hypergraph/materialization/_writes.py
+++ b/src/hypergraph/materialization/_writes.py
@@ -15,6 +15,7 @@ from hypergraph.materialization._provenance import (
     ReconcileResult,
     ReconcileUnavailable,
     normalize_value,
+    split_boundary_provenance,
 )
 from hypergraph.materialization._recipe_journal import RecipeJournal
 from hypergraph.materialization._schema import (
@@ -1202,6 +1203,53 @@ class WritePlanner:
         inputs = self._source_inputs(item)
         return existing.get("_row_fingerprint") == self._provenance.root_fingerprint(inputs)
 
+    def _children_missing(self, existing: dict[str, Any]) -> bool:
+        """Read-only completeness probe for the unchanged-parent sync fast path (#204).
+
+        Compares each child table's recorded fan-out count (the
+        ``<provenance>#<count>`` value stamped on the parent row) against the
+        physically present deduplicated child rows. One ``read_rows`` per child
+        table per parent row; never writes. Child specs whose boundary cannot
+        be reconciled column-scoped (no boundary node, or the boundary also
+        produces a stored parent column) are skipped — for them a heal could
+        not honor the "present children and parent are not re-derived"
+        contract, so the fast path is preserved unchanged.
+        """
+        identity_value = existing[self._identity]
+        for child_spec in self._spec.children:
+            if child_spec.child_graph is None or not child_spec.map_input:
+                continue
+            boundary = self._provenance.boundary_node(child_spec)
+            if boundary is None or any(boundary in self._provenance.column_producers(column) for column in self._provenance.derived_columns()):
+                continue
+            _, expected = split_boundary_provenance(existing.get(f"_provenance_{child_spec.map_input}"))
+            if expected is None:
+                continue
+            rows = self._read_rows(
+                child_spec.name,
+                (("_parent_id", "eq", identity_value),),
+                columns=(child_spec.identity, "_parent_id", "_write_gen"),
+            )
+            if len(dedup_child_rows(rows, child_spec.identity)) != expected:
+                return True
+        return False
+
+    def _heal_missing_children(self, item: dict[str, Any], write_gen: int) -> Generator[RunGraph, Any, RowReceipt]:
+        """Rebuild physically missing child rows under an unchanged parent (#204).
+
+        Delegates to the ordinary reconcile path: fresh parent columns are
+        reused, the fan-out boundary re-runs once to regenerate the item list,
+        and only children without a matching physical row run the child graph.
+        The receipt reports the repair as ``HEALED`` whenever child rows were
+        written — never ``SKIPPED`` on a path that wrote rows.
+        """
+        gens_before = {child_spec.name: self._store.max_write_gen(child_spec.name) for child_spec in self._spec.children}
+        receipt = yield from self._insert_one(item, write_gen)
+        wrote_children = any(self._store.max_write_gen(name) > gen for name, gen in gens_before.items())
+        if wrote_children and receipt.outcome is WriteOutcome.SKIPPED:
+            return replace(receipt, outcome=WriteOutcome.HEALED)
+        return receipt
+
     def sync(self, items: list[dict[str, Any]]) -> WriteOperation:
         rows = self._read_rows(self._spec.name)
         existing_by_id = {str(row[self._identity]): row for row in dedup_rows(rows, self._identity) if row.get(self._identity) is not None}
@@ -1218,7 +1266,10 @@ class WritePlanner:
             elif self._row_unchanged(item, existing) and existing.get("_status") in (None, "complete"):
                 if self._provenance.row_missing_stamp(existing, RECIPE_COLUMN):
                     self._refresh_missing_stamps(existing)
-                receipts.append(RowReceipt(identity_value, WriteOutcome.SKIPPED, RowStatus.COMPLETE))
+                if self._children_missing(existing):
+                    receipts.append((yield from self._heal_missing_children(item, write_gen)))
+                else:
+                    receipts.append(RowReceipt(identity_value, WriteOutcome.SKIPPED, RowStatus.COMPLETE))
             else:
                 if self._row_unchanged(item, existing):
                     receipts.append((yield from self._insert_one(item, write_gen)))

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -209,7 +209,7 @@ def test_hypertable_docs_pin_graph_backed_receipt_contract() -> None:
     assert tuple(WaitingRow.__dataclass_fields__) == ("id", "pause", "row", "provenance")
     assert tuple(ErroredRow.__dataclass_fields__) == ("id", "error", "row")
     assert {status.value for status in RowStatus} == {"complete", "waiting", "error"}
-    assert {outcome.value for outcome in WriteOutcome} == {"inserted", "updated", "skipped"}
+    assert {outcome.value for outcome in WriteOutcome} == {"inserted", "updated", "skipped", "healed"}
     assert LanceDBStore.__module__ == "hypergraph.materialization._lancedb_store"
 
     living = "\n".join((*pages.values(), examples, human))

--- a/tests/test_hypertable_child_healing.py
+++ b/tests/test_hypertable_child_healing.py
@@ -1,0 +1,411 @@
+"""Unchanged-parent sync heals physically missing child rows (#204 / #238).
+
+A successful parent row must not make known child loss permanent. When
+``sync()`` meets an unchanged parent fingerprint it now compares each child
+table's recorded fan-out count (the ``<provenance>#<count>`` value stored on
+the parent row) against the physical deduplicated child rows:
+
+- all children present  -> today's fast path: ``skipped``, zero derivation
+  executions, zero writes (byte-identical store);
+- child rows missing    -> the fan-out boundary re-runs once to regenerate the
+  item list, ONLY the missing children run the child graph, present children
+  and parent derived columns are not re-derived, and the receipt reports
+  ``healed`` — never ``skipped`` on a path that wrote rows.
+
+Healed child writes honor the #205 generation-ordering contract: the child
+generation lands strictly above every physical row in that child table.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+import pytest
+
+from hypergraph import Graph, node
+from hypergraph.materialization import TableStore
+from hypergraph.runners import AsyncRunner, SyncRunner
+
+
+class MemoryStore(TableStore):
+    def __init__(self, rows: dict[str, list[dict[str, Any]]] | None = None) -> None:
+        self.rows: dict[str, list[dict[str, Any]]] = rows if rows is not None else {}
+
+    def open(self, spec, children):
+        self.rows.setdefault(spec.name, [])
+        for child in children:
+            self.rows.setdefault(child.name, [])
+        return {name: list(rows[0].keys()) if rows else [] for name, rows in self.rows.items()}
+
+    def count(self, table_name):
+        return len(self.rows.get(table_name, []))
+
+    def read_rows(self, table_name, where=None, *, limit=None):
+        rows = [row.copy() for row in self.rows.get(table_name, []) if _matches(row, where or [])]
+        return rows[:limit] if limit is not None else rows
+
+    def read_one(self, table_name, identity_column, identity_value):
+        rows = self.read_rows(table_name, [(identity_column, "eq", identity_value)])
+        if not rows:
+            return None
+        return max(rows, key=lambda row: row.get("_write_gen", 0))
+
+    def write_rows(self, table_name, rows):
+        self.rows.setdefault(table_name, []).extend(row.copy() for row in rows)
+
+    def delete_rows(self, table_name, where):
+        existing = self.rows.get(table_name, [])
+        keep = [row for row in existing if not _matches(row, where)]
+        self.rows[table_name] = keep
+        return len(existing) - len(keep)
+
+    def max_write_gen(self, table_name):
+        return max((row.get("_write_gen", 0) for row in self.rows.get(table_name, [])), default=0)
+
+    def evolve_schema(self, table_name, new_columns):
+        return []
+
+
+def _matches(row: dict[str, Any], where) -> bool:
+    for col, op, value in where:
+        current = row.get(col)
+        if op == "eq" and current != value:
+            return False
+        if op == "lt" and not (current is not None and current < value):
+            return False
+        if op == "in" and current not in value:
+            return False
+    return True
+
+
+class AccessProbeStore(MemoryStore):
+    """Counts reads and writes per table — the detection-cost witness."""
+
+    def __init__(self, rows: dict[str, list[dict[str, Any]]] | None = None) -> None:
+        super().__init__(rows)
+        self.reads: dict[str, int] = {}
+        self.writes: dict[str, int] = {}
+        self.deletes: dict[str, int] = {}
+
+    def read_rows(self, table_name, where=None, *, limit=None):
+        self.reads[table_name] = self.reads.get(table_name, 0) + 1
+        return super().read_rows(table_name, where, limit=limit)
+
+    def write_rows(self, table_name, rows):
+        self.writes[table_name] = self.writes.get(table_name, 0) + 1
+        super().write_rows(table_name, rows)
+
+    def delete_rows(self, table_name, where):
+        self.deletes[table_name] = self.deletes.get(table_name, 0) + 1
+        return super().delete_rows(table_name, where)
+
+
+class Utterance(TypedDict):
+    utterance_id: str
+    text: str
+
+
+executions = {"clean": 0, "split": 0, "child": 0}
+
+
+@node(output_name="clean_text")
+def clean(text: str) -> str:
+    executions["clean"] += 1
+    return text.upper()
+
+
+@node(output_name="utterances")
+def split_words(text: str) -> list[Utterance]:
+    executions["split"] += 1
+    return [Utterance(utterance_id=f"u{i}", text=word) for i, word in enumerate(text.split())]
+
+
+@node(output_name="clean_word")
+def clean_word(text: str) -> str:
+    executions["child"] += 1
+    return text.upper()
+
+
+process_word = Graph([clean_word], name="process_word")
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    executions["clean"] = 0
+    executions["split"] = 0
+    executions["child"] = 0
+
+
+def _table(store, runner=None):
+    return Graph(
+        [clean, split_words, process_word.as_node().map_over("utterances", identity="utterance_id")],
+        name="doc",
+    ).as_table(identity="doc_id", store=store, runner=runner or SyncRunner())
+
+
+def _child_ids(store):
+    return sorted(row["utterance_id"] for row in store.rows["utterance"])
+
+
+# ---------------------------------------------------------------------------
+# 1. RED: unchanged parent + physically deleted child row is rebuilt by sync()
+# ---------------------------------------------------------------------------
+
+
+def test_sync_heals_physically_missing_child_row_under_unchanged_parent():
+    """On master the unchanged-parent fast path never inspects the child table,
+    so a physically deleted child row stays missing forever. After the fix the
+    same sync() call rebuilds it."""
+
+    store = MemoryStore()
+    _table(store).sync([{"doc_id": "d1", "text": "alpha beta gamma"}])
+    assert _child_ids(store) == ["u0", "u1", "u2"]
+
+    store.delete_rows("utterance", [("utterance_id", "eq", "u1")])
+    assert _child_ids(store) == ["u0", "u2"]
+
+    # A FRESH handle over the same physical rows: detection must read the
+    # store, not same-handle caches.
+    fresh = _table(MemoryStore(store.rows))
+    receipt = fresh.sync([{"doc_id": "d1", "text": "alpha beta gamma"}])
+
+    assert _child_ids(store) == ["u0", "u1", "u2"], "sync() must rebuild the physically missing child row"
+    healed = next(row for row in store.rows["utterance"] if row["utterance_id"] == "u1")
+    assert healed["clean_word"] == "BETA"
+    assert [(row.outcome.value, row.status.value) for row in receipt.receipts] == [("healed", "complete")]
+
+
+def test_sync_rebuilds_fully_truncated_child_table():
+    """Even total child loss (table truncated) is healed under an unchanged parent."""
+
+    store = MemoryStore()
+    _table(store).sync([{"doc_id": "d1", "text": "alpha beta gamma"}])
+    store.delete_rows("utterance", [("_parent_id", "eq", "d1")])
+    assert store.rows["utterance"] == []
+
+    fresh = _table(MemoryStore(store.rows))
+    receipt = fresh.sync([{"doc_id": "d1", "text": "alpha beta gamma"}])
+
+    assert _child_ids(store) == ["u0", "u1", "u2"]
+    assert {row["utterance_id"]: row["clean_word"] for row in store.rows["utterance"]} == {"u0": "ALPHA", "u1": "BETA", "u2": "GAMMA"}
+    assert receipt.healed == 1
+
+
+# ---------------------------------------------------------------------------
+# 2. Fast path preserved: all children present -> zero executions, zero writes
+# ---------------------------------------------------------------------------
+
+
+def test_unchanged_parent_with_all_children_present_stays_zero_execution_and_zero_write():
+    store = MemoryStore()
+    table = _table(store)
+    table.sync([{"doc_id": "d1", "text": "alpha beta gamma"}])
+    snapshot = {name: [row.copy() for row in rows] for name, rows in store.rows.items()}
+    executions["clean"] = executions["split"] = executions["child"] = 0
+
+    receipt = table.sync([{"doc_id": "d1", "text": "alpha beta gamma"}])
+
+    assert [(row.outcome.value, row.status.value) for row in receipt.receipts] == [("skipped", "complete")]
+    assert (executions["clean"], executions["split"], executions["child"]) == (0, 0, 0), "the fast path must stay zero-execution"
+    assert store.rows == snapshot, "the fast path must stay zero-write: store byte-identical, no generation inflation"
+
+
+def test_fast_path_detection_is_one_child_table_read_per_unchanged_parent():
+    """Detection-cost honesty: the fast path now performs exactly one read of
+    each child table per unchanged parent row (the completeness probe) and
+    still writes and deletes nothing."""
+
+    seed = MemoryStore()
+    _table(seed).sync([{"doc_id": "d1", "text": "alpha beta gamma"}])
+
+    probe = AccessProbeStore(seed.rows)
+    table = _table(probe)
+    probe.reads.clear()
+    probe.writes.clear()
+    probe.deletes.clear()
+
+    table.sync([{"doc_id": "d1", "text": "alpha beta gamma"}])
+
+    assert probe.reads.get("utterance", 0) == 1, "detection is one per-child-table read per unchanged parent"
+    assert probe.writes == {}, "the fast path must not write"
+    assert probe.deletes == {}, "the fast path must not delete"
+
+
+# ---------------------------------------------------------------------------
+# 3. Partial heal: only the MISSING children derive
+# ---------------------------------------------------------------------------
+
+
+def test_partial_heal_derives_only_missing_children():
+    store = MemoryStore()
+    _table(store).sync([{"doc_id": "d1", "text": "alpha beta gamma"}])
+    parent_gen_before = store.read_one("doc", "doc_id", "d1")["_write_gen"]
+    present_values = {row["utterance_id"]: row["clean_word"] for row in store.rows["utterance"] if row["utterance_id"] != "u1"}
+
+    store.delete_rows("utterance", [("utterance_id", "eq", "u1")])
+    executions["clean"] = executions["split"] = executions["child"] = 0
+
+    fresh = _table(MemoryStore(store.rows))
+    fresh.sync([{"doc_id": "d1", "text": "alpha beta gamma"}])
+
+    # Only the missing child runs the child graph; the fan-out boundary re-runs
+    # exactly once to regenerate the item list (physically missing rows exist
+    # nowhere else); parent derived columns are not re-derived.
+    assert executions["child"] == 1, "only the MISSING child may derive"
+    assert executions["split"] == 1, "the boundary regenerates the item list exactly once"
+    assert executions["clean"] == 0, "parent derived columns must not re-derive"
+    assert store.read_one("doc", "doc_id", "d1")["_write_gen"] == parent_gen_before, "the parent row must not be rewritten"
+    assert {row["utterance_id"]: row["clean_word"] for row in store.rows["utterance"] if row["utterance_id"] != "u1"} == present_values, (
+        "present children keep their derived values"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. Truthful receipts: healed is distinct, skipped never writes
+# ---------------------------------------------------------------------------
+
+
+def test_healing_sync_reports_healed_not_skipped():
+    store = MemoryStore()
+    table = _table(store)
+    table.sync([{"doc_id": "d1", "text": "alpha beta"}, {"doc_id": "d2", "text": "delta"}])
+    store.delete_rows("utterance", [("_parent_id", "eq", "d1"), ("utterance_id", "eq", "u1")])
+
+    fresh = _table(MemoryStore(store.rows))
+    receipt = fresh.sync([{"doc_id": "d1", "text": "alpha beta"}, {"doc_id": "d2", "text": "delta"}])
+
+    outcomes = {row.id: row.outcome.value for row in receipt.receipts}
+    assert outcomes == {"d1": "healed", "d2": "skipped"}, "the repaired row reports the repair distinctly; untouched rows stay skipped"
+    assert receipt.healed == 1
+    assert receipt.skipped == 1
+    assert all(row.status.value == "complete" for row in receipt.receipts)
+
+
+# ---------------------------------------------------------------------------
+# 5. Generation safety: healed children land above every physical child row
+# ---------------------------------------------------------------------------
+
+
+def test_healed_children_allocate_generation_above_physical_child_max():
+    """The #205 ordering contract under healing: even when annotation bumps have
+    pushed the child counter ahead of the root counter, the heal allocates
+    strictly above every physical child row — no tie can survive cleanup."""
+
+    store = MemoryStore()
+    table = _table(store)
+    table.sync([{"doc_id": "d1", "text": "alpha beta gamma"}])
+    table.child("utterance").set({"utterance_id": "u0"}, note="first")
+    table.child("utterance").set({"utterance_id": "u0"}, note="second")
+    child_max_before = store.max_write_gen("utterance")
+    assert child_max_before > store.max_write_gen("doc"), "annotation bumps must outrun the root counter for this witness"
+
+    store.delete_rows("utterance", [("utterance_id", "eq", "u1")])
+
+    fresh = _table(MemoryStore(store.rows))
+    receipt = fresh.sync([{"doc_id": "d1", "text": "alpha beta gamma"}])
+
+    assert receipt.healed == 1
+    physical = store.rows["utterance"]
+    by_key: dict[tuple[Any, Any], list[int]] = {}
+    for row in physical:
+        by_key.setdefault((row["_parent_id"], row["utterance_id"]), []).append(row["_write_gen"])
+    for key, gens in by_key.items():
+        assert len(gens) == len(set(gens)), f"equal-generation tie for {key}: {gens}"
+    assert min(row["_write_gen"] for row in physical) > child_max_before, (
+        "every child write in the healing mutation lands strictly above the pre-heal physical max"
+    )
+
+    reader = _table(MemoryStore(store.rows))
+    assert [child["clean_word"] for child in reader.child("utterance").rows(parent="d1")] == ["ALPHA", "BETA", "GAMMA"]
+
+
+# ---------------------------------------------------------------------------
+# LanceDB: the heal path against a real store through fresh connections
+# ---------------------------------------------------------------------------
+
+
+def test_sync_heals_missing_child_row_lancedb_fresh_handles(tmp_path):
+    from hypergraph.materialization import LanceDBStore
+
+    path = str(tmp_path / "healing_store")
+    _table(LanceDBStore(path)).sync([{"doc_id": "d1", "text": "alpha beta gamma"}])
+
+    damage_store = LanceDBStore(path)
+    damage_store.delete_rows("utterance", [("utterance_id", "eq", "u1")])
+    child_max_before = damage_store.max_write_gen("utterance")
+    assert sorted(row["utterance_id"] for row in damage_store.read_rows("utterance")) == ["u0", "u2"]
+
+    heal_store = LanceDBStore(path)
+    receipt = _table(heal_store).sync([{"doc_id": "d1", "text": "alpha beta gamma"}])
+    assert [(row.outcome.value, row.status.value) for row in receipt.receipts] == [("healed", "complete")]
+
+    read_store = LanceDBStore(path)
+    physical = read_store.read_rows("utterance")
+    assert sorted(row["utterance_id"] for row in physical) == ["u0", "u1", "u2"]
+    by_key: dict[tuple[Any, Any], list[int]] = {}
+    for row in physical:
+        by_key.setdefault((row["_parent_id"], row["utterance_id"]), []).append(row["_write_gen"])
+    for key, gens in by_key.items():
+        assert len(gens) == len(set(gens)), f"equal-generation tie for {key}: {gens}"
+    assert min(row["_write_gen"] for row in physical) > child_max_before, "the healing mutation lands strictly above the pre-heal physical max"
+
+    inspector = _table(read_store)
+    assert [child["clean_word"] for child in inspector.child("utterance").rows(parent="d1")] == ["ALPHA", "BETA", "GAMMA"]
+
+
+def test_sync_fast_path_stays_zero_write_lancedb(tmp_path):
+    from hypergraph.materialization import LanceDBStore
+
+    path = str(tmp_path / "fastpath_store")
+    _table(LanceDBStore(path)).sync([{"doc_id": "d1", "text": "alpha beta"}])
+
+    snapshot_store = LanceDBStore(path)
+    snapshot = {
+        name: sorted((sorted(row.items(), key=lambda kv: kv[0]) for row in snapshot_store.read_rows(name)), key=str) for name in ("doc", "utterance")
+    }
+    executions["clean"] = executions["split"] = executions["child"] = 0
+
+    receipt = _table(LanceDBStore(path)).sync([{"doc_id": "d1", "text": "alpha beta"}])
+
+    assert [(row.outcome.value, row.status.value) for row in receipt.receipts] == [("skipped", "complete")]
+    assert (executions["clean"], executions["split"], executions["child"]) == (0, 0, 0)
+    verify_store = LanceDBStore(path)
+    after = {
+        name: sorted((sorted(row.items(), key=lambda kv: kv[0]) for row in verify_store.read_rows(name)), key=str) for name in ("doc", "utterance")
+    }
+    assert after == snapshot, "the fast path must not write to the physical store"
+
+
+# ---------------------------------------------------------------------------
+# Async parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_sync_heals_missing_child_row():
+    store = MemoryStore()
+    await _table(store, runner=AsyncRunner()).sync([{"doc_id": "d1", "text": "alpha beta gamma"}])
+    store.delete_rows("utterance", [("utterance_id", "eq", "u1")])
+    executions["clean"] = executions["split"] = executions["child"] = 0
+
+    fresh = _table(MemoryStore(store.rows), runner=AsyncRunner())
+    receipt = await fresh.sync([{"doc_id": "d1", "text": "alpha beta gamma"}])
+
+    assert _child_ids(store) == ["u0", "u1", "u2"]
+    assert [(row.outcome.value, row.status.value) for row in receipt.receipts] == [("healed", "complete")]
+    assert (executions["clean"], executions["split"], executions["child"]) == (0, 1, 1)
+
+
+@pytest.mark.asyncio
+async def test_async_fast_path_stays_zero_execution_and_zero_write():
+    store = MemoryStore()
+    table = _table(store, runner=AsyncRunner())
+    await table.sync([{"doc_id": "d1", "text": "alpha beta gamma"}])
+    snapshot = {name: [row.copy() for row in rows] for name, rows in store.rows.items()}
+    executions["clean"] = executions["split"] = executions["child"] = 0
+
+    receipt = await table.sync([{"doc_id": "d1", "text": "alpha beta gamma"}])
+
+    assert [(row.outcome.value, row.status.value) for row in receipt.receipts] == [("skipped", "complete")]
+    assert (executions["clean"], executions["split"], executions["child"]) == (0, 0, 0)
+    assert store.rows == snapshot


### PR DESCRIPTION
Closes #238. Implements locked decision #204 ("a successful parent must not make child loss permanent"), building on #311's generation contract.

## Before / after
```text
before: unchanged parent + physically deleted child row → sync() reports skipped/complete
        forever; the data is silently gone
after:  a read-only completeness probe (recorded fan-out count vs physically present
        deduplicated children; one projected read per child table per unchanged parent)
        detects the gap; ONLY the missing children re-derive; parent untouched; result
        reported as the new WriteOutcome.HEALED — never SKIPPED on a path that wrote rows
```
**Public-shape note for maintainer:** `WriteOutcome.HEALED` is a new public enum member — the locked "distinct truthful report" requires it (SKIPPED would lie); one-line revert to UPDATED possible if preferred.

Known limitation (follow-up filed): with `on_error="store"`, a child whose heal derivation fails is stored as an error row that later syncs count as present — repair is via `insert()`; strictly better than master's silent loss.

## Test plan
Red-first on master (builder + reviewer with different children and both damage vectors, raw-store delete and ChildTable.delete). Fast path proven zero-execution AND zero-write (5× byte-identical snapshots, both stores — no generation drift). Adversarial review SHIP: zero-fan-out no-heal-loop, duplicate-residue dedup, stale-copy truthfulness, recipe-change key closure, 4-children/2-deleted partial-heal counters, async+LanceDB combined axis. CI-equivalent 3915 passed; mypy clean; pre-commit green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `sync()` now automatically detects and rebuilds missing child rows for unchanged parent records.
  * Added a `healed` outcome and receipt counter to distinguish repaired rows from skipped rows.
  * Repairs only missing children while preserving existing data and avoiding unnecessary parent rewrites.

* **Documentation**
  * Updated API reference, getting-started guidance, changelog, and method documentation with the new self-repair behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->