### PR TITLE
fix(runners): surface pre-run failures through AsyncRunner.iter()

### DIFF
--- a/src/hypergraph/runners/_shared/handles.py
+++ b/src/hypergraph/runners/_shared/handles.py
@@ -122,6 +122,12 @@ class AsyncRunEventHandle(AsyncEventProcessor):
             self._live_tasks.discard(completed)
             if not completed.cancelled():
                 completed.exception()
+            # A run that settles without ever reaching processor shutdown —
+            # e.g. a pre-run validation failure like GraphChangedError — will
+            # never call shutdown_async(), so close the stream here or
+            # __anext__ waits forever on an event that cannot arrive.
+            self._stream_closed = True
+            self._available.set()
 
         task.add_done_callback(_observe_completion)
         return self

--- a/tests/test_run_event_iterator.py
+++ b/tests/test_run_event_iterator.py
@@ -165,3 +165,66 @@ async def test_iter_drops_oldest_preview_chunks_but_retains_lifecycle_events() -
     ]
     assert handle.dropped_chunks > 0
     assert handle.dropped_chunks + len(delivered_chunks) == chunk_count
+
+
+async def test_iter_surfaces_pre_run_graph_change_error(tmp_path) -> None:
+    """A run rejected before any event must end iteration and raise via result()."""
+    from hypergraph import GraphChangedError
+    from hypergraph.checkpointers import SqliteCheckpointer
+
+    @node(output_name="a")
+    def first(value: int) -> int:
+        return value + 1
+
+    @node(output_name="a")
+    def first_changed(value: int) -> int:
+        return value + 2
+
+    checkpointer = SqliteCheckpointer(str(tmp_path / "iter.db"))
+    try:
+        runner = AsyncRunner(checkpointer=checkpointer)
+        await runner.run(Graph([first]), {"value": 1}, workflow_id="wf-iter")
+
+        async def consume() -> Exception:
+            async with runner.iter(Graph([first_changed]), {"value": 1}, workflow_id="wf-iter") as handle:
+                async for _event in handle:
+                    pass
+                with pytest.raises(GraphChangedError) as excinfo:
+                    await handle.result()
+                return excinfo.value
+
+        error = await asyncio.wait_for(consume(), timeout=10)
+        assert isinstance(error, GraphChangedError)
+    finally:
+        await checkpointer.close()
+
+
+async def test_iter_surfaces_pre_run_policy_change_error(tmp_path) -> None:
+    """RetryPolicyChangedError raised before any event must not hang the iterator."""
+    from hypergraph import RetryPolicy, RetryPolicyChangedError
+    from hypergraph.checkpointers import SqliteCheckpointer
+
+    def graph_with(max_attempts: int) -> Graph:
+        @node(output_name="a", retry=RetryPolicy(max_attempts=max_attempts, retry_on=(ConnectionError,)))
+        def flaky(value: int) -> int:
+            return value + 1
+
+        return Graph([flaky])
+
+    checkpointer = SqliteCheckpointer(str(tmp_path / "iter-policy.db"))
+    try:
+        runner = AsyncRunner(checkpointer=checkpointer)
+        await runner.run(graph_with(3), {"value": 1}, workflow_id="wf-policy")
+
+        async def consume() -> Exception:
+            async with runner.iter(graph_with(5), {"value": 1}, workflow_id="wf-policy") as handle:
+                async for _event in handle:
+                    pass
+                with pytest.raises(RetryPolicyChangedError) as excinfo:
+                    await handle.result()
+                return excinfo.value
+
+        error = await asyncio.wait_for(consume(), timeout=10)
+        assert isinstance(error, RetryPolicyChangedError)
+    finally:
+        await checkpointer.close()


### PR DESCRIPTION
Closes #310 (found during the #232 adversarial review; reproduces on master with GraphChangedError, so not a #232 regression).

## Before / after
```python
async with runner.iter(changed_graph, workflow_id=w) as handle:
    async for event in handle:   # before: hangs forever — no event ever arrives
        ...                       # after: iteration ends promptly
    await handle.result()         # after: raises GraphChangedError / RetryPolicyChangedError
```
The task-completion observer now closes the event stream and wakes a waiting `__anext__` — covering any run that settles without reaching processor shutdown. Normal runs are unaffected (shutdown already closed the stream first, and buffered events still drain after close).

## Test plan
Red-first: two `wait_for`-bounded tests (GraphChangedError + RetryPolicyChangedError over a checkpointed workflow) hang on master, pass after. Full iterator suite 8/8; CI-equivalent full suite green; mypy clean. `iter()` is async-only (no sync twin exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)