### PR TITLE
fix(viz): canonical container entrypoints in GraphIR

### DIFF
--- a/src/hypergraph/viz/AGENTS.md
+++ b/src/hypergraph/viz/AGENTS.md
@@ -16,7 +16,7 @@ scene client-side without a kernel round-trip.
 1. `Graph` → `to_flat_graph()`
 2. `renderer/ir_builder.py:build_graph_ir(flat_graph)` → `GraphIR`
    (pure facts: nodes, edges, expandable_nodes, external_inputs,
-   configured_entrypoints, graph_output_visibility)
+   configured_entrypoints, graph_output_visibility, container_entrypoints)
 3. `widget.py:render_flat_graph` embeds the IR + initial expansion/options in
    HTML with empty top-level `nodes`/`edges`; the browser derives the scene.
 4. `scene_builder.py:build_initial_scene(ir, expansion_state, ...)` is the
@@ -42,10 +42,14 @@ pipelines differ.
 - Scene derivation changes usually have Python and JavaScript twins. Update
   `scene_builder.py`, `assets/scene_builder.js`, and derivation helpers
   together unless the difference is intentionally documented in a test.
-- Container entrypoint detection must compare a child only with outputs owned
-  by other children. A child's own output name must not make it depend on
-  itself, and multiple valid entrypoints should be preserved when the IR says
-  they are independent.
+- Container entrypoints have ONE derivation authority (locked decision D14,
+  #211): `renderer/scope.py:compute_container_entrypoints`, stamped on
+  `GraphIR.container_entrypoints` by the IR builder. Semantics are
+  self-EXCLUSIVE — a child is compared only with outputs owned by *other*
+  children, so a self-loop never disqualifies it, and multiple independent
+  entrypoints are preserved (cyclic containers fall back to the first child).
+  Scene builders (Python and JS) and the Mermaid exporter consume it; never
+  re-derive entrypoints from node inputs/outputs.
 - Treat unordered semantic fields as unordered in parity tests. Sort or
   normalize fields such as target sets before comparing Python and JS output.
 
@@ -68,8 +72,9 @@ side-effect in the order defined by `FIRST_PARTY_ASSET_NAMES`
 (`HypergraphDerivation`, `HypergraphSceneBuilder`, `HypergraphViz*`):
 
 1. `derivation.js` — pure graph-walk primitives over GraphIR + expansion
-   state (visibility, expansion-aware routing, container entrypoints); no
-   React Flow, layout, or styling knowledge
+   state (visibility, expansion-aware routing, container-entrypoint lookup
+   from the canonical `ir.container_entrypoints` field); no React Flow,
+   layout, or styling knowledge
 2. `scene_builder.js` — JS twin of `scene_builder.py`; consumes `derivation.js`
 3. `viz_runtime.js` — shared constants + helpers: `NODE_TYPE_OFFSETS`,
    `NODE_TYPE_TOP_INSETS`, `EDGE_ENDPOINT_PADDING`, node-type resolution,

--- a/src/hypergraph/viz/assets/derivation.js
+++ b/src/hypergraph/viz/assets/derivation.js
@@ -72,62 +72,43 @@
 
   // For each currently-expanded GRAPH, return the inner child(ren) that
   // should receive START / control edges that would otherwise attach to
-  // the container hull. Entrypoints are direct children whose inputs are
-  // not produced by a sibling. Cyclic containers fall back to first child.
+  // the container hull. Consumes the canonical `ir.container_entrypoints`
+  // field computed once by the Python IR builder (locked decision D14,
+  // #211) — the JS side never re-derives entrypoints from node
+  // inputs/outputs.
   function expandedContainerEntrypoints(ir, expansionState) {
-    var childrenByParent = {};
-    var nodeById = {};
-    for (var i = 0; i < ir.nodes.length; i++) {
-      var n = ir.nodes[i];
-      nodeById[n.id] = n;
-      if (n.parent) {
-        if (!childrenByParent[n.parent]) childrenByParent[n.parent] = [];
-        childrenByParent[n.parent].push(n.id);
-      }
-    }
+    var canonical = (ir && ir.container_entrypoints) || {};
     var overrides = {};
-    for (var j = 0; j < ir.nodes.length; j++) {
-      var node = ir.nodes[j];
-      if (node.node_type !== 'GRAPH') continue;
-      if (!expansionState[node.id]) continue;
-      var kids = childrenByParent[node.id] || [];
-      if (kids.length > 0) overrides[node.id] = containerEntrypoints(kids, nodeById);
+    for (var containerId in canonical) {
+      if (!Object.prototype.hasOwnProperty.call(canonical, containerId)) continue;
+      if (!expansionState[containerId]) continue;
+      var entrypoints = canonical[containerId] || [];
+      overrides[containerId] = entrypoints.slice();
     }
     return overrides;
   }
 
-  function containerEntrypoints(children, nodeById) {
-    var siblingOutputs = {};
-    for (var i = 0; i < children.length; i++) {
-      var childId = children[i];
-      var outputNode = nodeById[childId] || {};
-      var outputs = outputNode.outputs || [];
-      for (var o = 0; o < outputs.length; o++) {
-        if (outputs[o] && outputs[o].name !== undefined) {
-          var name = outputs[o].name;
-          if (!siblingOutputs[name]) siblingOutputs[name] = {};
-          siblingOutputs[name][childId] = true;
+  // Recursively replace expanded containers with their canonical descendants
+  // while preserving every plain sibling in declaration order.
+  function resolveExpandedEntrypoints(entry, overrides) {
+    var resolved = [];
+    var pending = [entry];
+
+    while (pending.length > 0) {
+      var target = pending.pop();
+      if (Object.prototype.hasOwnProperty.call(overrides, target)) {
+        var replacement = overrides[target];
+        if (replacement.length > 0) {
+          for (var r = replacement.length - 1; r >= 0; r--) {
+            pending.push(replacement[r]);
+          }
         }
+      } else if (resolved.indexOf(target) === -1) {
+        resolved.push(target);
       }
     }
 
-    var entrypoints = [];
-    for (var c = 0; c < children.length; c++) {
-      var childId = children[c];
-      var inputNode = nodeById[childId] || {};
-      var inputs = inputNode.inputs || [];
-      var dependsOnSibling = false;
-      for (var p = 0; p < inputs.length; p++) {
-        var owners = inputs[p] && siblingOutputs[inputs[p].name];
-        if (owners && Object.keys(owners).some(function(ownerId) { return ownerId !== childId; })) {
-          dependsOnSibling = true;
-          break;
-        }
-      }
-      if (!dependsOnSibling) entrypoints.push(childId);
-    }
-
-    return entrypoints.length > 0 ? entrypoints : [children[0]];
+    return resolved;
   }
 
   // ── Branch / END routing ────────────────────────────────────────────────
@@ -171,6 +152,7 @@
     resolveToVisible: resolveToVisible,
     visibleOwner: visibleOwner,
     expandedContainerEntrypoints: expandedContainerEntrypoints,
+    resolveExpandedEntrypoints: resolveExpandedEntrypoints,
     routesToEnd: routesToEnd,
     buildParentMap: buildParentMap,
     sceneNodeType: sceneNodeType,

--- a/src/hypergraph/viz/assets/scene_builder.js
+++ b/src/hypergraph/viz/assets/scene_builder.js
@@ -15,17 +15,19 @@
   // Pinned by Python via GraphIR.schema_version. Bump in lockstep with
   // ir_schema.py:CURRENT_SCHEMA_VERSION when the IR shape changes.
   // v3: tuple target_when_expanded (multi field-pill fan-out) + map_fed inputs.
-  var SUPPORTED_SCHEMA_VERSION = '3';
+  // v4: canonical container_entrypoints field (D14, #211) — this scene
+  // builder no longer derives entrypoints, so a v3 payload without the
+  // field must banner instead of silently mis-routing START/control edges.
+  var SUPPORTED_SCHEMA_VERSION = '4';
 
   function isSchemaSupported(ir) {
-    if (!ir) return true;
-    var v = ir.schema_version;
-    return v === undefined || v === null || v === SUPPORTED_SCHEMA_VERSION;
+    return !!ir && ir.schema_version === SUPPORTED_SCHEMA_VERSION;
   }
 
   var ancestorCollapsed = D.ancestorCollapsed;
   var inputHidden = D.inputHidden;
   var resolveToVisible = D.resolveToVisible;
+  var resolveExpandedEntrypoints = D.resolveExpandedEntrypoints;
   var visibleOwner = D.visibleOwner;
   var expandedContainerEntrypoints = D.expandedContainerEntrypoints;
   var routesToEnd = D.routesToEnd;
@@ -216,6 +218,7 @@
     }
 
     var sceneEdges = [];
+    var edgeEntrypointOverrides = expandedContainerEntrypoints(ir, expansionState);
 
     for (var p = 0; p < ir.edges.length; p++) {
       var irEdge = ir.edges[p];
@@ -229,10 +232,19 @@
       // item-field INPUT pills, so target_when_expanded can be an array; emit
       // one edge per target (mirrors the multi-source fan-out below).
       var targets = [irEdge.target];
-      if (expansionState[irEdge.target] && irEdge.target_when_expanded) {
-        targets = Array.isArray(irEdge.target_when_expanded)
-          ? irEdge.target_when_expanded.slice()
-          : [irEdge.target_when_expanded];
+      if (expansionState[irEdge.target]) {
+        if (irEdge.target_when_expanded) {
+          targets = Array.isArray(irEdge.target_when_expanded)
+            ? irEdge.target_when_expanded.slice()
+            : [irEdge.target_when_expanded];
+        }
+        var resolvedTargets = [];
+        for (var rt = 0; rt < targets.length; rt++) {
+          resolvedTargets = resolvedTargets.concat(
+            resolveExpandedEntrypoints(targets[rt], edgeEntrypointOverrides)
+          );
+        }
+        targets = resolvedTargets;
       }
 
       // A data edge can carry multiple value_names (one NetworkX edge per
@@ -399,30 +411,6 @@
           hidden: false,
         });
       }
-    }
-  }
-
-  function resolveExpandedEntrypoints(entry, overrides) {
-    var targets = [entry];
-    var seen = {};
-
-    while (true) {
-      var nextTargets = [];
-      var changed = false;
-      for (var i = 0; i < targets.length; i++) {
-        var target = targets[i];
-        if (seen[target]) continue;
-        seen[target] = true;
-        var replacement = overrides[target];
-        if (replacement && replacement.length > 0) {
-          for (var r = 0; r < replacement.length; r++) nextTargets.push(replacement[r]);
-          changed = true;
-        } else {
-          nextTargets.push(target);
-        }
-      }
-      if (!changed) return nextTargets;
-      targets = nextTargets;
     }
   }
 

--- a/src/hypergraph/viz/ir_schema.py
+++ b/src/hypergraph/viz/ir_schema.py
@@ -112,7 +112,13 @@ class IRExternalInput:
 # v3: ``IREdge.target_when_expanded`` may be a tuple (multi field-pill fan-out
 # re-route) and ``IRExternalInput`` gained ``map_fed`` — an old v2 scene builder
 # would mis-render both, so it must hit the mismatch banner instead.
-CURRENT_SCHEMA_VERSION = "3"
+# v4: ``GraphIR.container_entrypoints`` is the canonical expanded-container
+# entrypoint authority (locked decision D14, #211). Scene builders no longer
+# derive entrypoints from node inputs/outputs, so a v3 payload (field absent)
+# read by a v4 scene builder — or a v4 payload read by a v3 scene builder that
+# still re-derives with the old self-inclusive rule — must hit the mismatch
+# banner instead of silently mis-routing START/control edges.
+CURRENT_SCHEMA_VERSION = "4"
 
 
 class IRSchemaError(ValueError):
@@ -134,4 +140,12 @@ class GraphIR:
     # (consumed exclusively by descendants) are absent so they don't leak
     # to the container surface.
     graph_output_visibility: dict[str, tuple[str, ...]] = field(default_factory=dict)
+    # Canonical per-container entrypoints (locked decision D14, #211):
+    # GRAPH-id -> ordered direct children whose inputs are not produced by
+    # any *sibling*. Self-EXCLUSIVE: a child's own outputs never disqualify
+    # it (a self-loop accumulator is still an entrypoint). Cyclic containers
+    # where every child consumes a sibling output fall back to the first
+    # declared child. Computed once by the IR builder; scene builders and
+    # frontends must consume this field, never re-derive it.
+    container_entrypoints: dict[str, tuple[str, ...]] = field(default_factory=dict)
     schema_version: str = CURRENT_SCHEMA_VERSION

--- a/src/hypergraph/viz/mermaid.py
+++ b/src/hypergraph/viz/mermaid.py
@@ -36,8 +36,9 @@ from hypergraph.viz.renderer.nodes import (
     is_internal_gate_output,
 )
 from hypergraph.viz.renderer.scope import (
-    find_container_entrypoints,
+    compute_container_entrypoints,
     find_internal_producer_for_output,
+    resolve_expanded_entrypoints,
 )
 
 __all__ = ["MermaidDiagram", "to_mermaid", "_MermaidIdAllocator", "_sanitize_id"]
@@ -216,6 +217,7 @@ def _format_node(safe_id: str, label: str, node_type: str) -> str:
 def _render_merged_edges(
     flat_graph: nx.DiGraph,
     expansion_state: dict[str, bool],
+    container_entrypoints: dict[str, tuple[str, ...]],
     exclusive_data_edges: set[tuple[str, str, str]],
     id_allocator: _MermaidIdAllocator,
 ) -> list[tuple[str, str]]:
@@ -249,6 +251,7 @@ def _render_merged_edges(
                 target,
                 flat_graph,
                 expansion_state,
+                container_entrypoints,
             )
             if actual_target is None:
                 continue
@@ -287,6 +290,7 @@ def _render_merged_edges(
                 flat_graph,
                 expansion_state,
                 param_to_consumers,
+                container_entrypoints,
             )
             if actual_source is None or actual_target is None:
                 continue
@@ -305,6 +309,7 @@ def _render_merged_edges(
 def _render_separate_edges(
     flat_graph: nx.DiGraph,
     expansion_state: dict[str, bool],
+    container_entrypoints: dict[str, tuple[str, ...]],
     exclusive_data_edges: set[tuple[str, str, str]],
     id_allocator: _MermaidIdAllocator,
 ) -> list[tuple[str, str]]:
@@ -318,6 +323,10 @@ def _render_separate_edges(
         flat_graph,
         expansion_state,
         use_deepest=True,
+    )
+    param_to_consumers = build_param_to_consumer_map(
+        flat_graph,
+        expansion_state,
     )
     seen_edges: set[tuple[str, ...]] = set()
 
@@ -360,15 +369,25 @@ def _render_separate_edges(
                 )
                 if actual_source is None:
                     continue
+                actual_target = _resolve_data_target(
+                    target,
+                    value_name,
+                    flat_graph,
+                    expansion_state,
+                    param_to_consumers,
+                    container_entrypoints,
+                )
+                if actual_target is None:
+                    continue
                 source_attrs = flat_graph.nodes.get(actual_source, {})
                 if is_internal_gate_output(actual_source, value_name, source_attrs):
                     continue
                 data_id = f"data_{actual_source}_{value_name}"
-                edge_key = (id_allocator.get(data_id), id_allocator.get(target))
+                edge_key = (id_allocator.get(data_id), id_allocator.get(actual_target))
                 if edge_key not in seen_edges:
                     seen_edges.add(edge_key)
                     is_exclusive = (source, target, value_name) in exclusive_data_edges
-                    out.append((_format_edge(data_id, target, value_name, exclusive=is_exclusive, id_allocator=id_allocator), "data"))
+                    out.append((_format_edge(data_id, actual_target, value_name, exclusive=is_exclusive, id_allocator=id_allocator), "data"))
 
         elif edge_type == "ordering":
             value_name = value_names[0] if value_names else ""
@@ -383,6 +402,7 @@ def _render_separate_edges(
                 target,
                 flat_graph,
                 expansion_state,
+                container_entrypoints,
             )
             if actual_target is None:
                 continue
@@ -447,14 +467,22 @@ def _resolve_control_target(
     target: str,
     flat_graph: nx.DiGraph,
     expansion_state: dict[str, bool],
+    container_entrypoints: dict[str, tuple[str, ...]],
 ) -> str | None:
-    """Resolve the actual target for a control edge, entering containers."""
-    actual_target = target
-    target_attrs = flat_graph.nodes.get(target, {})
-    if target_attrs.get("node_type") == "GRAPH" and expansion_state.get(target, False):
-        entrypoints = find_container_entrypoints(target, flat_graph, expansion_state)
-        if entrypoints:
-            actual_target = entrypoints[0]
+    """Resolve the actual target for a control edge, entering containers.
+
+    Uses the canonical container-entrypoint derivation (D14, #211) shared
+    with the IR builder; Mermaid renders its first entry, matching the
+    interactive renderer's ``IREdge.target_when_expanded`` fallback.
+    """
+    entrypoints = resolve_expanded_entrypoints(
+        (target,),
+        container_entrypoints,
+        expansion_state,
+    )
+    if not entrypoints:
+        return None
+    actual_target = entrypoints[0]
     if not is_node_visible(actual_target, flat_graph, expansion_state):
         return None
     return actual_target
@@ -494,6 +522,7 @@ def _resolve_data_target(
     flat_graph: nx.DiGraph,
     expansion_state: dict[str, bool],
     param_to_consumers: dict[str, list[str]],
+    container_entrypoints: dict[str, tuple[str, ...]],
 ) -> str | None:
     """Resolve actual target for a data edge, entering expanded containers."""
     actual_target = target
@@ -504,9 +533,14 @@ def _resolve_data_target(
         if internal:
             actual_target = internal[0]
         else:
-            entry = find_container_entrypoints(target, flat_graph, expansion_state)
-            if entry:
-                actual_target = entry[0]
+            entrypoints = resolve_expanded_entrypoints(
+                (target,),
+                container_entrypoints,
+                expansion_state,
+            )
+            if not entrypoints:
+                return None
+            actual_target = entrypoints[0]
     if not is_node_visible(actual_target, flat_graph, expansion_state):
         return None
     return actual_target
@@ -692,6 +726,7 @@ def to_mermaid(
         raise ValueError(msg)
 
     expansion_state = build_expansion_state(flat_graph, depth)
+    container_entrypoints = compute_container_entrypoints(flat_graph)
     input_spec = flat_graph.graph.get("input_spec", {})
     bound_params = set(input_spec.get("bound", {}).keys())
     param_to_consumers = build_param_to_consumer_map(flat_graph, expansion_state)
@@ -705,7 +740,11 @@ def to_mermaid(
     if shared_params:
         lines.append(f"    %% shared state: {', '.join(shared_params)}")
 
-    start_targets = get_start_targets(flat_graph, expansion_state)
+    start_targets = get_start_targets(
+        flat_graph,
+        expansion_state,
+        container_entrypoints,
+    )
 
     # --- START node (emit early so layout keeps START visually above flow) ---
     if start_targets:
@@ -823,15 +862,37 @@ def to_mermaid(
             id_segs = [id_for_param.get(p, external_input_display_name(p)) for p in params]
             input_node_id = f"input_group_{'_'.join(id_segs)}"
 
-        targets = _get_input_targets(params, flat_graph, param_to_consumers, expansion_state)
+        targets = _get_input_targets(
+            params,
+            flat_graph,
+            param_to_consumers,
+            expansion_state,
+            container_entrypoints,
+        )
         for tgt in targets:
             edge_pairs.append((_format_edge(input_node_id, tgt, None, id_allocator=id_allocator), "input"))
 
     exclusive_data_edges = compute_exclusive_data_edges(flat_graph)
     if separate_outputs:
-        edge_pairs.extend(_render_separate_edges(flat_graph, expansion_state, exclusive_data_edges, id_allocator))
+        edge_pairs.extend(
+            _render_separate_edges(
+                flat_graph,
+                expansion_state,
+                container_entrypoints,
+                exclusive_data_edges,
+                id_allocator,
+            )
+        )
     else:
-        edge_pairs.extend(_render_merged_edges(flat_graph, expansion_state, exclusive_data_edges, id_allocator))
+        edge_pairs.extend(
+            _render_merged_edges(
+                flat_graph,
+                expansion_state,
+                container_entrypoints,
+                exclusive_data_edges,
+                id_allocator,
+            )
+        )
 
     edge_pairs.extend((line, "end") for line in _render_end_edges(flat_graph, expansion_state, id_allocator))
 
@@ -878,6 +939,7 @@ def _get_input_targets(
     flat_graph: nx.DiGraph,
     param_to_consumers: dict[str, list[str]],
     expansion_state: dict[str, bool],
+    container_entrypoints: dict[str, tuple[str, ...]],
 ) -> list[str]:
     """Get unique target nodes for input parameters.
 
@@ -892,6 +954,8 @@ def _get_input_targets(
     for param in params:
         for target in param_to_consumers.get(param, []):
             if target in seen:
+                continue
+            if expansion_state.get(target) and target in container_entrypoints and not container_entrypoints[target]:
                 continue
             # Skip only if the specific gate controlling this target
             # also consumes this same param

--- a/src/hypergraph/viz/renderer/ir_builder.py
+++ b/src/hypergraph/viz/renderer/ir_builder.py
@@ -26,6 +26,7 @@ from hypergraph.viz.renderer._format import format_type
 from hypergraph.viz.renderer.nodes import build_input_groups, get_param_type
 from hypergraph.viz.renderer.scope import (
     build_graph_output_visibility,
+    compute_container_entrypoints,
     compute_deepest_input_scope,
     get_deepest_consumers,
     is_output_externally_consumed,
@@ -49,8 +50,12 @@ def build_graph_ir(flat_graph: nx.DiGraph) -> GraphIR:
     exclusive_edges = compute_exclusive_data_edges(flat_graph)
     mutex_groups = _compute_mutex_groups(flat_graph)
     back_edges = _find_back_edges(flat_graph)
+    # The ONE canonical container-entrypoint derivation (D14, #211): stamped
+    # on the IR below and reused for the entrypoint fallback of edges that
+    # enter an expanded container.
+    container_entrypoints = compute_container_entrypoints(flat_graph)
     edges = [
-        _build_ir_edge(src, tgt, attrs, flat_graph, exclusive_edges, mutex_groups, back_edges)
+        _build_ir_edge(src, tgt, attrs, flat_graph, exclusive_edges, mutex_groups, back_edges, container_entrypoints)
         for src, tgt, attrs in flat_graph.edges(data=True)
         if src not in hidden_nodes and tgt not in hidden_nodes
     ]
@@ -91,6 +96,7 @@ def build_graph_ir(flat_graph: nx.DiGraph) -> GraphIR:
         external_inputs=external_inputs,
         configured_entrypoints=configured_entrypoints,
         graph_output_visibility=graph_output_visibility,
+        container_entrypoints=container_entrypoints,
     )
 
 
@@ -263,6 +269,7 @@ def _build_ir_edge(
     exclusive_edges: set[tuple[str, str, str]],
     mutex_groups: list[list[set[str]]],
     back_edges: set[tuple[str, str]],
+    container_entrypoints: dict[str, tuple[str, ...]],
 ) -> IREdge:
     """Pre-compute the source-when-expanded / target-when-expanded rewrites
     so the JS scene_builder can re-route edges on container expansion
@@ -294,8 +301,10 @@ def _build_ir_edge(
         # here: control edges (value_names is empty, so the consumer search is
         # a no-op) and identity-mode fan-out edges (the value names a parent
         # column — e.g. "pages" — that no inner node consumes by name).
+        # First entry of the canonical container_entrypoints map (D14, #211).
         if target_when_expanded is None:
-            target_when_expanded = _first_container_entrypoint(tgt, flat_graph)
+            entrypoints = container_entrypoints.get(tgt)
+            target_when_expanded = entrypoints[0] if entrypoints else None
 
     label = _branch_label_for_edge(src_attrs, tgt) if edge_type == "control" else None
 
@@ -385,28 +394,6 @@ def _find_back_edges(flat_graph: nx.DiGraph) -> set[tuple[str, str]]:
         if color.get(node, WHITE) == WHITE:
             dfs(node)
     return back
-
-
-def _first_container_entrypoint(container_id: str, flat_graph: nx.DiGraph) -> str | None:
-    """State-independent first entrypoint of a container — the first
-    direct child whose inputs are not produced by any sibling. Used to
-    re-route control edges when the container is expanded."""
-    direct_children = [node_id for node_id, attrs in flat_graph.nodes(data=True) if attrs.get("parent") == container_id]
-    if not direct_children:
-        return None
-
-    sibling_outputs: set[str] = set()
-    for child_id in direct_children:
-        sibling_outputs.update(flat_graph.nodes.get(child_id, {}).get("outputs", ()))
-
-    for child_id in direct_children:
-        child_inputs = set(flat_graph.nodes.get(child_id, {}).get("inputs", ()))
-        if not child_inputs & sibling_outputs:
-            return child_id
-
-    # Cyclic container — no pure-external child exists; fall back to the
-    # first declared child so callers get a stable target.
-    return direct_children[0]
 
 
 def _inner_output_name(container_id: str, value_name: str, flat_graph: nx.DiGraph) -> str:

--- a/src/hypergraph/viz/renderer/nodes.py
+++ b/src/hypergraph/viz/renderer/nodes.py
@@ -11,7 +11,7 @@ from typing import Any
 import networkx as nx
 
 from hypergraph.viz._common import is_node_visible
-from hypergraph.viz.renderer.scope import find_container_entrypoints
+from hypergraph.viz.renderer.scope import resolve_expanded_entrypoints
 
 # =============================================================================
 # Input Grouping
@@ -108,6 +108,7 @@ def has_end_routing(
 def get_start_targets(
     flat_graph: nx.DiGraph,
     expansion_state: dict[str, bool],
+    container_entrypoints: dict[str, tuple[str, ...]],
 ) -> list[str]:
     """Get visible targets for the synthetic START node.
 
@@ -131,9 +132,19 @@ def get_start_targets(
 
         attrs = flat_graph.nodes.get(resolved, {})
         if attrs.get("node_type") == "GRAPH" and expansion_state.get(resolved, False):
-            entrypoints = find_container_entrypoints(resolved, flat_graph, expansion_state)
-            if entrypoints:
-                resolved = entrypoints[0]
+            # Canonical derivation (D14, #211). Mermaid draws a single START
+            # edge, so only the first entrypoint is used here.
+            entrypoints = resolve_expanded_entrypoints(
+                (resolved,),
+                container_entrypoints,
+                expansion_state,
+            )
+            if not entrypoints:
+                continue
+            resolved = entrypoints[0]
+
+        if not is_node_visible(resolved, flat_graph, expansion_state):
+            continue
 
         if resolved in seen:
             continue

--- a/src/hypergraph/viz/renderer/scope.py
+++ b/src/hypergraph/viz/renderer/scope.py
@@ -7,6 +7,7 @@ and which outputs are externally consumed (visible outside their container).
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Iterable, Mapping
 from typing import TYPE_CHECKING
 
 from hypergraph.viz._common import (
@@ -178,38 +179,67 @@ def build_graph_output_visibility(flat_graph: nx.DiGraph) -> dict[str, set[str]]
     return visibility
 
 
-def find_container_entrypoints(
-    container_id: str,
-    flat_graph: nx.DiGraph,
-    expansion_state: dict[str, bool],
-) -> list[str]:
-    """Find entry point nodes inside a container for control edge routing."""
-    direct_children = [node_id for node_id, attrs in flat_graph.nodes(data=True) if attrs.get("parent") == container_id]
+def compute_container_entrypoints(flat_graph: nx.DiGraph) -> dict[str, tuple[str, ...]]:
+    """Canonical container-entrypoint map (locked decision D14, #211).
 
-    internal_outputs = set()
-    for node_id in direct_children:
-        attrs = flat_graph.nodes.get(node_id, {})
-        for output in attrs.get("outputs", ()):
-            internal_outputs.add(output)
+    ``GRAPH-id -> ordered entrypoint children``: direct children whose inputs
+    are not produced by any *sibling*. Only visible entrypoints become edge
+    targets; an empty tuple tells consumers to suppress an edge when every
+    structural entrypoint is hidden.
+    Self-EXCLUSIVE:
+    a child's own outputs never disqualify it — a self-loop accumulator is
+    still an entrypoint. Cyclic containers where every child consumes a
+    sibling output fall back to the first declared child so consumers get a
+    stable target. State-independent: consumers filter by expansion state.
 
-    entrypoints = []
-    for node_id in direct_children:
-        attrs = flat_graph.nodes.get(node_id, {})
-        inputs = set(attrs.get("inputs", ()))
+    This is the single derivation authority. The IR builder stamps it on
+    ``GraphIR.container_entrypoints``; scene builders (Python and JS) and the
+    Mermaid exporter consume it. Do not re-derive entrypoints elsewhere.
+    """
+    entrypoint_map: dict[str, tuple[str, ...]] = {}
+    for container_id, attrs in flat_graph.nodes(data=True):
+        if attrs.get("node_type") != "GRAPH" or attrs.get("hide", False):
+            continue
+        all_children = [(child_id, child_attrs) for child_id, child_attrs in flat_graph.nodes(data=True) if child_attrs.get("parent") == container_id]
+        if not all_children:
+            continue
+        structural_entrypoints = []
+        for child_id, child_attrs in all_children:
+            sibling_outputs = {output for other_id, other_attrs in all_children if other_id != child_id for output in other_attrs.get("outputs", ())}
+            if not set(child_attrs.get("inputs", ())) & sibling_outputs:
+                structural_entrypoints.append(child_id)
 
-        consumes_internal = bool(inputs & internal_outputs)
+        visible_entrypoints = [child_id for child_id in structural_entrypoints if not flat_graph.nodes[child_id].get("hide", False)]
+        if visible_entrypoints:
+            entrypoint_map[container_id] = tuple(visible_entrypoints)
+        elif structural_entrypoints:
+            entrypoint_map[container_id] = ()
+        else:
+            visible_children = [child_id for child_id, child_attrs in all_children if not child_attrs.get("hide", False)]
+            entrypoint_map[container_id] = (visible_children[0],) if visible_children else ()
+    return entrypoint_map
 
-        if not consumes_internal and is_node_visible(node_id, flat_graph, expansion_state):
-            entrypoints.append(node_id)
 
-    if entrypoints:
-        return entrypoints
+def resolve_expanded_entrypoints(
+    entries: Iterable[str],
+    container_entrypoints: Mapping[str, tuple[str, ...]],
+    expansion_state: Mapping[str, bool],
+) -> tuple[str, ...]:
+    """Resolve expanded entrypoint containers to descendant targets."""
+    resolved: list[str] = []
+    pending = list(reversed(tuple(entries)))
 
-    # Cyclic containers can have no "pure external" child by this heuristic.
-    # Fall back to visible direct children so expanded containers are not used
-    # as edge endpoints in the visualization.
-    fallback = [node_id for node_id in direct_children if is_node_visible(node_id, flat_graph, expansion_state)]
-    return fallback
+    while pending:
+        target = pending.pop()
+        if expansion_state.get(target) and target in container_entrypoints:
+            overrides = container_entrypoints[target]
+            if overrides:
+                pending.extend(reversed(overrides))
+            continue
+        if target not in resolved:
+            resolved.append(target)
+
+    return tuple(resolved)
 
 
 def find_internal_producer_for_output(

--- a/src/hypergraph/viz/scene_builder.py
+++ b/src/hypergraph/viz/scene_builder.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from typing import Any
 
 from hypergraph.viz.ir_schema import CURRENT_SCHEMA_VERSION, GraphIR, IRSchemaError
+from hypergraph.viz.renderer.scope import resolve_expanded_entrypoints
 
 
 def build_initial_scene(
@@ -182,7 +183,6 @@ def build_initial_scene(
                 scene_nodes.append(scene_node)
 
     visible_ids = {n["id"] for n in scene_nodes if not n["hidden"]}
-
     scene_edges: list[dict[str, Any]] = []
 
     for ir_edge in ir.edges:
@@ -197,9 +197,11 @@ def build_initial_scene(
         # -field INPUT pills, so target_when_expanded can be a tuple; emit one
         # edge per target (mirrors the multi-source fan-out below).
         targets = [ir_edge.target]
-        if expansion_state.get(ir_edge.target) and ir_edge.target_when_expanded:
-            expanded_targets = ir_edge.target_when_expanded
-            targets = list(expanded_targets) if isinstance(expanded_targets, tuple) else [expanded_targets]
+        if expansion_state.get(ir_edge.target):
+            if ir_edge.target_when_expanded:
+                expanded_targets = ir_edge.target_when_expanded
+                targets = list(expanded_targets) if isinstance(expanded_targets, tuple) else [expanded_targets]
+            targets = list(resolve_expanded_entrypoints(targets, ir.container_entrypoints, expansion_state))
 
         # A data edge can carry multiple value_names (one NetworkX edge per
         # (src,tgt) merges them). Merged-output mode should still render one
@@ -298,12 +300,10 @@ def _add_start_end_nodes_and_edges(
     # When an entrypoint is itself a GRAPH and currently expanded, the
     # START edge should attach to its real inner entrypoint(s) so it
     # visually connects to executable code instead of the container chrome.
-    entrypoint_overrides = _expanded_container_entrypoints(ir, expansion_state)
-
     start_targets: list[str] = []
     seen_start: set[str] = set()
     for entry in ir.configured_entrypoints:
-        for target in _resolve_expanded_entrypoints(entry, entrypoint_overrides):
+        for target in resolve_expanded_entrypoints((entry,), ir.container_entrypoints, expansion_state):
             resolved = _resolve_to_visible(target, parent_map, expansion_state, visible_ids)
             if resolved is None or resolved in seen_start:
                 continue
@@ -393,76 +393,6 @@ def _resolve_to_visible(
     while current is not None and current not in visible_ids:
         current = parent_map.get(current)
     return current
-
-
-def _expanded_container_entrypoints(
-    ir: GraphIR,
-    expansion_state: dict[str, bool],
-) -> dict[str, list[str]]:
-    """For each GRAPH currently expanded, find inner child(ren) to receive
-    edges that would otherwise attach to the container hull.
-
-    Entrypoints are direct children whose inputs are not produced by a
-    sibling. Cyclic containers have no pure source, so they fall back to
-    the first declared child for stable rendering.
-    """
-    children_by_parent: dict[str, list[str]] = {}
-    node_by_id = {ir_node.id: ir_node for ir_node in ir.nodes}
-    for ir_node in ir.nodes:
-        if ir_node.parent is not None:
-            children_by_parent.setdefault(ir_node.parent, []).append(ir_node.id)
-
-    overrides: dict[str, list[str]] = {}
-    for ir_node in ir.nodes:
-        if ir_node.node_type != "GRAPH":
-            continue
-        if not expansion_state.get(ir_node.id):
-            continue
-        children = children_by_parent.get(ir_node.id, [])
-        if children:
-            overrides[ir_node.id] = _container_entrypoints(children, node_by_id)
-    return overrides
-
-
-def _container_entrypoints(
-    children: list[str],
-    node_by_id: dict[str, Any],
-) -> list[str]:
-    entrypoints = []
-    for child_id in children:
-        sibling_outputs = {
-            output["name"] for other_id in children if other_id != child_id for output in node_by_id[other_id].outputs if "name" in output
-        }
-        child_inputs = {input_["name"] for input_ in node_by_id[child_id].inputs if "name" in input_}
-        if not child_inputs & sibling_outputs:
-            entrypoints.append(child_id)
-
-    return entrypoints or [children[0]]
-
-
-def _resolve_expanded_entrypoints(
-    entry: str,
-    entrypoint_overrides: dict[str, list[str]],
-) -> list[str]:
-    targets = [entry]
-    seen: set[str] = set()
-
-    while True:
-        next_targets: list[str] = []
-        changed = False
-        for target in targets:
-            if target in seen:
-                continue
-            seen.add(target)
-            overrides = entrypoint_overrides.get(target)
-            if overrides:
-                next_targets.extend(overrides)
-                changed = True
-            else:
-                next_targets.append(target)
-        if not changed:
-            return next_targets
-        targets = next_targets
 
 
 def _synthetic_node(node_id: str, node_type: str, label: str) -> dict[str, Any]:

--- a/tests/test_frozen_baselines/baselines/mermaid/container_entrypoint_expanded.mmd
+++ b/tests/test_frozen_baselines/baselines/mermaid/container_entrypoint_expanded.mmd
@@ -19,7 +19,7 @@ flowchart TD
     input_request --> intake
     input_seed --> worker__kickoff
     intake --> dispatch
-    dispatch -.-> worker__kickoff
+    dispatch -.-> worker__accumulate
     dispatch -.-> __end__
 
     %% Styling

--- a/tests/test_frozen_baselines/graph_cases.py
+++ b/tests/test_frozen_baselines/graph_cases.py
@@ -192,26 +192,28 @@ def build_multi_output() -> Graph:
 
 
 # ---------------------------------------------------------------------------
-# container entrypoint (the #211 divergence case)
+# container entrypoint (the #211 divergence case, now unified)
 # ---------------------------------------------------------------------------
 #
-# The inner "worker" container is deliberately shaped so today's
-# self-INCLUSIVE container-entrypoint derivation (viz/renderer/scope.py,
-# used by the Mermaid exporter for edges entering an expanded container)
-# picks a DIFFERENT entrypoint than the corrected self-EXCLUSIVE derivation
-# in viz/scene_builder.py:
+# The inner "worker" container is deliberately shaped so the historical
+# self-INCLUSIVE container-entrypoint derivation (pre-#211 Mermaid path)
+# picked a DIFFERENT entrypoint than the canonical self-EXCLUSIVE derivation
+# that #211 made authoritative (``compute_container_entrypoints`` in
+# viz/renderer/scope.py, stamped on ``GraphIR.container_entrypoints``):
 #
-# - ``accumulate`` consumes its own output (self-loop on ``history``), so the
-#   self-inclusive rule disqualifies it and picks ``kickoff``.
-# - The self-exclusive rule ignores a node's own outputs, so it would pick
-#   ``accumulate`` (declared first).
+# - ``accumulate`` consumes its own output (self-loop on ``history``). The
+#   old self-inclusive rule disqualified it and picked ``kickoff``.
+# - The canonical self-exclusive rule ignores a node's own outputs, so it
+#   picks ``accumulate`` (declared first) — and keeps ``kickoff`` as a
+#   second independent entrypoint.
 #
 # The self-loop makes the inner graph cyclic, so it declares both children
 # as execution entrypoints (required at construction; keeps both active).
 #
-# When #211 unifies the derivations, the frozen Mermaid baseline for this
-# case MUST change — that diff is the deliberate, visible before/after
-# evidence #211's PR carries.
+# #211 landed that unification: the frozen Mermaid baseline flipped exactly
+# one edge (``dispatch -.-> worker__kickoff`` → ``dispatch -.->
+# worker__accumulate``) as the deliberate, visible before/after evidence.
+# This case now pins the canonical behavior against future drift.
 
 
 @node(output_name="history")

--- a/tests/test_frozen_baselines/test_mermaid_baselines.py
+++ b/tests/test_frozen_baselines/test_mermaid_baselines.py
@@ -5,11 +5,13 @@ Each case freezes the FULL Mermaid source emitted today into a checked-in
 This is the before/after baseline for the Mermaid-on-GraphIR migration
 (#212) and the container-entrypoint unification (#211).
 
-KNOWN DELIBERATE CHANGE AHEAD: ``container_entrypoint_expanded.mmd`` freezes
-today's self-INCLUSIVE container-entrypoint derivation (viz/renderer/scope.py).
-When #211 switches the Mermaid path to the corrected self-EXCLUSIVE
-derivation (as in viz/scene_builder.py), that fixture MUST be updated in the
-same PR -- the fixture diff IS the visible evidence of the behavior change.
+DELIBERATE CHANGE LANDED (#211): ``container_entrypoint_expanded.mmd`` now
+freezes the canonical self-EXCLUSIVE container-entrypoint derivation
+(``compute_container_entrypoints`` in viz/renderer/scope.py, stamped on
+``GraphIR.container_entrypoints``). The one-line flip
+``dispatch -.-> worker__kickoff`` → ``dispatch -.-> worker__accumulate`` was
+the visible evidence of that unification; any NEW drift in this fixture is a
+regression against the canonical derivation.
 
 To regenerate after an INTENTIONAL change:
 

--- a/tests/viz/conftest.py
+++ b/tests/viz/conftest.py
@@ -51,6 +51,142 @@ def scene_for_state(
     )
 
 
+def make_nested_container_entrypoint_graph() -> Graph:
+    """A routed container whose first entrypoint is another container."""
+    from hypergraph import END, route
+
+    @node(output_name="history")
+    def acc_step(history: list, raw: str) -> list:
+        return [*history, raw]
+
+    @node(output_name="ready")
+    def starter(seed: str) -> str:
+        return seed
+
+    @node(output_name="signal")
+    def intake(request: str) -> str:
+        return request
+
+    @route(targets=["mid", END])
+    def dispatch(signal: str) -> str:
+        return "mid"
+
+    accumulator = Graph([acc_step], name="accum", entrypoint="acc_step")
+    middle = Graph(
+        [accumulator.as_node(), starter],
+        name="mid",
+        entrypoint=["accum", "starter"],
+    )
+    return Graph(
+        [intake, dispatch, middle.as_node()],
+        name="outer",
+        entrypoint="intake",
+    )
+
+
+def make_hidden_only_container_graph() -> Graph:
+    """A routed container whose only child is absent from the scene."""
+    from hypergraph import END, route
+
+    @node(output_name="inner_out", hide=True)
+    def only_child(signal: str) -> str:
+        return signal
+
+    @node(output_name="signal")
+    def intake(request: str) -> str:
+        return request
+
+    @route(targets=["box", END])
+    def dispatch(signal: str) -> str:
+        return "box"
+
+    box = Graph([only_child], name="box", entrypoint="only_child")
+    return Graph([intake, dispatch, box.as_node()], entrypoint="intake")
+
+
+def make_hidden_sibling_dependency_graph() -> Graph:
+    """A hidden producer feeds one visible child beside a true entrypoint."""
+    from hypergraph import END, route
+
+    @node(output_name="hidden_value", hide=True)
+    def hidden_source(seed: str) -> str:
+        return seed
+
+    @node(output_name="derived")
+    def dependent(hidden_value: str) -> str:
+        return hidden_value
+
+    @node(output_name="ready")
+    def independent(external: str) -> str:
+        return external
+
+    @node(output_name="signal")
+    def intake(request: str) -> str:
+        return request
+
+    @route(targets=["box", END])
+    def dispatch(signal: str) -> str:
+        return "box"
+
+    box = Graph(
+        [hidden_source, dependent, independent],
+        name="box",
+        entrypoint=["hidden_source", "independent"],
+    )
+    return Graph([intake, dispatch, box.as_node()], entrypoint="intake")
+
+
+def make_hidden_source_only_dependency_graph() -> Graph:
+    """A hidden source is the sole true entrypoint for a visible dependent."""
+    from hypergraph import END, route
+
+    @node(output_name="hidden_value", hide=True)
+    def hidden_source(seed: str) -> str:
+        return seed
+
+    @node(output_name="derived")
+    def dependent(hidden_value: str) -> str:
+        return hidden_value
+
+    @node(output_name="signal")
+    def intake(request: str) -> str:
+        return request
+
+    @route(targets=["box", END])
+    def dispatch(signal: str) -> str:
+        return "box"
+
+    box = Graph(
+        [hidden_source, dependent],
+        name="box",
+        entrypoint="hidden_source",
+    )
+    return Graph([intake, dispatch, box.as_node()], entrypoint="intake")
+
+
+def make_hidden_source_data_dependency_graph() -> Graph:
+    """A data edge enters a container whose only true source is hidden."""
+
+    @node(output_name="seed")
+    def produce(request: str) -> str:
+        return request
+
+    @node(output_name="hidden_value", hide=True)
+    def hidden_source(seed: str) -> str:
+        return seed
+
+    @node(output_name="derived")
+    def dependent(hidden_value: str) -> str:
+        return hidden_value
+
+    box = Graph(
+        [hidden_source, dependent],
+        name="box",
+        entrypoint="hidden_source",
+    )
+    return Graph([produce, box.as_node()], entrypoint="produce")
+
+
 def _check_playwright_available() -> bool:
     """Check if playwright is installed AND browser binaries are available.
 

--- a/tests/viz/test_derivation_js.py
+++ b/tests/viz/test_derivation_js.py
@@ -45,6 +45,7 @@ def test_module_attaches_to_globalthis():
             "buildParentMap",
             "expandedContainerEntrypoints",
             "inputHidden",
+            "resolveExpandedEntrypoints",
             "resolveToVisible",
             "routesToEnd",
             "sceneNodeType",
@@ -129,17 +130,67 @@ def test_visible_owner_picks_first_expanded_ancestor():
     }
 
 
-def test_expanded_container_entrypoints_picks_dependency_entrypoint():
+def test_expanded_container_entrypoints_consumes_canonical_field_for_expanded_only():
+    """The JS side consumes ``ir.container_entrypoints`` (D14, #211) filtered
+    to currently-expanded containers — collapsed containers get no override."""
+    result = _run("""
+        const ir = {
+            nodes: [
+                {id: 'outer', node_type: 'GRAPH', parent: null},
+                {id: 'outer/upstream', node_type: 'FUNCTION', parent: 'outer'},
+                {id: 'collapsed', node_type: 'GRAPH', parent: null},
+                {id: 'collapsed/x', node_type: 'FUNCTION', parent: 'collapsed'},
+            ],
+            container_entrypoints: {
+                outer: ['outer/upstream'],
+                collapsed: ['collapsed/x'],
+            },
+        };
+        return D.expandedContainerEntrypoints(ir, {outer: true});
+    """)
+    assert result == {"outer": ["outer/upstream"]}
+
+
+def test_expanded_container_entrypoints_never_rederives_from_node_shapes():
+    """The canonical field wins VERBATIM. The IR below is shaped so any
+    hidden re-derivation from inputs/outputs would pick 'outer/upstream'
+    (the dependency source); the field deliberately says 'outer/downstream'.
+    If this test fails with 'outer/upstream', a duplicate derivation crept
+    back into the JS side — delete it and consume the field (#211)."""
+    result = _run("""
+        const ir = {
+            nodes: [
+                {id: 'outer', node_type: 'GRAPH', parent: null},
+                {
+                    id: 'outer/downstream',
+                    node_type: 'FUNCTION',
+                    parent: 'outer',
+                    inputs: [{name: 'started'}],
+                    outputs: [{name: 'done'}],
+                },
+                {
+                    id: 'outer/upstream',
+                    node_type: 'FUNCTION',
+                    parent: 'outer',
+                    inputs: [{name: 'x'}],
+                    outputs: [{name: 'started'}],
+                },
+            ],
+            container_entrypoints: {outer: ['outer/downstream']},
+        };
+        return D.expandedContainerEntrypoints(ir, {outer: true});
+    """)
+    assert result == {"outer": ["outer/downstream"]}
+
+
+def test_expanded_container_entrypoints_missing_field_yields_no_overrides():
+    """A payload without ``container_entrypoints`` produces NO overrides —
+    the JS side must not fall back to a local derivation. (In production a
+    v3 payload never reaches this code: the scene builder banners on the
+    schema-version mismatch first.)"""
     result = _run("""
         const ir = {nodes: [
             {id: 'outer', node_type: 'GRAPH', parent: null},
-            {
-                id: 'outer/downstream',
-                node_type: 'FUNCTION',
-                parent: 'outer',
-                inputs: [{name: 'started'}],
-                outputs: [{name: 'done'}],
-            },
             {
                 id: 'outer/upstream',
                 node_type: 'FUNCTION',
@@ -147,43 +198,30 @@ def test_expanded_container_entrypoints_picks_dependency_entrypoint():
                 inputs: [{name: 'x'}],
                 outputs: [{name: 'started'}],
             },
-            {id: 'collapsed', node_type: 'GRAPH', parent: null},
-            {id: 'collapsed/x', node_type: 'FUNCTION', parent: 'collapsed'},
         ]};
         return D.expandedContainerEntrypoints(ir, {outer: true});
     """)
-    assert result == {"outer": ["outer/upstream"]}
+    assert result == {}
 
 
-def test_expanded_container_entrypoints_ignore_self_outputs_and_keep_multiple_entrypoints():
+def test_resolve_expanded_entrypoints_preserves_plain_siblings():
+    """Nested resolution expands containers without dropping other targets."""
     result = _run("""
-        const ir = {nodes: [
-            {id: 'outer', node_type: 'GRAPH', parent: null},
-            {
-                id: 'outer/selfish',
-                node_type: 'FUNCTION',
-                parent: 'outer',
-                inputs: [{name: 'loop'}],
-                outputs: [{name: 'loop'}],
-            },
-            {
-                id: 'outer/independent',
-                node_type: 'FUNCTION',
-                parent: 'outer',
-                inputs: [{name: 'x'}],
-                outputs: [{name: 'y'}],
-            },
-            {
-                id: 'outer/downstream',
-                node_type: 'FUNCTION',
-                parent: 'outer',
-                inputs: [{name: 'y'}],
-                outputs: [{name: 'z'}],
-            },
-        ]};
-        return D.expandedContainerEntrypoints(ir, {outer: true});
+        const overrides = {
+            mid: ['mid/accum', 'mid/starter'],
+            'mid/accum': ['mid/accum/step'],
+        };
+        return D.resolveExpandedEntrypoints('mid', overrides);
     """)
-    assert result == {"outer": ["outer/selfish", "outer/independent"]}
+    assert result == ["mid/accum/step", "mid/starter"]
+
+
+def test_resolve_expanded_entrypoints_suppresses_empty_override():
+    """An expanded container with no visible entrypoint has no edge target."""
+    result = _run("""
+        return D.resolveExpandedEntrypoints('box', {box: []});
+    """)
+    assert result == []
 
 
 def test_routes_to_end_handles_all_branch_shapes():

--- a/tests/viz/test_ir_builder.py
+++ b/tests/viz/test_ir_builder.py
@@ -8,7 +8,11 @@ precomputation.
 from hypergraph.viz.ir_schema import GraphIR
 from hypergraph.viz.renderer import render_graph
 from hypergraph.viz.renderer.ir_builder import build_graph_ir
-from tests.viz.conftest import make_simple_graph, make_workflow
+from tests.viz.conftest import (
+    make_hidden_source_only_dependency_graph,
+    make_simple_graph,
+    make_workflow,
+)
 
 
 def test_two_node_graph_appears_in_ir_with_connecting_edge():
@@ -105,3 +109,160 @@ def test_function_node_signatures_match_render_graph_wrapper():
     ir_sigs = {(n.id, n.node_type, n.parent) for n in ir.nodes if n.node_type == "FUNCTION"}
     oracle_sigs = {(n["id"], n["data"]["nodeType"], n.get("parentId")) for n in oracle["nodes"] if n.get("data", {}).get("nodeType") == "FUNCTION"}
     assert ir_sigs == oracle_sigs
+
+
+# ---------------------------------------------------------------------------
+# Canonical container entrypoints (locked decision D14, #211)
+# ---------------------------------------------------------------------------
+
+
+def _entrypoint_fixture_ir() -> GraphIR:
+    """IR for the frozen ``container_entrypoint_expanded`` baseline shape:
+    a route gate targeting a container whose ``accumulate`` child self-loops."""
+    from hypergraph import END, Graph, node, route
+
+    @node(output_name="history")
+    def accumulate(history: str, raw: str) -> str:
+        return history + raw
+
+    @node(output_name="status")
+    def kickoff(seed: str) -> str:
+        return seed
+
+    @node(output_name="signal")
+    def intake(request: str) -> str:
+        return request
+
+    @route(targets=["worker", END])
+    def dispatch(signal: str) -> str:
+        return "worker"
+
+    inner = Graph(
+        [accumulate, kickoff],
+        name="worker",
+        entrypoint=["accumulate", "kickoff"],
+    )
+    outer = Graph(
+        [intake, dispatch, inner.as_node()],
+        name="container_entrypoint",
+        entrypoint="intake",
+    )
+    return build_graph_ir(outer.to_flat_graph())
+
+
+def test_container_entrypoints_are_self_exclusive_and_keep_multiple():
+    """A child's own outputs never disqualify it: the self-looping
+    ``accumulate`` stays an entrypoint (first, in declared order) and the
+    independent ``kickoff`` is preserved alongside it."""
+    ir = _entrypoint_fixture_ir()
+
+    assert ir.container_entrypoints == {"worker": ("worker/accumulate", "worker/kickoff")}
+
+
+def test_control_edge_fallback_uses_first_canonical_entrypoint():
+    """The ``target_when_expanded`` fallback for a control edge into a
+    container must come from the canonical field — the #263 tripwire flip:
+    ``dispatch`` re-routes to ``worker/accumulate`` (self-exclusive first
+    entry), not the old self-inclusive pick ``worker/kickoff``."""
+    ir = _entrypoint_fixture_ir()
+
+    control_edge = next(e for e in ir.edges if e.source == "dispatch" and e.target == "worker")
+    assert control_edge.target_when_expanded == "worker/accumulate"
+
+
+def test_container_entrypoints_dependency_order_not_declaration_order():
+    """A child consuming a sibling's output is not an entrypoint, even when
+    declared first."""
+    from hypergraph import Graph, node
+
+    @node(output_name="done")
+    def downstream(started: int) -> int:
+        return started + 1
+
+    @node(output_name="started")
+    def upstream(x: int) -> int:
+        return x
+
+    inner = Graph(nodes=[downstream, upstream], name="inner")
+    outer = Graph(nodes=[inner.as_node()])
+
+    ir = build_graph_ir(outer.to_flat_graph())
+
+    assert ir.container_entrypoints == {"inner": ("inner/upstream",)}
+
+
+def test_container_entrypoints_use_empty_tuple_when_only_source_is_hidden():
+    """The canonical field must not point at a node omitted from the IR."""
+    graph = make_hidden_source_only_dependency_graph()
+
+    ir = build_graph_ir(graph.to_flat_graph())
+
+    assert ir.container_entrypoints == {"box": ()}
+
+
+def test_container_entrypoints_cyclic_falls_back_to_first_child():
+    """When every child consumes a sibling output (a true cycle), the canonical
+    map falls back to the first declared child for a stable target."""
+    from hypergraph import Graph, node
+
+    @node(output_name="ping_out")
+    def ping(pong_out: int) -> int:
+        return pong_out
+
+    @node(output_name="pong_out")
+    def pong(ping_out: int) -> int:
+        return ping_out
+
+    inner = Graph(nodes=[ping, pong], name="cycle_box", entrypoint="ping")
+    outer = Graph(nodes=[inner.as_node()], entrypoint="cycle_box")
+
+    ir = build_graph_ir(outer.to_flat_graph())
+
+    assert ir.container_entrypoints == {"cycle_box": ("cycle_box/ping",)}
+
+
+def test_container_entrypoints_cover_nested_containers():
+    """Every GRAPH container gets a canonical entry — including a container
+    nested inside another container."""
+    from hypergraph import Graph, node
+
+    @node(output_name="core_out")
+    def core(seed: int) -> int:
+        return seed
+
+    @node(output_name="wrap_out")
+    def wrap(core_out: int) -> int:
+        return core_out
+
+    inner = Graph(nodes=[core], name="inner")
+    middle = Graph(nodes=[inner.as_node(), wrap], name="middle")
+    outer = Graph(nodes=[middle.as_node()])
+
+    ir = build_graph_ir(outer.to_flat_graph())
+
+    assert ir.container_entrypoints == {
+        "middle": ("middle/inner",),
+        "middle/inner": ("middle/inner/core",),
+    }
+
+
+def test_container_entrypoints_unaffected_by_boundary_renames():
+    """Boundary renames (``with_inputs`` aliases) change the container's
+    parent-facing port names, not the inner sibling comparison — the
+    canonical derivation still compares the children's own inner names."""
+    from hypergraph import Graph, node
+
+    @node(output_name="prepared")
+    def prepare(text: str) -> str:
+        return text
+
+    @node(output_name="final")
+    def finish(prepared: str) -> str:
+        return prepared
+
+    inner = Graph(nodes=[prepare, finish], name="inner")
+    outer = Graph(nodes=[inner.as_node().with_inputs(text="document")])
+
+    ir = build_graph_ir(outer.to_flat_graph())
+
+    assert ir.container_entrypoints == {"inner": ("inner/prepare",)}

--- a/tests/viz/test_mermaid.py
+++ b/tests/viz/test_mermaid.py
@@ -4,6 +4,12 @@ import pytest
 
 from hypergraph import END, Graph, ifelse, node, route
 from hypergraph.viz.mermaid import to_mermaid
+from tests.viz.conftest import (
+    make_hidden_sibling_dependency_graph,
+    make_hidden_source_data_dependency_graph,
+    make_hidden_source_only_dependency_graph,
+    make_nested_container_entrypoint_graph,
+)
 
 # =============================================================================
 # Test Nodes
@@ -474,6 +480,47 @@ class TestSubgraphs:
         assert "end" in mermaid
         assert "step1" in mermaid
         assert "step2" in mermaid
+
+    def test_hidden_sibling_output_still_disqualifies_dependent_entrypoint(self):
+        """Control routing must enter at a true visible dependency source."""
+        graph = make_hidden_sibling_dependency_graph()
+
+        mermaid = graph.to_mermaid(depth=1)
+
+        assert "dispatch -.-> box__independent" in mermaid
+
+    def test_nested_expanded_entrypoint_routes_to_leaf(self):
+        """Mermaid must not attach an edge to an expanded subgraph id."""
+        graph = make_nested_container_entrypoint_graph()
+
+        mermaid = graph.to_mermaid(depth=2)
+
+        assert "dispatch -.-> mid__accum__acc_step" in mermaid
+
+    @pytest.mark.parametrize("separate_outputs", [False, True])
+    def test_container_without_visible_entrypoint_has_no_hull_edges(
+        self,
+        separate_outputs: bool,
+    ):
+        """An empty canonical tuple suppresses every expanded-hull edge."""
+        graph = make_hidden_source_only_dependency_graph()
+
+        mermaid = graph.to_mermaid(
+            depth=1,
+            separate_outputs=separate_outputs,
+        ).source
+        edge_lines = [line.strip() for line in mermaid.splitlines() if " --> " in line or " -.-> " in line]
+        box_edges = [line for line in edge_lines if line.split()[0] == "box" or line.split()[-1] == "box"]
+
+        assert box_edges == []
+
+    def test_separate_data_edge_does_not_target_empty_entrypoint_container(self):
+        """Separate DATA edges obey the same expanded-hull invariant."""
+        graph = make_hidden_source_data_dependency_graph()
+
+        mermaid = graph.to_mermaid(depth=1, separate_outputs=True).source
+
+        assert "data_produce_seed -->|seed| box" not in mermaid
 
 
 # =============================================================================

--- a/tests/viz/test_parity.py
+++ b/tests/viz/test_parity.py
@@ -23,6 +23,10 @@ from hypergraph.viz.renderer.ir_builder import build_graph_ir
 from hypergraph.viz.scene_builder import build_initial_scene
 from tests.viz.conftest import (
     make_chain_graph,
+    make_hidden_only_container_graph,
+    make_hidden_sibling_dependency_graph,
+    make_hidden_source_only_dependency_graph,
+    make_nested_container_entrypoint_graph,
     make_outer,
     make_simple_graph,
     make_workflow,
@@ -178,6 +182,88 @@ def make_unordered_nested_entrypoint_graph():
     return Graph(nodes=[inner.as_node()], entrypoint="inner")
 
 
+def make_multi_entrypoint_self_loop_graph():
+    """Container with a self-loop child + an independent child (#211).
+
+    Exercises the canonical self-EXCLUSIVE ``container_entrypoints``: the
+    self-looping ``selfish`` stays an entrypoint and both entrypoints get
+    START edges when the container is expanded — Python and JS must agree."""
+    from hypergraph import Graph, node
+
+    @node(output_name="loop")
+    def selfish(loop: str) -> str:
+        return loop
+
+    @node(output_name="y")
+    def independent(x: str) -> str:
+        return x
+
+    @node(output_name="z")
+    def downstream(y: str) -> str:
+        return y
+
+    inner = Graph(
+        nodes=[selfish, independent, downstream],
+        name="inner",
+        entrypoint=["selfish", "independent"],
+    )
+    return Graph(nodes=[inner.as_node()], entrypoint="inner")
+
+
+def make_nested_multi_entrypoint_start_graph():
+    """A nested entrypoint plus a plain sibling must both reach START."""
+    return make_nested_container_entrypoint_graph().with_entrypoint("mid")
+
+
+def make_renamed_boundary_entrypoint_graph():
+    """Container entrypoint behind boundary renames (aliases, #211).
+
+    ``with_inputs``/``with_outputs`` change the parent-facing port names;
+    the canonical entrypoint derivation compares inner sibling names and
+    must be unaffected — in both scene builders."""
+    from hypergraph import Graph, node
+
+    @node(output_name="prepared")
+    def prepare(text: str) -> str:
+        return text
+
+    @node(output_name="final")
+    def finish(prepared: str) -> str:
+        return prepared
+
+    inner = Graph(nodes=[prepare, finish], name="inner")
+    renamed = inner.as_node().with_inputs(text="document").with_outputs(final="result")
+    return Graph(nodes=[renamed], entrypoint="inner")
+
+
+def make_selected_subgraph_entrypoint_graph():
+    """``with_entrypoint`` selecting mid-graph (#211 selected-subgraph case).
+
+    The configured entrypoint is a container in the middle of a chain, so
+    START routing must resolve through ``container_entrypoints`` while
+    upstream producers still render."""
+    from hypergraph import Graph, node
+
+    @node(output_name="raw")
+    def fetch(source: str) -> str:
+        return source
+
+    @node(output_name="cleaned")
+    def clean(raw: str) -> str:
+        return raw
+
+    @node(output_name="summary")
+    def summarize(cleaned: str) -> str:
+        return cleaned
+
+    @node(output_name="report")
+    def publish(summary: str) -> str:
+        return summary
+
+    inner = Graph(nodes=[clean, summarize], name="middle")
+    return Graph(nodes=[fetch, inner.as_node(), publish]).with_entrypoint("middle")
+
+
 FIXTURES = {
     "simple": make_simple_graph,
     "chain": make_chain_graph,
@@ -185,6 +271,14 @@ FIXTURES = {
     "outer": make_outer,
     "bound": make_bound_graph,
     "unordered_entrypoint": make_unordered_nested_entrypoint_graph,
+    "multi_entrypoint_self_loop": make_multi_entrypoint_self_loop_graph,
+    "nested_container_entrypoint": make_nested_container_entrypoint_graph,
+    "nested_multi_entrypoint_start": make_nested_multi_entrypoint_start_graph,
+    "hidden_only_container": make_hidden_only_container_graph,
+    "hidden_source_only_dependency": make_hidden_source_only_dependency_graph,
+    "hidden_sibling_dependency": make_hidden_sibling_dependency_graph,
+    "renamed_boundary_entrypoint": make_renamed_boundary_entrypoint_graph,
+    "selected_subgraph_entrypoint": make_selected_subgraph_entrypoint_graph,
 }
 
 

--- a/tests/viz/test_scene_builder.py
+++ b/tests/viz/test_scene_builder.py
@@ -10,7 +10,14 @@ from hypergraph.viz.ir_schema import GraphIR, IRNode
 from hypergraph.viz.renderer import render_graph
 from hypergraph.viz.renderer.ir_builder import build_graph_ir
 from hypergraph.viz.scene_builder import build_initial_scene
-from tests.viz.conftest import make_outer, make_simple_graph, make_workflow
+from tests.viz.conftest import (
+    make_hidden_only_container_graph,
+    make_hidden_source_only_dependency_graph,
+    make_nested_container_entrypoint_graph,
+    make_outer,
+    make_simple_graph,
+    make_workflow,
+)
 
 
 def _visible_node_sigs(scene_nodes: list[dict]) -> set[tuple[str, str]]:
@@ -256,38 +263,125 @@ def test_start_edge_to_expanded_container_targets_real_entrypoint():
 
 
 def test_expanded_container_entrypoints_ignore_self_outputs_and_keep_multiple_entrypoints():
-    ir = GraphIR(
-        nodes=[
-            IRNode(id="outer", node_type="GRAPH"),
-            IRNode(
-                id="outer/selfish",
-                node_type="FUNCTION",
-                parent="outer",
-                inputs=({"name": "loop"},),
-                outputs=({"name": "loop"},),
-            ),
-            IRNode(
-                id="outer/independent",
-                node_type="FUNCTION",
-                parent="outer",
-                inputs=({"name": "x"},),
-                outputs=({"name": "y"},),
-            ),
-            IRNode(
-                id="outer/downstream",
-                node_type="FUNCTION",
-                parent="outer",
-                inputs=({"name": "y"},),
-                outputs=({"name": "z"},),
-            ),
-        ],
-        configured_entrypoints=("outer",),
+    """End-to-end through the canonical ``GraphIR.container_entrypoints``
+    field (D14, #211): a self-loop child stays an entrypoint (self-EXCLUSIVE
+    rule) and independent entrypoints are all preserved."""
+
+    @node(output_name="loop")
+    def selfish(loop: str) -> str:
+        return loop
+
+    @node(output_name="y")
+    def independent(x: str) -> str:
+        return x
+
+    @node(output_name="z")
+    def downstream(y: str) -> str:
+        return y
+
+    # The self-loop makes the inner graph cyclic — execution entrypoints are
+    # required at construction (both kept active, mirroring the frozen
+    # container_entrypoint_expanded baseline case).
+    inner = Graph(
+        nodes=[selfish, independent, downstream],
+        name="outer",
+        entrypoint=["selfish", "independent"],
     )
+    outer = Graph(nodes=[inner.as_node()], entrypoint="outer")
+
+    ir = build_graph_ir(outer.to_flat_graph())
+    assert ir.container_entrypoints == {"outer": ("outer/selfish", "outer/independent")}
 
     scene = build_initial_scene(ir, expansion_state={"outer": True})
 
     start_targets = {edge["target"] for edge in scene["edges"] if edge["source"] == "__start__"}
     assert start_targets == {"outer/selfish", "outer/independent"}
+
+
+def test_scene_builder_consumes_container_entrypoints_field_verbatim():
+    """The scene builder must consume ``GraphIR.container_entrypoints``, not
+    re-derive it. The hand-built IR is shaped so any re-derivation from node
+    inputs/outputs would pick 'outer/upstream'; the field deliberately says
+    'outer/downstream'. If this fails with 'outer/upstream', a duplicate
+    derivation crept back into scene_builder.py — delete it (#211)."""
+    ir = GraphIR(
+        nodes=[
+            IRNode(id="outer", node_type="GRAPH"),
+            IRNode(
+                id="outer/downstream",
+                node_type="FUNCTION",
+                parent="outer",
+                inputs=({"name": "started"},),
+                outputs=({"name": "done"},),
+            ),
+            IRNode(
+                id="outer/upstream",
+                node_type="FUNCTION",
+                parent="outer",
+                inputs=({"name": "x"},),
+                outputs=({"name": "started"},),
+            ),
+        ],
+        configured_entrypoints=("outer",),
+        container_entrypoints={"outer": ("outer/downstream",)},
+    )
+
+    scene = build_initial_scene(ir, expansion_state={"outer": True})
+
+    start_targets = {edge["target"] for edge in scene["edges"] if edge["source"] == "__start__"}
+    assert start_targets == {"outer/downstream"}
+
+
+def test_edge_into_nested_expanded_container_targets_visible_leaf():
+    """An edge may never terminate on an expanded compound parent."""
+    graph = make_nested_container_entrypoint_graph()
+    ir = build_graph_ir(graph.to_flat_graph())
+
+    scene = build_initial_scene(
+        ir,
+        expansion_state={"mid": True, "mid/accum": True},
+    )
+
+    dispatch_edges = [edge for edge in scene["edges"] if edge["source"] == "dispatch" and edge["target"] != "__end__"]
+    assert [(edge["source"], edge["target"]) for edge in dispatch_edges] == [("dispatch", "mid/accum/acc_step")]
+
+
+def test_nested_expansion_preserves_every_start_entrypoint():
+    """Resolving one nested entrypoint must not drop its plain sibling."""
+    graph = make_nested_container_entrypoint_graph().with_entrypoint("mid")
+    ir = build_graph_ir(graph.to_flat_graph())
+
+    scene = build_initial_scene(
+        ir,
+        expansion_state={"mid": True, "mid/accum": True},
+    )
+
+    start_targets = {edge["target"] for edge in scene["edges"] if edge["source"] == "__start__" and edge["target"].startswith("mid/")}
+    assert start_targets == {"mid/accum/acc_step", "mid/starter"}
+
+
+def test_edge_into_all_hidden_container_is_not_attached_to_expanded_hull():
+    """An expanded container with no visible child must remain layoutable."""
+    graph = make_hidden_only_container_graph()
+    ir = build_graph_ir(graph.to_flat_graph())
+
+    scene = build_initial_scene(ir, expansion_state={"box": True})
+
+    visible_box_edges = [edge for edge in scene["edges"] if not edge["hidden"] and edge["target"] == "box"]
+    assert visible_box_edges == []
+
+
+def test_hidden_source_does_not_promote_visible_dependent_to_entrypoint():
+    """A hidden dependency source remains the structural entrypoint."""
+    graph = make_hidden_source_only_dependency_graph()
+    ir = build_graph_ir(graph.to_flat_graph())
+
+    scene = build_initial_scene(ir, expansion_state={"box": True})
+
+    visible_dispatch_targets = {
+        edge["target"] for edge in scene["edges"] if edge["source"] == "dispatch" and edge["target"] != "__end__" and not edge["hidden"]
+    }
+    assert visible_dispatch_targets == set()
 
 
 def test_expanded_graph_container_data_nodes_are_hidden_in_separate_mode():

--- a/tests/viz/test_schema_version.py
+++ b/tests/viz/test_schema_version.py
@@ -29,8 +29,11 @@ NODE = shutil.which("node")
 
 def test_current_schema_version_pinned() -> None:
     """A bump must be deliberate — pin both ends so the hard-coded JS
-    constant in scene_builder.js stays in lockstep with Python."""
-    assert CURRENT_SCHEMA_VERSION == "3"
+    constant in scene_builder.js stays in lockstep with Python.
+
+    v4 (#211): ``GraphIR.container_entrypoints`` became the canonical
+    entrypoint authority and both scene builders stopped re-deriving it."""
+    assert CURRENT_SCHEMA_VERSION == "4"
 
 
 def test_build_graph_ir_emits_current_schema_version() -> None:
@@ -69,12 +72,75 @@ def test_js_scene_builder_returns_mismatch_sentinel_for_future_version() -> None
     )
     assert proc.returncode == 0, proc.stderr
     scene = json.loads(proc.stdout)
-    assert scene.get("schemaVersionMismatch") == {"got": "999", "supported": "3"}
+    assert scene.get("schemaVersionMismatch") == {"got": "999", "supported": "4"}
     # The mismatch-sentinel must short-circuit derivation entirely so the
     # frontend can render the static fallback without dragging in any
     # potentially-stale interpretation of the IR.
     assert scene["nodes"] == []
     assert scene["edges"] == []
+
+
+def test_python_scene_builder_degrades_loudly_on_v3_payload_without_container_entrypoints() -> None:
+    """Wire-format consequence of #211: a v3 IR has no
+    ``container_entrypoints`` field, and the v4 scene builder no longer
+    re-derives entrypoints — so a saved v3 payload must fail LOUDLY on the
+    version pin, never render with silently mis-routed START/control edges."""
+    flat = make_simple_graph().to_flat_graph()
+    ir = build_graph_ir(flat)
+    v3_ir = replace(ir, schema_version="3", container_entrypoints={})
+    with pytest.raises(IRSchemaError, match="schema_version"):
+        build_initial_scene(v3_ir)
+
+
+@pytest.mark.skipif(NODE is None, reason="Node.js not installed")
+def test_js_scene_builder_degrades_loudly_on_v3_payload_without_container_entrypoints() -> None:
+    """JS twin of the wire-format consequence: an old saved notebook output
+    (v3 payload, no ``container_entrypoints``) hits the static-fallback
+    banner — degrade loudly, not silent entrypoint drift."""
+    flat = make_simple_graph().to_flat_graph()
+    ir = build_graph_ir(flat)
+    ir_dict = asdict(ir)
+    del ir_dict["container_entrypoints"]
+    ir_dict["schema_version"] = "3"
+    payload = json.dumps({"ir": ir_dict, "opts": {}})
+    proc = subprocess.run(
+        [NODE, str(RUNNER), str(REPO_ROOT)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert proc.returncode == 0, proc.stderr
+    scene = json.loads(proc.stdout)
+    assert scene.get("schemaVersionMismatch") == {"got": "3", "supported": "4"}
+    assert scene["nodes"] == []
+    assert scene["edges"] == []
+
+
+@pytest.mark.skipif(NODE is None, reason="Node.js not installed")
+def test_js_scene_builder_degrades_loudly_when_schema_version_is_missing() -> None:
+    """A version-less payload must not bypass the v4 field contract."""
+    flat = make_simple_graph().to_flat_graph()
+    ir_dict = asdict(build_graph_ir(flat))
+    del ir_dict["schema_version"]
+    del ir_dict["container_entrypoints"]
+    payload = json.dumps({"ir": ir_dict, "opts": {}})
+
+    proc = subprocess.run(
+        [NODE, str(RUNNER), str(REPO_ROOT)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    scene = json.loads(proc.stdout)
+    assert scene == {
+        "nodes": [],
+        "edges": [],
+        "schemaVersionMismatch": {"got": None, "supported": "4"},
+    }
 
 
 @pytest.mark.skipif(NODE is None, reason="Node.js not installed")


### PR DESCRIPTION
Closes #211. Implements locked D14 and absorbs #142.

`GraphIR.container_entrypoints` is the single self-exclusive authority. The IR builder computes it once; Python, JavaScript, Mermaid, widget, and debug paths consume it. Superseded derivations are deleted.

## Before / after

Nested expanded target:

```text
Before: dispatch -> mid/accum
        # mid/accum is itself expanded, so Dagre can render a blank canvas

After:  dispatch -> mid/accum/acc_step
        # edge terminates on a visible leaf
```

Hidden structural source:

```text
Before: container_entrypoints = {"box": ("box/dependent",)}
        dispatch -> box/dependent

After:  container_entrypoints = {"box": ()}
        # no visible entrypoint, so the edge is suppressed in every renderer
```

Old or version-less payload:

```text
Before: JavaScript accepted a missing schema_version and rendered silently
After:  {schemaVersionMismatch: {got: null, supported: "4"}}
```

## What changed

- Recursively resolve nested expanded entrypoints for ordinary edges and START edges.
- Preserve every sibling entrypoint while resolving nested containers.
- Count hidden sibling outputs when deciding dependency sources.
- Represent no visible structural entrypoint with an empty tuple, never a dangling hidden node id.
- Suppress empty-entrypoint hull edges in Python, JavaScript, and Mermaid, including separate-output DATA edges.
- Compute the Mermaid canonical map once per export instead of once per edge.
- Reject missing JavaScript schema versions loudly.
- Keep pure JavaScript graph walking in `derivation.js`; `scene_builder.js` only consumes it.

## Frozen fixture contract

Exactly one Mermaid baseline line changes from master:

```diff
- dispatch -.-> worker__kickoff
+ dispatch -.-> worker__accumulate
```

Hash baselines remain byte-identical.

## Test plan and proof

- `4160 passed`, zero skipped, warning-as-error full suite after rebase on current `origin/master`.
- `237 passed` focused viz, parity, schema, JavaScript derivation, and frozen-baseline gate.
- `uv run pre-commit run --all-files` passed.
- `uv run mypy` passed: 149 source files.
- Python and JavaScript probes preserve both nested START targets.
- No probe edge touches an expanded container.
- Mermaid canonical derivation: one call for a 336-node graph.
- Three adversarial reviewers completed. Initial rejection cases are now covered by regressions.
- Final standards review: no blocker.
- Final issue-contract review: no blocker.

All refreshed GitHub code checks passed; ready for review.

Generated with Claude Code and Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added canonical container-entrypoint handling for more accurate visualization routing.
  * Improved nested and expanded container connections, including multiple entrypoints and hidden-content scenarios.
  * Updated Mermaid and scene rendering to consistently reflect resolved entrypoints.

* **Bug Fixes**
  * Corrected dispatch routing to target the appropriate worker entrypoint.
  * Prevented invalid edges and hulls for containers without visible entrypoints.

* **Compatibility**
  * Updated the visualization format to version 4, with clear handling of older or incomplete data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->