### PR TITLE
fix(runners): resume first-node interrupts whose question inputs were run-provided

### DIFF
--- a/src/hypergraph/runners/_shared/value_resolution.py
+++ b/src/hypergraph/runners/_shared/value_resolution.py
@@ -181,7 +181,26 @@ def has_all_inputs(node: HyperNode, graph: Graph, state: GraphState) -> bool:
     """Check if all inputs for a node are available."""
     if graphnode_has_resume_values(node, state):
         return True
+    if interrupt_has_resume_answer(node, state):
+        return True
     return all(has_input(param, node, graph, state) for param in node.inputs)
+
+
+def interrupt_has_resume_answer(node: HyperNode, state: GraphState) -> bool:
+    """Return whether state carries this interrupt's answer as a resume payload.
+
+    Checkpoint state folds step outputs only, so question inputs that were
+    run-provided in the paused run are absent on resume. The answer-supplied
+    path never calls the handler, so those inputs are not required (#316).
+    """
+    from hypergraph.nodes.interrupt import InterruptNode
+
+    if not isinstance(node, InterruptNode):
+        return False
+    resume_values = state.resume_values
+    if not resume_values:
+        return False
+    return all(output in resume_values for output in node.data_outputs)
 
 
 def graphnode_has_resume_values(node: HyperNode, state: GraphState) -> bool:
@@ -341,12 +360,12 @@ def collect_inputs_for_node(
         Dict mapping input names to their values
     """
     inputs = {}
-    graphnode_resume = graphnode_has_resume_values(node, state)
+    resume_bypass = graphnode_has_resume_values(node, state) or interrupt_has_resume_answer(node, state)
     for param in node.inputs:
         try:
             inputs[param] = _resolve_input(param, node, graph, state, provided_values)
         except KeyError:
-            if graphnode_resume:
+            if resume_bypass:
                 continue
             raise
     return inputs

--- a/src/hypergraph/runners/async_/executors/interrupt_node.py
+++ b/src/hypergraph/runners/async_/executors/interrupt_node.py
@@ -26,18 +26,12 @@ class AsyncInterruptNodeExecutor:
     ) -> dict[str, Any]:
         data_outputs = node.data_outputs
 
-        # Collect all input values with validation
-        input_values = {}
-        for name in node.inputs:
-            if name not in inputs:
-                raise KeyError(
-                    f"InterruptNode '{node.name}' requires input '{name}' but it was not provided. Available inputs: {list(inputs.keys())}"
-                )
-            input_values[name] = inputs[name]
-
         # Answer-supplied path. Checkpointer-free runs deliberately set
         # is_resuming=True so an answer supplied up front skips the question;
         # checkpointed fresh runs reserve this path for an actual resume.
+        # Checked BEFORE input validation: checkpoint state folds step outputs
+        # only, so run-provided question inputs are absent on resume — and the
+        # answer path never calls the handler, so it doesn't need them (#316).
         # After consuming, we pop the keys so a second cycle iteration
         # through this node correctly invokes the handler and pauses.
         if ctx.is_resuming:
@@ -46,6 +40,15 @@ class AsyncInterruptNodeExecutor:
             if all_outputs_provided:
                 result = {o: pv.pop(o) for o in data_outputs}
                 return _add_emit_sentinels(result, node)
+
+        # Question path requires every input for the handler call.
+        input_values = {}
+        for name in node.inputs:
+            if name not in inputs:
+                raise KeyError(
+                    f"InterruptNode '{node.name}' requires input '{name}' but it was not provided. Available inputs: {list(inputs.keys())}"
+                )
+            input_values[name] = inputs[name]
 
         # Handler path: invoke the function
         try:

--- a/tests/test_interrupt_answer_name.py
+++ b/tests/test_interrupt_answer_name.py
@@ -413,3 +413,33 @@ async def test_question_payload_must_expose_every_runtime_seam_field():
 
     with pytest.raises(RuntimeError, match="options must be"):
         await AsyncRunner().run(Graph([review]), {"draft": "v4"})
+
+
+@pytest.mark.asyncio
+async def test_first_node_interrupt_resumes_when_question_inputs_were_run_provided():
+    """Issue #316: interrupt whose question inputs came from run() values, not a producer.
+
+    Checkpoint state folds step outputs only, so 'topic' is absent on resume.
+    The answer-supplied path must still fire — it never calls the handler, so
+    the question inputs are not required.
+    """
+
+    @interrupt(answer_name="decision")
+    def ask(topic: str) -> Confirm:
+        return Confirm(prompt=f"Approve {topic}?")
+
+    @node(output_name="v")
+    def after(decision: bool) -> str:
+        return f"applied:{decision}"
+
+    graph = Graph([ask, after])
+    runner = AsyncRunner(checkpointer=MemoryCheckpointer())
+
+    paused = await runner.run(graph, {"topic": "launch"}, workflow_id="wf-316")
+    assert paused.status == RunStatus.PAUSED
+
+    resumed = await runner.run(graph, {"decision": True}, workflow_id="wf-316")
+
+    assert resumed.status == RunStatus.COMPLETED
+    assert resumed["v"] == "applied:True"
+    assert "after" in resumed.log.node_stats


### PR DESCRIPTION
Closes #316 (found during the #233 adversarial review; reproduces on master).

## Before / after
```python
paused = await runner.run(Graph([ask, after]), {"topic": "launch"}, workflow_id="wf")
# paused.status == PAUSED ✓
resumed = await runner.run(Graph([ask, after]), {"decision": True}, workflow_id="wf")
# before: COMPLETED, node_stats == {}, no "v" — the answer silently swallowed
# after:  COMPLETED, ask consumed the answer, after ran, resumed["v"] == "applied:True"
```
Root cause: `Checkpoint.values` folds step outputs only, so run-provided question inputs (`topic`) vanish on resume; the interrupt never became ready and the empty frontier reported success. Fix per the documented "resume with only the answer" pattern: the answer-supplied path never calls the handler, so readiness/input-collection now honor the explicit `resume_values` signal for interrupts — exactly mirroring the existing GraphNode nested-interrupt bypass — and the executor branches to the answer path before demanding handler inputs. Question-path validation unchanged; headless no-checkpointer behavior unchanged (`resume_values` is only set on genuine checkpoint restores). SyncRunner rejects interrupts at validation, so async-only by design.

## Test plan
Red-first regression (silent-swallow reproduced, then fixed); all 4 interrupt suites green (37 tests); CI-equivalent full suite green; mypy clean; pre-commit green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)