### PR TITLE
refactor(nodes): centralize GraphNode boundary projection

### DIFF
--- a/src/hypergraph/nodes/_boundary.py
+++ b/src/hypergraph/nodes/_boundary.py
@@ -1,0 +1,254 @@
+"""BoundaryProjection - single owner of GraphNode parent/child address translation.
+
+A GraphNode boundary answers one question in many shapes: "what is this port
+called on the other side?". Inputs and outputs each have three name layers:
+
+- original: the name inside the wrapped graph, before any rename
+- local: the current name on the GraphNode surface, after rename_inputs/
+  rename_outputs (still un-prefixed)
+- address: the parent-facing name after projection (flat, ``name.local`` when
+  namespaced, or the expose alias)
+
+``BoundaryProjection`` precomputes every map between those layers exactly once
+per boundary mutation. Validation, binding, defaults, selection, execution,
+and inspection all consume this one object (directly or through the thin
+GraphNode methods that delegate here); nothing else may rebuild rename or
+projection semantics.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from hypergraph.nodes._rename import RenameEntry, build_forward_rename_map, build_reverse_rename_map
+
+
+@dataclass(frozen=True)
+class BoundaryProjection:
+    """Immutable translation table for one GraphNode boundary.
+
+    Built via :meth:`build` from the boundary's construction state (name,
+    namespacing, expose aliases, local port lists, rename history). All maps
+    are precomputed; every method is a pure lookup.
+    """
+
+    node_name: str
+    namespaced: bool
+    exposed: Mapping[str, str]
+    former_names: tuple[str, ...]
+    local_inputs: tuple[str, ...]
+    local_outputs: tuple[str, ...]
+    local_data_outputs: tuple[str, ...]
+    inputs: tuple[str, ...]
+    outputs: tuple[str, ...]
+    data_outputs: tuple[str, ...]
+    input_locals_by_address: Mapping[str, tuple[str, ...]]
+    output_local_by_address: Mapping[str, str]
+    output_address_by_local: Mapping[str, str]
+    input_original_by_local: Mapping[str, str]
+    input_local_by_original: Mapping[str, str]
+    output_original_by_local: Mapping[str, str]
+    output_local_by_original: Mapping[str, str]
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        node_name: str,
+        namespaced: bool,
+        exposed: Mapping[str, str],
+        local_inputs: tuple[str, ...],
+        local_outputs: tuple[str, ...],
+        local_data_outputs: tuple[str, ...],
+        rename_history: Sequence[RenameEntry],
+    ) -> BoundaryProjection:
+        """Compute the full projection for one boundary state.
+
+        Raises:
+            ValueError: If two outputs project to the same parent address, or
+                an input and a *differently named* output share an address.
+        """
+        exposed = dict(exposed)
+        former_names = tuple(entry.old for entry in rename_history if entry.kind == "name")
+        history = list(rename_history)
+        input_original_by_local = build_reverse_rename_map(history, "inputs")
+        output_original_by_local = build_reverse_rename_map(history, "outputs")
+        input_local_by_original = build_forward_rename_map(history, "inputs")
+        output_local_by_original = build_forward_rename_map(history, "outputs")
+
+        def project(local_name: str) -> str:
+            if namespaced:
+                if local_name in exposed:
+                    return exposed[local_name]
+                return f"{node_name}.{local_name}"
+            return local_name
+
+        input_address_to_local: dict[str, list[str]] = {}
+        projected_inputs: list[str] = []
+        for local in local_inputs:
+            address = project(local)
+            input_address_to_local.setdefault(address, []).append(local)
+            if address not in projected_inputs:
+                projected_inputs.append(address)
+
+        output_local_to_address: dict[str, str] = {}
+        projected_outputs: list[str] = []
+        for local in local_outputs:
+            address = project(local)
+            if address in projected_outputs:
+                raise ValueError(f"GraphNode '{node_name}' projects multiple outputs to {address!r}")
+            input_locals = input_address_to_local.get(address, ())
+            if input_locals and local not in input_locals:
+                raise ValueError(
+                    f"GraphNode '{node_name}' projects input(s) {input_locals!r} and output {local!r} "
+                    f"to the same address {address!r}. Use the same local name for cyclic seed/update "
+                    f"ports, or choose distinct aliases."
+                )
+            output_local_to_address[local] = address
+            projected_outputs.append(address)
+
+        return cls(
+            node_name=node_name,
+            namespaced=namespaced,
+            exposed=exposed,
+            former_names=former_names,
+            local_inputs=local_inputs,
+            local_outputs=local_outputs,
+            local_data_outputs=local_data_outputs,
+            inputs=tuple(projected_inputs),
+            outputs=tuple(projected_outputs),
+            data_outputs=tuple(project(local) for local in local_data_outputs if local in output_local_to_address),
+            input_locals_by_address={address: tuple(locals_) for address, locals_ in input_address_to_local.items()},
+            output_local_by_address={address: local for local, address in output_local_to_address.items()},
+            output_address_by_local=output_local_to_address,
+            input_original_by_local=input_original_by_local,
+            input_local_by_original=input_local_by_original,
+            output_original_by_local=output_original_by_local,
+            output_local_by_original=output_local_by_original,
+        )
+
+    # === Layer hops (single-step lookups) ===
+
+    def project_local(self, local_name: str) -> str:
+        """Parent-facing address for a local port name."""
+        if self.namespaced:
+            if local_name in self.exposed:
+                return self.exposed[local_name]
+            return f"{self.node_name}.{local_name}"
+        return local_name
+
+    def locals_for_input(self, address: str) -> tuple[str, ...]:
+        """Local input names behind a parent-facing address."""
+        return self.input_locals_by_address.get(address, (address,))
+
+    def local_for_output(self, address: str) -> str:
+        """Local output name behind a parent-facing address."""
+        return self.output_local_by_address.get(address, address)
+
+    def original_input(self, local_name: str) -> str:
+        """Original inner-graph name for a local input name."""
+        return self.input_original_by_local.get(local_name, local_name)
+
+    def original_output(self, local_name: str) -> str:
+        """Original inner-graph name for a local output name."""
+        return self.output_original_by_local.get(local_name, local_name)
+
+    # === Address <-> original (composed hops) ===
+
+    def original_inputs_for_address(self, address: str) -> tuple[str, ...]:
+        """Original inner-graph names behind a parent-facing input address."""
+        return tuple(self.original_input(local) for local in self.locals_for_input(address))
+
+    def original_output_for_address(self, address: str) -> str:
+        """Original inner-graph name behind a parent-facing output address."""
+        return self.original_output(self.local_for_output(address))
+
+    def input_address_for_original(self, original_name: str) -> str:
+        """Parent-facing address for an original inner-graph input name."""
+        return self.project_local(self.input_local_by_original.get(original_name, original_name))
+
+    def output_address_for_original(self, original_name: str) -> str:
+        """Parent-facing address for an original inner-graph output name."""
+        local = self.output_local_by_original.get(original_name, original_name)
+        return self.output_address_by_local.get(local, local)
+
+    # === Dict translation (execution boundary) ===
+
+    def translate_inputs(self, values: Mapping[str, Any]) -> dict[str, Any]:
+        """Parent-address-keyed input values -> original inner-graph names."""
+        mapped: dict[str, Any] = {}
+        for address, value in values.items():
+            for local in self.locals_for_input(address):
+                mapped[self.original_input(local)] = value
+        return mapped
+
+    def translate_outputs(self, values: Mapping[str, Any]) -> dict[str, Any]:
+        """Original-keyed output values -> parent-facing addresses.
+
+        Emit-only local outputs the inner run did not produce are backfilled
+        with the emit sentinel so downstream ordering edges stay satisfied.
+        """
+        from hypergraph.nodes.base import _EMIT_SENTINEL
+
+        mapped = {self.output_address_for_original(key): value for key, value in values.items()}
+        for local in self.local_outputs:
+            if local in self.local_data_outputs:
+                continue
+            address = self.output_address_by_local.get(local)
+            if address is not None and address not in mapped:
+                mapped[address] = _EMIT_SENTINEL
+        return mapped
+
+    # === Structured keys ===
+
+    def resume_key_from_original(self, resume_key: str) -> str:
+        """Map a nested resume key from inner names to parent-facing names.
+
+        If the key is on this boundary's current local output surface, map the
+        whole key. This matters when a child namespaced GraphNode has already
+        produced a local output address such as ``inner.decision``.
+
+        Only the first path component can be renamed by the boundary: for
+        example ``decision`` may become ``verdict`` while ``review.decision``
+        stays unchanged because ``review`` is internal.
+        """
+        if resume_key in self.local_outputs:
+            return self.output_address_for_original(resume_key)
+        head, sep, tail = resume_key.partition(".")
+        mapped_head = self.output_address_for_original(head)
+        if not sep:
+            return mapped_head
+        return f"{mapped_head}.{tail}"
+
+    def replacement_for_stale_input_address(self, address: str) -> str | None:
+        """Current parent-facing input address for a stale namespaced one."""
+        prefixes = [self.node_name, *self.former_names]
+        prefix = next((f"{name}." for name in prefixes if address.startswith(f"{name}.")), None)
+        if prefix is None:
+            return None
+        local_name = address[len(prefix) :]
+        if local_name not in self.local_inputs:
+            for current in self.local_inputs:
+                if self.original_input(current) == local_name:
+                    local_name = current
+                    break
+            else:
+                if local_name in self.inputs:
+                    return local_name
+                return None
+        current = self.project_local(local_name)
+        return current if current != address else None
+
+    # === Inspection maps (nx_attrs / viz dagre boundary renames) ===
+
+    @property
+    def input_name_map(self) -> dict[str, tuple[str, ...]]:
+        """Parent input address -> original inner names (viz boundary renames)."""
+        return {address: self.original_inputs_for_address(address) for address in self.inputs}
+
+    @property
+    def output_name_map(self) -> dict[str, str]:
+        """Parent output address -> original inner name (viz boundary renames)."""
+        return {address: self.original_output_for_address(address) for address in self.outputs}

--- a/src/hypergraph/nodes/_rename.py
+++ b/src/hypergraph/nodes/_rename.py
@@ -135,3 +135,26 @@ def build_reverse_rename_map(
         reverse_map.update(batch_updates)
 
     return reverse_map
+
+
+def build_forward_rename_map(
+    rename_history: list[RenameEntry],
+    kind: Literal["inputs", "outputs"] = "inputs",
+) -> dict[str, str]:
+    """Build a forward mapping from original names to current names.
+
+    The canonical inverse of :func:`build_reverse_rename_map` — the one place
+    that turns rename history around. For chained renames (a->x, then x->z)
+    the reverse map keeps the intermediate entry (x maps to a); inverting in
+    batch order makes the newest current name win, so the forward map reads
+    a maps to z.
+
+    Args:
+        rename_history: List of RenameEntry from node._rename_history
+        kind: Which type of renames to process ("inputs" or "outputs")
+
+    Returns:
+        Dict mapping original names to current names.
+        Names that were never renamed won't appear in the dict.
+    """
+    return {original: current for current, original in build_reverse_rename_map(rename_history, kind).items()}

--- a/src/hypergraph/nodes/graph_node.py
+++ b/src/hypergraph/nodes/graph_node.py
@@ -6,8 +6,27 @@ import keyword
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
-from hypergraph.nodes._rename import RenameError, build_reverse_rename_map, get_next_batch_id
+from hypergraph.nodes._boundary import BoundaryProjection
+from hypergraph.nodes._rename import RenameError, get_next_batch_id
 from hypergraph.nodes.base import HyperNode, RenameEntry, _invalidate_cached_properties
+
+# Sentinel distinguishing "no default resolved" from a legitimate None default.
+_UNSET = object()
+
+
+@dataclass(frozen=True)
+class _DefaultResolution:
+    """Result of the single boundary default resolver.
+
+    ``found`` False always means the matching ``get_*`` raises KeyError, so
+    ``has_*`` and ``get_*`` can never disagree. ``bound_blocked`` marks a
+    signature-only lookup that failed because the parameter is bound.
+    """
+
+    found: bool
+    value: Any = None
+    bound_blocked: bool = False
+
 
 # TypeVar for self-referential return types (Python 3.10 compatible)
 _GN = TypeVar("_GN", bound="GraphNode")
@@ -225,76 +244,28 @@ class GraphNode(HyperNode):
         # Exact boundary name maps (outer address -> original inner names).
         # Renames from rename_inputs/rename_outputs are invisible in the flat
         # graph otherwise, leaving consumers (viz) to guess by substring.
-        attrs["input_name_map"] = {
-            address: tuple(self._resolve_original_input_name(local) for local in self._local_inputs_for_address(address)) for address in self.inputs
-        }
-        attrs["output_name_map"] = {address: self.resolve_original_output_name(address) for address in self.outputs}
+        attrs["input_name_map"] = self._projection.input_name_map
+        attrs["output_name_map"] = self._projection.output_name_map
         return attrs
 
     def _refresh_projected_ports(self) -> None:
-        """Recompute parent-facing addresses and boundary maps."""
-        input_address_to_local: dict[str, list[str]] = {}
-        projected_inputs: list[str] = []
-        for local in self._local_inputs:
-            address = self._project_address(local)
-            input_address_to_local.setdefault(address, []).append(local)
-            if address not in projected_inputs:
-                projected_inputs.append(address)
-
-        output_local_to_address: dict[str, str] = {}
-        projected_outputs: list[str] = []
-        for local in self._local_outputs:
-            address = self._project_address(local)
-            if address in projected_outputs:
-                raise ValueError(f"GraphNode '{self.name}' projects multiple outputs to {address!r}")
-            input_locals = input_address_to_local.get(address, ())
-            if input_locals and local not in input_locals:
-                raise ValueError(
-                    f"GraphNode '{self.name}' projects input(s) {input_locals!r} and output {local!r} "
-                    f"to the same address {address!r}. Use the same local name for cyclic seed/update "
-                    f"ports, or choose distinct aliases."
-                )
-            output_local_to_address[local] = address
-            projected_outputs.append(address)
-
-        self._input_address_to_local = {key: tuple(values) for key, values in input_address_to_local.items()}
-        self._output_local_to_address = output_local_to_address
-        self._output_address_to_local = {address: local for local, address in output_local_to_address.items()}
-        self.inputs = tuple(projected_inputs)
-        self.outputs = tuple(projected_outputs)
-        self._data_outputs = tuple(self._project_address(local) for local in self._local_data_outputs if local in output_local_to_address)
-
-    def _project_address(self, local_name: str) -> str:
-        if self._namespaced:
-            if local_name in self._exposed:
-                return self._exposed[local_name]
-            return f"{self.name}.{local_name}"
-        return local_name
-
-    def _local_inputs_for_address(self, address: str) -> tuple[str, ...]:
-        return self._input_address_to_local.get(address, (address,))
-
-    def _local_output_for_address(self, address: str) -> str:
-        return self._output_address_to_local.get(address, address)
+        """Rebuild the boundary projection and parent-facing ports from it."""
+        self._projection = BoundaryProjection.build(
+            node_name=self.name,
+            namespaced=self._namespaced,
+            exposed=self._exposed,
+            local_inputs=self._local_inputs,
+            local_outputs=self._local_outputs,
+            local_data_outputs=self._local_data_outputs,
+            rename_history=self._rename_history,
+        )
+        self.inputs = self._projection.inputs
+        self.outputs = self._projection.outputs
+        self._data_outputs = self._projection.data_outputs
 
     def replacement_for_stale_input_address(self, address: str) -> str | None:
         """Return the current parent-facing input address for a stale namespaced one."""
-        prefixes = [self.name, *(entry.old for entry in self._rename_history if entry.kind == "name")]
-        prefix = next((f"{name}." for name in prefixes if address.startswith(f"{name}.")), None)
-        if prefix is None:
-            return None
-        local_name = address[len(prefix) :]
-        if local_name not in self._local_inputs:
-            for current in self._local_inputs:
-                if self._resolve_original_input_name(current) == local_name:
-                    local_name = current
-                    break
-            else:
-                if local_name in self.inputs:
-                    return local_name
-                return None
-        current = self._project_address(local_name)
-        return current if current != address else None
+        return self._projection.replacement_for_stale_input_address(address)
 
     def _validate_local_port_name(self, name: str, *, role: str) -> None:
         for char in self._RESERVED_CHARS:
@@ -452,8 +423,7 @@ class GraphNode(HyperNode):
         Sorted by inner node name so boundary type selection is deterministic.
         """
         candidates: list[tuple[str, Any]] = []
-        for local_param in self._local_inputs_for_address(param):
-            original_param = self._resolve_original_input_name(local_param)
+        for original_param in self._projection.original_inputs_for_address(param):
             for inner_node in self.iter_active_inner_nodes():
                 if original_param in inner_node.inputs:
                     candidates.append((inner_node.name, inner_node.get_input_type(original_param)))
@@ -465,8 +435,7 @@ class GraphNode(HyperNode):
 
         Sorted by inner node name so boundary type selection is deterministic.
         """
-        local_output = self._local_output_for_address(output)
-        original_output = self.resolve_original_output_name(local_output)
+        original_output = self._projection.original_output_for_address(output)
         candidates: list[tuple[str, Any]] = []
         for inner_node in self.iter_active_inner_nodes():
             if original_output in inner_node.outputs:
@@ -492,24 +461,6 @@ class GraphNode(HyperNode):
         """
         return _conflicting_candidates(self._boundary_output_type_candidates(output))
 
-    def _resolve_original_input_name(self, param: str) -> str:
-        """Resolve a possibly-renamed input name back to the original.
-
-        Traces back through rename history to find what the input was
-        originally called in the inner graph. Batch-aware: parallel renames
-        from one ``rename_inputs`` call (e.g. ``rename_inputs(x="y", y="x")``)
-        are treated as simultaneous transforms, matching the semantics of
-        :func:`build_reverse_rename_map` used by ``map_inputs_to_params``.
-
-        Args:
-            param: Current input parameter name
-
-        Returns:
-            Original name used in the inner graph.
-        """
-        reverse_map = build_reverse_rename_map(self._rename_history, "inputs")
-        return reverse_map.get(param, param)
-
     def map_inputs_to_params(self, inputs: dict[str, Any]) -> dict[str, Any]:
         """Map renamed input names back to original inner graph parameter names.
 
@@ -523,29 +474,17 @@ class GraphNode(HyperNode):
         Returns:
             Dict with original inner graph parameter names as keys
         """
-        reverse_map = build_reverse_rename_map(self._rename_history, "inputs")
-        mapped: dict[str, Any] = {}
-        for address, value in inputs.items():
-            for local_name in self._local_inputs_for_address(address):
-                mapped[reverse_map.get(local_name, local_name)] = value
-        return mapped
+        return self._projection.translate_inputs(inputs)
 
     def _original_map_params(self) -> list[str] | None:
         """Get map_over params translated to original inner graph names.
-
-        Uses build_reverse_rename_map() to handle parallel renames correctly
-        (e.g., rename_inputs(x='y', y='x')), matching the semantics of
-        map_inputs_to_params().
 
         Returns:
             List of original param names if map_over is set, else None.
         """
         if self._map_over is None:
             return None
-        reverse_map = build_reverse_rename_map(self._rename_history, "inputs")
-        if not reverse_map:
-            return list(self._map_over)
-        return [reverse_map.get(p, p) for p in self._map_over]
+        return [self._projection.original_input(p) for p in self._map_over]
 
     def _original_clone(self) -> bool | list[str]:
         """Get clone config translated to original inner graph names.
@@ -558,10 +497,7 @@ class GraphNode(HyperNode):
         """
         if not isinstance(self._clone, list):
             return self._clone
-        reverse_map = build_reverse_rename_map(self._rename_history, "inputs")
-        if not reverse_map:
-            return list(self._clone)
-        return [reverse_map.get(p, p) for p in self._clone]
+        return [self._projection.original_input(p) for p in self._clone]
 
     def map_outputs_from_original(self, outputs: dict[str, Any]) -> dict[str, Any]:
         """Map original inner graph output names to renamed external names.
@@ -576,38 +512,19 @@ class GraphNode(HyperNode):
         Returns:
             Dict with renamed (external) output names as keys
         """
-        from hypergraph.nodes.base import _EMIT_SENTINEL
-
-        reverse_map = build_reverse_rename_map(self._rename_history, "outputs")
-        forward_map = {v: k for k, v in reverse_map.items()}
-        mapped = {self._output_local_to_address.get(forward_map.get(key, key), forward_map.get(key, key)): value for key, value in outputs.items()}
-        for local_output in self._local_outputs:
-            if local_output in self._local_data_outputs:
-                continue
-            address = self._output_local_to_address.get(local_output)
-            if address is not None and address not in mapped:
-                mapped[address] = _EMIT_SENTINEL
-        return mapped
+        return self._projection.translate_outputs(outputs)
 
     def map_output_name_from_original(self, output_name: str) -> str:
         """Map a single inner output name to its external renamed name."""
-        reverse_map = build_reverse_rename_map(self._rename_history, "outputs")
-        forward_map = {v: k for k, v in reverse_map.items()}
-        local_name = forward_map.get(output_name, output_name)
-        return self._output_local_to_address.get(local_name, local_name)
+        return self._projection.output_address_for_original(output_name)
 
     def resolve_original_output_name(self, output_name: str) -> str:
         """Resolve an external output name back to the inner graph's name."""
-        reverse_map = build_reverse_rename_map(self._rename_history, "outputs")
-        local_name = self._local_output_for_address(output_name)
-        return reverse_map.get(local_name, local_name)
+        return self._projection.original_output_for_address(output_name)
 
     def map_input_name_from_original(self, input_name: str) -> str:
         """Map a single inner input name to its external renamed name."""
-        reverse_map = build_reverse_rename_map(self._rename_history, "inputs")
-        forward_map = {v: k for k, v in reverse_map.items()}
-        local_name = forward_map.get(input_name, input_name)
-        return self._project_address(local_name)
+        return self._projection.input_address_for_original(input_name)
 
     def map_resume_key_from_original(self, resume_key: str) -> str:
         """Map a nested resume key from inner names to external names.
@@ -620,13 +537,7 @@ class GraphNode(HyperNode):
         For example, ``decision`` may become ``verdict`` while
         ``review.decision`` remains unchanged because ``review`` is internal.
         """
-        if resume_key in self._local_outputs:
-            return self.map_output_name_from_original(resume_key)
-        head, sep, tail = resume_key.partition(".")
-        mapped_head = self.map_output_name_from_original(head)
-        if not sep:
-            return mapped_head
-        return f"{mapped_head}.{tail}"
+        return self._projection.resume_key_from_original(resume_key)
 
     def iter_active_inner_nodes(self) -> tuple[HyperNode, ...]:
         """Return the inner graph nodes visible through this GraphNode boundary."""
@@ -640,40 +551,69 @@ class GraphNode(HyperNode):
         )
         return tuple(active_nodes.values())
 
+    def _resolve_boundary_default(self, param: str, *, signature_only: bool = False) -> _DefaultResolution:
+        """The one resolver behind all four public default lookup methods.
+
+        A parent address may fan into several original inner params, and each
+        original may have several inner consumers. The address has a default
+        only when EVERY original is satisfied: bound in the inner graph
+        (ordinary lookups only — bound blocks signature lookups), or defaulted
+        by ALL of its inner consumers. The resolved value comes from the first
+        original in address order, preserving the historical lookup order.
+
+        Off-surface addresses (local or original names hidden behind
+        namespacing, aliases, or renames) never resolve.
+        """
+        if param not in self.inputs:
+            return _DefaultResolution(found=False)
+
+        value: Any = _UNSET
+        for original_param in self._projection.original_inputs_for_address(param):
+            if original_param in self._graph.inputs.bound:
+                if signature_only:
+                    return _DefaultResolution(found=False, bound_blocked=True)
+                if value is _UNSET:
+                    value = self._graph.inputs.bound[original_param]
+                continue
+            consumers = [n for n in self._graph.iter_nodes() if original_param in n.inputs]
+            if not consumers:
+                return _DefaultResolution(found=False)
+            if signature_only:
+                if not all(n.has_signature_default_for(original_param) for n in consumers):
+                    return _DefaultResolution(found=False)
+                if value is _UNSET:
+                    value = consumers[0].get_signature_default_for(original_param)
+            else:
+                if not all(n.has_default_for(original_param) for n in consumers):
+                    return _DefaultResolution(found=False)
+                if value is _UNSET:
+                    value = consumers[0].get_default_for(original_param)
+        return _DefaultResolution(found=True, value=value)
+
     def has_default_for(self, param: str) -> bool:
         """Check if a parameter has a default or bound value in the inner graph.
 
-        Returns True if the parameter is bound in the inner graph, or if any
-        inner node has a default for it.
+        Returns True only when every inner fan-in consumer is satisfied —
+        bound in the inner graph or holding a default — so this always agrees
+        with :meth:`get_default_for`.
 
         Args:
-            param: Input parameter name (may be a renamed external name)
+            param: Parent-facing input address (may be a renamed external name)
 
         Returns:
-            True if param is bound or any inner node has a default.
+            True if the address is bound or fully defaulted in the inner graph.
         """
-        if param not in self.inputs:
-            return False
-
-        for local_param in self._local_inputs_for_address(param):
-            original_param = self._resolve_original_input_name(local_param)
-            if original_param in self._graph.inputs.bound:
-                continue
-            inner_nodes_with_param = [n for n in self._graph.iter_nodes() if original_param in n.inputs]
-            if not inner_nodes_with_param:
-                return False
-            if not all(inner_node.has_default_for(original_param) for inner_node in inner_nodes_with_param):
-                return False
-        return True
+        return self._resolve_boundary_default(param).found
 
     def get_default_for(self, param: str) -> Any:
         """Get the default or bound value for a parameter from the inner graph.
 
-        Returns the bound value if the parameter is bound, otherwise returns
-        the default value from an inner node.
+        Returns the bound value if the parameter is bound, otherwise the
+        default value shared by the inner consumers. Raises whenever
+        :meth:`has_default_for` is False for the same address.
 
         Args:
-            param: Input parameter name (may be a renamed external name)
+            param: Parent-facing input address (may be a renamed external name)
 
         Returns:
             The bound or default value.
@@ -681,53 +621,36 @@ class GraphNode(HyperNode):
         Raises:
             KeyError: If no default or bound value exists for this parameter.
         """
-        local_param = self._local_inputs_for_address(param)[0]
-        original_param = self._resolve_original_input_name(local_param)
-
-        # Check if bound in inner graph first
-        if original_param in self._graph.inputs.bound:
-            return self._graph.inputs.bound[original_param]
-        # Check inner nodes for defaults
-        for inner_node in self._graph.iter_nodes():
-            if original_param in inner_node.inputs and inner_node.has_default_for(original_param):
-                return inner_node.get_default_for(original_param)
-        raise KeyError(f"No default value for parameter '{param}'")
+        resolution = self._resolve_boundary_default(param)
+        if not resolution.found:
+            raise KeyError(f"No default value for parameter '{param}'")
+        return resolution.value
 
     def has_signature_default_for(self, param: str) -> bool:
         """Check if a parameter has consistent signature defaults in all inner nodes.
 
         This only checks actual function signature defaults, NOT bound values.
-        Used for validation to ensure consistent defaults across nodes.
+        Used for validation to ensure consistent defaults across nodes. Always
+        agrees with :meth:`get_signature_default_for`.
 
         Args:
-            param: Input parameter name (may be a renamed external name)
+            param: Parent-facing input address (may be a renamed external name)
 
         Returns:
             True if all inner nodes using this parameter have a signature default.
             False if parameter is bound or if any inner node lacks a signature default.
         """
-        if param not in self.inputs:
-            return False
-
-        for local_param in self._local_inputs_for_address(param):
-            original_param = self._resolve_original_input_name(local_param)
-            if original_param in self._graph.inputs.bound:
-                return False
-            inner_nodes_with_param = [n for n in self._graph.iter_nodes() if original_param in n.inputs]
-            if not inner_nodes_with_param:
-                return False
-            if not all(n.has_signature_default_for(original_param) for n in inner_nodes_with_param):
-                return False
-        return True
+        return self._resolve_boundary_default(param, signature_only=True).found
 
     def get_signature_default_for(self, param: str) -> Any:
         """Get the signature default value for a parameter.
 
         Returns ONLY signature defaults from inner nodes, NOT bound values.
-        Used for validation to compare actual default values.
+        Used for validation to compare actual default values. Raises whenever
+        :meth:`has_signature_default_for` is False for the same address.
 
         Args:
-            param: Input parameter name (may be a renamed external name)
+            param: Parent-facing input address (may be a renamed external name)
 
         Returns:
             The signature default value from an inner node.
@@ -735,19 +658,12 @@ class GraphNode(HyperNode):
         Raises:
             KeyError: If no signature default exists (bound values don't count).
         """
-        local_param = self._local_inputs_for_address(param)[0]
-        original_param = self._resolve_original_input_name(local_param)
-
-        # Bound parameters don't have signature defaults
-        if original_param in self._graph.inputs.bound:
+        resolution = self._resolve_boundary_default(param, signature_only=True)
+        if resolution.bound_blocked:
             raise KeyError(f"Parameter '{param}' is bound, not a signature default")
-
-        # Get signature default from inner nodes (not bound values)
-        for inner_node in self._graph.iter_nodes():
-            if original_param in inner_node.inputs and inner_node.has_signature_default_for(original_param):
-                return inner_node.get_signature_default_for(original_param)
-
-        raise KeyError(f"No signature default for parameter '{param}'")
+        if not resolution.found:
+            raise KeyError(f"No signature default for parameter '{param}'")
+        return resolution.value
 
     def map_over(
         self: _GN,
@@ -888,7 +804,7 @@ class GraphNode(HyperNode):
         if param in self._local_inputs:
             return param
         if param in self.inputs:
-            local_candidates = self._local_inputs_for_address(param)
+            local_candidates = self._projection.locals_for_input(param)
             if len(local_candidates) == 1 and local_candidates[0] in self._local_inputs:
                 return local_candidates[0]
         raise ValueError(

--- a/src/hypergraph/runners/_shared/value_resolution.py
+++ b/src/hypergraph/runners/_shared/value_resolution.py
@@ -161,12 +161,12 @@ def get_value_source(
     if bound_addr in graph.inputs.bound:
         return (ValueSource.BOUND, graph.inputs.bound[bound_addr])
 
-    # 3b. For GraphNode: check if inner graph has it bound
+    # 3b. For GraphNode: check if inner graph has it bound. The boundary
+    # projection translates the parent-facing address to original inner names.
     if isinstance(node, GraphNode):
-        for local_param in node._local_inputs_for_address(param):
-            original_param = node._resolve_original_input_name(local_param)
-            if original_param in node._graph.inputs.bound:
-                return (ValueSource.BOUND, node._graph.inputs.bound[original_param])
+        for original_param in node._projection.original_inputs_for_address(param):
+            if original_param in node.graph.inputs.bound:
+                return (ValueSource.BOUND, node.graph.inputs.bound[original_param])
 
     # 4. Function default (from signature)
     if node.has_signature_default_for(param):

--- a/tests/test_nodes_boundary_projection.py
+++ b/tests/test_nodes_boundary_projection.py
@@ -1,0 +1,514 @@
+"""BoundaryProjection unit tests + GraphNode boundary regression coverage (issue #209).
+
+Two layers:
+
+1. ``BoundaryProjection`` in isolation — every translation direction exercised
+   directly against synthetic construction state, no Graph required.
+2. GraphNode-level regressions the consolidation must preserve: fan-in
+   defaults, expose aliases, nested renames, mutex outputs, and the has/get
+   default agreement property (red on pre-#209 master: ``get_default_for``
+   succeeded for off-surface names where ``has_default_for`` said False).
+"""
+
+import functools
+
+import pytest
+
+from hypergraph import Graph, node
+from hypergraph.nodes._boundary import BoundaryProjection
+from hypergraph.nodes._rename import RenameEntry
+from hypergraph.nodes.base import _EMIT_SENTINEL
+
+
+def build_projection(
+    *,
+    node_name: str = "sub",
+    namespaced: bool = False,
+    exposed: dict[str, str] | None = None,
+    local_inputs: tuple[str, ...] = (),
+    local_outputs: tuple[str, ...] = (),
+    local_data_outputs: tuple[str, ...] | None = None,
+    rename_history: list[RenameEntry] | None = None,
+) -> BoundaryProjection:
+    return BoundaryProjection.build(
+        node_name=node_name,
+        namespaced=namespaced,
+        exposed=exposed or {},
+        local_inputs=local_inputs,
+        local_outputs=local_outputs,
+        local_data_outputs=local_data_outputs if local_data_outputs is not None else local_outputs,
+        rename_history=rename_history or [],
+    )
+
+
+class TestFlatProjection:
+    """Non-namespaced boundary: address == local == original."""
+
+    def test_identity_surface(self):
+        proj = build_projection(local_inputs=("x", "y"), local_outputs=("out",))
+        assert proj.inputs == ("x", "y")
+        assert proj.outputs == ("out",)
+        assert proj.data_outputs == ("out",)
+        assert proj.locals_for_input("x") == ("x",)
+        assert proj.original_inputs_for_address("x") == ("x",)
+        assert proj.original_output_for_address("out") == "out"
+        assert proj.input_address_for_original("x") == "x"
+        assert proj.output_address_for_original("out") == "out"
+
+    def test_unknown_names_pass_through(self):
+        proj = build_projection(local_inputs=("x",), local_outputs=("out",))
+        assert proj.locals_for_input("ghost") == ("ghost",)
+        assert proj.local_for_output("ghost") == "ghost"
+        assert proj.original_input("ghost") == "ghost"
+        assert proj.output_address_for_original("ghost") == "ghost"
+
+    def test_translate_inputs_identity(self):
+        proj = build_projection(local_inputs=("x", "y"), local_outputs=())
+        assert proj.translate_inputs({"x": 1, "y": 2}) == {"x": 1, "y": 2}
+
+    def test_name_maps_identity(self):
+        proj = build_projection(local_inputs=("x",), local_outputs=("out",))
+        assert proj.input_name_map == {"x": ("x",)}
+        assert proj.output_name_map == {"out": "out"}
+
+
+class TestNamespacedProjection:
+    def test_prefixed_addresses(self):
+        proj = build_projection(namespaced=True, local_inputs=("x",), local_outputs=("out",))
+        assert proj.inputs == ("sub.x",)
+        assert proj.outputs == ("sub.out",)
+        assert proj.locals_for_input("sub.x") == ("x",)
+        assert proj.local_for_output("sub.out") == "out"
+        assert proj.input_address_for_original("x") == "sub.x"
+        assert proj.output_address_for_original("out") == "sub.out"
+
+    def test_exposed_alias_wins_over_prefix(self):
+        proj = build_projection(
+            namespaced=True,
+            exposed={"x": "flat_x", "out": "result"},
+            local_inputs=("x", "y"),
+            local_outputs=("out",),
+        )
+        assert proj.inputs == ("flat_x", "sub.y")
+        assert proj.outputs == ("result",)
+        assert proj.locals_for_input("flat_x") == ("x",)
+        assert proj.input_address_for_original("x") == "flat_x"
+        assert proj.output_address_for_original("out") == "result"
+        assert proj.input_name_map == {"flat_x": ("x",), "sub.y": ("y",)}
+        assert proj.output_name_map == {"result": "out"}
+
+    def test_translate_inputs_resolves_namespaced_addresses(self):
+        proj = build_projection(namespaced=True, exposed={"x": "ex"}, local_inputs=("x", "y"), local_outputs=())
+        assert proj.translate_inputs({"ex": 1, "sub.y": 2}) == {"x": 1, "y": 2}
+
+
+class TestRenameTranslation:
+    def test_single_input_rename(self):
+        history = [RenameEntry("inputs", "x", "items", batch_id=1)]
+        proj = build_projection(local_inputs=("items",), local_outputs=(), rename_history=history)
+        assert proj.original_input("items") == "x"
+        assert proj.original_inputs_for_address("items") == ("x",)
+        assert proj.input_address_for_original("x") == "items"
+        assert proj.translate_inputs({"items": [1]}) == {"x": [1]}
+        assert proj.input_name_map == {"items": ("x",)}
+
+    def test_parallel_swap_same_batch(self):
+        history = [
+            RenameEntry("inputs", "x", "y", batch_id=7),
+            RenameEntry("inputs", "y", "x", batch_id=7),
+        ]
+        proj = build_projection(local_inputs=("y", "x"), local_outputs=(), rename_history=history)
+        assert proj.original_input("y") == "x"
+        assert proj.original_input("x") == "y"
+        assert proj.translate_inputs({"y": "was_x", "x": "was_y"}) == {"x": "was_x", "y": "was_y"}
+
+    def test_chained_renames_across_batches(self):
+        history = [
+            RenameEntry("outputs", "a", "b", batch_id=1),
+            RenameEntry("outputs", "b", "c", batch_id=2),
+        ]
+        proj = build_projection(local_inputs=(), local_outputs=("c",), rename_history=history)
+        assert proj.original_output("c") == "a"
+        assert proj.original_output_for_address("c") == "a"
+        assert proj.output_address_for_original("a") == "c"
+        assert proj.output_name_map == {"c": "a"}
+
+    def test_rename_under_namespace(self):
+        history = [RenameEntry("inputs", "x", "items", batch_id=1)]
+        proj = build_projection(namespaced=True, local_inputs=("items",), local_outputs=(), rename_history=history)
+        assert proj.inputs == ("sub.items",)
+        assert proj.original_inputs_for_address("sub.items") == ("x",)
+        assert proj.input_address_for_original("x") == "sub.items"
+        assert proj.input_name_map == {"sub.items": ("x",)}
+
+    def test_name_rename_history_ignored_for_ports(self):
+        history = [RenameEntry("name", "old_sub", "sub", batch_id=1)]
+        proj = build_projection(local_inputs=("x",), local_outputs=(), rename_history=history)
+        assert proj.original_input("x") == "x"
+        assert proj.former_names == ("old_sub",)
+
+
+class TestTranslateOutputs:
+    def test_renamed_output_values(self):
+        history = [RenameEntry("outputs", "tripled", "final", batch_id=1)]
+        proj = build_projection(local_inputs=(), local_outputs=("doubled", "final"), rename_history=history)
+        assert proj.translate_outputs({"doubled": 4, "tripled": 12}) == {"doubled": 4, "final": 12}
+
+    def test_off_surface_keys_pass_through(self):
+        proj = build_projection(local_inputs=(), local_outputs=("out",))
+        assert proj.translate_outputs({"out": 1, "internal": 2}) == {"out": 1, "internal": 2}
+
+    def test_emit_only_outputs_backfilled_with_sentinel(self):
+        proj = build_projection(
+            local_outputs=("data_out", "signal"),
+            local_data_outputs=("data_out",),
+        )
+        mapped = proj.translate_outputs({"data_out": 5})
+        assert mapped["data_out"] == 5
+        assert mapped["signal"] is _EMIT_SENTINEL
+
+    def test_emit_backfill_does_not_override_produced_value(self):
+        proj = build_projection(local_outputs=("data_out", "signal"), local_data_outputs=("data_out",))
+        mapped = proj.translate_outputs({"data_out": 5, "signal": "fired"})
+        assert mapped["signal"] == "fired"
+
+    def test_data_outputs_filter_and_projection(self):
+        proj = build_projection(
+            namespaced=True,
+            local_outputs=("data_out", "signal"),
+            local_data_outputs=("data_out",),
+        )
+        assert proj.outputs == ("sub.data_out", "sub.signal")
+        assert proj.data_outputs == ("sub.data_out",)
+
+
+class TestResumeKeys:
+    def test_local_output_key_maps_whole_key(self):
+        history = [RenameEntry("outputs", "decision", "verdict", batch_id=1)]
+        proj = build_projection(local_inputs=(), local_outputs=("verdict",), rename_history=history)
+        assert proj.resume_key_from_original("decision") == "verdict"
+
+    def test_nested_key_maps_head_only(self):
+        proj = build_projection(local_inputs=(), local_outputs=("out",))
+        assert proj.resume_key_from_original("review.decision") == "review.decision"
+
+    def test_nested_local_output_address_key(self):
+        # A child namespaced GraphNode already produced "inner.decision" as a
+        # local output name — the whole key is on the local surface.
+        proj = build_projection(namespaced=True, local_inputs=(), local_outputs=("inner.decision",))
+        assert proj.resume_key_from_original("inner.decision") == "sub.inner.decision"
+
+    def test_namespaced_head_mapping(self):
+        proj = build_projection(namespaced=True, local_inputs=(), local_outputs=("decision",))
+        assert proj.resume_key_from_original("decision") == "sub.decision"
+
+
+class TestStaleAddressReplacement:
+    def test_renamed_local_input(self):
+        history = [RenameEntry("inputs", "x", "items", batch_id=1)]
+        proj = build_projection(namespaced=True, local_inputs=("items",), local_outputs=(), rename_history=history)
+        assert proj.replacement_for_stale_input_address("sub.x") == "sub.items"
+
+    def test_former_node_name_prefix(self):
+        history = [RenameEntry("name", "sub", "worker", batch_id=1)]
+        proj = build_projection(node_name="worker", namespaced=True, local_inputs=("x",), local_outputs=(), rename_history=history)
+        assert proj.replacement_for_stale_input_address("sub.x") == "worker.x"
+
+    def test_exposed_local(self):
+        proj = build_projection(namespaced=True, exposed={"x": "flat_x"}, local_inputs=("x",), local_outputs=())
+        assert proj.replacement_for_stale_input_address("sub.x") == "flat_x"
+
+    def test_current_address_is_not_stale(self):
+        proj = build_projection(namespaced=True, local_inputs=("x",), local_outputs=())
+        assert proj.replacement_for_stale_input_address("sub.x") is None
+
+    def test_unknown_prefix_and_unknown_local(self):
+        proj = build_projection(namespaced=True, local_inputs=("x",), local_outputs=())
+        assert proj.replacement_for_stale_input_address("other.x") is None
+        assert proj.replacement_for_stale_input_address("sub.ghost") is None
+
+
+class TestProjectionCollisions:
+    def test_two_outputs_projecting_to_same_address(self):
+        with pytest.raises(ValueError, match="projects multiple outputs to 'z'"):
+            build_projection(
+                namespaced=True,
+                exposed={"a": "z", "b": "z"},
+                local_outputs=("a", "b"),
+            )
+
+    def test_input_and_output_colliding_on_different_locals(self):
+        with pytest.raises(ValueError, match="projects input\\(s\\) \\['a'\\] and output 'b'"):
+            build_projection(
+                namespaced=True,
+                exposed={"a": "z", "b": "z"},
+                local_inputs=("a",),
+                local_outputs=("b",),
+            )
+
+    def test_cyclic_seed_port_shares_address_without_error(self):
+        proj = build_projection(local_inputs=("state",), local_outputs=("state",))
+        assert proj.inputs == ("state",)
+        assert proj.outputs == ("state",)
+
+
+# === GraphNode-level regression coverage ===
+
+
+@node(output_name="doubled")
+def double(x: int, factor: int = 2) -> int:
+    return x * factor
+
+
+@node(output_name="summed")
+def sum_with_factor(doubled: int, factor: int = 2) -> int:
+    return doubled + factor
+
+
+def _get_succeeds(fn) -> bool:
+    try:
+        fn()
+        return True
+    except KeyError:
+        return False
+
+
+def _default_matrix_nodes():
+    inner = Graph([double, sum_with_factor], name="inner")
+    bound_inner = Graph([double, sum_with_factor], name="bound_inner").bind(factor=7)
+    nested = Graph([inner.as_node(name="mid")], name="nest_outer")
+    return {
+        "flat": inner.as_node(name="flat"),
+        "namespaced": inner.as_node(name="ns", namespaced=True),
+        "exposed": inner.as_node(name="ex", namespaced=True).expose(x="flat_x", factor="shared_factor"),
+        "renamed": inner.as_node(name="ren").rename_inputs(factor="mult").rename_outputs(summed="total"),
+        "bound": bound_inner.as_node(name="bnd"),
+        "bound_namespaced": bound_inner.as_node(name="bns", namespaced=True),
+        "nested": nested.as_node(name="outer"),
+    }
+
+
+class TestDefaultLookupAgreement:
+    """has_*/get_* cannot disagree for ANY address (issue #209 fan-in fix).
+
+    Red on pre-#209 master: for off-surface addresses (local or original
+    names hidden behind namespacing/renames) has_default_for returned False
+    while get_default_for still resolved a value through the first local.
+    """
+
+    @pytest.mark.parametrize("case", sorted(_default_matrix_nodes()))
+    def test_has_get_agreement_over_address_matrix(self, case):
+        gn = _default_matrix_nodes()[case]
+        probe_addresses = {
+            *gn.inputs,
+            *gn.local_inputs,
+            "x",
+            "factor",
+            "doubled",
+            "nonexistent",
+            f"{gn.name}.factor",
+        }
+        for address in sorted(probe_addresses):
+            has = gn.has_default_for(address)
+            got = _get_succeeds(functools.partial(gn.get_default_for, address))
+            assert has == got, f"{case}: has_default_for({address!r})={has} but get success={got}"
+
+            has_sig = gn.has_signature_default_for(address)
+            got_sig = _get_succeeds(functools.partial(gn.get_signature_default_for, address))
+            assert has_sig == got_sig, f"{case}: has_signature_default_for({address!r})={has_sig} but get success={got_sig}"
+
+    def test_fan_in_consumers_agree_with_value(self):
+        """Two inner consumers of 'factor' (consistent defaults): has=True, get=value."""
+        gn = _default_matrix_nodes()["flat"]
+        assert gn.has_default_for("factor") is True
+        assert gn.get_default_for("factor") == 2
+        assert gn.has_signature_default_for("factor") is True
+        assert gn.get_signature_default_for("factor") == 2
+
+    def test_bound_fan_in_agrees_with_bound_value(self):
+        gn = _default_matrix_nodes()["bound"]
+        assert gn.has_default_for("factor") is True
+        assert gn.get_default_for("factor") == 7
+        assert gn.has_signature_default_for("factor") is False
+        with pytest.raises(KeyError, match="bound, not a signature default"):
+            gn.get_signature_default_for("factor")
+
+    def test_exposed_alias_defaults_resolve_through_alias(self):
+        gn = _default_matrix_nodes()["exposed"]
+        assert gn.has_default_for("shared_factor") is True
+        assert gn.get_default_for("shared_factor") == 2
+
+    def test_off_surface_get_now_raises(self):
+        """The concrete pre-#209 asymmetry: off-surface name resolved a value."""
+        gn = _default_matrix_nodes()["namespaced"]
+        assert gn.has_default_for("factor") is False
+        with pytest.raises(KeyError):
+            gn.get_default_for("factor")
+
+
+def _fan_in_boundary(*, consumer_has_value: bool):
+    """One fan-in address 'shared' feeding two inner consumers.
+
+    Toggling ``consumer_has_value`` gives the first consumer (a nested graph)
+    its value via an inner-graph bind — the only way one consumer can gain a
+    value while the graph stays constructible, because build validation
+    rejects mixed signature defaults (asserted separately below).
+    """
+
+    @node(output_name="left")
+    def use_left(shared: int) -> int:
+        return shared
+
+    @node(output_name="right")
+    def use_right(shared: int) -> int:
+        return -shared
+
+    left_inner = Graph([use_left], name="left_inner")
+    if consumer_has_value:
+        left_inner = left_inner.bind(shared=11)
+    g1 = left_inner.as_node(name="left_box")
+    g2 = Graph([use_right], name="right_inner").as_node(name="right_box")
+    return Graph([g1, g2], name="mid").as_node(name="box")
+
+
+def _signature_fan_in_boundary(*, consumers_have_default: bool):
+    """Fan-in address 'shared' with two function-node consumers."""
+    if consumers_have_default:
+
+        @node(output_name="left")
+        def use_left(shared: int = 11) -> int:
+            return shared
+
+        @node(output_name="right")
+        def use_right(shared: int = 11) -> int:
+            return -shared
+    else:
+
+        @node(output_name="left")
+        def use_left(shared: int) -> int:
+            return shared
+
+        @node(output_name="right")
+        def use_right(shared: int) -> int:
+            return -shared
+
+    return Graph([use_left, use_right], name="mid").as_node(name="box")
+
+
+class TestFanInDefaultFalsifier:
+    """C4 falsifier: one fan-in consumer gains its default and the public
+    outcome flips from False/KeyError to True/value."""
+
+    def test_consumer_without_value_fails_then_gaining_it_resolves(self):
+        missing = _fan_in_boundary(consumer_has_value=False)
+        assert missing.has_default_for("shared") is False
+        with pytest.raises(KeyError, match="No default value for parameter 'shared'"):
+            missing.get_default_for("shared")
+
+        having = _fan_in_boundary(consumer_has_value=True)
+        assert having.has_default_for("shared") is True
+        assert having.get_default_for("shared") == 11
+
+    def test_gained_value_reaches_execution(self):
+        """The resolved default is a real public outcome, not a map stamp."""
+        from hypergraph import SyncRunner
+
+        having = _fan_in_boundary(consumer_has_value=True)
+        result = SyncRunner().run(Graph([having], name="root"), {})
+        assert result["left"] == 11
+        assert result["right"] == -11
+
+    def test_signature_agreement_repeats_the_flip(self):
+        missing = _signature_fan_in_boundary(consumers_have_default=False)
+        assert missing.has_signature_default_for("shared") is False
+        with pytest.raises(KeyError, match="No signature default for parameter 'shared'"):
+            missing.get_signature_default_for("shared")
+        assert missing.has_default_for("shared") is False
+        with pytest.raises(KeyError):
+            missing.get_default_for("shared")
+
+        having = _signature_fan_in_boundary(consumers_have_default=True)
+        assert having.has_signature_default_for("shared") is True
+        assert having.get_signature_default_for("shared") == 11
+        assert having.has_default_for("shared") is True
+        assert having.get_default_for("shared") == 11
+
+    def test_bound_consumer_fails_loudly_as_signature_default(self):
+        having = _fan_in_boundary(consumer_has_value=True)
+        assert having.has_signature_default_for("shared") is False
+        with pytest.raises(KeyError, match="bound, not a signature default"):
+            having.get_signature_default_for("shared")
+
+    def test_lone_signature_default_still_rejected_at_build(self):
+        """Why the signature flip changes both consumers: build validation
+        (unchanged by #209) rejects the mixed state with its exact diagnostic."""
+        from hypergraph.graph.validation import GraphConfigError
+
+        @node(output_name="left")
+        def use_left(shared: int = 11) -> int:
+            return shared
+
+        @node(output_name="right")
+        def use_right(shared: int) -> int:
+            return -shared
+
+        with pytest.raises(GraphConfigError, match="Inconsistent defaults for 'shared'"):
+            Graph([use_left, use_right], name="mid")
+
+
+class TestBoundaryRegressionScenarios:
+    def test_nested_rename_chain_translates_both_boundaries(self):
+        """GraphNode inside GraphNode, renames at both boundaries."""
+        inner = Graph([double], name="inner")
+        mid = inner.as_node(name="mid").rename_outputs(doubled="mid_out")
+
+        @node(output_name="final")
+        def consume(mid_out: int) -> int:
+            return mid_out + 1
+
+        outer = Graph([mid, consume], name="outer")
+        outer_gn = outer.as_node(name="top").rename_outputs(final="top_final")
+
+        assert outer_gn._projection.output_address_for_original("final") == "top_final"
+        assert mid._projection.output_address_for_original("doubled") == "mid_out"
+        assert outer_gn._projection.original_output_for_address("top_final") == "final"
+
+        from hypergraph import SyncRunner
+
+        result = SyncRunner().run(Graph([outer_gn], name="root"), {"x": 3})
+        assert result["top_final"] == 7
+
+    def test_mutex_outputs_translate_through_renamed_boundary(self):
+        """Exclusive branches producing the same output stay addressable after rename."""
+        from hypergraph import SyncRunner
+        from hypergraph.nodes.gate import ifelse
+
+        @node(output_name="result")
+        def process(a: int) -> int:
+            return a * 2
+
+        @node(output_name="result")
+        def skip(a: int) -> int:
+            return a
+
+        @ifelse(when_true="process", when_false="skip")
+        def is_positive(a: int) -> bool:
+            return a > 0
+
+        inner = Graph([is_positive, process, skip], name="mutex_inner")
+        gn = inner.as_node(name="mutex").rename_outputs(result="branch_result")
+        assert "branch_result" in gn.outputs
+        assert gn._projection.output_name_map["branch_result"] == "result"
+
+        runner = SyncRunner()
+        assert runner.run(Graph([gn], name="root_pos"), {"a": 3})["branch_result"] == 6
+        assert runner.run(Graph([gn], name="root_neg"), {"a": -3})["branch_result"] == -3
+
+    def test_nx_attrs_name_maps_come_from_projection(self):
+        inner = Graph([double], name="inner")
+        gn = inner.as_node(name="cx", namespaced=True).expose(x="ex").rename_inputs(factor="mult")
+        attrs = gn.nx_attrs
+        assert attrs["input_name_map"] == gn._projection.input_name_map
+        assert attrs["output_name_map"] == gn._projection.output_name_map
+        assert attrs["input_name_map"] == {"ex": ("x",), "cx.mult": ("factor",)}
+        assert attrs["output_name_map"] == {"cx.doubled": "doubled"}


### PR DESCRIPTION
Closes #209.

## Problem / Bug / Challenge

GraphNode translated the same parent/child boundary in several places: projected ports, validation, defaults, execution, resume keys, and visualization maps. Rename directions were reconstructed per call, and the four default lookup methods could disagree. A namespaced input could report no default through `has_default_for()` while `get_default_for()` still reached the hidden inner name and returned a value.

## Before / After

**Before:**

```python
gn = inner.as_node(name="box", namespaced=True)

assert gn.has_default_for("factor") is False
assert gn.get_default_for("factor") == 2  # hidden off-surface bypass
```

Boundary ownership was also duplicated:

```text
GraphNode method -> rebuild reverse map -> invert it -> project address
runner/viz method -> repeat a related translation
```

**After:**

```python
gn = inner.as_node(name="box", namespaced=True)

assert gn.has_default_for("factor") is False
with pytest.raises(KeyError):
    gn.get_default_for("factor")
```

```text
boundary mutation -> build one internal BoundaryProjection
all validation/default/execution/resume/viz consumers -> use that projection
```

The projection stays internal: there is no new public `GraphNode.projection` property or package export. `_rename.py` now owns the canonical forward and reverse rename maps. One resolver supplies all four default lookup methods and checks every fan-in original and consumer.

## Test Plan

- [x] Fresh environment: `uv sync --frozen --group dev --extra daft`
- [x] Focused boundary, runner, viz, map-input, and frozen-baseline suite: `118 passed`
- [x] Fan-in outcome falsifier: `5 passed`
- [x] CI-equivalent warning-as-error suite: `4208 passed`, `0 skipped`
- [x] `uv run pre-commit run --all-files`
- [x] CI-matching Python 3.10 mypy: `Success: no issues found in 150 source files`
- [x] All eight frozen hash fixtures remain byte-identical; no fixture edits
- [x] Public black-box address/map/run witness matches master exactly
- [x] Fresh independent Fable review: `ACCEPT`, no blocker
- [x] Foreman code-smell passes: indirection, data honesty, control flow, ownership, Python traps, coordination, Hypergraph boundaries, and fresh-world checks