### PR TITLE
refactor(graph): make construction choices explicit

### DIFF
--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -627,8 +627,12 @@ class Graph:
     def _build_graph(self, nodes: list[HyperNode]) -> nx.DiGraph:
         """Build NetworkX DiGraph from nodes.
 
-        Uses explicit edges if provided, otherwise infers edges from
-        matching output/input names.
+        Construction makes two independent choices: whether to infer data
+        edges from matching output/input names, and whether to add the
+        user-declared edges. Declared edges without shared params disable
+        inference (``edges=[]`` counts as declared: it means "no edges");
+        with shared params, inference stays on for non-shared values and
+        declared edges land on top.
         """
         G = nx.DiGraph()
         self._add_nodes_to_graph(G, nodes)
@@ -637,31 +641,20 @@ class Graph:
         # Shared params allow multiple producers — exclude from conflict checks
         conflict_sources = {k: v for k, v in output_to_sources.items() if k not in self._shared} if self._shared else output_to_sources
 
-        if self._explicit_edges is not None and not self._shared:
-            # Explicit mode: user-declared data edges (no auto-inference)
+        infer_data_edges = self._explicit_edges is None or bool(self._shared)
+        add_declared_edges = self._explicit_edges is not None
+
+        if infer_data_edges:
+            self._add_data_edges(G, nodes, output_to_sources)
+        if add_declared_edges:
+            assert self._explicit_edges is not None
             self._add_explicit_data_edges(G, self._explicit_edges)
-            self._add_control_edges(G, nodes)
-            self._add_ordering_edges(G, nodes, output_to_sources)
-            validate_output_conflicts(
-                G,
-                nodes,
-                conflict_sources,
-                explicit_edges=True,
-            )
-        elif self._shared:
-            # Shared mode: auto-infer non-shared edges, add explicit as ordering
-            self._add_data_edges(G, nodes, output_to_sources)
-            if self._explicit_edges is not None:
-                self._add_explicit_data_edges(G, self._explicit_edges)
-            self._add_control_edges(G, nodes)
-            self._add_ordering_edges(G, nodes, output_to_sources)
-            validate_output_conflicts(G, nodes, conflict_sources)
-        else:
-            # Auto-inference mode (default)
-            self._add_data_edges(G, nodes, output_to_sources)
-            self._add_control_edges(G, nodes)
-            self._add_ordering_edges(G, nodes, output_to_sources)
-            validate_output_conflicts(G, nodes, conflict_sources)
+        self._add_control_edges(G, nodes)
+        self._add_ordering_edges(G, nodes, output_to_sources)
+        # Conflict validation trusts declared topology only when inference
+        # is off; with inference on, contested name-matches need auto-mode
+        # analysis even if declared edges were also added.
+        validate_output_conflicts(G, nodes, conflict_sources, explicit_edges=not infer_data_edges)
 
         if self._shared:
             self._validate_shared_connectivity(G, nodes)

--- a/tests/test_construction_matrix.py
+++ b/tests/test_construction_matrix.py
@@ -1,0 +1,145 @@
+"""Construction-choice matrix (issue #208).
+
+Graph construction makes two independent choices: whether data edges are
+inferred from matching output/input names, and whether user-declared edges
+are added. The four ``edges``/``shared`` combinations cover the matrix.
+``edges=[]`` is the boundary case: it means "declared: no edges", not
+"nothing declared", so it must disable inference exactly like a non-empty
+declaration.
+
+All assertions use the public graph surface (``nx_graph``, ``inputs``,
+``has_explicit_edges``, ``explicit_predecessors``).
+"""
+
+import pytest
+
+from hypergraph import Graph, GraphConfigError, node
+
+
+@node(output_name=("a", "b"))
+def produce(seed: int) -> tuple[int, int]:
+    return seed, seed + 1
+
+
+@node(output_name="marker")
+def annotate(token: str) -> str:
+    return token
+
+
+@node(output_name="total")
+def consume(a: int, b: int) -> int:
+    return a + b
+
+
+def _edges(graph: Graph) -> dict[tuple[str, str], tuple[str, tuple[str, ...]]]:
+    """Snapshot of (source, target) -> (edge_type, value_names)."""
+    return {(u, v): (d.get("edge_type"), tuple(d.get("value_names", []))) for u, v, d in graph.nx_graph.edges(data=True)}
+
+
+class TestConstructionChoiceMatrix:
+    """One test per edges/shared combination, plus the F1/F2 falsifiers."""
+
+    def test_default_infers_name_matched_edges(self):
+        """No edges, no shared: name matching wires producer to consumer."""
+        g = Graph([produce, consume])
+        assert _edges(g) == {("produce", "consume"): ("data", ("a", "b"))}
+        assert g.inputs.required == ("seed",)
+        assert g.has_explicit_edges is False
+        assert g.explicit_predecessors == {}
+
+    def test_empty_edges_disables_inference(self):
+        """F1: same nodes, only edges=None -> edges=[] changes; inference must stop."""
+        g = Graph([produce, consume], edges=[])
+        assert _edges(g) == {}
+        assert set(g.inputs.required) == {"seed", "a", "b"}
+        assert g.has_explicit_edges is True
+
+    def test_declared_edges_are_the_only_topology(self):
+        """Explicit mode: declared edges land; name matches do not."""
+        g = Graph([produce, annotate, consume], edges=[(annotate, consume)])
+        assert _edges(g) == {("annotate", "consume"): ("ordering", ())}
+        assert set(g.inputs.required) == {"seed", "token", "a", "b"}
+        assert g.has_explicit_edges is True
+        assert g.explicit_predecessors == {"consume": frozenset({"annotate"})}
+
+    def test_shared_keeps_inference_for_non_shared_values(self):
+        """Shared mode: inference stays on, shared values flow through state."""
+        g = Graph([produce, consume], shared="b")
+        assert _edges(g) == {("produce", "consume"): ("data", ("a",))}
+        assert set(g.inputs.required) == {"seed", "b"}
+        assert g.has_explicit_edges is False
+
+    def test_shared_plus_declared_infers_and_adds(self):
+        """F2: adding shared to a declared-edge graph turns inference back on."""
+        g = Graph([produce, annotate, consume], shared="b", edges=[(annotate, consume)])
+        assert _edges(g) == {
+            ("produce", "consume"): ("data", ("a",)),
+            ("annotate", "consume"): ("ordering", ()),
+        }
+        assert set(g.inputs.required) == {"seed", "token", "b"}
+        assert g.has_explicit_edges is True
+        assert g.explicit_predecessors == {"consume": frozenset({"annotate"})}
+
+
+@node(output_name="x")
+def left() -> int:
+    return 1
+
+
+@node(output_name="x")
+def right() -> int:
+    return 2
+
+
+@node(output_name="done")
+def use(x: int) -> int:
+    return x
+
+
+class TestConstructionChoiceDiagnostics:
+    """F3: invalid graphs keep the exact per-mode diagnostics."""
+
+    def test_unknown_source_exact_message(self):
+        with pytest.raises(GraphConfigError, match=r"^Edge references unknown source node 'missing'$"):
+            Graph([produce, consume], edges=[("missing", "consume")])
+
+    def test_duplicate_producers_auto_diagnostic(self):
+        with pytest.raises(GraphConfigError) as exc:
+            Graph([left, right, use])
+        assert str(exc.value) == (
+            "Multiple nodes produce 'x'\n\n"
+            "  -> left creates 'x'\n"
+            "  -> right creates 'x'\n\n"
+            "How to fix:\n"
+            "  - Add ordering with emit/wait_for between the producers\n"
+            "  - Or place them in exclusive gate branches"
+        )
+
+    def test_duplicate_producers_declared_diagnostic(self):
+        with pytest.raises(GraphConfigError) as exc:
+            Graph([left, right, use], edges=[(left, use), (right, use)])
+        assert str(exc.value) == (
+            "Multiple nodes produce 'x'\n\n"
+            "  -> left creates 'x'\n"
+            "  -> right creates 'x'\n\n"
+            "How to fix:\n"
+            "  - Add an edge between the producers to declare ordering\n"
+            "  - Or place them in exclusive gate branches"
+        )
+
+    def test_shared_plus_declared_keeps_auto_conflict_diagnostic(self):
+        """Declared edges do not select explicit conflict rules while inference is on."""
+        with pytest.raises(GraphConfigError) as exc:
+            Graph(
+                [left, right, use],
+                shared="done",
+                edges=[(left, use), (right, use)],
+            )
+        assert str(exc.value) == (
+            "Multiple nodes produce 'x'\n\n"
+            "  -> left creates 'x'\n"
+            "  -> right creates 'x'\n\n"
+            "How to fix:\n"
+            "  - Add ordering with emit/wait_for between the producers\n"
+            "  - Or place them in exclusive gate branches"
+        )


### PR DESCRIPTION
## Problem / Bug / Challenge

`Graph._build_graph` encoded automatic inference, declared edges, and shared-state construction as a three-way branch. The behavior was correct, but the real two choices were coupled and the control/ordering/validation tail appeared in every arm.

This is the remaining construction-mode slice of #208. PR #307 already delivered polymorphic structural-signature ownership and shared gate initialization.

Closes #208.

## Before / After

**Before:**

```python
if self._explicit_edges is not None and not self._shared:
    self._add_explicit_data_edges(G, self._explicit_edges)
    self._add_control_edges(G, nodes)
    self._add_ordering_edges(G, nodes, output_to_sources)
    validate_output_conflicts(..., explicit_edges=True)
elif self._shared:
    self._add_data_edges(G, nodes, output_to_sources)
    if self._explicit_edges is not None:
        self._add_explicit_data_edges(G, self._explicit_edges)
    self._add_control_edges(G, nodes)
    self._add_ordering_edges(G, nodes, output_to_sources)
    validate_output_conflicts(...)
else:
    self._add_data_edges(G, nodes, output_to_sources)
    self._add_control_edges(G, nodes)
    self._add_ordering_edges(G, nodes, output_to_sources)
    validate_output_conflicts(...)
```

**After:**

```python
infer_data_edges = self._explicit_edges is None or bool(self._shared)
add_declared_edges = self._explicit_edges is not None

if infer_data_edges:
    self._add_data_edges(G, nodes, output_to_sources)
if add_declared_edges:
    assert self._explicit_edges is not None
    self._add_explicit_data_edges(G, self._explicit_edges)

self._add_control_edges(G, nodes)
self._add_ordering_edges(G, nodes, output_to_sources)
validate_output_conflicts(
    G,
    nodes,
    conflict_sources,
    explicit_edges=not infer_data_edges,
)
```

The four existing combinations remain exact:

| `edges` | `shared` | Infer data | Add declared |
|---|---:|---:|---:|
| omitted | no | yes | no |
| supplied, including `[]` | no | no | yes |
| omitted | yes | yes | no |
| supplied | yes | yes | yes |

The focused matrix also pins the key boundary: `edges=[]` means “declare no edges,” not “infer edges.” It pins the other subtle rule too: shared-plus-declared graphs keep auto-inference conflict diagnostics because inference is still active.

## Test Plan

- [x] Fresh `uv sync --frozen --python 3.12 --group dev --extra daft`
- [x] Foreman black-box construction witness matches the base JSON exactly
- [x] `uv run pytest -W error -W 'ignore::pytest.PytestUnraisableExceptionWarning'` — 4,217 passed, 0 failed, 0 skipped
- [x] `uv run pre-commit run --all-files` — all hooks passed
- [x] `uv run --python 3.10 mypy` — success, 150 source files
- [x] Frozen definition/structural hash fixtures pass with zero fixture edits
- [x] Deliberate wrong conflict flag makes the new shared-plus-declared diagnostic test fail; restored code passes
- [x] Eight-pass code-smell review — no findings
- [x] Fresh read-only Fable review of final commit `20fba625` — ACCEPT, no blockers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graph construction so inferred data connections and explicitly declared connections are handled consistently.
  * Preserved automatic inference for non-shared values when shared values are configured.
  * Improved validation and diagnostics for unknown connections and conflicting outputs.

* **Tests**
  * Added coverage for graph construction combinations, connection ordering, shared values, and configuration error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->