### PR TITLE
feat(host): durable result projection — client.result() for Runs and Batches

### DIFF
--- a/docs/06-api-reference/host.md
+++ b/docs/06-api-reference/host.md
@@ -475,6 +475,70 @@ is `None` while a Run executes or is terminal — including while a running
 Run is queued behind a [provider permit](#provider-resource-admission),
 which is execution, not waiting.
 
+## Reading Results
+
+`client.result(ref)` answers what durable work **produced**. The worker keeps
+no `RunResult`, so outputs are reconstructed from the same checkpointer rows
+that back resume — no graph code, no second store.
+
+```python
+outcome = await client.result(receipt.run_ref)   # RunOutcome | None
+outcome.status                                   # WorkflowStatus | None
+outcome.outputs                                  # dict | None
+outcome.failure                                  # RunFailure | None
+outcome.to_dict()                                # JSON-safe primitives
+```
+
+Four situations a caller must tell apart, and how each reads:
+
+| situation | `result()` | `started` | `settled` | `outputs` |
+| --- | --- | --- | --- | --- |
+| never submitted here | `None` | — | — | — |
+| submitted, still in flight | outcome | any | `False` | `None` |
+| stopped/closed before starting | outcome | `False` | `True` | `None` |
+| ran and produced nothing | outcome | `True` | `True` | `{}` |
+
+So `outputs is None` never means "produced nothing" — that is `{}`.
+`settled` uses the same settled-child rule as `BatchView` and the rerun
+gate, so a Run is never settled for one reader and in flight for another; a
+paused Run is **not** settled, because an outstanding answer can still
+change it.
+
+Two honest caveats on `outputs`:
+
+- They are the run's **folded step outputs**, not a projection narrowed to
+  the graph's declared outputs. Narrowing needs the `Graph` object, and this
+  client is graph-free by contract, so it reports every value the run's
+  steps produced rather than guessing.
+- They are JSON-safe because a Run Home's checkpointer defaults to
+  `JsonSerializer`. A Home explicitly configured with `PickleSerializer`
+  returns whatever it stored; `to_dict()` falls back to `repr` for anything
+  that will not serialize.
+
+`RunFailure` carries the **privacy-safe** projection the step persisted —
+an exception type name, a stable `HG_*` code, and static wording — never
+raw exception message text, which Hypergraph does not persist (see
+[the privacy boundary](errors.md#the-privacy-boundary)). The real message,
+type, and traceback go to the
+[OpenTelemetry export](../05-how-to/observe-execution.md#exception-detail-and-redacting-it)
+instead, so a failure is debugged there and merely identified here.
+
+A `BatchRef` reads every child at once:
+
+```python
+outcome = await client.result(receipt.batch_ref)   # BatchOutcome | None
+outcome.items                                      # item_key -> RunOutcome | None
+```
+
+`items` is keyed by logical item key in **manifest order** — completion
+order never changes result identity. An item whose child never executed maps
+to `None`: Hypergraph does not fabricate results for work that did not run,
+and that stays distinct from a child that ran and produced nothing
+(`outputs == {}`). The whole Batch reads in a bounded number of statements
+regardless of child count, so 100+ children stay a handful of queries.
+
+`result_sync()` is the synchronous mirror.
+
 ## Stopping a Run
 
 `client.stop(ref, info=None)` records a **durable stop command**: the

--- a/src/hypergraph/checkpointers/sqlite.py
+++ b/src/hypergraph/checkpointers/sqlite.py
@@ -7,7 +7,7 @@ import contextlib
 import json
 import threading
 import uuid
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import dataclass, replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -70,6 +70,9 @@ _STEPS_COLS = (
 _STEP_TIME_ORDER = "COALESCE(completed_at, created_at), created_at, id"
 _STEP_TIME_ORDER_DESC = "COALESCE(completed_at, created_at) DESC, created_at DESC, id DESC"
 _STEP_TIME_ORDER_DESC_WITH_ALIAS = "COALESCE(s.completed_at, s.created_at) DESC, s.created_at DESC, s.id DESC"
+# SQLite's default SQLITE_MAX_VARIABLE_NUMBER is 999 on older builds; chunk
+# well under it so a large Batch read never trips the host's sqlite limit.
+_MAX_SQL_VARIABLES = 500
 _RETENTION_BASELINE_NODE_NAME = "__retained_state__"
 _RETENTION_BASELINE_NODE_TYPE = "RetentionBaseline"
 _PUBLIC_STEP_FILTER = f"node_name != '{_RETENTION_BASELINE_NODE_NAME}' AND (node_type IS NULL OR node_type != '{_RETENTION_BASELINE_NODE_TYPE}')"
@@ -366,6 +369,20 @@ def _pause_slot_insert_params(slot: PauseSlot) -> tuple[Any, ...]:
         slot.settled_at.isoformat() if slot.settled_at is not None else None,
         None if slot.settled_at is None else json.dumps(slot.answer),
     )
+
+
+def _collect_first_failures(
+    rows: Iterable[Any],
+    failures: dict[str, tuple[str, str | None, int | None]],
+) -> None:
+    """Keep the FIRST errored step per run — the failure that started it.
+
+    Rows arrive in execution order, so a run's first row is its earliest
+    failure; later ones are downstream fallout of the same collapse.
+    """
+    for run_id, error, node_name, superstep in rows:
+        if run_id not in failures:
+            failures[run_id] = (error, node_name, None if superstep is None else int(superstep))
 
 
 def _row_to_pause_slot(row: Sequence[Any]) -> PauseSlot:
@@ -1204,6 +1221,100 @@ class SqliteCheckpointer(Checkpointer):
                     if values:
                         state.update(values)
             return state
+
+    # -- Batched projection reads ---------------------------------------------
+    #
+    # ``get_state`` answers for ONE run. A Batch result read asks the same
+    # question of every child at once, so these fold many runs in a bounded
+    # number of statements instead of one round trip per child. Same rows,
+    # same fold order, same serializer — no second store, and no second notion
+    # of what a run produced.
+
+    def _chunk_run_ids(self, run_ids: Sequence[str]) -> list[list[str]]:
+        """Split ids into SQLite-variable-safe batches, order preserved."""
+        unique = list(dict.fromkeys(run_ids))
+        return [unique[i : i + _MAX_SQL_VARIABLES] for i in range(0, len(unique), _MAX_SQL_VARIABLES)]
+
+    def _fold_states(self, rows: Iterable[Any]) -> dict[str, dict[str, Any]]:
+        """Fold ``(run_id, values_blob)`` rows exactly as ``get_state`` does."""
+        states: dict[str, dict[str, Any]] = {}
+        for run_id, values_blob in rows:
+            state = states.setdefault(run_id, {})
+            if values_blob is not None:
+                values = self._serializer.deserialize(values_blob)
+                if values:
+                    state.update(values)
+        return states
+
+    async def get_states(self, run_ids: Sequence[str]) -> dict[str, dict[str, Any]]:
+        """Folded state for several runs at once. Runs with no steps are absent."""
+        await self._ensure_db()
+        states: dict[str, dict[str, Any]] = {}
+        for chunk in self._chunk_run_ids(run_ids):
+            placeholders = ",".join("?" * len(chunk))
+            async with self._txn_lock():
+                cursor = await self._db.execute(
+                    f"SELECT run_id, values_data FROM steps WHERE run_id IN ({placeholders}) ORDER BY run_id, {_STEP_TIME_ORDER}",
+                    chunk,
+                )
+                rows = await cursor.fetchall()
+            states.update(self._fold_states(rows))
+        return states
+
+    def get_states_sync(self, run_ids: Sequence[str]) -> dict[str, dict[str, Any]]:
+        """Sync mirror of ``get_states``."""
+        states: dict[str, dict[str, Any]] = {}
+        for chunk in self._chunk_run_ids(run_ids):
+            placeholders = ",".join("?" * len(chunk))
+            with self._sync_lock:
+                rows = (
+                    self._sync_db()
+                    .execute(
+                        f"SELECT run_id, values_data FROM steps WHERE run_id IN ({placeholders}) ORDER BY run_id, {_STEP_TIME_ORDER}",
+                        chunk,
+                    )
+                    .fetchall()
+                )
+            states.update(self._fold_states(rows))
+        return states
+
+    async def get_step_failures(self, run_ids: Sequence[str]) -> dict[str, tuple[str, str | None, int | None]]:
+        """First errored step per run: ``(error, node_name, superstep)``.
+
+        The error text is whatever the step persisted — the privacy-safe
+        projection from ``safe_error_text``, never raw message text.
+        """
+        await self._ensure_db()
+        failures: dict[str, tuple[str, str | None, int | None]] = {}
+        for chunk in self._chunk_run_ids(run_ids):
+            placeholders = ",".join("?" * len(chunk))
+            async with self._txn_lock():
+                cursor = await self._db.execute(
+                    f"SELECT run_id, error, node_name, superstep FROM steps "
+                    f"WHERE run_id IN ({placeholders}) AND error IS NOT NULL ORDER BY run_id, {_STEP_TIME_ORDER}",
+                    chunk,
+                )
+                rows = await cursor.fetchall()
+            _collect_first_failures(rows, failures)
+        return failures
+
+    def get_step_failures_sync(self, run_ids: Sequence[str]) -> dict[str, tuple[str, str | None, int | None]]:
+        """Sync mirror of ``get_step_failures``."""
+        failures: dict[str, tuple[str, str | None, int | None]] = {}
+        for chunk in self._chunk_run_ids(run_ids):
+            placeholders = ",".join("?" * len(chunk))
+            with self._sync_lock:
+                rows = (
+                    self._sync_db()
+                    .execute(
+                        f"SELECT run_id, error, node_name, superstep FROM steps "
+                        f"WHERE run_id IN ({placeholders}) AND error IS NOT NULL ORDER BY run_id, {_STEP_TIME_ORDER}",
+                        chunk,
+                    )
+                    .fetchall()
+                )
+            _collect_first_failures(rows, failures)
+        return failures
 
     async def get_steps(
         self,

--- a/src/hypergraph/host/client.py
+++ b/src/hypergraph/host/client.py
@@ -35,8 +35,11 @@ from hypergraph.host.views import (
     SUBMISSION_STATE_PAUSED,
     TERMINAL_WORKFLOW_STATUSES,
     BatchItemView,
+    BatchOutcome,
     BatchUpdate,
     BatchView,
+    RunFailure,
+    RunOutcome,
     RunQuery,
     RunUpdate,
     RunView,
@@ -217,6 +220,85 @@ def _build_batch_view(
         settled=settled,
         tolerance_tripped=tripped,
         retry_of=batch["retry_of"],
+    )
+
+
+def _started_child_ids(child_rows: dict[str, tuple[dict[str, Any], Run | None]]) -> list[str]:
+    """Workflow ids of children that actually executed.
+
+    Only these have step rows, so only these are worth asking the store
+    about — an unstarted child would cost a placeholder and return nothing.
+    """
+    return [submission["workflow_id"] for submission, run in child_rows.values() if run is not None]
+
+
+def _build_run_outcome(
+    ref: RunRef,
+    submission: dict[str, Any] | None,
+    run: Run | None,
+    state: dict[str, Any] | None,
+    failure: tuple[str, str | None, int | None] | None,
+) -> RunOutcome:
+    """Project one run's durable rows into a ``RunOutcome``.
+
+    ``settled`` routes through the SAME predicate as ``BatchView`` and the
+    rerun gate, so a run is never settled for one reader and in flight for
+    another. Outputs appear only once the run is settled AND started:
+    reporting a partial fold mid-flight would hand a caller a result that
+    can still change.
+    """
+    started = run is not None
+    settled = _child_settled(submission, run) if submission is not None else (run is not None and run.status in TERMINAL_WORKFLOW_STATUSES)
+    outputs = (state or {}) if (settled and started) else None
+    run_failure = None
+    if failure is not None and settled:
+        error, node_name, superstep = failure
+        run_failure = RunFailure(error=error, node_name=node_name, superstep=superstep)
+    return RunOutcome(
+        run_ref=ref,
+        workflow_id=ref.run_id,
+        status=run.status if run is not None else None,
+        settled=settled,
+        started=started,
+        outputs=outputs,
+        failure=run_failure,
+    )
+
+
+def _build_batch_outcome(
+    ref: BatchRef,
+    batch: dict[str, Any],
+    child_rows: dict[str, tuple[dict[str, Any], Run | None]],
+    home_uri: str,
+    states: dict[str, dict[str, Any]],
+    failures: dict[str, tuple[str, str | None, int | None]],
+) -> BatchOutcome:
+    """Project every child into a ``RunOutcome``, keyed in manifest order.
+
+    A child that never executed maps to None rather than an empty outcome:
+    Hypergraph does not fabricate results for work that did not run, and
+    that has to stay distinguishable from a child that ran and produced
+    nothing (``outputs == {}``).
+    """
+    items: dict[str, RunOutcome | None] = {}
+    for key in json.loads(batch["items_json"]):
+        submission, run = child_rows[key]
+        if run is None:
+            items[key] = None
+            continue
+        workflow_id = submission["workflow_id"]
+        items[key] = _build_run_outcome(
+            RunRef(home=home_uri, run_id=workflow_id),
+            submission,
+            run,
+            states.get(workflow_id),
+            failures.get(workflow_id),
+        )
+    return BatchOutcome(
+        batch_ref=ref,
+        workflow_id=batch["workflow_id"],
+        settled=all(_child_settled(submission, run) for submission, run in child_rows.values()),
+        items=items,
     )
 
 
@@ -591,6 +673,89 @@ class RunHomeClient:
         submission = self._home._get_submission_sync(ref.run_id)
         run = self._home.get_run(ref.run_id)
         return _build_view(self._home.uri, ref.run_id, submission, run, admission_full=self._home._admission_is_full_sync())
+
+    async def result(self, ref: RunRef | BatchRef) -> RunOutcome | BatchOutcome | None:
+        """Return what ``ref`` durably produced, or None if unknown.
+
+        Accepts a ``RunRef`` (→ ``RunOutcome``) or a ``BatchRef`` (→
+        ``BatchOutcome`` keyed by logical item key, in manifest order).
+
+        The host worker keeps no ``RunResult``, so outputs are reconstructed
+        from the checkpointer rows that already back resume — the run's steps
+        folded in execution order. No graph code is loaded, and no second
+        store exists. See :class:`~hypergraph.host.views.RunOutcome` for the
+        four states a caller must distinguish (unknown, unsettled,
+        stopped-before-start, ran-and-produced-nothing) and for the two
+        caveats on ``outputs``: they are folded step outputs rather than the
+        graph's declared outputs, and their JSON-safety comes from the Home's
+        default ``JsonSerializer``.
+
+        Failure evidence is the privacy-safe projection the step persisted,
+        never raw exception text — the real message and traceback go to the
+        OpenTelemetry export instead.
+
+        A Batch reads in a bounded number of statements regardless of child
+        count, so 100+ children stay a handful of queries.
+        """
+        if isinstance(ref, BatchRef):
+            batch = await self._home._get_batch(ref.batch_id)
+            if batch is None:
+                return None
+            child_rows = await self._home._batch_child_rows(ref.batch_id)
+            started = _started_child_ids(child_rows)
+            return _build_batch_outcome(
+                ref,
+                batch,
+                child_rows,
+                self._home.uri,
+                await self._home.get_states(started),
+                await self._home.get_step_failures(started),
+            )
+        if not isinstance(ref, RunRef):
+            raise TypeError(f"result() expects a RunRef or BatchRef, got {type(ref).__name__}.")
+        submission = await self._home._get_submission(ref.run_id)
+        run = await self._home.get_run_async(ref.run_id)
+        if submission is None and run is None:
+            return None
+        run_ids = [ref.run_id] if run is not None else []
+        return _build_run_outcome(
+            ref,
+            submission,
+            run,
+            (await self._home.get_states(run_ids)).get(ref.run_id),
+            (await self._home.get_step_failures(run_ids)).get(ref.run_id),
+        )
+
+    def result_sync(self, ref: RunRef | BatchRef) -> RunOutcome | BatchOutcome | None:
+        """Sync mirror of ``result``."""
+        if isinstance(ref, BatchRef):
+            batch = self._home._get_batch_sync(ref.batch_id)
+            if batch is None:
+                return None
+            child_rows = self._home._batch_child_rows_sync(ref.batch_id)
+            started = _started_child_ids(child_rows)
+            return _build_batch_outcome(
+                ref,
+                batch,
+                child_rows,
+                self._home.uri,
+                self._home.get_states_sync(started),
+                self._home.get_step_failures_sync(started),
+            )
+        if not isinstance(ref, RunRef):
+            raise TypeError(f"result() expects a RunRef or BatchRef, got {type(ref).__name__}.")
+        submission = self._home._get_submission_sync(ref.run_id)
+        run = self._home.get_run(ref.run_id)
+        if submission is None and run is None:
+            return None
+        run_ids = [ref.run_id] if run is not None else []
+        return _build_run_outcome(
+            ref,
+            submission,
+            run,
+            self._home.get_states_sync(run_ids).get(ref.run_id),
+            self._home.get_step_failures_sync(run_ids).get(ref.run_id),
+        )
 
     async def stop(self, ref: RunRef | BatchRef, *, info: Any = None, source_ref: str | None = None) -> CommandReceipt | BatchCommandReceipt:
         """Record a durable stop command for ``ref``.

--- a/src/hypergraph/host/client.py
+++ b/src/hypergraph/host/client.py
@@ -233,7 +233,8 @@ def _started_child_ids(child_rows: dict[str, tuple[dict[str, Any], Run | None]])
 
 
 def _build_run_outcome(
-    ref: RunRef,
+    home_uri: str,
+    run_id: str,
     submission: dict[str, Any] | None,
     run: Run | None,
     state: dict[str, Any] | None,
@@ -243,7 +244,9 @@ def _build_run_outcome(
 
     ``settled`` routes through the SAME predicate as ``BatchView`` and the
     rerun gate, so a run is never settled for one reader and in flight for
-    another. Outputs appear only once the run is settled AND started:
+    another. The returned ref is rebuilt from THIS Home's uri, exactly as
+    ``_build_view`` does: an outcome must never claim a foreign home while
+    carrying rows this Home returned. Outputs appear only once the run is settled AND started:
     reporting a partial fold mid-flight would hand a caller a result that
     can still change.
     """
@@ -255,8 +258,8 @@ def _build_run_outcome(
         error, node_name, superstep = failure
         run_failure = RunFailure(error=error, node_name=node_name, superstep=superstep)
     return RunOutcome(
-        run_ref=ref,
-        workflow_id=ref.run_id,
+        run_ref=RunRef(home=home_uri, run_id=run_id),
+        workflow_id=run_id,
         status=run.status if run is not None else None,
         settled=settled,
         started=started,
@@ -266,7 +269,6 @@ def _build_run_outcome(
 
 
 def _build_batch_outcome(
-    ref: BatchRef,
     batch: dict[str, Any],
     child_rows: dict[str, tuple[dict[str, Any], Run | None]],
     home_uri: str,
@@ -288,14 +290,15 @@ def _build_batch_outcome(
             continue
         workflow_id = submission["workflow_id"]
         items[key] = _build_run_outcome(
-            RunRef(home=home_uri, run_id=workflow_id),
+            home_uri,
+            workflow_id,
             submission,
             run,
             states.get(workflow_id),
             failures.get(workflow_id),
         )
     return BatchOutcome(
-        batch_ref=ref,
+        batch_ref=BatchRef(home=home_uri, batch_id=batch["batch_id"]),
         workflow_id=batch["workflow_id"],
         settled=all(_child_settled(submission, run) for submission, run in child_rows.values()),
         items=items,
@@ -704,7 +707,6 @@ class RunHomeClient:
             child_rows = await self._home._batch_child_rows(ref.batch_id)
             started = _started_child_ids(child_rows)
             return _build_batch_outcome(
-                ref,
                 batch,
                 child_rows,
                 self._home.uri,
@@ -719,7 +721,8 @@ class RunHomeClient:
             return None
         run_ids = [ref.run_id] if run is not None else []
         return _build_run_outcome(
-            ref,
+            self._home.uri,
+            ref.run_id,
             submission,
             run,
             (await self._home.get_states(run_ids)).get(ref.run_id),
@@ -735,7 +738,6 @@ class RunHomeClient:
             child_rows = self._home._batch_child_rows_sync(ref.batch_id)
             started = _started_child_ids(child_rows)
             return _build_batch_outcome(
-                ref,
                 batch,
                 child_rows,
                 self._home.uri,
@@ -750,7 +752,8 @@ class RunHomeClient:
             return None
         run_ids = [ref.run_id] if run is not None else []
         return _build_run_outcome(
-            ref,
+            self._home.uri,
+            ref.run_id,
             submission,
             run,
             self._home.get_states_sync(run_ids).get(ref.run_id),

--- a/src/hypergraph/host/views.py
+++ b/src/hypergraph/host/views.py
@@ -6,6 +6,7 @@ condition — it is never a ``WorkflowStatus`` and never enters the run row.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from datetime import timedelta
 from enum import Enum
@@ -424,3 +425,152 @@ class BatchUpdate:
     kind: str
     payload: dict[str, Any] = field(default_factory=dict)
     timestamp: str = ""
+
+
+@dataclass(frozen=True)
+class RunFailure:
+    """Why a settled Run failed, from durable evidence only.
+
+    ``error`` is the privacy-safe projection the step persisted — an
+    exception type name, a stable ``HG_*`` diagnostic code, and static
+    wording. It is never raw exception message text: Hypergraph does not
+    persist that (see the privacy boundary in
+    ``docs/06-api-reference/errors.md``). The real message, type and
+    traceback are exported to the OpenTelemetry trace instead, so a failure
+    is debugged there and merely *identified* here.
+
+    Attributes:
+        error: Privacy-safe error projection from the first failed step.
+        node_name: Node that raised it, when a step recorded one.
+        superstep: Superstep the failure happened in, when recorded.
+    """
+
+    error: str
+    node_name: str | None = None
+    superstep: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """JSON-safe dict of primitives."""
+        return {"error": self.error, "node_name": self.node_name, "superstep": self.superstep}
+
+
+@dataclass(frozen=True)
+class RunOutcome:
+    """What a Run durably produced — outputs or failure — with no graph code.
+
+    Read with ``RunHomeClient.result(run_ref)``. The host worker keeps no
+    ``RunResult``, so this is reconstructed from the same checkpointer rows
+    that back resume: the run's steps folded in execution order.
+
+    Four states a caller must be able to tell apart, and how each reads:
+
+    ==============================  ========  =========  ==========  =======
+    situation                       result()  ``started``  ``settled``  ``outputs``
+    ==============================  ========  =========  ==========  =======
+    never submitted here            ``None``  --         --          --
+    submitted, still in flight      outcome   any        False       ``None``
+    stopped/closed before starting  outcome   False      True        ``None``
+    ran and produced nothing        outcome   True       True        ``{}``
+    ==============================  ========  =========  ==========  =======
+
+    So ``outputs is None`` never means "produced nothing" — that is ``{}``.
+
+    Two honest caveats:
+
+    * ``outputs`` is the run's FOLDED STEP OUTPUTS, not a projection
+      narrowed to the graph's declared outputs. Narrowing needs the
+      ``Graph`` object, and this client is graph-free by contract, so it
+      reports every value the run's steps produced rather than guessing.
+    * The values are JSON-safe because the Run Home's checkpointer defaults
+      to ``JsonSerializer``, which round-trips through ``json``. A Home
+      explicitly configured with ``PickleSerializer`` returns whatever it
+      stored, and ``to_dict()`` falls back to ``repr`` for anything that
+      will not serialize.
+
+    Attributes:
+        run_ref: Inert address of the Run.
+        workflow_id: The Run's workflow id (same as ``run_ref.run_id``).
+        status: The run's ``WorkflowStatus``, or None while it has no runs
+            row (accepted but never started).
+        settled: True when the Run can never change outcome again. A paused
+            Run is NOT settled — an outstanding answer can still change it.
+        started: Whether the Run ever began executing (it has a runs row).
+            False separates "requested but never admitted" from "ran and
+            produced nothing".
+        outputs: Folded step outputs once settled and started, else None.
+        failure: Durable failure evidence when the Run failed, else None.
+    """
+
+    run_ref: RunRef
+    workflow_id: str
+    status: WorkflowStatus | None
+    settled: bool
+    started: bool
+    outputs: dict[str, Any] | None = None
+    failure: RunFailure | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """JSON-safe dict of primitives, for transport straight to an API."""
+        return {
+            "workflow_id": self.workflow_id,
+            "status": self.status.value if self.status is not None else None,
+            "settled": self.settled,
+            "started": self.started,
+            "outputs": None if self.outputs is None else json.loads(json.dumps(self.outputs, default=repr)),
+            "failure": self.failure.to_dict() if self.failure is not None else None,
+        }
+
+    def __repr__(self) -> str:
+        status = self.status.value if self.status is not None else ("unstarted" if self.settled else "pending")
+        parts = [f"RunOutcome: {self.workflow_id}", status]
+        if self.outputs is not None:
+            parts.append(f"{len(self.outputs)} values")
+        if self.failure is not None:
+            parts.append(f"error: {self.failure.error[:60]}")
+        return " | ".join(parts)
+
+
+@dataclass(frozen=True)
+class BatchOutcome:
+    """Every child's :class:`RunOutcome`, keyed by logical item key.
+
+    Read with ``RunHomeClient.result(batch_ref)``. One read per Batch, not
+    one per child: the children's outputs and failures are folded in a
+    bounded number of statements, so a 100+ item Batch stays a handful of
+    queries.
+
+    An item whose child never executed maps to ``None`` — Hypergraph never
+    fabricates a result for work that did not run. That is deliberately
+    distinct from a child that ran and produced nothing, which maps to a
+    ``RunOutcome`` with ``outputs == {}``.
+
+    Attributes:
+        batch_ref: Inert address of the Batch.
+        workflow_id: The Batch's caller-chosen workflow id.
+        settled: True when no child is active, paused, or queued.
+        items: Logical item key → ``RunOutcome``, or None for a child that
+            never started, in immutable manifest order.
+    """
+
+    batch_ref: BatchRef
+    workflow_id: str
+    settled: bool
+    items: dict[str, RunOutcome | None] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """JSON-safe dict of primitives, for transport straight to an API."""
+        return {
+            "workflow_id": self.workflow_id,
+            "settled": self.settled,
+            "items": {key: None if outcome is None else outcome.to_dict() for key, outcome in self.items.items()},
+        }
+
+    def __repr__(self) -> str:
+        started = sum(1 for outcome in self.items.values() if outcome is not None)
+        return " | ".join(
+            [
+                f"BatchOutcome: {self.workflow_id}",
+                "settled" if self.settled else "in flight",
+                f"{started}/{len(self.items)} items ran",
+            ]
+        )

--- a/tests/test_host/test_durable_result_projection.py
+++ b/tests/test_host/test_durable_result_projection.py
@@ -1,0 +1,456 @@
+"""``RunHomeClient.result`` — what a settled Run durably produced.
+
+The host worker discards the runner's ``RunResult``, so before this there
+was no way to read back what durable work produced without loading graph
+code and re-deriving it. ``result()`` reconstructs outputs from the same
+checkpointer rows that back resume.
+
+Pinned here: the four states a caller must tell apart (unknown, unsettled,
+stopped-before-start, ran-and-produced-nothing), privacy-safe failure
+evidence, keyed Batch reads in manifest order with no fabricated results
+for items that never ran, a bounded query count for 100+ children,
+crash-recovered and rerun-lineage runs, sync/async parity, and JSON-safe
+transport.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+
+import pytest
+import pytest_asyncio
+
+from hypergraph import (
+    BatchRef,
+    BatchTolerance,
+    Graph,
+    RunHome,
+    RunHomeClient,
+    RunRef,
+    SyncRunner,
+    node,
+    serve,
+)
+from hypergraph.checkpointers.types import StepRecord, StepStatus, WorkflowStatus
+from hypergraph.host.views import BatchOutcome, RunFailure, RunOutcome
+from tests.test_host._batch_api import serve_graphs, submit_keyed
+
+aiosqlite = pytest.importorskip("aiosqlite")
+
+SECRET = "sk-live-RESULT-9182"
+
+
+@node(output_name="doubled")
+def double(x: int, item: str = "") -> int:
+    return x * 2
+
+
+@node(output_name="tripled")
+def triple(doubled: int) -> int:
+    return doubled * 3
+
+
+@node
+def side_effect_only(x: int, item: str = "") -> None:
+    """Runs, produces no values — the ``outputs == {}`` case."""
+
+
+@node(output_name="out")
+def leaky(x: int, item: str = "") -> int:
+    if x == 1:
+        raise ValueError(f"token {SECRET} rejected")
+    return x * 10
+
+
+def _chain_graph(name: str = "chain") -> Graph:
+    return Graph([double, triple], name=name).with_runner(SyncRunner())
+
+
+def _empty_graph(name: str = "quiet") -> Graph:
+    return Graph([side_effect_only], name=name).with_runner(SyncRunner())
+
+
+def _leaky_graph(name: str = "leaky") -> Graph:
+    return Graph([leaky], name=name).with_runner(SyncRunner())
+
+
+@pytest_asyncio.fixture
+async def home(tmp_path):
+    h = RunHome.open(f"file:{tmp_path / 'runs.db'}")
+    yield h
+    await h.close()
+
+
+@contextlib.asynccontextmanager
+async def _worker(host, worker_id: str = "w-result", **kwargs):
+    task = asyncio.create_task(host.work_forever(worker_id, **kwargs))
+    try:
+        yield task
+    finally:
+        host.shutdown()
+        await asyncio.wait_for(task, timeout=20)
+
+
+async def _wait_for(check, timeout: float = 15.0, interval: float = 0.02):
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while True:
+        value = await check()
+        if value:
+            return value
+        if loop.time() > deadline:
+            raise AssertionError("timed out waiting for condition")
+        await asyncio.sleep(interval)
+
+
+async def _settled(client, ref):
+    """Poll until the ref can no longer change outcome (Run or Batch)."""
+    outcome = await client.result(ref)
+    return outcome if outcome is not None and outcome.settled else None
+
+
+class TestRunOutcome:
+    async def test_unknown_ref_is_none(self, home):
+        client = RunHomeClient(home)
+        assert await client.result(RunRef(home=home.uri, run_id="never-submitted")) is None
+        assert await client.result(BatchRef(home=home.uri, batch_id="no-such-batch")) is None
+
+    async def test_completed_run_reports_its_folded_outputs(self, home):
+        host, served = serve_graphs(_chain_graph(), home=home)
+        receipt = await host.submit(served["chain"], {"x": 4}, workflow_id="wf-ok")
+        async with _worker(host):
+            await _wait_for(lambda: _settled(RunHomeClient(home), receipt.run_ref))
+
+        outcome = await RunHomeClient(home).result(receipt.run_ref)
+        assert isinstance(outcome, RunOutcome)
+        assert outcome.workflow_id == "wf-ok"
+        assert outcome.status is WorkflowStatus.COMPLETED
+        assert outcome.settled is True
+        assert outcome.started is True
+        assert outcome.failure is None
+        # Folded step outputs: every value the run's steps produced.
+        assert outcome.outputs == {"doubled": 8, "tripled": 24}
+
+    async def test_unsettled_run_withholds_outputs(self, home):
+        host, served = serve_graphs(_chain_graph(), home=home)
+        receipt = await host.submit(served["chain"], {"x": 4}, workflow_id="wf-pending")
+
+        # Accepted, never claimed — no worker has run.
+        outcome = await RunHomeClient(home).result(receipt.run_ref)
+        assert outcome is not None
+        assert outcome.settled is False
+        assert outcome.started is False
+        assert outcome.status is None
+        assert outcome.outputs is None, "a result that can still change is never reported"
+
+    async def test_stopped_before_start_is_settled_but_never_started(self, home):
+        host, served = serve_graphs(_chain_graph(), home=home)
+        receipt = await host.submit(served["chain"], {"x": 4}, workflow_id="wf-stopped")
+        await RunHomeClient(home).stop(receipt.run_ref)
+        async with _worker(host):
+            await _wait_for(lambda: _settled(RunHomeClient(home), receipt.run_ref))
+
+        outcome = await RunHomeClient(home).result(receipt.run_ref)
+        assert outcome is not None
+        assert outcome.settled is True
+        assert outcome.started is False, "it never executed"
+        assert outcome.outputs is None, "None is 'never ran', not 'produced nothing'"
+
+    async def test_run_that_produced_nothing_reports_empty_outputs(self, home):
+        host, served = serve_graphs(_empty_graph(), home=home)
+        receipt = await host.submit(served["quiet"], {"x": 4}, workflow_id="wf-quiet")
+        async with _worker(host):
+            await _wait_for(lambda: _settled(RunHomeClient(home), receipt.run_ref))
+
+        outcome = await RunHomeClient(home).result(receipt.run_ref)
+        assert outcome is not None
+        assert outcome.settled is True
+        assert outcome.started is True
+        assert outcome.outputs == {}, "ran and produced nothing is {}, never None"
+        assert outcome.outputs is not None
+
+    async def test_the_four_states_are_mutually_distinguishable(self, home):
+        """The whole point: no two of them read the same."""
+        host, served = serve_graphs(_chain_graph(), _empty_graph(), home=home)
+        stopped = await host.submit(served["chain"], {"x": 2}, workflow_id="wf-4-stopped")
+        await RunHomeClient(home).stop(stopped.run_ref)
+        quiet = await host.submit(served["quiet"], {"x": 3}, workflow_id="wf-4-quiet")
+
+        async with _worker(host):
+            await _wait_for(lambda: _settled(RunHomeClient(home), quiet.run_ref))
+            await _wait_for(lambda: _settled(RunHomeClient(home), stopped.run_ref))
+
+        # Submitted with no worker left to claim it: genuinely in flight.
+        pending = await host.submit(served["chain"], {"x": 1}, workflow_id="wf-4-pending")
+
+        client = RunHomeClient(home)
+        unknown = await client.result(RunRef(home=home.uri, run_id="wf-4-nope"))
+        readings = {
+            "unknown": unknown,
+            "unsettled": await client.result(pending.run_ref),
+            "stopped_before_start": await client.result(stopped.run_ref),
+            "produced_nothing": await client.result(quiet.run_ref),
+        }
+        assert readings["unknown"] is None
+        assert (readings["unsettled"].settled, readings["unsettled"].outputs) == (False, None)
+        assert (readings["stopped_before_start"].started, readings["stopped_before_start"].outputs) == (False, None)
+        assert (readings["produced_nothing"].started, readings["produced_nothing"].outputs) == (True, {})
+
+
+class TestFailureEvidence:
+    async def test_failed_run_reports_privacy_safe_evidence(self, home):
+        host, served = serve_graphs(_leaky_graph(), home=home)
+        receipt = await host.submit(served["leaky"], {"x": 1}, workflow_id="wf-fail")
+        async with _worker(host):
+            await _wait_for(lambda: _settled(RunHomeClient(home), receipt.run_ref))
+
+        outcome = await RunHomeClient(home).result(receipt.run_ref)
+        assert outcome is not None
+        assert outcome.status is WorkflowStatus.FAILED
+        assert outcome.settled is True
+        assert isinstance(outcome.failure, RunFailure)
+        assert outcome.failure.node_name == "leaky"
+        assert outcome.failure.superstep == 0
+        assert "ValueError" in outcome.failure.error
+        assert SECRET not in outcome.failure.error, "durable failure evidence is the safe projection"
+        assert SECRET not in json.dumps(outcome.to_dict())
+
+    async def test_completed_run_has_no_failure(self, home):
+        host, served = serve_graphs(_leaky_graph(), home=home)
+        receipt = await host.submit(served["leaky"], {"x": 2}, workflow_id="wf-pass")
+        async with _worker(host):
+            await _wait_for(lambda: _settled(RunHomeClient(home), receipt.run_ref))
+
+        outcome = await RunHomeClient(home).result(receipt.run_ref)
+        assert outcome is not None and outcome.failure is None
+        assert outcome.outputs == {"out": 20}
+
+
+class TestBatchOutcome:
+    async def test_items_are_keyed_in_manifest_order(self, home):
+        host, served = serve_graphs(_chain_graph(), home=home)
+        manifest = {"p-2": {"x": 2}, "p-1": {"x": 1}, "p-3": {"x": 3}}
+        receipt = await submit_keyed(host, served["chain"], manifest, workflow_id="drop-order")
+        async with _worker(host):
+            await _wait_for(lambda: _settled(RunHomeClient(home), receipt.batch_ref))
+
+        outcome = await RunHomeClient(home).result(receipt.batch_ref)
+        assert isinstance(outcome, BatchOutcome)
+        assert outcome.workflow_id == "drop-order"
+        assert outcome.settled is True
+        assert list(outcome.items) == ["p-2", "p-1", "p-3"], "manifest order, not completion order"
+        assert outcome.items["p-1"].outputs == {"doubled": 2, "tripled": 6}
+        assert outcome.items["p-2"].outputs == {"doubled": 4, "tripled": 12}
+        assert outcome.items["p-3"].outputs == {"doubled": 6, "tripled": 18}
+
+    async def test_unstarted_items_have_no_fabricated_result(self, home):
+        host, served = serve_graphs(_chain_graph(), home=home)
+        receipt = await submit_keyed(host, served["chain"], {"a": {"x": 1}, "b": {"x": 2}}, workflow_id="drop-stopped")
+        await RunHomeClient(home).stop(receipt.batch_ref)
+        async with _worker(host):
+            await _wait_for(lambda: _settled(RunHomeClient(home), receipt.batch_ref))
+
+        outcome = await RunHomeClient(home).result(receipt.batch_ref)
+        view = await RunHomeClient(home).get(receipt.batch_ref)
+        assert set(view.unstarted_items), "the scenario must actually produce unstarted items"
+        for key in view.unstarted_items:
+            assert outcome.items[key] is None, "an item that never ran has no result, not an empty one"
+
+    async def test_mixed_batch_separates_outputs_from_failures(self, home):
+        host, served = serve_graphs(_leaky_graph(), home=home)
+        receipt = await submit_keyed(
+            host,
+            served["leaky"],
+            {"ok": {"x": 2}, "bad": {"x": 1}},
+            workflow_id="drop-mixed",
+            tolerance=BatchTolerance(max_failed=5),
+        )
+        async with _worker(host):
+            await _wait_for(lambda: _settled(RunHomeClient(home), receipt.batch_ref))
+
+        outcome = await RunHomeClient(home).result(receipt.batch_ref)
+        assert outcome.items["ok"].outputs == {"out": 20}
+        assert outcome.items["ok"].failure is None
+        assert outcome.items["bad"].failure is not None
+        assert SECRET not in outcome.items["bad"].failure.error
+        assert outcome.items["bad"].status is WorkflowStatus.FAILED
+
+    async def test_hundred_children_read_in_a_bounded_number_of_queries(self, home):
+        """One read per Batch, not one per child."""
+        host, served = serve_graphs(_chain_graph(), home=home)
+        manifest = {f"p-{i}": {"x": i} for i in range(120)}
+        receipt = await submit_keyed(host, served["chain"], manifest, workflow_id="drop-big")
+        async with _worker(host):
+            await _wait_for(lambda: _settled(RunHomeClient(home), receipt.batch_ref), timeout=90.0)
+
+        client = RunHomeClient(home)
+        calls: list[str] = []
+        real_states, real_failures = home.get_states, home.get_step_failures
+
+        async def counted_states(run_ids):
+            calls.append("states")
+            return await real_states(run_ids)
+
+        async def counted_failures(run_ids):
+            calls.append("failures")
+            return await real_failures(run_ids)
+
+        home.get_states, home.get_step_failures = counted_states, counted_failures
+        try:
+            outcome = await client.result(receipt.batch_ref)
+        finally:
+            home.get_states, home.get_step_failures = real_states, real_failures
+
+        assert len(outcome.items) == 120
+        assert all(item is not None and item.outputs for item in outcome.items.values())
+        assert len(calls) == 2, f"expected one batched read each, got {calls}"
+
+
+class TestLineageAndRecovery:
+    async def test_rerun_lineage_reads_each_generation_independently(self, home):
+        """Rerun repeats inputs verbatim, so the fix has to be transient."""
+        attempts: dict[str, int] = {"n": 0}
+
+        @node(output_name="out")
+        def flaky(x: int) -> int:
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                raise ValueError(f"transient {SECRET} outage")
+            return x * 10
+
+        graph = Graph([flaky], name="flaky").with_runner(SyncRunner())
+        host = serve(graph, home=home)
+        first = await host.submit(graph, {"x": 2}, workflow_id="wf-gen-1")
+        async with _worker(host):
+            await _wait_for(lambda: _settled(RunHomeClient(home), first.run_ref))
+
+        client = RunHomeClient(home)
+        failed = await client.result(first.run_ref)
+        assert failed.status is WorkflowStatus.FAILED
+        assert failed.failure is not None and SECRET not in failed.failure.error
+
+        # Repetition under a fresh workflow id, same inputs (A16).
+        retry = await client.rerun(first.run_ref)
+        async with _worker(host):
+            await _wait_for(lambda: _settled(RunHomeClient(home), retry.run_ref))
+
+        repeated = await client.result(retry.run_ref)
+        assert repeated.workflow_id != failed.workflow_id
+        assert repeated.status is WorkflowStatus.COMPLETED
+        assert repeated.outputs == {"out": 20}
+        assert repeated.failure is None
+        # The source generation is untouched by its own repetition.
+        still_failed = await client.result(first.run_ref)
+        assert still_failed.status is WorkflowStatus.FAILED
+        assert still_failed.failure is not None
+        assert still_failed.outputs == {}, "the failed run committed no step values"
+
+    async def test_crash_recovered_run_folds_pre_and_post_crash_steps(self, home):
+        """A run whose steps span two worker generations reads as one result.
+
+        Staged the way ticket-04 stages a lost process: the dead worker's
+        committed step is already in the store, its submission is still
+        ``claimed``, and the restart scan re-adopts it. The resumed run must
+        NOT re-execute the committed step, and ``result()`` must fold what
+        both generations produced into one outputs dict.
+        """
+        ran: dict[str, int] = {"first": 0, "second": 0}
+
+        @node(output_name="first")
+        def first_step(x: int) -> int:
+            ran["first"] += 1
+            return x + 1
+
+        @node(output_name="second")
+        def second_step(first: int) -> int:
+            ran["second"] += 1
+            return first * 2
+
+        graph = Graph([first_step, second_step], name="crashy").with_runner(SyncRunner())
+        host = serve(graph, home=home)
+        receipt = await host.submit(graph, {"x": 5}, workflow_id="wf-crash")
+
+        # The dead process's committed work, and the claim it never released.
+        home.create_run_sync("wf-crash", graph_name="crashy")
+        home.save_step_sync(
+            StepRecord(
+                run_id="wf-crash",
+                superstep=0,
+                node_name="first_step",
+                index=0,
+                status=StepStatus.COMPLETED,
+                input_versions={},
+                values={"first": 6},
+            )
+        )
+        db = home._sync_db()
+        db.execute("UPDATE host_submissions SET state = 'claimed' WHERE workflow_id = 'wf-crash'")
+        db.commit()
+
+        await home._restart_scan()
+        assert home._get_submission_sync("wf-crash")["state"] == "pending", "the orphan must be re-adopted"
+
+        async with _worker(host, worker_id="w-recovered"):
+            await _wait_for(lambda: _settled(RunHomeClient(home), receipt.run_ref), timeout=30.0)
+
+        outcome = await RunHomeClient(home).result(receipt.run_ref)
+        assert outcome.settled is True
+        assert outcome.started is True
+        assert outcome.status is WorkflowStatus.COMPLETED
+        assert outcome.outputs == {"first": 6, "second": 12}, "pre-crash and post-recovery steps fold together"
+        assert ran["first"] == 0, "the committed step must be resumed, never re-executed"
+        assert ran["second"] == 1
+
+
+async def _flag(event: asyncio.Event):
+    return event.is_set()
+
+
+class TestTransportAndParity:
+    async def test_to_dict_is_json_safe_primitives(self, home):
+        host, served = serve_graphs(_chain_graph(), home=home)
+        receipt = await host.submit(served["chain"], {"x": 4}, workflow_id="wf-json")
+        async with _worker(host):
+            await _wait_for(lambda: _settled(RunHomeClient(home), receipt.run_ref))
+
+        outcome = await RunHomeClient(home).result(receipt.run_ref)
+        payload = outcome.to_dict()
+        assert json.loads(json.dumps(payload)) == payload
+        assert payload["status"] == "completed"
+        assert payload["outputs"] == {"doubled": 8, "tripled": 24}
+        assert payload["failure"] is None
+
+    async def test_batch_to_dict_keeps_none_for_unstarted(self, home):
+        host, served = serve_graphs(_chain_graph(), home=home)
+        receipt = await submit_keyed(host, served["chain"], {"a": {"x": 1}, "b": {"x": 2}}, workflow_id="drop-json")
+        await RunHomeClient(home).stop(receipt.batch_ref)
+        async with _worker(host):
+            await _wait_for(lambda: _settled(RunHomeClient(home), receipt.batch_ref))
+
+        payload = (await RunHomeClient(home).result(receipt.batch_ref)).to_dict()
+        assert json.loads(json.dumps(payload)) == payload
+        view = await RunHomeClient(home).get(receipt.batch_ref)
+        for key in view.unstarted_items:
+            assert payload["items"][key] is None
+
+    async def test_sync_mirror_matches_async(self, home):
+        host, served = serve_graphs(_chain_graph(), home=home)
+        run = await host.submit(served["chain"], {"x": 4}, workflow_id="wf-parity")
+        batch = await submit_keyed(host, served["chain"], {"a": {"x": 1}}, workflow_id="drop-parity")
+        async with _worker(host):
+            await _wait_for(lambda: _settled(RunHomeClient(home), run.run_ref))
+            await _wait_for(lambda: _settled(RunHomeClient(home), batch.batch_ref))
+
+        client = RunHomeClient(home)
+        assert (await client.result(run.run_ref)).to_dict() == client.result_sync(run.run_ref).to_dict()
+        assert (await client.result(batch.batch_ref)).to_dict() == client.result_sync(batch.batch_ref).to_dict()
+        assert client.result_sync(RunRef(home=home.uri, run_id="nope")) is None
+
+    async def test_wrong_ref_type_is_refused(self, home):
+        client = RunHomeClient(home)
+        with pytest.raises(TypeError, match="expects a RunRef or BatchRef"):
+            await client.result("wf-not-a-ref")
+        with pytest.raises(TypeError, match="expects a RunRef or BatchRef"):
+            client.result_sync(42)

--- a/tests/test_host/test_durable_result_projection.py
+++ b/tests/test_host/test_durable_result_projection.py
@@ -448,6 +448,30 @@ class TestTransportAndParity:
         assert (await client.result(batch.batch_ref)).to_dict() == client.result_sync(batch.batch_ref).to_dict()
         assert client.result_sync(RunRef(home=home.uri, run_id="nope")) is None
 
+    async def test_returned_refs_name_this_home_not_the_callers(self, home):
+        """An outcome must never claim a foreign home while carrying our rows.
+
+        Refs are inert addresses, so a ref minted against another Home can be
+        handed to this client. Every other builder rebuilds the ref from THIS
+        Home's uri; ``result`` does the same.
+        """
+        host, served = serve_graphs(_chain_graph(), home=home)
+        run = await host.submit(served["chain"], {"x": 4}, workflow_id="wf-home")
+        batch = await submit_keyed(host, served["chain"], {"a": {"x": 1}}, workflow_id="drop-home")
+        async with _worker(host):
+            await _wait_for(lambda: _settled(RunHomeClient(home), run.run_ref))
+            await _wait_for(lambda: _settled(RunHomeClient(home), batch.batch_ref))
+
+        client = RunHomeClient(home)
+        foreign_run = RunRef(home="file:/somewhere/else.db", run_id="wf-home")
+        foreign_batch = BatchRef(home="file:/somewhere/else.db", batch_id=batch.batch_ref.batch_id)
+
+        outcome = await client.result(foreign_run)
+        assert outcome.run_ref.home == home.uri
+        batch_outcome = await client.result(foreign_batch)
+        assert batch_outcome.batch_ref.home == home.uri
+        assert all(item.run_ref.home == home.uri for item in batch_outcome.items.values() if item is not None)
+
     async def test_wrong_ref_type_is_refused(self, home):
         client = RunHomeClient(home)
         with pytest.raises(TypeError, match="expects a RunRef or BatchRef"):


### PR DESCRIPTION
Closes the known durable-result gap: the host worker discards the runner's `RunResult`, so after a Run settled there was no way to read what it produced without loading graph code and re-deriving it, or keeping a side store.

`client.result(ref)` reconstructs outputs from the same checkpointer rows that already back resume — the run's steps folded in execution order. **No graph code, no second store.**

## API

```python
outcome = await client.result(receipt.run_ref)   # RunOutcome | None
outcome.status                                   # WorkflowStatus | None
outcome.outputs                                  # dict | None
outcome.failure                                  # RunFailure | None
outcome.to_dict()                                # JSON-safe primitives

batch = await client.result(receipt.batch_ref)   # BatchOutcome | None
batch.items                                      # item_key -> RunOutcome | None
```

`result_sync()` is the synchronous mirror, following the client's existing async-canonical / `X_sync` convention. Both accept either ref type, exactly like `get()`/`stop()`/`watch()`.

## The four states, mutually distinguishable

| situation | `result()` | `started` | `settled` | `outputs` |
| --- | --- | --- | --- | --- |
| never submitted here | `None` | — | — | — |
| submitted, still in flight | outcome | any | `False` | `None` |
| stopped/closed before starting | outcome | `False` | `True` | `None` |
| ran and produced nothing | outcome | `True` | `True` | `{}` |

So `outputs is None` never means "produced nothing" — that is `{}`. `settled` routes through the **same** `is_child_settled` rule as `BatchView` and the rerun gate, so a Run is never settled for one reader and in flight for another.

## Batch

`items` is keyed by logical item key in **manifest order** — completion order never changes result identity. An item whose child never executed maps to `None`: Hypergraph does not fabricate results for work that did not run, and that stays distinct from a child that ran and produced nothing.

Children are read through two new batched store reads (`get_states`, `get_step_failures`, both with sync mirrors) instead of one round trip per child, chunked under the SQLite variable limit. A 120-child Batch is **two queries**, pinned by a test that counts them.

## Failure evidence — Option A, as decided

`RunFailure` carries the privacy-safe projection the step persisted (exception type name, stable `HG_*` code, static wording) plus `node_name` and `superstep`. Never raw exception text.

Rationale: it matches panda's written contract (privacy-safe failure evidence), it adds no durable write of raw exception text, and full detail already lives in the OTel trace since #362. A durable raw-text write would move the #187 privacy boundary, needs an ADR, and is explicitly deferred.

## Two caveats, documented rather than papered over

- `outputs` are the **folded step outputs**, not a projection narrowed to the graph's declared outputs. Narrowing needs the `Graph` object and this client is graph-free by contract, so it reports every value the run's steps produced rather than guessing.
- They are JSON-safe because a Run Home's checkpointer defaults to `JsonSerializer`. A Home explicitly configured with `PickleSerializer` returns whatever it stored; `to_dict()` falls back to `repr` for anything that will not serialize.

Both appear in the `RunOutcome` docstring and in `docs/06-api-reference/host.md`.

## Tests — `tests/test_host/test_durable_result_projection.py` (18)

Unknown refs; each of the four states individually and then all four side by side; privacy-safe failure evidence (asserts a secret in the exception message reaches neither the outcome nor `to_dict()`); keyed manifest order; unstarted items staying `None`; a mixed batch separating outputs from failures; the 120-child bounded-query proof; **rerun lineage** (a transient failure, since `rerun` repeats inputs verbatim by A16 — each generation reads independently and the source stays failed); **crash recovery** staged the way ticket-04 stages a lost process, asserting the committed step is resumed and never re-executed while both generations' values fold into one outputs dict; sync/async parity; JSON round-trip; and ref-type refusal.

## Verification

- `uv run pytest` → **4848 passed, 15 skipped** (from 4830; +18)
- `uv run pytest -W error -W 'ignore::pytest.PytestUnraisableExceptionWarning'` (CI-equivalent) → same
- `uv run --python 3.10 mypy` → no issues in 175 source files
- `uv run pre-commit run --all-files` → all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable result inspection for individual runs and batches.
  * Results now show execution status, settlement state, outputs, and privacy-safe failure details.
  * Batch results preserve manifest order and identify items that did not execute.
  * Added JSON-friendly result representations with support for non-JSON output values.

* **Documentation**
  * Added API documentation covering synchronous and asynchronous result retrieval.

* **Tests**
  * Added comprehensive coverage for run, batch, failure, recovery, serialization, and sync/async result scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->