### PR TITLE
feat(otel): production wave — exception detail, trace correlation, trace_io, concurrent-run fix

### DIFF
--- a/docs/05-how-to/observe-execution.md
+++ b/docs/05-how-to/observe-execution.md
@@ -124,15 +124,78 @@ Intermediate failed attempts never mark the node span as error and never
 close it; only the terminal escaping failure sets error status. A cache hit
 opens no attempts and emits no attempt span events.
 
-### Export Privacy
+### Exception Detail, and Redacting It
 
-Exported spans follow the diagnostics privacy boundary: span error status,
-`exception.message`, and attempt `error_type` attributes carry the safe
-projection — exception type names and stable `hypergraph.diagnostic.code`
-values — never raw exception message text (which can embed secrets; see the
-OTel `exception.message` sensitivity warning). The exact exception object
-stays local on `RunResult.error` and `get_failure_evidence(...)`. See
+Exported spans carry the **real** exception by default: span error status,
+`exception.message`, `exception.type`, and `exception.stacktrace` come from
+the exact raised exception. This matches standard OTel
+`Span.record_exception`, and it is what makes a trace debuggable.
+
+```python
+OpenTelemetryProcessor(redact_errors=True)
+```
+
+turns that off: the export falls back to the privacy-safe projection —
+exception type names and stable `hypergraph.diagnostic.code` values, never
+raw message text (which can embed secrets; see the OTel `exception.message`
+sensitivity warning). Use it where exception text may carry regulated data.
+`exception.type` is unaffected either way; only message text and the
+stacktrace are redacted.
+
+The redaction flag governs the **export only**. Durable Hypergraph records —
+RunLog, StepRecord, checkpoints, the attempt ledger, `RunResult.to_dict()` —
+always store the safe projection, whatever this flag says. The exact
+exception object stays local on `RunResult.error` and
+`get_failure_evidence(...)`; the in-memory `NodeErrorEvent.error_detail` /
+`RunEndEvent.error_detail` fields carry the same raw detail for live
+consumers and are never persisted. See
 [Errors — diagnostic code registry](../06-api-reference/errors.md#diagnostic-code-registry).
+
+### Node Inputs and Outputs on Spans
+
+Off by default. Opt a node in with `@node(trace_io=True)`, or default a whole
+graph with `Graph(..., trace_io=True)` / `graph.with_trace_io()`:
+
+```python
+@node(output_name="answer", trace_io=True)
+def call_llm(prompt: str) -> str: ...
+```
+
+An opted-in node's span carries OpenInference `input.value` /
+`input.mime_type` (the input kwargs) and `output.value` / `output.mime_type`
+(the outputs by name), JSON-serialized, so Phoenix and similar backends
+render them natively.
+
+- **Precedence**: processor kill switch > node explicit > graph default > off.
+  A node's own `trace_io=True`/`False` always beats the graph default;
+  leaving it unset (`None`) follows the graph.
+- **Kill switch**: `OpenTelemetryProcessor(redact_payloads=True)` refuses
+  every payload regardless of node or graph opt-ins.
+- **Caps**: each value is truncated past `max_payload_chars` (default 4096)
+  and then marked `text/plain`, because a cut JSON document is not JSON.
+  Values that serialize as neither JSON nor `repr` are omitted; capture never
+  fails or slows a run.
+- **Boundary**: payloads ride spans only. No durable record changes shape or
+  content because a node opted in.
+
+### One Processor Across Concurrent Runs
+
+A single `OpenTelemetryProcessor` — passed to several `run()` calls, or
+carried by a graph via `with_processors` — is safe under concurrent
+top-level runs. Each run's spans are tracked independently, and the
+processor's span sweep happens when the *last* concurrent run settles, not
+the first.
+
+Link a run back to its trace with `processor.trace_id_for(run_id)`:
+
+```python
+result = runner.run(graph, inputs, event_processors=[processor])
+trace_id = processor.trace_id_for(result.run_id)  # 32-char hex, or None
+```
+
+It is populated when the run's span starts, survives the processor shutdown
+the runner performs before `run()` returns, and is kept for the last 1024
+runs.
 
 ### Tag Spans and Keep the Global Tracer Untouched
 

--- a/docs/06-api-reference/errors.md
+++ b/docs/06-api-reference/errors.md
@@ -9,13 +9,22 @@ document their other validation errors next to each operation.
 ## The privacy boundary
 
 Local object surfaces keep the **exact exception object**: the raised
-exception, `RunResult.error`, and `FailureEvidence.error`. Durable and
-telemetry surfaces — events, `RunLog`, checkpoint `StepRecord`s, attempt
-ledger rows, `RunResult.to_dict()`, and OpenTelemetry export — receive only a
+exception, `RunResult.error`, and `FailureEvidence.error`. Durable surfaces —
+`NodeErrorEvent.error` / `RunEndEvent.error`, `RunLog`, checkpoint
+`StepRecord`s, attempt ledger rows, and `RunResult.to_dict()` — receive only a
 privacy-safe `Diagnostic` projection: stable codes, exception type names,
 node identity, counts/timing, booleans, and static help. Raw inputs, response
 bodies, exception arguments, stack traces, and arbitrary `repr` never enter a
 durable record.
+
+Two surfaces sit deliberately outside that boundary, because a scrubbed
+failure cannot be debugged. In-memory events carry an `error_detail`
+companion (`ErrorDetail`: `message`, `type_name`, `traceback`) alongside the
+safe `error`, and the OpenTelemetry export uses it by default — matching
+standard `Span.record_exception`. Neither is ever persisted, and
+`OpenTelemetryProcessor(redact_errors=True)` puts the export back on the safe
+projection for regulated deployments. See
+[Observe execution](../05-how-to/observe-execution.md#exception-detail-and-redacting-it).
 
 ```python
 try:

--- a/docs/06-api-reference/events.md
+++ b/docs/06-api-reference/events.md
@@ -100,6 +100,7 @@ class RunEndEvent(BaseEvent):
     batch_stopped_items: int | None
     batch_outcome: str | None
     batch_restored_items: int | None
+    error_detail: ErrorDetail | None  # Unredacted failure detail (in-memory only)
 ```
 
 For map parents, `batch_completed_items` remains inclusive of checkpoint-restored successes and `batch_restored_items` reports that subset. OpenTelemetry processors export the same value as `hypergraph.batch.restored_items`. Restored children were skipped, so they do not emit new child execution events.
@@ -121,6 +122,7 @@ class NodeStartEvent(BaseEvent):
     node_name: str               # Name of the node
     graph_name: str              # Graph containing the node
     superstep: int | None        # Zero-indexed superstep, if known
+    trace_inputs: dict | None    # Input kwargs, only when the node opted into trace_io
 ```
 
 ### NodeEndEvent
@@ -135,7 +137,14 @@ class NodeEndEvent(BaseEvent):
     superstep: int | None        # Zero-indexed superstep, if known
     duration_ms: float           # Wall-clock duration in milliseconds
     cached: bool                 # True if result was served from cache
+    trace_outputs: dict | None   # Outputs by name, only when the node opted into trace_io
 ```
+
+`trace_inputs` / `trace_outputs` are present only for nodes that resolve
+`trace_io` on (`@node(trace_io=True)`, or a `Graph(..., trace_io=True)`
+default). They carry live objects for span export and are never persisted —
+no durable record changes shape or content because a node opted in. See
+[Observe execution](../05-how-to/observe-execution.md).
 
 ### NodeAttemptStartEvent
 
@@ -208,12 +217,19 @@ class NodeErrorEvent(BaseEvent):
     error_type: str              # Fully qualified exception type
     superstep: int | None        # Zero-indexed superstep, if known
     diagnostic: Diagnostic | None  # Typed privacy-safe diagnostic
+    error_detail: ErrorDetail | None  # Unredacted failure detail (in-memory only)
 ```
 
 `error` carries the safe projection — exception type name, stable diagnostic
-code, and static wording. Raw exception message text never enters the event
-stream; the exact exception object stays on local surfaces
-(`RunResult.error`, `get_failure_evidence`). See
+code, and static wording — and is what every durable record stores.
+`error_detail` is the unredacted counterpart (`message`, `type_name`,
+`traceback`) for live consumers that must debug the failure; it rides
+in-memory events only and is never persisted. The exact exception object
+still stays on local surfaces (`RunResult.error`, `get_failure_evidence`).
+
+The OpenTelemetry export uses `error_detail` by default, following standard
+`record_exception`; `OpenTelemetryProcessor(redact_errors=True)` exports the
+safe projection instead. See
 [Errors — diagnostic code registry](errors.md#diagnostic-code-registry).
 
 ### RouteDecisionEvent

--- a/docs/06-api-reference/events.md
+++ b/docs/06-api-reference/events.md
@@ -91,7 +91,7 @@ Emitted when a graph run completes (successfully or not).
 class RunEndEvent(BaseEvent):
     graph_name: str              # Name of the graph
     status: str                  # "completed", "failed", "paused", "partial", or "stopped"
-    error: str | None            # Error message if failed
+    error: str | None            # Privacy-safe error projection if failed (never str(exception))
     duration_ms: float           # Wall-clock duration in milliseconds
     batch_total_items: int | None
     batch_completed_items: int | None

--- a/docs/06-api-reference/events.md
+++ b/docs/06-api-reference/events.md
@@ -475,7 +475,10 @@ Every runner merges carried processors in front of call-site ones:
   **same processor instance** at more than one level (call-site and carried,
   or on both an outer graph and a graph nested inside it) delivers that
   instance the same events more than once — carry stateful processors like
-  `OpenTelemetryProcessor` at exactly one level.
+  `OpenTelemetryProcessor` at exactly one level. Reusing one instance across
+  *separate* runs, concurrent or sequential, is supported:
+  `OpenTelemetryProcessor` tracks each run's spans independently and defers
+  its span sweep until the last concurrent run settles.
 - All entry points participate: `run()`, `map()` (including the top-level map
   span), and `map_iter()` (which delegates through `run()` per item, so
   carried processors observe each item; there is no top-level map span).

--- a/docs/06-api-reference/graph.md
+++ b/docs/06-api-reference/graph.md
@@ -36,7 +36,7 @@ inference applies **producer shadow-elimination**:
 
 ## Constructor
 
-### `Graph(nodes, *, edges=None, entrypoint=None, name=None, strict_types=False, shared=None)`
+### `Graph(nodes, *, edges=None, entrypoint=None, name=None, strict_types=False, shared=None, trace_io=False)`
 
 Create a graph from nodes.
 

--- a/docs/06-api-reference/graph.md
+++ b/docs/06-api-reference/graph.md
@@ -720,6 +720,29 @@ for a permit is neither a failure nor a retry attempt. See
 **Raises:**
 - `TypeError` - If `provider_limit` is not a `ProcessLocalLimiter`.
 
+### `with_trace_io(trace_io=True) -> Graph`
+
+Set the graph-level default for attaching node inputs/outputs to their
+observability spans. Returns a new Graph (immutable pattern). Also available
+as the `Graph(..., trace_io=...)` constructor argument.
+
+```python
+traced = graph.with_trace_io()
+traced.trace_io                              # True
+traced.definition_hash == graph.definition_hash  # True — metadata only
+```
+
+A node's own `@node(trace_io=True/False)` always overrides this default; a
+node that leaves it unset follows the graph. An exporter can refuse payloads
+outright with `OpenTelemetryProcessor(redact_payloads=True)`. Payloads ride
+spans only — no durable record changes shape or content. See
+[Observe execution](../05-how-to/observe-execution.md#node-inputs-and-outputs-on-spans).
+
+**Args:**
+- `trace_io`: The default applied to nodes that do not declare one.
+
+**Returns:** New Graph carrying the default
+
 ### `as_node(*, name=None, namespaced=False, runner=None, complete_on_stop=False) -> GraphNode`
 
 Wrap graph as a node for composition. Returns a new GraphNode.

--- a/docs/06-api-reference/nodes.md
+++ b/docs/06-api-reference/nodes.md
@@ -164,6 +164,7 @@ def __init__(
     retry: RetryPolicy | None = None,
     timeout: float | None = None,
     provider_limit: ProcessLocalLimiter | None = None,
+    trace_io: bool | None = None,
 ) -> None: ...
 ```
 
@@ -183,6 +184,7 @@ def __init__(
 - `retry`: Optional [RetryPolicy](#retrypolicy). Node-owned only — there is no runner, graph, or per-call retry default, and no `retry=True` shorthand. Direct calls stay raw single-shot invocations
 - `timeout`: Optional positive, finite seconds for cooperative cancellation of async functions/generators under `AsyncRunner`. Unsupported runner/callable combinations are rejected before execution. Direct calls stay raw
 - `provider_limit`: Optional [ProcessLocalLimiter](#processlocallimiter) capping how many executions of this node run at once in this process. Direct calls stay raw and take no permit
+- `trace_io`: Attach this node's inputs and output to its observability span. Tri-state: `None` (default) defers to the graph's `trace_io`, `True`/`False` decide for this node. Spans only — durable records are unaffected. See [Observe execution](../05-how-to/observe-execution.md#node-inputs-and-outputs-on-spans)
 
 **Returns:** FunctionNode instance
 
@@ -508,6 +510,7 @@ def node(
     retry: RetryPolicy | None = None,
     timeout: float | None = None,
     provider_limit: ProcessLocalLimiter | None = None,
+    trace_io: bool | None = None,
 ) -> FunctionNode | Callable[[Callable], FunctionNode]: ...
 ```
 
@@ -522,6 +525,7 @@ def node(
 - `retry`: Optional [RetryPolicy](#retrypolicy) declaring which failures are safe to repeat and with what budget/backoff. See [How to Retry Transient Failures](../05-how-to/retry-transient-failures.md)
 - `timeout`: Optional positive, finite seconds for cooperative per-attempt cancellation of async functions/generators under `AsyncRunner`. See [Bound one async attempt with timeout](../05-how-to/retry-transient-failures.md#bound-one-async-attempt-with-timeout)
 - `provider_limit`: Optional [ProcessLocalLimiter](#processlocallimiter) capping how many executions of this node run at once in this process. Not the durable host's active-Run cap — see [ProcessLocalLimiter](#processlocallimiter)
+- `trace_io`: Attach this node's inputs and output to its observability span so a trace backend can render them. `None` (default) defers to the graph's `trace_io` default; `True`/`False` decide for this node. Payloads ride spans only — no durable record changes. See [Observe execution](../05-how-to/observe-execution.md#node-inputs-and-outputs-on-spans)
 
 **Returns:**
 - FunctionNode if source provided (decorator without parens)

--- a/src/hypergraph/diagnostics.py
+++ b/src/hypergraph/diagnostics.py
@@ -1,12 +1,20 @@
-"""Typed, privacy-safe diagnostics for terminal execution failures (#233).
+"""Typed diagnostics for terminal execution failures (#233).
 
 The privacy boundary locked on #187: local object surfaces (the raised
 exception, ``RunResult.error``, ``FailureEvidence.error``) keep the exact
-exception object, while events, checkpoints, serialization, and telemetry
-receive only a safe :class:`Diagnostic` projection — stable codes, exception
-type names, node identity, counts/timing, booleans, and static help. Raw
-inputs, response bodies, exception arguments, stack traces, and arbitrary
-``repr`` never enter a durable record.
+exception object, while **durable** records — checkpoints, StepRecord,
+attempt-ledger rows, RunLog, ``RunResult.to_dict()`` — receive only a safe
+:class:`Diagnostic` projection: stable codes, exception type names, node
+identity, counts/timing, booleans, and static help. Raw inputs, response
+bodies, exception arguments, stack traces, and arbitrary ``repr`` never enter
+a durable record.
+
+In-memory events additionally carry :class:`ErrorDetail`, the *unredacted*
+counterpart (message, type, traceback), for live consumers that must be able
+to debug a failure — chiefly the OpenTelemetry export, which follows the
+ecosystem norm of ``Span.record_exception`` and carries the real message by
+default. ``OpenTelemetryProcessor(redact_errors=True)`` exports the safe
+projection instead. ``ErrorDetail`` is never persisted.
 
 Codes and context field meanings are stable; human wording and additive
 fields may evolve. The wire form carries ``schema="hypergraph.diagnostic/v1"``.
@@ -17,6 +25,7 @@ hypergraph so events, checkpointers, and runners can all project through it.
 
 from __future__ import annotations
 
+import traceback as _traceback
 from contextlib import suppress
 from dataclasses import dataclass, replace
 from typing import Any, Literal
@@ -318,3 +327,47 @@ def safe_error_text(error: BaseException, *, node_name: str | None = None) -> st
     """
     diagnostic = derive_diagnostic(error, node_name=node_name)
     return f"{qualified_type_name(type(error))} [{diagnostic.code}]: {diagnostic.problem}"
+
+
+_MAX_TRACEBACK_CHARS = 16_384
+
+
+@dataclass(frozen=True)
+class ErrorDetail:
+    """The real exception, for live surfaces that must be able to debug it.
+
+    The deliberate counterpart to :func:`safe_error_text`: it carries exactly
+    what the safe projection withholds. Rides in-memory events only
+    (``NodeErrorEvent.error_detail``, ``RunEndEvent.error_detail``) and is
+    never persisted — every durable Hypergraph record keeps the safe
+    projection regardless of what this holds.
+
+    Attributes:
+        message: ``str(exception)`` — the raw message, verbatim.
+        type_name: Canonical ``module.qualname`` exception name.
+        traceback: Formatted traceback, truncated to 16 KiB, or ``None`` when
+            the exception carries no traceback (never raised) or formatting
+            it failed.
+    """
+
+    message: str
+    type_name: str
+    traceback: str | None = None
+
+
+def full_error_detail(error: BaseException) -> ErrorDetail:
+    """Capture the unredacted detail of an exception. Never raises."""
+    try:
+        message = str(error)
+    except Exception:  # pragma: no cover - a __str__ that itself fails
+        message = ""
+    text: str | None = None
+    if error.__traceback__ is not None:
+        try:
+            text = "".join(_traceback.format_exception(type(error), error, error.__traceback__))
+        except Exception:  # pragma: no cover - defensive: formatting is best-effort
+            text = None
+        else:
+            if len(text) > _MAX_TRACEBACK_CHARS:
+                text = text[:_MAX_TRACEBACK_CHARS] + "\n... [truncated]"
+    return ErrorDetail(message=message, type_name=qualified_type_name(type(error)), traceback=text)

--- a/src/hypergraph/events/otel.py
+++ b/src/hypergraph/events/otel.py
@@ -201,6 +201,10 @@ class OpenTelemetryProcessor(TypedEventProcessor):
         self._workflow_span_contexts_lock = Lock()
         self._trace_ids: OrderedDict[str, str] = OrderedDict()
         self._trace_ids_lock = Lock()
+        # One shared processor can serve several CONCURRENT top-level runs;
+        # every one of them calls shutdown() when it settles.  See shutdown().
+        self._live_top_level_runs = 0
+        self._lifecycle_lock = Lock()
 
     def _owner_id(self, span_id: str | None) -> str | None:
         if span_id is None:
@@ -351,6 +355,11 @@ class OpenTelemetryProcessor(TypedEventProcessor):
             return self._trace_ids.get(run_id)
 
     def on_run_start(self, event: RunStartEvent) -> None:
+        if event.parent_span_id is None:
+            # A top-level run: the runner will call shutdown() exactly once
+            # for it (the `_parent_span_id is None` gate in the run templates).
+            with self._lifecycle_lock:
+                self._live_top_level_runs += 1
         parent_owner = self._owner_id(event.parent_span_id)
         parent_ctx = self._context_for(event.parent_span_id)
         links = []
@@ -767,7 +776,30 @@ class OpenTelemetryProcessor(TypedEventProcessor):
         )
 
     def shutdown(self) -> None:
-        """End any remaining spans while preserving bounded lineage history."""
+        """Release this top-level run; sweep only when the last one leaves.
+
+        The runners call ``shutdown()`` once per TOP-LEVEL run, so one shared
+        processor (passed to several ``run()`` calls, or carried by a graph
+        via ``Graph.with_processors``) receives one call per concurrent run.
+        Sweeping on the first call is what made a long run export as the
+        short run that finished beside it: the sweep ended the long run's
+        live spans early, cleared the contexts its later node spans needed
+        for parentage, and dropped its run-end attributes.
+
+        So each call releases one live top-level run, and the full sweep runs
+        only once no run is left. Sequential use is unchanged — one run in,
+        one full sweep out. A run that dies without a ``RunEndEvent`` (a
+        ``BaseException`` escaping the run template) still leaves its spans
+        for the sweep, which now happens when the last concurrent sibling
+        settles rather than immediately.
+
+        Never clears the :meth:`trace_id_for` mapping: callers look up a
+        trace id *after* ``run()`` returns, and ``run()`` returns after this.
+        """
+        with self._lifecycle_lock:
+            self._live_top_level_runs = max(0, self._live_top_level_runs - 1)
+            if self._live_top_level_runs:
+                return
         # Leftover tokens exist only on abnormal exits (e.g. BaseException
         # escaping the run template). Detach newest-first, and only where this
         # execution unit owns the attach — cross-context leftovers died with

--- a/src/hypergraph/events/otel.py
+++ b/src/hypergraph/events/otel.py
@@ -184,6 +184,8 @@ class OpenTelemetryProcessor(TypedEventProcessor):
         self._StatusCode = StatusCode
         self._set_success_status = set_success_status
         self._enrich_openinference = enrich_openinference
+        if isinstance(max_payload_chars, bool) or not isinstance(max_payload_chars, int) or max_payload_chars <= 0:
+            raise ValueError(f"max_payload_chars must be a positive integer, got {max_payload_chars!r}.")
         self._redact_errors = redact_errors
         self._redact_payloads = redact_payloads
         self._max_payload_chars = max_payload_chars
@@ -796,23 +798,28 @@ class OpenTelemetryProcessor(TypedEventProcessor):
         Never clears the :meth:`trace_id_for` mapping: callers look up a
         trace id *after* ``run()`` returns, and ``run()`` returns after this.
         """
+        # The sweep runs UNDER the lock, not merely the count check: a run
+        # starting in between would register its root span into the very dicts
+        # the sweep is about to clear, and be torn down exactly like the bug
+        # this method exists to fix. ``on_run_start`` takes the same lock
+        # before it registers anything, so it simply waits out the sweep.
         with self._lifecycle_lock:
             self._live_top_level_runs = max(0, self._live_top_level_runs - 1)
             if self._live_top_level_runs:
                 return
-        # Leftover tokens exist only on abnormal exits (e.g. BaseException
-        # escaping the run template). Detach newest-first, and only where this
-        # execution unit owns the attach — cross-context leftovers died with
-        # their task's context copy and are dropped.
-        self._aliases.clear()
-        self._absorbed_run.clear()
-        for span_id in reversed(list(self._tokens)):
-            self._detach_ambient_if_current(span_id)
-        self._tokens.clear()
-        for span in self._spans.values():
-            span.end()
-        self._spans.clear()
-        self._contexts.clear()
-        self._collapse_candidates.clear()
-        self._nested_outcome.clear()
-        self._logical_ids.clear()
+            # Leftover tokens exist only on abnormal exits (e.g. BaseException
+            # escaping the run template). Detach newest-first, and only where
+            # this execution unit owns the attach — cross-context leftovers
+            # died with their task's context copy and are dropped.
+            self._aliases.clear()
+            self._absorbed_run.clear()
+            for span_id in reversed(list(self._tokens)):
+                self._detach_ambient_if_current(span_id)
+            self._tokens.clear()
+            for span in self._spans.values():
+                span.end()
+            self._spans.clear()
+            self._contexts.clear()
+            self._collapse_candidates.clear()
+            self._nested_outcome.clear()
+            self._logical_ids.clear()

--- a/src/hypergraph/events/otel.py
+++ b/src/hypergraph/events/otel.py
@@ -7,6 +7,7 @@ observability backends without replacing Hypergraph's native inspect/debug UX.
 
 from __future__ import annotations
 
+import json
 from collections import OrderedDict
 from threading import Lock
 from typing import TYPE_CHECKING, Any
@@ -76,6 +77,34 @@ def _lineage_kind(event: RunStartEvent) -> str | None:
 
 
 _MAX_LINEAGE_CONTEXTS = 256
+_MAX_TRACE_IDS = 1024
+_DEFAULT_MAX_PAYLOAD_CHARS = 4096
+_TRUNCATION_SUFFIX = "…[truncated]"
+
+
+def _payload_attrs(prefix: str, payload: Any, max_chars: int) -> dict[str, Any]:
+    """Serialize a trace payload into OpenInference ``input``/``output`` attrs.
+
+    JSON first (so Phoenix renders it structurally), ``repr`` as the fallback
+    for anything not JSON-serializable, and truncation past ``max_chars``. A
+    value that cannot be rendered at all is omitted rather than exported
+    half-formed; capture never raises and never fails the run.
+    """
+    try:
+        text = json.dumps(payload, default=repr, ensure_ascii=False)
+        mime = "application/json"
+    except Exception:
+        try:
+            text = repr(payload)
+            mime = "text/plain"
+        except Exception:
+            return {}
+    if len(text) > max_chars:
+        text = text[:max_chars] + _TRUNCATION_SUFFIX
+        # A truncated JSON document is no longer valid JSON; say so honestly
+        # rather than handing a backend something it will fail to parse.
+        mime = "text/plain"
+    return {f"{prefix}.value": text, f"{prefix}.mime_type": mime}
 
 
 class OpenTelemetryProcessor(TypedEventProcessor):
@@ -89,6 +118,9 @@ class OpenTelemetryProcessor(TypedEventProcessor):
         tracer_provider: Any | None = None,
         set_success_status: bool = False,
         enrich_openinference: bool = False,
+        redact_errors: bool = False,
+        redact_payloads: bool = False,
+        max_payload_chars: int = _DEFAULT_MAX_PAYLOAD_CHARS,
     ) -> None:
         """Create an OTel export processor.
 
@@ -111,6 +143,25 @@ class OpenTelemetryProcessor(TypedEventProcessor):
                 containment attributes and ``openinference.span.kind=CHAIN``.
                 Disabled by default because not every Hypergraph workflow is
                 an AI chain.
+            redact_errors: Export only the privacy-safe error projection
+                (``NodeErrorEvent.error`` / ``RunEndEvent.error``) instead of
+                the real exception message and traceback. **Off by default**:
+                a trace whose ``exception.message`` reads "Node 'x' raised
+                ValueError." cannot be debugged, and standard OTel
+                ``record_exception`` carries the real message. Turn it on for
+                regulated deployments where exception text may contain
+                regulated data; the export is then byte-identical to the
+                pre-``redact_errors`` behavior. Durable Hypergraph records
+                (RunLog, StepRecord, checkpoints, attempt ledger) always keep
+                the safe projection and are unaffected by this flag.
+            redact_payloads: Refuse ALL node input/output payloads regardless
+                of any ``trace_io=True`` on a node or graph. The
+                regulated-deployment kill switch, symmetric with
+                ``redact_errors``; precedence is kill switch > node explicit >
+                graph default > off.
+            max_payload_chars: Per-value cap for an exported payload. Longer
+                values are truncated (and marked ``text/plain``, since a cut
+                JSON document is no longer parseable).
         """
         _require_opentelemetry()
         from opentelemetry import context as otel_context
@@ -133,6 +184,9 @@ class OpenTelemetryProcessor(TypedEventProcessor):
         self._StatusCode = StatusCode
         self._set_success_status = set_success_status
         self._enrich_openinference = enrich_openinference
+        self._redact_errors = redact_errors
+        self._redact_payloads = redact_payloads
+        self._max_payload_chars = max_payload_chars
         self._spans: dict[str, Any] = {}
         self._contexts: dict[str, Any] = {}
         self._tokens: dict[str, Any] = {}
@@ -145,6 +199,8 @@ class OpenTelemetryProcessor(TypedEventProcessor):
         self._collapse_candidates: set[str] = set()
         self._workflow_span_contexts: OrderedDict[str, Any] = OrderedDict()
         self._workflow_span_contexts_lock = Lock()
+        self._trace_ids: OrderedDict[str, str] = OrderedDict()
+        self._trace_ids_lock = Lock()
 
     def _owner_id(self, span_id: str | None) -> str | None:
         if span_id is None:
@@ -251,6 +307,49 @@ class OpenTelemetryProcessor(TypedEventProcessor):
             if len(self._workflow_span_contexts) > _MAX_LINEAGE_CONTEXTS:
                 self._workflow_span_contexts.popitem(last=False)
 
+    # -- Run <-> trace correlation --------------------------------------------
+
+    def _remember_trace_id(self, run_id: str, span: Any) -> None:
+        """Record the hex trace id a run's spans landed in (bounded, LRU)."""
+        span_context = span.get_span_context()
+        if not span_context.is_valid:
+            return
+        trace_id = format(span_context.trace_id, "032x")
+        with self._trace_ids_lock:
+            self._trace_ids.pop(run_id, None)
+            self._trace_ids[run_id] = trace_id
+            if len(self._trace_ids) > _MAX_TRACE_IDS:
+                self._trace_ids.popitem(last=False)
+
+    def trace_id_for(self, run_id: str) -> str | None:
+        """The 32-char hex OTel trace id this run's spans were exported under.
+
+        Populated when the run's span starts, and — unlike the span
+        bookkeeping — deliberately NOT cleared by :meth:`shutdown`: the runner
+        shuts the processor down before ``runner.run()`` returns, so clearing
+        here would destroy the mapping exactly when the caller wants to link
+        its ``RunResult.run_id`` to a trace URL.
+
+        Recorded for every run that gets a span — top-level runs, nested graph
+        runs, and mapped items alike — in an LRU bounded to the last
+        ``1024`` runs, so a long-lived process cannot grow without limit. A
+        run evicted by that bound (or one that never produced a valid span
+        context, e.g. under a no-op tracer provider) returns ``None``.
+
+        Args:
+            run_id: The ``RunResult.run_id`` / ``event.run_id`` to look up.
+
+        Returns:
+            The lowercase hex trace id, or ``None`` if unknown.
+
+        Example:
+            >>> result = runner.run(graph, event_processors=[processor])  # doctest: +SKIP
+            >>> processor.trace_id_for(result.run_id)  # doctest: +SKIP
+            '4bf92f3577b34da6a3ce929d0e0e4736'
+        """
+        with self._trace_ids_lock:
+            return self._trace_ids.get(run_id)
+
     def on_run_start(self, event: RunStartEvent) -> None:
         parent_owner = self._owner_id(event.parent_span_id)
         parent_ctx = self._context_for(event.parent_span_id)
@@ -294,6 +393,7 @@ class OpenTelemetryProcessor(TypedEventProcessor):
             for link in links:
                 span.add_link(link.context, link.attributes)
             self._add_lineage_events(span, event)
+            self._remember_trace_id(event.run_id, span)
             return
 
         graph_name = event.graph_name or "graph"
@@ -324,6 +424,7 @@ class OpenTelemetryProcessor(TypedEventProcessor):
         self._logical_ids[event.span_id] = name
         self._contexts[event.span_id] = self._trace.set_span_in_context(span)
         self._attach_ambient(event.span_id)
+        self._remember_trace_id(event.run_id, span)
 
         self._add_lineage_events(span, event)
 
@@ -403,21 +504,20 @@ class OpenTelemetryProcessor(TypedEventProcessor):
             },
         )
         if event.status.value == "failed" or event.error:
-            span.set_status(self._Status(self._StatusCode.ERROR, event.error))
+            span.set_status(self._Status(self._StatusCode.ERROR, self._status_description(event)))
         if event.error:
-            span.add_event(
-                "exception",
-                attributes=_clean_attrs(
-                    {
-                        "exception.message": event.error,
-                    }
-                ),
-            )
+            span.add_event("exception", attributes=_clean_attrs(self._exception_attrs(event)))
         elif self._set_success_status and event.status.value == "completed":
             span.set_status(self._Status(self._StatusCode.OK))
         if event.workflow_id is not None:
             self._remember_workflow_context(event.workflow_id, span.get_span_context())
         span.end()
+
+    def _trace_payload_attrs(self, prefix: str, payload: Any) -> dict[str, Any]:
+        """Payload attrs for an opted-in node, or nothing at all."""
+        if payload is None or self._redact_payloads:
+            return {}
+        return _payload_attrs(prefix, payload, self._max_payload_chars)
 
     def on_node_start(self, event: NodeStartEvent) -> None:
         parent_ctx = self._context_for(event.parent_span_id)
@@ -434,6 +534,7 @@ class OpenTelemetryProcessor(TypedEventProcessor):
                     "hypergraph.node_name": event.node_name,
                     "hypergraph.graph_name": event.graph_name,
                     "hypergraph.superstep": event.superstep,
+                    **self._trace_payload_attrs("input", getattr(event, "trace_inputs", None)),
                 }.items()
                 if v is not None
             },
@@ -508,6 +609,7 @@ class OpenTelemetryProcessor(TypedEventProcessor):
                 "hypergraph.duration_ms": event.duration_ms,
                 "hypergraph.cached": event.cached,
                 "hypergraph.superstep": event.superstep,
+                **self._trace_payload_attrs("output", getattr(event, "trace_outputs", None)),
             },
         )
         if self._set_success_status and (not absorbed_run or self._nested_outcome.get(event.span_id) == "completed"):
@@ -516,12 +618,39 @@ class OpenTelemetryProcessor(TypedEventProcessor):
         self._logical_ids.pop(event.span_id, None)
         span.end()
 
+    # -- Failure projection ---------------------------------------------------
+    #
+    # Two shapes travel on every failure event: ``error`` is the privacy-safe
+    # projection durable Hypergraph records store, and ``error_detail`` is the
+    # real exception (message, type, traceback).  By DEFAULT the export
+    # carries the real detail, because the OTel ecosystem norm
+    # (``Span.record_exception``) does and a scrubbed trace cannot be
+    # debugged.  ``redact_errors=True`` falls back to the safe projection for
+    # deployments where exception text may carry regulated data.
+
+    def _status_description(self, event: Any) -> str | None:
+        detail = None if self._redact_errors else getattr(event, "error_detail", None)
+        if detail is None or not detail.message:
+            return event.error or None
+        return f"{detail.type_name}: {detail.message}"
+
+    def _exception_attrs(self, event: Any) -> dict[str, Any]:
+        # ``exception.type`` never depends on the flag: only message text and
+        # the stacktrace are redacted.
+        error_type = getattr(event, "error_type", None) or None
+        detail = None if self._redact_errors else getattr(event, "error_detail", None)
+        if detail is None:
+            return {"exception.type": error_type, "exception.message": event.error}
+        return {
+            "exception.type": error_type or detail.type_name,
+            "exception.message": detail.message,
+            "exception.stacktrace": detail.traceback,
+            "exception.escaped": False,
+        }
+
     def on_node_error(self, event: NodeErrorEvent) -> None:
         # Only the terminal escaping failure reaches this handler and marks
         # the logical node span as error; intermediate attempts never do.
-        # ``event.error`` is the privacy-safe projection, so the exported
-        # status description and exception.message carry no raw message text
-        # (per the OTel exception.message sensitivity warning).
         self._detach_ambient(event.span_id)
         span = self._spans.pop(event.span_id, None)
         self._contexts.pop(event.span_id, None)
@@ -540,16 +669,8 @@ class OpenTelemetryProcessor(TypedEventProcessor):
                 "hypergraph.diagnostic.docs_ref": (event.diagnostic.docs_ref if event.diagnostic is not None else None),
             },
         )
-        span.set_status(self._Status(self._StatusCode.ERROR, event.error))
-        span.add_event(
-            "exception",
-            attributes=_clean_attrs(
-                {
-                    "exception.type": event.error_type,
-                    "exception.message": event.error,
-                }
-            ),
-        )
+        span.set_status(self._Status(self._StatusCode.ERROR, self._status_description(event)))
+        span.add_event("exception", attributes=_clean_attrs(self._exception_attrs(event)))
         span.end()
 
     def on_superstep_start(self, event: SuperstepStartEvent) -> None:

--- a/src/hypergraph/events/types.py
+++ b/src/hypergraph/events/types.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Literal
 
-from hypergraph.diagnostics import Diagnostic
+from hypergraph.diagnostics import Diagnostic, ErrorDetail
 
 
 class RunStatus(Enum):
@@ -92,10 +92,16 @@ class RunStartEvent(BaseEvent):
 class RunEndEvent(BaseEvent):
     """Emitted when a graph run completes.
 
+    ``error`` is the privacy-safe projection durable records store;
+    ``error_detail`` is the unredacted counterpart for live consumers. See
+    :class:`~hypergraph.diagnostics.ErrorDetail`.
+
     Attributes:
         graph_name: Name of the graph that was executed.
         status: Outcome of the run (completed, failed, paused, partial, stopped).
-        error: Error message if status is FAILED.
+        error: Privacy-safe error projection if status is FAILED.
+        error_detail: Unredacted message/type/traceback of the failure, when
+            one was raised. In-memory only — never persisted.
         duration_ms: Wall-clock duration in milliseconds.
         batch_*: Aggregate mapped-item counts for parent map runs.
         batch_outcome: Aggregate mapped-item outcome for parent map runs.
@@ -112,6 +118,7 @@ class RunEndEvent(BaseEvent):
     batch_stopped_items: int | None = None
     batch_outcome: str | None = None
     batch_restored_items: int | None = None
+    error_detail: ErrorDetail | None = None
 
     def __post_init__(self) -> None:
         # Coerce string status values to RunStatus enum
@@ -127,11 +134,15 @@ class NodeStartEvent(BaseEvent):
         node_name: Name of the node.
         graph_name: Name of the graph containing the node.
         superstep: Zero-indexed superstep number, if known.
+        trace_inputs: The node's input kwargs, present ONLY when the node
+            opted into ``trace_io``. Live objects, not copies of their
+            contents — for span export, never for a durable record.
     """
 
     node_name: str = ""
     graph_name: str = ""
     superstep: int | None = None
+    trace_inputs: dict | None = None
 
 
 @dataclass(frozen=True)
@@ -143,6 +154,9 @@ class NodeEndEvent(BaseEvent):
         graph_name: Name of the graph containing the node.
         duration_ms: Wall-clock duration in milliseconds.
         superstep: Zero-indexed superstep number, if known.
+        trace_outputs: The node's output values by name, present ONLY when
+            the node opted into ``trace_io``. Live objects, not copies of
+            their contents — for span export, never for a durable record.
     """
 
     node_name: str = ""
@@ -151,6 +165,7 @@ class NodeEndEvent(BaseEvent):
     duration_ms: float = 0.0
     cached: bool = False
     inner_logs: tuple = ()  # tuple[RunLog, ...] at runtime; untyped to avoid import
+    trace_outputs: dict | None = None
 
 
 @dataclass(frozen=True)
@@ -254,10 +269,14 @@ class NodeErrorEvent(BaseEvent):
     """Emitted when a node fails with an exception.
 
     Emitted once per logical failure — never for intermediate retry attempts.
-    ``error`` carries the privacy-safe projection (type name, stable code,
-    static problem wording), never raw exception message text; the exact
-    exception object stays on local surfaces (``RunResult.error``,
-    ``get_failure_evidence``).
+
+    Two shapes of the same failure travel together. ``error`` (with
+    ``diagnostic``) is the privacy-safe projection — type name, stable code,
+    static problem wording — and is what durable records store.
+    ``error_detail`` is the unredacted message/type/traceback, for live
+    consumers that must be able to debug the failure; it is never persisted.
+    The exact exception object still stays on local surfaces only
+    (``RunResult.error``, ``get_failure_evidence``).
 
     Attributes:
         node_name: Name of the node.
@@ -266,6 +285,8 @@ class NodeErrorEvent(BaseEvent):
         error_type: Fully qualified exception type name.
         superstep: Zero-indexed superstep number, if known.
         diagnostic: Typed privacy-safe diagnostic, when derivable.
+        error_detail: Unredacted message/type/traceback of the exact
+            exception. In-memory only — never persisted.
     """
 
     node_name: str = ""
@@ -274,6 +295,7 @@ class NodeErrorEvent(BaseEvent):
     error_type: str = ""
     superstep: int | None = None
     diagnostic: Diagnostic | None = None
+    error_detail: ErrorDetail | None = None
 
 
 @dataclass(frozen=True)

--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -27,6 +27,18 @@ if TYPE_CHECKING:
     from hypergraph.viz.debug import VizDebugger
 
 
+def _validate_trace_io(trace_io: bool) -> bool:
+    """Reject non-bool ``trace_io``; never coerce it.
+
+    ``bool("false")`` is ``True``, so coercing would let a config string turn
+    payload capture ON. This is a privacy control, so it fails loudly instead —
+    matching the node-level ``@node(trace_io=...)`` check.
+    """
+    if not isinstance(trace_io, bool):
+        raise TypeError(f"trace_io must be True or False, got {trace_io!r}.")
+    return trace_io
+
+
 def _ambiguous_producer_message(param: str, consumer: str, producers: list[str]) -> str:
     """Build a human-readable error for ambiguous implicit wiring."""
     # ASCII diagram showing competing producers
@@ -197,7 +209,7 @@ class Graph:
                 or anything a durable record stores.
         """
         self.name = name
-        self._trace_io = bool(trace_io)
+        self._trace_io = _validate_trace_io(trace_io)
         self._strict_types = strict_types
         self._shared = self._normalize_shared(shared)
         self._bound: dict[str, Any] = {}
@@ -1143,9 +1155,11 @@ class Graph:
             entrypoint=list(self._entrypoints) if self._entrypoints else None,
             strict_types=self._strict_types,
             shared=sorted(self._shared) if self._shared else None,
+            trace_io=self._trace_io,
         )
         new_graph._default_event_processors = self._default_event_processors
         new_graph._bound_runner = self._bound_runner
+        new_graph._provider_limit = self._provider_limit
 
         if self._bound:
             valid_names = set(new_graph.inputs.all)
@@ -1356,11 +1370,14 @@ class Graph:
         Returns:
             New Graph carrying the default.
 
+        Raises:
+            TypeError: If ``trace_io`` is not a bool.
+
         Example:
             >>> graph = graph.with_trace_io()  # doctest: +SKIP
         """
         new_graph = self._shallow_copy()
-        new_graph._trace_io = bool(trace_io)
+        new_graph._trace_io = _validate_trace_io(trace_io)
         return new_graph
 
     @property

--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -154,6 +154,7 @@ class Graph:
         name: str | None = None,
         strict_types: bool = False,
         shared: str | list[str] | tuple[str, ...] | None = None,
+        trace_io: bool = False,
     ) -> None:
         """Create a graph from nodes.
 
@@ -188,8 +189,15 @@ class Graph:
                 Nodes read the latest value from run state. The user must
                 provide ordering via ``edges`` or ``emit/wait_for``.
                 Shared params are required at ``run()`` time unless bound.
+            trace_io: Default for every node in this graph: attach node inputs
+                and outputs to their observability spans. A node that declares
+                its own ``trace_io=True/False`` overrides this; a node leaving
+                it ``None`` follows this default. Off by default. Metadata
+                only — it does not change graph structure, ``definition_hash``,
+                or anything a durable record stores.
         """
         self.name = name
+        self._trace_io = bool(trace_io)
         self._strict_types = strict_types
         self._shared = self._normalize_shared(shared)
         self._bound: dict[str, Any] = {}
@@ -1334,6 +1342,31 @@ class Graph:
     def provider_limit(self) -> ProcessLocalLimiter | None:
         """The graph-scope provider budget, or None when unset (read-only)."""
         return self._provider_limit
+
+    def with_trace_io(self, trace_io: bool = True) -> Graph:
+        """Set the graph-level input/output span-capture default. Returns new Graph.
+
+        Same precedence as the constructor argument: a node's own explicit
+        ``trace_io`` wins, otherwise this default applies. Metadata only — no
+        effect on structure, ``definition_hash``, or durable records.
+
+        Args:
+            trace_io: The default to apply to nodes that do not declare one.
+
+        Returns:
+            New Graph carrying the default.
+
+        Example:
+            >>> graph = graph.with_trace_io()  # doctest: +SKIP
+        """
+        new_graph = self._shallow_copy()
+        new_graph._trace_io = bool(trace_io)
+        return new_graph
+
+    @property
+    def trace_io(self) -> bool:
+        """The graph-level input/output span-capture default (read-only)."""
+        return self._trace_io
 
     @property
     def has_cycles(self) -> bool:

--- a/src/hypergraph/nodes/base.py
+++ b/src/hypergraph/nodes/base.py
@@ -188,6 +188,16 @@ class HyperNode(ABC):
         return False
 
     @property
+    def trace_io(self) -> bool | None:
+        """Should this node's inputs/output be attached to its trace span?
+
+        Tri-state: ``None`` means "not declared here", so the graph-level
+        ``trace_io`` default decides. Default: ``None``. Override in
+        subclasses that support payload capture.
+        """
+        return None
+
+    @property
     def wait_for(self) -> tuple[str, ...]:
         """Ordering-only graph-scope addresses this node waits for.
 

--- a/src/hypergraph/nodes/function.py
+++ b/src/hypergraph/nodes/function.py
@@ -107,6 +107,7 @@ class FunctionNode(CallableMixin, HyperNode):
     _retry: RetryPolicy | None
     _timeout: float | None
     _provider_limit: ProcessLocalLimiter | None
+    _trace_io: bool | None
 
     def __init__(
         self,
@@ -122,6 +123,7 @@ class FunctionNode(CallableMixin, HyperNode):
         retry: RetryPolicy | None = None,
         timeout: float | None = None,
         provider_limit: ProcessLocalLimiter | None = None,
+        trace_io: bool | None = None,
     ) -> None:
         """Wrap a function as a node.
 
@@ -151,6 +153,14 @@ class FunctionNode(CallableMixin, HyperNode):
                      limiter at the exact scarce call instead. Waiting for a
                      permit is not a failure and spends no retry attempt.
                      Direct calls stay raw and do not acquire it.
+            trace_io: Attach this node's input kwargs and output values to its
+                     observability span, so a trace backend can show them.
+                     Tri-state: ``None`` (default) defers to the graph's
+                     ``trace_io`` default; ``True``/``False`` decide for this
+                     node regardless of the graph. Payloads ride SPANS ONLY —
+                     durable records (RunLog, StepRecord, checkpoints) never
+                     change shape or content. An exporter may refuse them
+                     outright (``OpenTelemetryProcessor(redact_payloads=True)``).
         Warning:
             If the function has a return type annotation but no output_name
             is provided, a warning is emitted. This helps catch cases where
@@ -191,12 +201,16 @@ class FunctionNode(CallableMixin, HyperNode):
                 "  capacity: provider_limit=ProcessLocalLimiter(max_in_flight=4)."
             )
 
+        if trace_io is not None and not isinstance(trace_io, bool):
+            raise TypeError(f"trace_io must be True, False, or None (defer to the graph), got {trace_io!r}.")
+
         self.func = func
         self._cache = cache
         self._hide = hide
         self._retry = retry
         self._timeout = timeout
         self._provider_limit = provider_limit
+        self._trace_io = trace_io
         self._definition_hash = hash_definition(func)
         self._emit = ensure_tuple(emit) if emit else ()
         self._wait_for = ensure_tuple(wait_for) if wait_for else ()
@@ -255,6 +269,11 @@ class FunctionNode(CallableMixin, HyperNode):
     def hide(self) -> bool:
         """Whether this node is hidden from visualization."""
         return self._hide
+
+    @property
+    def trace_io(self) -> bool | None:
+        """Node-level input/output span capture, or None to defer to the graph."""
+        return self._trace_io
 
     @property
     def wait_for(self) -> tuple[str, ...]:
@@ -367,6 +386,7 @@ def node(
     retry: RetryPolicy | None = None,
     timeout: float | None = None,
     provider_limit: ProcessLocalLimiter | None = None,
+    trace_io: bool | None = None,
 ) -> FunctionNode | Callable[[Callable], FunctionNode]:
     """Decorator to wrap a function as a FunctionNode.
 
@@ -401,6 +421,11 @@ def node(
                  provider-resource work budget, never the host's active-Run
                  cap. Waiting for a permit is not a failure and spends no
                  retry attempt. Direct calls stay raw and do not acquire it.
+        trace_io: Attach this node's inputs and output to its observability
+                 span so a trace backend can render them. ``None`` (default)
+                 defers to the graph's ``trace_io``; ``True``/``False`` decide
+                 for this node. Spans only — durable records are unaffected,
+                 and an exporter can refuse payloads outright.
     Returns:
         FunctionNode if source provided, else decorator function.
 
@@ -427,6 +452,7 @@ def node(
             retry=retry,
             timeout=timeout,
             provider_limit=provider_limit,
+            trace_io=trace_io,
         )
         fn_node.__wrapped__ = func  # type: ignore[attr-defined]
         return fn_node

--- a/src/hypergraph/runners/_shared/event_helpers.py
+++ b/src/hypergraph/runners/_shared/event_helpers.py
@@ -40,6 +40,20 @@ def create_dispatcher(
 # ------------------------------------------------------------------
 
 
+def trace_io_enabled(node: HyperNode, graph: Graph) -> bool:
+    """Resolve node/graph ``trace_io``: an explicit node value wins.
+
+    Precedence is node explicit -> graph default -> off. An exporter can
+    still refuse the payloads it receives (the processor-side kill switch),
+    which is deliberately NOT consulted here: the runner does not know which
+    processors are attached, and the capture itself is a shallow dict copy.
+    """
+    declared = getattr(node, "trace_io", None)
+    if declared is not None:
+        return bool(declared)
+    return bool(getattr(graph, "trace_io", False))
+
+
 def build_node_start_event(
     run_id: str,
     run_span_id: str,
@@ -49,8 +63,13 @@ def build_node_start_event(
     workflow_id: str | None = None,
     item_index: int | None = None,
     superstep: int | None = None,
+    inputs: dict[str, Any] | None = None,
 ) -> tuple[str, Any]:
-    """Build a NodeStartEvent. Returns (span_id, event)."""
+    """Build a NodeStartEvent. Returns (span_id, event).
+
+    ``inputs`` is carried on the event only when the node resolves
+    ``trace_io`` on; it feeds span export and never a durable record.
+    """
     from hypergraph.events.types import NodeStartEvent, _generate_span_id
 
     span_id = _generate_span_id()
@@ -63,6 +82,7 @@ def build_node_start_event(
         node_name=node.name,
         graph_name=graph.name,
         superstep=superstep,
+        trace_inputs=dict(inputs) if inputs is not None and trace_io_enabled(node, graph) else None,
     )
     return span_id, event
 
@@ -80,8 +100,13 @@ def build_node_end_event(
     workflow_id: str | None = None,
     item_index: int | None = None,
     superstep: int | None = None,
+    outputs: dict[str, Any] | None = None,
 ) -> Any:
-    """Build a NodeEndEvent."""
+    """Build a NodeEndEvent.
+
+    ``outputs`` is carried on the event only when the node resolves
+    ``trace_io`` on; it feeds span export and never a durable record.
+    """
     from hypergraph.events.types import NodeEndEvent
 
     return NodeEndEvent(
@@ -96,6 +121,7 @@ def build_node_end_event(
         duration_ms=duration_ms,
         cached=cached,
         inner_logs=inner_logs,
+        trace_outputs=dict(outputs) if outputs is not None and trace_io_enabled(node, graph) else None,
     )
 
 
@@ -140,11 +166,13 @@ def build_node_error_event(
 ) -> Any:
     """Build a NodeErrorEvent from the current exception context.
 
-    ``error`` carries the privacy-safe projection — never ``str(exception)``.
-    Events feed durable surfaces (RunLog, checkpoints, OTel export); the exact
-    exception object stays on local surfaces only.
+    ``error`` carries the privacy-safe projection — never ``str(exception)`` —
+    and is what durable surfaces (RunLog, StepRecord, checkpoints, the attempt
+    ledger) store. ``error_detail`` carries the unredacted message, type and
+    traceback for live consumers such as the OTel export; it is never
+    persisted. The exact exception object stays on local surfaces only.
     """
-    from hypergraph.diagnostics import derive_diagnostic, safe_error_text
+    from hypergraph.diagnostics import derive_diagnostic, full_error_detail, safe_error_text
     from hypergraph.events.types import NodeErrorEvent
 
     exc_type, exc_val, _ = sys.exc_info()
@@ -170,6 +198,7 @@ def build_node_error_event(
         error_type=f"{exc_type.__module__}.{exc_type.__qualname__}" if exc_type else "",
         superstep=superstep,
         diagnostic=diagnostic,
+        error_detail=full_error_detail(exc_val) if exc_val is not None else None,
     )
 
 
@@ -264,9 +293,12 @@ def build_run_end_event(
 ) -> Any:
     """Build a RunEndEvent.
 
-    ``error`` carries the privacy-safe projection — never ``str(exception)``.
+    ``error`` carries the privacy-safe projection — never ``str(exception)`` —
+    and is what durable surfaces store. ``error_detail`` carries the
+    unredacted message, type and traceback for live consumers; it is never
+    persisted.
     """
-    from hypergraph.diagnostics import safe_error_text
+    from hypergraph.diagnostics import full_error_detail, safe_error_text
     from hypergraph.events.types import RunEndEvent, RunStatus
 
     duration_ms = (time.time() - start_time) * 1000
@@ -279,6 +311,7 @@ def build_run_end_event(
         graph_name=graph.name,
         status=RunStatus(status) if status is not None else (RunStatus.FAILED if error else RunStatus.COMPLETED),
         error=safe_error_text(error) if error else None,
+        error_detail=full_error_detail(error) if error else None,
         duration_ms=duration_ms,
         batch_total_items=batch_summary.total_items if batch_summary is not None else None,
         batch_completed_items=batch_summary.completed_items if batch_summary is not None else None,

--- a/src/hypergraph/runners/async_/superstep.py
+++ b/src/hypergraph/runners/async_/superstep.py
@@ -140,6 +140,7 @@ async def run_superstep_async(
                 workflow_id=ctx_base.workflow_id,
                 item_index=ctx_base.item_index,
                 superstep=superstep_idx,
+                inputs=inputs,
             )
             inspection_time_ms = time.perf_counter() * 1000
             if inspection_session is not None:
@@ -194,6 +195,7 @@ async def run_superstep_async(
                         workflow_id=ctx_base.workflow_id,
                         item_index=ctx_base.item_index,
                         superstep=superstep_idx,
+                        outputs=outputs,
                     )
                 )
             return node, outputs, input_versions, wait_for_versions, 0.0, True, node_span_id
@@ -207,6 +209,7 @@ async def run_superstep_async(
             workflow_id=ctx_base.workflow_id,
             item_index=ctx_base.item_index,
             superstep=superstep_idx,
+            inputs=inputs,
         )
         inspection_started_at_ms = time.perf_counter() * 1000
         if inspection_session is not None:
@@ -374,6 +377,7 @@ async def run_superstep_async(
                         workflow_id=ctx_base.workflow_id,
                         item_index=ctx_base.item_index,
                         superstep=superstep_idx,
+                        outputs=outputs,
                     )
                 )
 

--- a/src/hypergraph/runners/sync/superstep.py
+++ b/src/hypergraph/runners/sync/superstep.py
@@ -122,6 +122,7 @@ def run_superstep_sync(
                 workflow_id=ctx_base.workflow_id,
                 item_index=ctx_base.item_index,
                 superstep=superstep_idx,
+                inputs=inputs,
             )
             inspection_time_ms = time.perf_counter() * 1000
             if inspection_session is not None:
@@ -176,6 +177,7 @@ def run_superstep_sync(
                         workflow_id=ctx_base.workflow_id,
                         item_index=ctx_base.item_index,
                         superstep=superstep_idx,
+                        outputs=outputs,
                     )
                 )
         else:
@@ -188,6 +190,7 @@ def run_superstep_sync(
                 workflow_id=ctx_base.workflow_id,
                 item_index=ctx_base.item_index,
                 superstep=superstep_idx,
+                inputs=inputs,
             )
             inspection_started_at_ms = time.perf_counter() * 1000
             if inspection_session is not None:
@@ -354,6 +357,7 @@ def run_superstep_sync(
                             workflow_id=ctx_base.workflow_id,
                             item_index=ctx_base.item_index,
                             superstep=superstep_idx,
+                            outputs=outputs,
                         )
                     )
 

--- a/tests/test_privacy_projection.py
+++ b/tests/test_privacy_projection.py
@@ -1,15 +1,24 @@
 """Durable privacy-boundary tests (#233, red-green item 3 — the graduation).
 
 Local object surfaces (the raised exception, ``RunResult.error``,
-``FailureEvidence.error``) keep the exact exception object. Durable and
-telemetry surfaces (events, RunLog, StepRecord, ``RunResult.to_dict()``,
-attempt-ledger rows, OTel export) receive only safe projections: codes,
-exception type names, node identity, counts/timing, booleans, static help —
-never raw exception message text.
+``FailureEvidence.error``) keep the exact exception object. **Durable**
+surfaces — ``NodeErrorEvent.error`` / ``RunEndEvent.error``, RunLog,
+StepRecord, ``RunResult.to_dict()``, attempt-ledger rows — receive only safe
+projections: codes, exception type names, node identity, counts/timing,
+booleans, static help — never raw exception message text.
 
 RED on master: ``str(exception)`` flows NodeErrorEvent.error -> RunLog /
 StepRecord -> RunResult.to_dict() -> OTel exception.message, so a secret in
 an exception message leaks to every durable surface.
+
+The OTel export is deliberately no longer on that list: it carries the real
+exception message by DEFAULT (the ecosystem norm — standard
+``record_exception`` does — and a scrubbed trace cannot be debugged), and
+``OpenTelemetryProcessor(redact_errors=True)`` is the explicit opt-in that
+restores the scrubbed export for regulated deployments. Both halves are
+pinned below. The in-memory ``event.error_detail`` companion carries the same
+raw detail and is never persisted — see
+``tests/test_run_log/test_otel_error_detail.py``.
 """
 
 from __future__ import annotations
@@ -200,10 +209,11 @@ class TestOTelExportPrivacy:
         )
         self.span_processor.shutdown()
 
-    async def test_otel_export_contains_no_raw_message_text(self, family, make_sqlite):
+    async def test_redacted_otel_export_contains_no_raw_message_text(self, family, make_sqlite):
+        """``redact_errors=True`` is the regulated-deployment guarantee."""
         from hypergraph.events.otel import OpenTelemetryProcessor
 
-        await _run_leaky(family, make_sqlite(), event_processors=[OpenTelemetryProcessor()])
+        await _run_leaky(family, make_sqlite(), event_processors=[OpenTelemetryProcessor(redact_errors=True)])
 
         spans = self.exporter.get_finished_spans()
         assert spans, "the failed run must still export spans"
@@ -215,3 +225,26 @@ class TestOTelExportPrivacy:
                     assert SECRET not in str(value), f"span event attr {key} leaked the secret: {span.name}"
             for key, value in (span.attributes or {}).items():
                 assert SECRET not in str(value), f"span attr {key} leaked the secret: {span.name}"
+
+    async def test_default_otel_export_carries_the_real_message(self, family, make_sqlite):
+        """The deliberate deviation: traces must be debuggable by default."""
+        from hypergraph.events.otel import OpenTelemetryProcessor
+
+        await _run_leaky(family, make_sqlite(), event_processors=[OpenTelemetryProcessor()])
+
+        spans = self.exporter.get_finished_spans()
+        messages = [event.attributes.get("exception.message") for span in spans for event in span.events if event.name == "exception"]
+        assert any(SECRET in (message or "") for message in messages)
+
+    async def test_durable_surfaces_stay_safe_when_otel_exports_detail(self, family, make_sqlite):
+        """Turning on detail for traces must not move the durable boundary."""
+        from hypergraph.events.otel import OpenTelemetryProcessor
+
+        cp = make_sqlite()
+        result = await _run_leaky(family, cp, event_processors=[OpenTelemetryProcessor()])
+
+        assert SECRET not in json.dumps(result.to_dict())
+        assert result.log is not None
+        assert SECRET not in json.dumps(result.log.to_dict())
+        for step in await cp.get_steps("wf-privacy"):
+            assert SECRET not in json.dumps(step.to_dict())

--- a/tests/test_run_log/test_otel_concurrent_runs.py
+++ b/tests/test_run_log/test_otel_concurrent_runs.py
@@ -1,0 +1,238 @@
+"""One shared OpenTelemetryProcessor under CONCURRENT top-level runs.
+
+A single processor instance (passed explicitly, or carried by a graph via
+``Graph.with_processors``) is the natural way to export a long-lived service.
+The runner calls ``processor.shutdown()`` at the end of EVERY top-level run,
+so before this module the first run to finish tore down the shared span
+bookkeeping of every other in-flight run: their root spans were ended early
+(a ~200ms run exported as ~22ms), their later node spans lost their parent
+context and started fresh traces, and their run-end attributes were dropped.
+
+These tests pin the fixed contract: each concurrent top-level run exports a
+complete, correctly parented span tree with its own trace id and its own
+duration, whichever run finishes first.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+
+import pytest
+
+from hypergraph import AsyncRunner, Graph, SyncRunner, node
+
+try:
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+    try:
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+    except ImportError:  # pragma: no cover - compatibility with older sdk layout
+        from opentelemetry.sdk.trace.export.in_memory import InMemorySpanExporter
+
+    HAS_OTEL_SDK = True
+except ImportError:  # pragma: no cover - optional dependency
+    HAS_OTEL_SDK = False
+
+requires_otel = pytest.mark.skipif(not HAS_OTEL_SDK, reason="opentelemetry-sdk not installed")
+
+SLOW_SECONDS = 0.20
+FAST_SECONDS = 0.01
+
+
+@node(output_name="slow_value")
+def slow_step(x: int) -> int:
+    time.sleep(SLOW_SECONDS)
+    return x
+
+
+@node(output_name="slow_tail")
+def slow_tail(slow_value: int) -> int:
+    time.sleep(SLOW_SECONDS)
+    return slow_value
+
+
+@node(output_name="fast_value")
+def fast_step(x: int) -> int:
+    time.sleep(FAST_SECONDS)
+    return x
+
+
+@node(output_name="slow_value")
+async def async_slow_step(x: int) -> int:
+    await asyncio.sleep(SLOW_SECONDS)
+    return x
+
+
+@node(output_name="slow_tail")
+async def async_slow_tail(slow_value: int) -> int:
+    await asyncio.sleep(SLOW_SECONDS)
+    return slow_value
+
+
+@node(output_name="fast_value")
+async def async_fast_step(x: int) -> int:
+    await asyncio.sleep(FAST_SECONDS)
+    return x
+
+
+@pytest.fixture
+def exporter():
+    """An isolated provider/exporter pair — never the global tracer provider."""
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    yield provider, exporter
+    exporter.clear()
+
+
+def _by_name(spans, name):
+    return [span for span in spans if span.name == name]
+
+
+def _duration_ms(span) -> float:
+    return (span.end_time - span.start_time) / 1_000_000
+
+
+def _assert_complete_run_tree(spans, graph_name: str, node_names: tuple[str, ...], *, min_duration_ms: float) -> None:
+    """One graph root, its nodes beneath it, one trace, real duration."""
+    roots = _by_name(spans, graph_name)
+    assert len(roots) == 1, f"expected exactly one {graph_name!r} root span, got {len(roots)}"
+    root = roots[0]
+
+    assert root.attributes.get("hypergraph.run.outcome") == "completed", (
+        f"{graph_name!r} root never received its run-end attributes — it was ended by another run's shutdown"
+    )
+    assert root.attributes.get("hypergraph.duration_ms") is not None
+    assert _duration_ms(root) >= min_duration_ms, f"{graph_name!r} exported {_duration_ms(root):.1f}ms, expected at least {min_duration_ms}ms"
+
+    for node_name in node_names:
+        node_spans = _by_name(spans, node_name)
+        assert len(node_spans) == 1, f"expected exactly one {node_name!r} span, got {len(node_spans)}"
+        node_span = node_spans[0]
+        assert node_span.parent is not None, f"{node_name!r} lost its parent context and started a new trace"
+        assert node_span.parent.span_id == root.context.span_id
+        assert node_span.context.trace_id == root.context.trace_id
+
+
+@requires_otel
+class TestConcurrentTopLevelRunsShareOneProcessor:
+    async def test_async_concurrent_runs_each_export_a_complete_tree(self, exporter):
+        from hypergraph.events.otel import OpenTelemetryProcessor
+
+        provider, span_exporter = exporter
+        processor = OpenTelemetryProcessor(tracer_provider=provider)
+
+        slow = Graph([async_slow_step, async_slow_tail], name="slow_graph")
+        fast = Graph([async_fast_step], name="fast_graph")
+        runner = AsyncRunner()
+
+        await asyncio.gather(
+            runner.run(slow, {"x": 1}, event_processors=[processor]),
+            runner.run(fast, {"x": 2}, event_processors=[processor]),
+        )
+
+        spans = span_exporter.get_finished_spans()
+        _assert_complete_run_tree(
+            spans,
+            "slow_graph",
+            ("async_slow_step", "async_slow_tail"),
+            min_duration_ms=SLOW_SECONDS * 2 * 1000 * 0.8,
+        )
+        _assert_complete_run_tree(spans, "fast_graph", ("async_fast_step",), min_duration_ms=0.0)
+
+        trace_ids = {_by_name(spans, name)[0].context.trace_id for name in ("slow_graph", "fast_graph")}
+        assert len(trace_ids) == 2, "concurrent top-level runs must not share a trace"
+
+    def test_sync_concurrent_runs_in_threads_each_export_a_complete_tree(self, exporter):
+        from hypergraph.events.otel import OpenTelemetryProcessor
+
+        provider, span_exporter = exporter
+        processor = OpenTelemetryProcessor(tracer_provider=provider)
+
+        slow = Graph([slow_step, slow_tail], name="slow_graph")
+        fast = Graph([fast_step], name="fast_graph")
+
+        started = threading.Barrier(2)
+
+        def run(graph, x):
+            started.wait()
+            SyncRunner().run(graph, {"x": x}, event_processors=[processor])
+
+        threads = [
+            threading.Thread(target=run, args=(slow, 1)),
+            threading.Thread(target=run, args=(fast, 2)),
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        spans = span_exporter.get_finished_spans()
+        _assert_complete_run_tree(
+            spans,
+            "slow_graph",
+            ("slow_step", "slow_tail"),
+            min_duration_ms=SLOW_SECONDS * 2 * 1000 * 0.8,
+        )
+        _assert_complete_run_tree(spans, "fast_graph", ("fast_step",), min_duration_ms=0.0)
+
+    async def test_graph_carried_processor_survives_the_first_run_finishing(self, exporter):
+        """``Graph.with_processors`` is the shared-processor shape users reach for."""
+        from hypergraph.events.otel import OpenTelemetryProcessor
+
+        provider, span_exporter = exporter
+        processor = OpenTelemetryProcessor(tracer_provider=provider)
+
+        slow = Graph([async_slow_step, async_slow_tail], name="slow_graph").with_processors(processor)
+        fast = Graph([async_fast_step], name="fast_graph").with_processors(processor)
+        runner = AsyncRunner()
+
+        await asyncio.gather(runner.run(slow, {"x": 1}), runner.run(fast, {"x": 2}))
+
+        spans = span_exporter.get_finished_spans()
+        _assert_complete_run_tree(
+            spans,
+            "slow_graph",
+            ("async_slow_step", "async_slow_tail"),
+            min_duration_ms=SLOW_SECONDS * 2 * 1000 * 0.8,
+        )
+        _assert_complete_run_tree(spans, "fast_graph", ("async_fast_step",), min_duration_ms=0.0)
+
+    async def test_last_run_out_still_sweeps_leftover_spans(self, exporter):
+        """The sweep is deferred, not lost: it runs when the last run leaves."""
+        from hypergraph.events.otel import OpenTelemetryProcessor
+        from hypergraph.events.types import NodeStartEvent, RunEndEvent, RunStartEvent
+
+        provider, span_exporter = exporter
+        processor = OpenTelemetryProcessor(tracer_provider=provider)
+
+        # Two top-level runs start; the first abandons a live node span.
+        processor.on_run_start(RunStartEvent(run_id="a", span_id="ra", graph_name="a"))
+        processor.on_run_start(RunStartEvent(run_id="b", span_id="rb", graph_name="b"))
+        processor.on_node_start(NodeStartEvent(run_id="a", span_id="na", parent_span_id="ra", node_name="leaked", graph_name="a"))
+        processor.on_run_end(RunEndEvent(run_id="a", span_id="ra", graph_name="a"))
+        processor.shutdown()
+
+        assert {span.name for span in span_exporter.get_finished_spans()} == {"a"}, "b must still be live after a's shutdown"
+
+        processor.on_run_end(RunEndEvent(run_id="b", span_id="rb", graph_name="b"))
+        processor.shutdown()
+
+        assert {span.name for span in span_exporter.get_finished_spans()} == {"a", "b", "leaked"}
+
+    def test_sequential_runs_still_sweep_on_each_shutdown(self, exporter):
+        """Sequential behavior is unchanged: one run in, one full sweep out."""
+        from hypergraph.events.otel import OpenTelemetryProcessor
+        from hypergraph.events.types import NodeStartEvent, RunStartEvent
+
+        provider, span_exporter = exporter
+        processor = OpenTelemetryProcessor(tracer_provider=provider)
+
+        processor.on_run_start(RunStartEvent(run_id="a", span_id="ra", graph_name="a"))
+        processor.on_node_start(NodeStartEvent(run_id="a", span_id="na", parent_span_id="ra", node_name="leaked", graph_name="a"))
+        processor.shutdown()
+
+        assert {span.name for span in span_exporter.get_finished_spans()} == {"a", "leaked"}

--- a/tests/test_run_log/test_otel_concurrent_runs.py
+++ b/tests/test_run_log/test_otel_concurrent_runs.py
@@ -242,6 +242,51 @@ class TestConcurrentTopLevelRunsShareOneProcessor:
 
         assert {span.name for span in span_exporter.get_finished_spans()} == {"a", "b", "leaked"}
 
+    def test_a_run_starting_during_the_sweep_is_made_to_wait(self, exporter):
+        """The sweep holds the lifecycle lock, so a starting run cannot slip in.
+
+        Checking the count under the lock but sweeping outside it reopens the
+        original bug in a narrower window: the new run registers its root span
+        into the very dicts the sweep is about to clear. White-box by
+        necessity — the window is invisible from the public surface, so the
+        test wedges itself into the sweep and proves ``on_run_start`` blocks.
+        """
+        from hypergraph.events.otel import OpenTelemetryProcessor
+        from hypergraph.events.types import RunEndEvent, RunStartEvent
+
+        provider, span_exporter = exporter
+        processor = OpenTelemetryProcessor(tracer_provider=provider)
+        processor.on_run_start(RunStartEvent(run_id="a", span_id="ra", graph_name="a"))
+        processor.on_run_end(RunEndEvent(run_id="a", span_id="ra", graph_name="a"))
+
+        sweeping = threading.Event()
+        b_registered = threading.Event()
+
+        class WedgedSpans(dict):
+            """Pauses inside the sweep, giving run B a real chance to race."""
+
+            def values(self):
+                sweeping.set()
+                b_registered.wait(timeout=0.5)
+                return super().values()
+
+        processor._spans = WedgedSpans(processor._spans)
+
+        def start_b():
+            sweeping.wait(timeout=5)
+            processor.on_run_start(RunStartEvent(run_id="b", span_id="rb", graph_name="b"))
+            b_registered.set()
+
+        thread = threading.Thread(target=start_b)
+        thread.start()
+        processor.shutdown()
+        raced = b_registered.is_set()
+        thread.join(timeout=5)
+
+        assert not raced, "on_run_start must block until the sweep finishes"
+        assert "rb" in processor._spans, "B registered after the sweep, so the sweep cannot have cleared it"
+        assert {span.name for span in span_exporter.get_finished_spans()} == {"a"}, "B must still be live"
+
     def test_sequential_runs_still_sweep_on_each_shutdown(self, exporter):
         """Sequential behavior is unchanged: one run in, one full sweep out."""
         from hypergraph.events.otel import OpenTelemetryProcessor

--- a/tests/test_run_log/test_otel_concurrent_runs.py
+++ b/tests/test_run_log/test_otel_concurrent_runs.py
@@ -80,12 +80,28 @@ async def async_fast_step(x: int) -> int:
 
 @pytest.fixture
 def exporter():
-    """An isolated provider/exporter pair — never the global tracer provider."""
+    """An isolated provider/exporter pair AND a clean ambient OTel context.
+
+    Both halves matter. The provider is private so these tests never touch the
+    global one. The empty ambient context is what makes "each top-level run
+    roots its own trace" a meaningful assertion: ``start_span(context=None)``
+    parents under whatever span is ambient, so a span left current by an
+    earlier test in the same worker legitimately merges both runs into ONE
+    trace — that is the documented ambient-nesting feature working, not a bug.
+    Attaching an empty context isolates the test from inherited state and,
+    because detach restores what was there, from leaking its own.
+    """
+    from opentelemetry import context as otel_context
+
     exporter = InMemorySpanExporter()
     provider = TracerProvider()
     provider.add_span_processor(SimpleSpanProcessor(exporter))
-    yield provider, exporter
-    exporter.clear()
+    token = otel_context.attach(otel_context.Context())
+    try:
+        yield provider, exporter
+    finally:
+        otel_context.detach(token)
+        exporter.clear()
 
 
 def _by_name(spans, name):
@@ -143,8 +159,11 @@ class TestConcurrentTopLevelRunsShareOneProcessor:
         )
         _assert_complete_run_tree(spans, "fast_graph", ("async_fast_step",), min_duration_ms=0.0)
 
+        # With no ambient parent span (see the `exporter` fixture), each
+        # top-level run roots its own trace. Under a caller-supplied ambient
+        # span they would legitimately share one — that is ambient nesting.
         trace_ids = {_by_name(spans, name)[0].context.trace_id for name in ("slow_graph", "fast_graph")}
-        assert len(trace_ids) == 2, "concurrent top-level runs must not share a trace"
+        assert len(trace_ids) == 2, "with no ambient parent, concurrent top-level runs root separate traces"
 
     def test_sync_concurrent_runs_in_threads_each_export_a_complete_tree(self, exporter):
         from hypergraph.events.otel import OpenTelemetryProcessor

--- a/tests/test_run_log/test_otel_error_detail.py
+++ b/tests/test_run_log/test_otel_error_detail.py
@@ -1,0 +1,212 @@
+"""Full exception detail on the OTel export, redaction as explicit opt-in.
+
+A trace whose ``exception.message`` reads "Node 'x' raised ValueError." cannot
+be debugged, and it deviates from the OTel ecosystem norm — standard
+``Span.record_exception`` carries the real message. So the export carries the
+real message, type and traceback BY DEFAULT, and
+``OpenTelemetryProcessor(redact_errors=True)`` restores the scrubbed export
+for regulated deployments.
+
+The privacy boundary itself did not move: durable records (RunLog,
+StepRecord, checkpoints, attempt ledger, ``RunResult.to_dict()``) still store
+only the safe projection. That is pinned in ``tests/test_privacy_projection.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hypergraph import AsyncRunner, Graph, SyncRunner, node
+
+try:
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.trace import StatusCode
+
+    try:
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+    except ImportError:  # pragma: no cover - compatibility with older sdk layout
+        from opentelemetry.sdk.trace.export.in_memory import InMemorySpanExporter
+
+    HAS_OTEL_SDK = True
+except ImportError:  # pragma: no cover - optional dependency
+    HAS_OTEL_SDK = False
+
+requires_otel = pytest.mark.skipif(not HAS_OTEL_SDK, reason="opentelemetry-sdk not installed")
+
+RAW_MESSAGE = "row 41 of shipment ABC-9 has a negative weight"
+
+
+@node(output_name="value")
+def explode(x: int) -> int:
+    raise ValueError(RAW_MESSAGE)
+
+
+@pytest.fixture
+def exporter():
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    yield provider, exporter
+    exporter.clear()
+
+
+def _exception_events(spans):
+    return [(span, event) for span in spans for event in span.events if event.name == "exception"]
+
+
+class TestErrorDetailOnEvents:
+    """The events carry both shapes; only the safe one reaches durable records."""
+
+    def test_node_error_event_carries_both_projections(self):
+        from hypergraph.events import NodeErrorEvent
+        from hypergraph.events.processor import EventProcessor
+
+        class Recorder(EventProcessor):
+            def __init__(self):
+                self.events = []
+
+            def on_event(self, event):
+                self.events.append(event)
+
+        recorder = Recorder()
+        SyncRunner().run(Graph([explode]), {"x": 1}, event_processors=[recorder], error_handling="continue")
+
+        errors = [e for e in recorder.events if isinstance(e, NodeErrorEvent)]
+        assert len(errors) == 1
+        event = errors[0]
+        assert RAW_MESSAGE not in event.error, "the safe projection is unchanged"
+        assert event.error_detail is not None
+        assert event.error_detail.message == RAW_MESSAGE
+        assert event.error_detail.type_name == "ValueError"
+        assert "explode" in (event.error_detail.traceback or ""), "the traceback names the failing frame"
+
+    def test_run_end_event_carries_both_projections(self):
+        from hypergraph.events import RunEndEvent
+        from hypergraph.events.processor import EventProcessor
+
+        class Recorder(EventProcessor):
+            def __init__(self):
+                self.events = []
+
+            def on_event(self, event):
+                self.events.append(event)
+
+        recorder = Recorder()
+        SyncRunner().run(Graph([explode]), {"x": 1}, event_processors=[recorder], error_handling="continue")
+
+        ends = [e for e in recorder.events if isinstance(e, RunEndEvent)]
+        assert ends
+        end = ends[-1]
+        assert end.error is not None and RAW_MESSAGE not in end.error
+        assert end.error_detail is not None
+        assert end.error_detail.message == RAW_MESSAGE
+
+    def test_run_log_and_result_dict_stay_on_the_safe_projection(self):
+        import json
+
+        result = SyncRunner().run(Graph([explode]), {"x": 1}, error_handling="continue")
+
+        assert result.failed
+        assert RAW_MESSAGE in str(result.error), "the local exception object is untouched"
+        assert RAW_MESSAGE not in json.dumps(result.to_dict())
+        assert result.log is not None
+        assert RAW_MESSAGE not in json.dumps(result.log.to_dict())
+
+
+@requires_otel
+class TestOTelErrorExport:
+    @pytest.mark.parametrize("runner_factory", [SyncRunner, AsyncRunner])
+    async def test_default_exports_the_real_message_and_traceback(self, exporter, runner_factory):
+        from hypergraph.events.otel import OpenTelemetryProcessor
+
+        provider, span_exporter = exporter
+        processor = OpenTelemetryProcessor(tracer_provider=provider)
+        result = runner_factory().run(Graph([explode]), {"x": 1}, event_processors=[processor], error_handling="continue")
+        if hasattr(result, "__await__"):
+            result = await result
+        assert result.failed
+
+        spans = span_exporter.get_finished_spans()
+        node_span = next(span for span in spans if span.name == "explode")
+        assert node_span.status.status_code == StatusCode.ERROR
+        assert RAW_MESSAGE in (node_span.status.description or "")
+
+        events = _exception_events(spans)
+        assert events, "a failed node must record an exception span event"
+        node_exception = next(event for span, event in events if span.name == "explode")
+        assert node_exception.attributes["exception.message"] == RAW_MESSAGE
+        # ``exception.type`` is identical in both modes: only message text and
+        # the stacktrace are redacted.
+        assert node_exception.attributes["exception.type"] == "builtins.ValueError"
+        assert "explode" in node_exception.attributes["exception.stacktrace"]
+
+        run_span = next(span for span in spans if span.name == "graph")
+        assert RAW_MESSAGE in (run_span.status.description or "")
+
+    def test_redact_errors_restores_the_scrubbed_export(self, exporter):
+        from hypergraph.events.otel import OpenTelemetryProcessor
+
+        provider, span_exporter = exporter
+        processor = OpenTelemetryProcessor(tracer_provider=provider, redact_errors=True)
+        SyncRunner().run(Graph([explode]), {"x": 1}, event_processors=[processor], error_handling="continue")
+
+        spans = span_exporter.get_finished_spans()
+        for span in spans:
+            assert RAW_MESSAGE not in (span.status.description or "")
+            for event in span.events:
+                for value in (event.attributes or {}).values():
+                    assert RAW_MESSAGE not in str(value)
+            for value in (span.attributes or {}).values():
+                assert RAW_MESSAGE not in str(value)
+
+        node_exception = next(event for span, event in _exception_events(spans) if span.name == "explode")
+        assert node_exception.attributes["exception.type"] == "builtins.ValueError"
+        assert "HG_NODE_FAILED" in node_exception.attributes["exception.message"]
+        assert "exception.stacktrace" not in node_exception.attributes
+
+    def test_redacted_export_matches_the_pre_change_shape(self, exporter):
+        """redact_errors=True is byte-identical to the old default."""
+        from hypergraph.events.otel import OpenTelemetryProcessor
+
+        provider, span_exporter = exporter
+        processor = OpenTelemetryProcessor(tracer_provider=provider, redact_errors=True)
+        SyncRunner().run(Graph([explode]), {"x": 1}, event_processors=[processor], error_handling="continue")
+
+        spans = span_exporter.get_finished_spans()
+        node_span = next(span for span in spans if span.name == "explode")
+        node_exception = next(event for event in node_span.events if event.name == "exception")
+        assert set(node_exception.attributes) == {"exception.type", "exception.message"}
+        assert node_span.status.description == node_exception.attributes["exception.message"]
+
+        run_span = next(span for span in spans if span.name == "graph")
+        run_exception = next(event for event in run_span.events if event.name == "exception")
+        assert set(run_exception.attributes) == {"exception.message"}
+
+
+class TestFullErrorDetailCapture:
+    def test_never_raised_exception_has_no_traceback(self):
+        from hypergraph.diagnostics import full_error_detail
+
+        detail = full_error_detail(ValueError("bare"))
+        assert detail.message == "bare"
+        assert detail.type_name == "ValueError"
+        assert detail.traceback is None
+
+    def test_traceback_is_truncated(self):
+        from hypergraph.diagnostics import _MAX_TRACEBACK_CHARS, full_error_detail
+
+        try:
+            raise ValueError("x" * (_MAX_TRACEBACK_CHARS * 2))
+        except ValueError as exc:
+            detail = full_error_detail(exc)
+        assert detail.traceback is not None
+        assert detail.traceback.endswith("... [truncated]")
+        assert len(detail.traceback) <= _MAX_TRACEBACK_CHARS + len("\n... [truncated]")
+
+    def test_qualified_type_name_for_non_builtin(self):
+        from hypergraph.diagnostics import full_error_detail
+        from hypergraph.graph.validation import GraphConfigError
+
+        detail = full_error_detail(GraphConfigError("nope"))
+        assert detail.type_name == "hypergraph.graph.validation.GraphConfigError"

--- a/tests/test_run_log/test_otel_run_correlation.py
+++ b/tests/test_run_log/test_otel_run_correlation.py
@@ -42,11 +42,24 @@ async def async_double(x: int) -> int:
 
 @pytest.fixture
 def exporter():
+    """Private provider plus an empty ambient context.
+
+    ``start_span(context=None)`` parents under whatever span is ambient, so a
+    span left current by an earlier test in the same worker would put both
+    runs in one trace. That is ambient nesting working as documented, but it
+    makes trace-identity assertions meaningless — so isolate.
+    """
+    from opentelemetry import context as otel_context
+
     exporter = InMemorySpanExporter()
     provider = TracerProvider()
     provider.add_span_processor(SimpleSpanProcessor(exporter))
-    yield provider, exporter
-    exporter.clear()
+    token = otel_context.attach(otel_context.Context())
+    try:
+        yield provider, exporter
+    finally:
+        otel_context.detach(token)
+        exporter.clear()
 
 
 @requires_otel

--- a/tests/test_run_log/test_otel_run_correlation.py
+++ b/tests/test_run_log/test_otel_run_correlation.py
@@ -1,0 +1,149 @@
+"""``OpenTelemetryProcessor.trace_id_for`` — link a run id to its trace.
+
+Without it, going from a ``RunResult`` to the trace in Phoenix/Jaeger means
+adding a throwaway graph node that reads the ambient span. The processor
+already knows the answer at span-start time; this just exposes it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from hypergraph import AsyncRunner, Graph, SyncRunner, node
+
+try:
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+    try:
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+    except ImportError:  # pragma: no cover - compatibility with older sdk layout
+        from opentelemetry.sdk.trace.export.in_memory import InMemorySpanExporter
+
+    HAS_OTEL_SDK = True
+except ImportError:  # pragma: no cover - optional dependency
+    HAS_OTEL_SDK = False
+
+requires_otel = pytest.mark.skipif(not HAS_OTEL_SDK, reason="opentelemetry-sdk not installed")
+
+
+@node(output_name="doubled")
+def double(x: int) -> int:
+    return x * 2
+
+
+@node(output_name="value")
+async def async_double(x: int) -> int:
+    await asyncio.sleep(0)
+    return x * 2
+
+
+@pytest.fixture
+def exporter():
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    yield provider, exporter
+    exporter.clear()
+
+
+@requires_otel
+class TestTraceIdForRun:
+    def test_returns_the_hex_trace_id_of_the_exported_run(self, exporter):
+        from hypergraph.events.otel import OpenTelemetryProcessor
+
+        provider, span_exporter = exporter
+        processor = OpenTelemetryProcessor(tracer_provider=provider)
+        result = SyncRunner().run(Graph([double]), {"x": 3}, event_processors=[processor])
+
+        trace_id = processor.trace_id_for(result.run_id)
+        assert trace_id is not None
+        assert len(trace_id) == 32 and int(trace_id, 16) != 0
+
+        spans = span_exporter.get_finished_spans()
+        assert {format(span.context.trace_id, "032x") for span in spans} == {trace_id}
+
+    def test_survives_shutdown_so_callers_can_read_it_after_run_returns(self, exporter):
+        """The runner shuts the processor down BEFORE run() returns."""
+        from hypergraph.events.otel import OpenTelemetryProcessor
+
+        provider, _ = exporter
+        processor = OpenTelemetryProcessor(tracer_provider=provider)
+        result = SyncRunner().run(Graph([double]), {"x": 3}, event_processors=[processor])
+
+        assert processor.trace_id_for(result.run_id) is not None
+        processor.shutdown()
+        assert processor.trace_id_for(result.run_id) is not None
+
+    def test_unknown_run_id_returns_none(self, exporter):
+        from hypergraph.events.otel import OpenTelemetryProcessor
+
+        provider, _ = exporter
+        processor = OpenTelemetryProcessor(tracer_provider=provider)
+        assert processor.trace_id_for("run-never-seen") is None
+
+    async def test_concurrent_runs_get_distinct_trace_ids(self, exporter):
+        from hypergraph.events.otel import OpenTelemetryProcessor
+
+        provider, _ = exporter
+        processor = OpenTelemetryProcessor(tracer_provider=provider)
+        runner = AsyncRunner()
+
+        first, second = await asyncio.gather(
+            runner.run(Graph([async_double], name="one"), {"x": 1}, event_processors=[processor]),
+            runner.run(Graph([async_double], name="two"), {"x": 2}, event_processors=[processor]),
+        )
+
+        one = processor.trace_id_for(first.run_id)
+        two = processor.trace_id_for(second.run_id)
+        assert one is not None and two is not None
+        assert one != two
+
+    def test_nested_run_shares_the_parent_trace(self, exporter):
+        from hypergraph.events import RunStartEvent
+        from hypergraph.events.otel import OpenTelemetryProcessor
+        from hypergraph.events.processor import EventProcessor
+
+        class RunIds(EventProcessor):
+            def __init__(self):
+                self.ids = []
+
+            def on_event(self, event):
+                if isinstance(event, RunStartEvent):
+                    self.ids.append(event.run_id)
+
+        provider, _ = exporter
+        processor = OpenTelemetryProcessor(tracer_provider=provider)
+        run_ids = RunIds()
+        inner = Graph([double], name="inner")
+        outer = Graph([inner.as_node(name="nested")], name="outer")
+        SyncRunner().run(outer, {"x": 2}, event_processors=[processor, run_ids])
+
+        assert len(run_ids.ids) == 2, "one top-level run and one nested run"
+        trace_ids = {processor.trace_id_for(run_id) for run_id in run_ids.ids}
+        assert None not in trace_ids
+        assert len(trace_ids) == 1, "a nested run belongs to its parent's trace"
+
+    def test_mapping_is_bounded(self, exporter):
+        from hypergraph.events.otel import _MAX_TRACE_IDS, OpenTelemetryProcessor
+        from hypergraph.events.types import RunStartEvent
+
+        provider, _ = exporter
+        processor = OpenTelemetryProcessor(tracer_provider=provider)
+        for index in range(_MAX_TRACE_IDS + 5):
+            processor.on_run_start(RunStartEvent(run_id=f"run-{index}", span_id=f"s{index}", graph_name="g"))
+
+        assert processor.trace_id_for("run-0") is None, "oldest entries are evicted"
+        assert processor.trace_id_for(f"run-{_MAX_TRACE_IDS + 4}") is not None
+
+    def test_noop_provider_reports_no_trace(self, exporter):
+        from opentelemetry import trace
+
+        from hypergraph.events.otel import OpenTelemetryProcessor
+
+        processor = OpenTelemetryProcessor(tracer_provider=trace.NoOpTracerProvider())
+        result = SyncRunner().run(Graph([double]), {"x": 3}, event_processors=[processor])
+
+        assert processor.trace_id_for(result.run_id) is None

--- a/tests/test_run_log/test_otel_trace_io.py
+++ b/tests/test_run_log/test_otel_trace_io.py
@@ -114,6 +114,18 @@ class TestTraceIoResolution:
             def bad(text: str) -> str:
                 return text
 
+    @pytest.mark.parametrize("bad", ["false", "true", 0, 1, None])
+    def test_graph_trace_io_is_never_coerced(self, bad):
+        """bool("false") is True — coercing would turn capture ON from config."""
+        with pytest.raises(TypeError, match="trace_io must be"):
+            Graph([untraced], trace_io=bad)
+        with pytest.raises(TypeError, match="trace_io must be"):
+            Graph([untraced]).with_trace_io(bad)
+
+    def test_add_nodes_preserves_the_graph_default(self):
+        graph = Graph([untraced], trace_io=True).add_nodes(opted_out)
+        assert graph.trace_io is True
+
     def test_trace_io_does_not_change_graph_identity(self):
         plain = Graph([untraced], name="g")
         traced_graph = Graph([untraced], name="g", trace_io=True)
@@ -192,6 +204,15 @@ class TestPayloadExport:
         assert value.endswith(_TRUNCATION_SUFFIX)
         assert len(value) == 64 + len(_TRUNCATION_SUFFIX)
         assert span.attributes["output.mime_type"] == "text/plain", "a cut JSON document is not JSON"
+
+    @pytest.mark.parametrize("bad", [0, -1, 4096.0, "4096", True])
+    def test_max_payload_chars_must_be_a_positive_int(self, exporter, bad):
+        """A bad cap would otherwise silently drop the span, not just the payload."""
+        from hypergraph.events.otel import OpenTelemetryProcessor
+
+        provider, _ = exporter
+        with pytest.raises(ValueError, match="max_payload_chars must be a positive integer"):
+            OpenTelemetryProcessor(tracer_provider=provider, max_payload_chars=bad)
 
     def test_default_cap_is_four_kib(self, exporter):
         from hypergraph.events.otel import _DEFAULT_MAX_PAYLOAD_CHARS, _TRUNCATION_SUFFIX, OpenTelemetryProcessor

--- a/tests/test_run_log/test_otel_trace_io.py
+++ b/tests/test_run_log/test_otel_trace_io.py
@@ -1,0 +1,281 @@
+"""Opt-in node input/output capture on spans (``trace_io``).
+
+Phoenix and friends render ``input.value``/``output.value`` natively, so an
+opted-in node shows what it received and what it produced. Opt-in because
+payloads are the expensive, sensitive part of a trace.
+
+Precedence: processor kill switch > node explicit > graph default > off.
+Payloads ride SPANS ONLY — no durable record changes shape or content.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from hypergraph import AsyncRunner, Graph, SyncRunner, node
+
+try:
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+    try:
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+    except ImportError:  # pragma: no cover - compatibility with older sdk layout
+        from opentelemetry.sdk.trace.export.in_memory import InMemorySpanExporter
+
+    HAS_OTEL_SDK = True
+except ImportError:  # pragma: no cover - optional dependency
+    HAS_OTEL_SDK = False
+
+requires_otel = pytest.mark.skipif(not HAS_OTEL_SDK, reason="opentelemetry-sdk not installed")
+
+
+@node(output_name="loud", trace_io=True)
+def traced(text: str) -> str:
+    return text.upper()
+
+
+@node(output_name="quiet")
+def untraced(text: str) -> str:
+    return text.lower()
+
+
+@node(output_name="opted_out", trace_io=False)
+def opted_out(text: str) -> str:
+    return text.title()
+
+
+@node(output_name="big", trace_io=True)
+def big_output(size: int) -> str:
+    return "x" * size
+
+
+class Unserializable:
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        raise RuntimeError("repr is broken too")
+
+
+@node(output_name="weird", trace_io=True)
+def unserializable(x: int) -> Unserializable:
+    return Unserializable()
+
+
+@node(output_name="cached_value", trace_io=True, cache=True)
+def cached_traced(text: str) -> str:
+    return text.upper()
+
+
+@pytest.fixture
+def exporter():
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    yield provider, exporter
+    exporter.clear()
+
+
+def _span(spans, name):
+    return next(span for span in spans if span.name == name)
+
+
+class TestTraceIoResolution:
+    """Precedence lives on the node/graph seam, independent of any exporter."""
+
+    def test_node_default_is_undeclared(self):
+        assert untraced.trace_io is None
+        assert traced.trace_io is True
+        assert opted_out.trace_io is False
+
+    def test_graph_default_is_off(self):
+        assert Graph([untraced]).trace_io is False
+        assert Graph([untraced], trace_io=True).trace_io is True
+        assert Graph([untraced]).with_trace_io().trace_io is True
+        assert Graph([untraced], trace_io=True).with_trace_io(False).trace_io is False
+
+    def test_node_explicit_overrides_graph_default(self):
+        from hypergraph.runners._shared.event_helpers import trace_io_enabled
+
+        on = Graph([traced, untraced, opted_out], trace_io=True)
+        off = Graph([traced, untraced, opted_out])
+
+        assert trace_io_enabled(traced, off) is True, "node True beats graph off"
+        assert trace_io_enabled(opted_out, on) is False, "node False beats graph on"
+        assert trace_io_enabled(untraced, on) is True, "undeclared follows the graph"
+        assert trace_io_enabled(untraced, off) is False
+
+    def test_trace_io_must_be_a_bool(self):
+        with pytest.raises(TypeError, match="trace_io must be"):
+
+            @node(output_name="x", trace_io="yes")
+            def bad(text: str) -> str:
+                return text
+
+    def test_trace_io_does_not_change_graph_identity(self):
+        plain = Graph([untraced], name="g")
+        traced_graph = Graph([untraced], name="g", trace_io=True)
+        assert plain.definition_hash == traced_graph.definition_hash
+
+
+@requires_otel
+class TestPayloadExport:
+    @pytest.mark.parametrize("runner_factory", [SyncRunner, AsyncRunner])
+    async def test_opted_in_node_exports_inputs_and_outputs(self, exporter, runner_factory):
+        from hypergraph.events.otel import OpenTelemetryProcessor
+
+        provider, span_exporter = exporter
+        result = runner_factory().run(
+            Graph([traced]),
+            {"text": "hello"},
+            event_processors=[OpenTelemetryProcessor(tracer_provider=provider)],
+        )
+        if hasattr(result, "__await__"):
+            await result
+
+        span = _span(span_exporter.get_finished_spans(), "traced")
+        assert json.loads(span.attributes["input.value"]) == {"text": "hello"}
+        assert span.attributes["input.mime_type"] == "application/json"
+        assert json.loads(span.attributes["output.value"]) == {"loud": "HELLO"}
+        assert span.attributes["output.mime_type"] == "application/json"
+
+    def test_default_node_exports_no_payloads(self, exporter):
+        from hypergraph.events.otel import OpenTelemetryProcessor
+
+        provider, span_exporter = exporter
+        SyncRunner().run(
+            Graph([untraced]),
+            {"text": "Hello"},
+            event_processors=[OpenTelemetryProcessor(tracer_provider=provider)],
+        )
+
+        for span in span_exporter.get_finished_spans():
+            assert not any(key.startswith(("input.", "output.")) for key in span.attributes)
+
+    def test_graph_default_turns_capture_on_and_node_opt_out_wins(self, exporter):
+        from hypergraph.events.otel import OpenTelemetryProcessor
+
+        provider, span_exporter = exporter
+        graph = Graph([untraced, opted_out], trace_io=True)
+        SyncRunner().run(graph, {"text": "Hello"}, event_processors=[OpenTelemetryProcessor(tracer_provider=provider)])
+
+        spans = span_exporter.get_finished_spans()
+        assert "input.value" in _span(spans, "untraced").attributes, "undeclared node follows the graph default"
+        assert "input.value" not in _span(spans, "opted_out").attributes, "node trace_io=False beats the graph default"
+
+    def test_kill_switch_beats_every_opt_in(self, exporter):
+        from hypergraph.events.otel import OpenTelemetryProcessor
+
+        provider, span_exporter = exporter
+        graph = Graph([traced, untraced], trace_io=True)
+        SyncRunner().run(
+            graph,
+            {"text": "Hello"},
+            event_processors=[OpenTelemetryProcessor(tracer_provider=provider, redact_payloads=True)],
+        )
+
+        for span in span_exporter.get_finished_spans():
+            assert not any(key.startswith(("input.", "output.")) for key in span.attributes)
+            assert "HELLO" not in json.dumps(dict(span.attributes))
+
+    def test_oversized_value_is_truncated(self, exporter):
+        from hypergraph.events.otel import _TRUNCATION_SUFFIX, OpenTelemetryProcessor
+
+        provider, span_exporter = exporter
+        processor = OpenTelemetryProcessor(tracer_provider=provider, max_payload_chars=64)
+        SyncRunner().run(Graph([big_output]), {"size": 5000}, event_processors=[processor])
+
+        span = _span(span_exporter.get_finished_spans(), "big_output")
+        value = span.attributes["output.value"]
+        assert value.endswith(_TRUNCATION_SUFFIX)
+        assert len(value) == 64 + len(_TRUNCATION_SUFFIX)
+        assert span.attributes["output.mime_type"] == "text/plain", "a cut JSON document is not JSON"
+
+    def test_default_cap_is_four_kib(self, exporter):
+        from hypergraph.events.otel import _DEFAULT_MAX_PAYLOAD_CHARS, _TRUNCATION_SUFFIX, OpenTelemetryProcessor
+
+        assert _DEFAULT_MAX_PAYLOAD_CHARS == 4096
+        provider, span_exporter = exporter
+        SyncRunner().run(
+            Graph([big_output]),
+            {"size": 50_000},
+            event_processors=[OpenTelemetryProcessor(tracer_provider=provider)],
+        )
+
+        value = _span(span_exporter.get_finished_spans(), "big_output").attributes["output.value"]
+        assert len(value) == _DEFAULT_MAX_PAYLOAD_CHARS + len(_TRUNCATION_SUFFIX)
+
+    def test_unserializable_value_is_omitted_and_the_run_still_succeeds(self, exporter):
+        from hypergraph.events.otel import OpenTelemetryProcessor
+
+        provider, span_exporter = exporter
+        result = SyncRunner().run(
+            Graph([unserializable]),
+            {"x": 1},
+            event_processors=[OpenTelemetryProcessor(tracer_provider=provider)],
+        )
+
+        assert result.completed, "capture failure must never fail the run"
+        span = _span(span_exporter.get_finished_spans(), "unserializable")
+        assert "input.value" in span.attributes, "the serializable half still exports"
+        assert "output.value" not in span.attributes
+
+    def test_cache_hit_still_exports_payloads(self, exporter):
+        from hypergraph import InMemoryCache
+        from hypergraph.events.otel import OpenTelemetryProcessor
+
+        provider, span_exporter = exporter
+        graph = Graph([cached_traced])
+        runner = SyncRunner(cache=InMemoryCache())
+        runner.run(graph, {"text": "hi"}, event_processors=[OpenTelemetryProcessor(tracer_provider=provider)])
+        span_exporter.clear()
+        runner.run(graph, {"text": "hi"}, event_processors=[OpenTelemetryProcessor(tracer_provider=provider)])
+
+        span = _span(span_exporter.get_finished_spans(), "cached_traced")
+        assert span.attributes["hypergraph.cached"] is True
+        assert json.loads(span.attributes["output.value"]) == {"cached_value": "HI"}
+
+
+class TestDurableRecordsAreUnaffected:
+    """``trace_io`` is a span concern; no durable record changes because of it."""
+
+    @staticmethod
+    def _volatile(step: dict) -> dict:
+        return {k: v for k, v in step.items() if k not in {"duration_ms", "span_id"}}
+
+    def test_run_log_does_not_change_shape_or_content(self):
+        graph = Graph([traced, untraced], trace_io=True)
+        with_capture = SyncRunner().run(graph, {"text": "hello"})
+        without_capture = SyncRunner().run(Graph([traced, untraced]), {"text": "hello"})
+
+        assert with_capture.log is not None and without_capture.log is not None
+        captured = [self._volatile(step) for step in with_capture.log.to_dict()["steps"]]
+        plain = [self._volatile(step) for step in without_capture.log.to_dict()["steps"]]
+        assert captured == plain
+
+        serialized = json.dumps(with_capture.log.to_dict())
+        assert "input.value" not in serialized and "trace_inputs" not in serialized
+
+    async def test_checkpointed_steps_do_not_change_shape_or_content(self, tmp_path):
+        """StepRecord already stores outputs for resume; trace_io adds nothing."""
+        from hypergraph.checkpointers import SqliteCheckpointer
+
+        pytest.importorskip("aiosqlite")
+        volatile = {"created_at", "completed_at", "duration_ms", "run_id", "workflow_id"}
+
+        async def steps_for(graph, name):
+            cp = SqliteCheckpointer(str(tmp_path / f"{name}.db"))
+            try:
+                SyncRunner(checkpointer=cp).run(graph, {"text": "hello"}, workflow_id=name)
+                return [{k: v for k, v in step.to_dict().items() if k not in volatile} for step in await cp.get_steps(name)]
+            finally:
+                await cp.close()
+
+        captured = await steps_for(Graph([traced], trace_io=True), "on")
+        plain = await steps_for(Graph([traced]), "off")
+
+        assert captured and captured == plain
+        assert "input.value" not in json.dumps(captured)
+        assert "trace_inputs" not in json.dumps(captured)


### PR DESCRIPTION
Four gaps a live Phoenix export spike surfaced, shipped as one wave. Every commit is independently green (verified by checking each out and running the affected suites).

## 1. Full exception detail by default, redaction as explicit opt-in

`NodeErrorEvent.error` / `RunEndEvent.error` carried only the privacy-safe projection, so a trace read `Node 'extract_text' raised ValueError.` and nothing else. That deviates from the ecosystem norm — standard `Span.record_exception` carries the real message — and makes traces useless for debugging.

- New `hypergraph.diagnostics.ErrorDetail(message, type_name, traceback)` + `full_error_detail()`; traceback capped at 16 KiB, capture never raises.
- New in-memory-only `error_detail` field on `NodeErrorEvent` / `RunEndEvent`, beside the **unchanged** `error`.
- New `OpenTelemetryProcessor(redact_errors=False)`. Default exports `exception.message`, `.type`, `.stacktrace`, `.escaped`; `redact_errors=True` restores the previous scrubbed export byte-identically.

**Durable blast radius: none.** RunLog, StepRecord, checkpoints, the attempt ledger, and `RunResult.to_dict()` keep the safe projection — `run_log.py` reads only `event.error`, and `checkpoint_helpers` projects straight from the exception.

One deliberate deviation from the brief: `exception.type` is now identical in both modes. Redacting a type name buys nothing and made the two modes gratuitously different — only message text and the stacktrace are redacted.

## 2. Run↔trace correlation

`OpenTelemetryProcessor.trace_id_for(run_id) -> str | None` (32-char hex), recorded at span start for every run — top-level, nested, and mapped items — in an LRU bounded to 1024 runs.

Deliberately **not** cleared by `shutdown()`: the runner shuts the processor down *before* `run()` returns, so clearing there would destroy the mapping exactly when the caller wants it.

No `hypergraph.trace_id` span attribute: the trace id is already on the span context and `hypergraph.run_id` is already on every span, so both directions are discoverable — an extra attribute on every span would be pure noise.

## 3. Concurrent-processor lifecycle bug (the known blocker)

One shared processor was unsafe under concurrent top-level runs: the runners call `shutdown()` once per top-level run, and it swept **all** bookkeeping, so the first run to finish ended every other live run's spans, cleared the contexts their later node spans needed for parentage, and dropped their run-end attributes. The documented repro exported a ~200ms run as 22–25ms.

Test written first — **4 of 5 failed on master** with the exact symptom (`'slow_graph' root never received its run-end attributes`).

Fixed with a refcount rather than per-run span keying: the run templates guarantee an exact 1:1 pairing between an emitted top-level `RunStartEvent` and a `shutdown()` call, *including* on `BaseException` (the `finally` block) — and a no-arg `shutdown()` could not identify which run it belongs to anyway. Sequential behavior is byte-identical.

## 4. Opt-in node input/output capture (`trace_io`)

- `@node(trace_io=None|True|False)`, `Graph(..., trace_io=False)`, `graph.with_trace_io()`, `HyperNode.trace_io`.
- Opted-in node spans carry OpenInference `input.value`/`input.mime_type` and `output.value`/`output.mime_type`.
- Precedence: `redact_payloads` kill switch > node explicit > graph default > off.
- JSON first with a `repr` fallback, capped at `max_payload_chars` (default 4096) and re-labelled `text/plain` once cut, because a truncated JSON document is not JSON. Unrenderable values are omitted; capture can never fail a run.
- Events carry the raw objects and the processor serializes, so there is zero serialization cost when no exporter is attached and the cap is genuinely ownable by the processor.
- `definition_hash` is untouched, and durable records are byte-identical with capture on vs off (proven by comparing two runs).

## Verification

- `uv run pytest` → **4818 passed, 15 skipped** (from 4776; +42 net new tests)
- `uv run pytest -W error -W 'ignore::pytest.PytestUnraisableExceptionWarning'` (CI-equivalent) → **4818 passed, 15 skipped**
- `uv run --python 3.10 mypy` → no issues in 175 source files
- `uv run pre-commit run --all-files` → all hooks pass

New tests: `test_otel_concurrent_runs.py` (5), `test_otel_error_detail.py` (10), `test_otel_run_correlation.py` (7), `test_otel_trace_io.py` (16), plus `test_privacy_projection.py` 12 → 16.

No existing assertion was weakened. The one test pinning the old contract (`test_otel_export_contains_no_raw_message_text`) kept every assertion and moved to `redact_errors=True`, and gained two companions proving the new default and that the durable boundary did not move.

Docs updated: `05-how-to/observe-execution.md`, `06-api-reference/{events,errors,graph,nodes}.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional OpenTelemetry tracing for node inputs and outputs, with graph- and node-level controls.
  * Added configurable payload redaction and size limits.
  * Added trace ID lookup by run ID.
  * Added detailed in-memory error information while keeping durable records privacy-safe.
  * Improved support for concurrent runs sharing telemetry processors.

* **Documentation**
  * Expanded guidance on tracing, privacy boundaries, error handling, payload retention, and concurrency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->