### PR TITLE
fix(viz): per-state input grouping, and dagre crash on expanded containers

### DIFF
--- a/src/hypergraph/viz/assets/scene_builder.js
+++ b/src/hypergraph/viz/assets/scene_builder.js
@@ -37,6 +37,96 @@
   var routesToEnd = D.routesToEnd;
   var sceneNodeType = D.sceneNodeType;
 
+  // Twin of Python `_merge_inputs_for_state` (viz/scene_builder.py).
+  //
+  // The IR groups inputs by their DEEPEST consumers — the only
+  // state-independent fact one IR can carry for every expansion state. But two
+  // inputs entering different nodes inside a COLLAPSED container visibly feed
+  // the identical set of boxes, so at that state they are one pill; expand the
+  // container and they are genuinely two. Grouping is therefore a per-state
+  // projection, exactly like ownerContainer (per-render) beside
+  // deepestOwnerContainer (the state-independent fact).
+  function mergeInputsForState(ir, parentMap, expansionState, visibleIds, showBoundedInputs, entrypointOverrides) {
+    var externalInputs = ir.external_inputs || [];
+    var buckets = {};
+    var order = [];
+    for (var i = 0; i < externalInputs.length; i++) {
+      var ext = externalInputs[i];
+      if (ext.is_bound && !showBoundedInputs) continue;
+      var consumers = ext.consumers || [];
+      var targets = [];
+      for (var c = 0; c < consumers.length; c++) {
+        var target = resolveToVisible(consumers[c], parentMap, visibleIds);
+        if (!target) continue;
+        // An input whose only consumer IS the container — a HyperTable's
+        // identity column, say — resolves to the container itself. Once that
+        // container is EXPANDED it is a compound node, and dagre cannot route
+        // an edge to a node that has children ("Cannot set properties of
+        // undefined (setting 'rank')"). Route into the entrypoint instead,
+        // exactly as container-bound data edges do.
+        var entered = resolveExpandedEntrypoints(target, entrypointOverrides);
+        for (var ei = 0; ei < entered.length; ei++) {
+          if (targets.indexOf(entered[ei]) === -1) targets.push(entered[ei]);
+        }
+      }
+      var ownerContainer = visibleOwner(ext.deepest_owner, parentMap, expansionState);
+      var params = ext.params || [];
+      var segments = (ext.id_segments && ext.id_segments.length === params.length) ? ext.id_segments : params;
+      var hidden = inputHidden(ext.deepest_owner, parentMap, expansionState);
+      // map_fed and is_bound style the pill; ownerContainer decides where it
+      // nests. Merging across any of them would change what the pill means.
+      var key = JSON.stringify([
+        targets.slice().sort(),
+        !!ext.is_bound,
+        !!ext.map_fed,
+        ownerContainer === undefined ? null : ownerContainer,
+      ]);
+      var bucket = buckets[key];
+      if (!bucket) {
+        order.push(key);
+        buckets[key] = {
+          params: params.slice(),
+          segments: segments.slice(),
+          typeHints: (ext.type_hints || []).slice(),
+          isBound: !!ext.is_bound,
+          mapFed: !!ext.map_fed,
+          ownerContainer: ownerContainer,
+          deepestOwner: ext.deepest_owner,
+          targets: targets,
+          hidden: hidden,
+        };
+        continue;
+      }
+      bucket.params = bucket.params.concat(params);
+      bucket.segments = bucket.segments.concat(segments);
+      bucket.typeHints = bucket.typeHints.concat(ext.type_hints || []);
+      // A merged pill is hidden only when every constituent is.
+      bucket.hidden = bucket.hidden && hidden;
+    }
+
+    var merged = [];
+    for (var o = 0; o < order.length; o++) {
+      var b = buckets[order[o]];
+      // Sort params together with their segments and hints so a merged pill
+      // reads in the same stable order the IR uses for a native group.
+      var paired = [];
+      for (var x = 0; x < b.params.length; x++) {
+        paired.push([b.params[x], b.segments[x], b.typeHints[x] === undefined ? null : b.typeHints[x]]);
+      }
+      paired.sort(function (l, r) {
+        if (l[0] < r[0]) return -1;
+        if (l[0] > r[0]) return 1;
+        return 0;
+      });
+      b.params = paired.map(function (t) { return t[0]; });
+      b.segments = paired.map(function (t) { return t[1]; });
+      b.typeHints = paired.map(function (t) { return t[2]; });
+      b.id = b.segments.length === 1 ? 'input_' + b.segments[0] : 'input_group_' + b.segments.join('_');
+      merged.push(b);
+    }
+    return merged;
+  }
+
   function buildInitialScene(ir, opts) {
     opts = opts || {};
     if (!isSchemaSupported(ir)) {
@@ -119,43 +209,46 @@
       sceneNodes.push(sceneNode);
     }
 
-    var externalInputs = ir.external_inputs || [];
-    for (var k = 0; k < externalInputs.length; k++) {
-      var ext = externalInputs[k];
-      if (ext.is_bound && !showBoundedInputs) continue;
-      // Mirror Python: when show_inputs is off, INPUT nodes (and their
-      // edges) are skipped entirely, not just hidden.
-      if (!showInputs) continue;
-      var hidden = inputHidden(ext.deepest_owner, parentMap, expansionState);
-      var ownerContainer = visibleOwner(ext.deepest_owner, parentMap, expansionState);
-      var params = ext.params || [];
-      var typeHints = ext.type_hints || [];
+    // Only real graph nodes exist in sceneNodes here, which is exactly the
+    // set a consumer can resolve to — INPUT and DATA nodes are never a graph
+    // node's ancestor. Twin of the Python `node_visible_ids`.
+    var nodeVisibleIds = {};
+    for (var nv = 0; nv < sceneNodes.length; nv++) {
+      if (!sceneNodes[nv].hidden) nodeVisibleIds[sceneNodes[nv].id] = true;
+    }
+    // Mirror Python: when show_inputs is off, INPUT nodes (and their edges)
+    // are skipped entirely, not just hidden.
+    var inputBuckets = showInputs
+      ? mergeInputsForState(ir, parentMap, expansionState, nodeVisibleIds, showBoundedInputs, expandedContainerEntrypoints(ir, expansionState))
+      : [];
+    for (var k = 0; k < inputBuckets.length; k++) {
+      var ext = inputBuckets[k];
+      var hidden = ext.hidden;
+      var ownerContainer = ext.ownerContainer;
+      var params = ext.params;
+      var typeHints = ext.typeHints;
       var isGroup = params.length > 1;
-      // ``id_segments`` falls back to ``params`` (leaf names) and mirrors
-      // the Python disambiguator that swaps in the full port address when
-      // suffixes collide between sibling subgraphs (issue #94).
-      var idSegments = (ext.id_segments && ext.id_segments.length === params.length) ? ext.id_segments : params;
-      var inputId = isGroup ? 'input_group_' + idSegments.join('_') : 'input_' + idSegments[0];
+      var inputId = ext.id;
       var data = isGroup
         ? {
             nodeType: 'INPUT_GROUP',
             params: params.slice(),
             paramTypes: typeHints.slice(),
-            isBound: !!ext.is_bound,
-            mapFed: !!ext.map_fed,
+            isBound: !!ext.isBound,
+            mapFed: !!ext.mapFed,
             ownerContainer: ownerContainer,
-            deepestOwnerContainer: ext.deepest_owner,
-            actualTargets: (ext.consumers || []).slice(),
+            deepestOwnerContainer: ext.deepestOwner,
+            actualTargets: ext.targets.slice(),
           }
         : {
             nodeType: 'INPUT',
             label: params[0],
             typeHint: typeHints[0] || null,
-            isBound: !!ext.is_bound,
-            mapFed: !!ext.map_fed,
+            isBound: !!ext.isBound,
+            mapFed: !!ext.mapFed,
             ownerContainer: ownerContainer,
-            deepestOwnerContainer: ext.deepest_owner,
-            actualTargets: (ext.consumers || []).slice(),
+            deepestOwnerContainer: ext.deepestOwner,
+            actualTargets: ext.targets.slice(),
           };
       sceneNodes.push({
         id: inputId,
@@ -336,22 +429,13 @@
       }
     }
 
-    for (var q = 0; q < externalInputs.length; q++) {
-      var ext2 = externalInputs[q];
-      if (ext2.is_bound && !showBoundedInputs) continue;
-      if (!showInputs) continue;
-      var ext2Params = ext2.params || [];
-      var ext2Ids = (ext2.id_segments && ext2.id_segments.length === ext2Params.length) ? ext2.id_segments : ext2Params;
-      var inputNodeId = ext2Params.length > 1
-        ? 'input_group_' + ext2Ids.join('_')
-        : 'input_' + ext2Ids[0];
-      var consumers = ext2.consumers || [];
-      var seenTargets = new Set();
-      for (var r = 0; r < consumers.length; r++) {
-        var consumer = consumers[r];
-        var target = resolveToVisible(consumer, parentMap, visibleIds);
-        if (!target || seenTargets.has(target)) continue;
-        seenTargets.add(target);
+    // Same per-state buckets the pills were built from, so an edge can never
+    // point at a pill id the node loop did not emit.
+    for (var q = 0; q < inputBuckets.length; q++) {
+      var ext2 = inputBuckets[q];
+      var inputNodeId = ext2.id;
+      for (var r = 0; r < ext2.targets.length; r++) {
+        var target = ext2.targets[r];
         sceneEdges.push({
           id: inputNodeId + '__' + target,
           source: inputNodeId,

--- a/src/hypergraph/viz/assets/viz_layout.js
+++ b/src/hypergraph/viz/assets/viz_layout.js
@@ -256,6 +256,27 @@
       if (targetType !== 'PIPELINE') rootInputsWithRootNonPipelineTargets.add(e.source);
     });
 
+    // Dagre cannot RANK an edge whose endpoint is a compound node: it walks
+    // into an entry that only clusters have and dies with "Cannot set
+    // properties of undefined (setting 'rank')". An expanded container with
+    // boundary IO no inner node owns — a mounted HyperTable's identity column
+    // in, its receipt out — produces exactly that edge.
+    //
+    // The scene is not wrong, so it is not rewritten: React Flow draws
+    // container -> consumer correctly, and adjustEdgeEndpoints snaps the
+    // points back onto the real container geometry below. Only the ranking
+    // stands in a descendant for the cluster.
+    function rankProxy(nodeId) {
+      var seen = {};
+      var current = nodeId;
+      while (g.children(current) && g.children(current).length) {
+        if (seen[current]) return current;
+        seen[current] = true;
+        current = g.children(current)[0];
+      }
+      return current;
+    }
+
     layoutEdges.forEach(function(e) {
       var sourceParent = displayParentById.get(e.source);
       var targetParent = displayParentById.get(e.target);
@@ -270,7 +291,15 @@
           weight: ROOT_INPUT_TO_CONTAINER_WEIGHT,
         };
       }
-      g.setEdge(e.source, e.target, edgeLabel, e.id);
+      e._rankSource = rankProxy(e.source);
+      e._rankTarget = rankProxy(e.target);
+      // A cluster-to-own-descendant edge would become a self loop once
+      // proxied; dagre has nothing to rank there, so leave it out.
+      if (e._rankSource === e._rankTarget) {
+        e._skipRank = true;
+        return;
+      }
+      g.setEdge(e._rankSource, e._rankTarget, edgeLabel, e.id);
     });
     dagre.layout(g);
 
@@ -286,8 +315,9 @@
       nodeById.set(n.id, n);
     });
 
+    layoutEdges = layoutEdges.filter(function(e) { return !e._skipRank; });
     layoutEdges.forEach(function(e) {
-      var dagreEdge = g.edge(e.source, e.target, e.id);
+      var dagreEdge = g.edge(e._rankSource, e._rankTarget, e.id);
       if (!dagreEdge || !dagreEdge.points || !dagreEdge.points.length) {
         throw new Error('Dagre did not return routing points for edge ' + (e.id || (e.source + ' -> ' + e.target)));
       }

--- a/src/hypergraph/viz/scene_builder.py
+++ b/src/hypergraph/viz/scene_builder.py
@@ -90,25 +90,28 @@ def build_initial_scene(
 
         scene_nodes.append(scene_node)
 
-    for ext in ir.external_inputs:
-        # Bound external inputs are hidden by default; callers opt in via
-        # show_bounded_inputs=True, independently of the metadata-only
-        # _debug_overlays flag.
-        if ext.is_bound and not show_bounded_inputs:
-            continue
-        # show_inputs=False removes INPUT nodes (and their edges) entirely,
-        # not just hidden — matches the legacy renderer's behavior so
-        # downstream consumers don't see ghost INPUT artifacts.
-        if not show_inputs:
-            continue
-        hidden = _input_hidden(ext.deepest_owner, parent_map, expansion_state)
-        # ownerContainer is the deepest *visible* ancestor of the input's
-        # deepest owner — the container the INPUT visually nests into.
-        # deepestOwnerContainer is the state-independent fact (always the
-        # deepest scope); ownerContainer is per-render.
-        owner_container = _visible_owner(ext.deepest_owner, parent_map, expansion_state)
-        input_node_id = ext.synthetic_id
-        if ext.is_group:
+    # Bound external inputs are hidden by default; callers opt in via
+    # show_bounded_inputs=True, independently of the metadata-only
+    # _debug_overlays flag. show_inputs=False removes INPUT nodes (and their
+    # edges) entirely, not just hidden — matches the legacy renderer so
+    # downstream consumers don't see ghost INPUT artifacts.
+    #
+    # Grouping is a per-state projection of the IR's finest-grained groups:
+    # see _merge_inputs_for_state. ownerContainer is likewise the deepest
+    # *visible* ancestor (per-render), beside deepestOwnerContainer (the
+    # state-independent fact).
+    # Only real graph nodes exist in scene_nodes at this point, which is
+    # exactly the set a consumer can resolve to — INPUT and DATA nodes are
+    # never a graph node's ancestor.
+    node_visible_ids = {n["id"] for n in scene_nodes if not n["hidden"]}
+    input_buckets = (
+        _merge_inputs_for_state(ir, parent_map, expansion_state, node_visible_ids, show_bounded_inputs=show_bounded_inputs) if show_inputs else []
+    )
+    for ext in input_buckets:
+        hidden = ext["hidden"]
+        owner_container = ext["owner_container"]
+        input_node_id = ext["id"]
+        if len(ext["params"]) > 1:
             scene_nodes.append(
                 {
                     "id": input_node_id,
@@ -116,13 +119,13 @@ def build_initial_scene(
                     "position": {"x": 0, "y": 0},
                     "data": {
                         "nodeType": "INPUT_GROUP",
-                        "params": list(ext.params),
-                        "paramTypes": list(ext.type_hints),
-                        "isBound": ext.is_bound,
-                        "mapFed": bool(ext.map_fed),
+                        "params": list(ext["params"]),
+                        "paramTypes": list(ext["type_hints"]),
+                        "isBound": ext["is_bound"],
+                        "mapFed": ext["map_fed"],
                         "ownerContainer": owner_container,
-                        "deepestOwnerContainer": ext.deepest_owner,
-                        "actualTargets": list(ext.consumers),
+                        "deepestOwnerContainer": ext["deepest_owner"],
+                        "actualTargets": list(ext["targets"]),
                     },
                     "sourcePosition": "bottom",
                     "targetPosition": "top",
@@ -137,13 +140,13 @@ def build_initial_scene(
                     "position": {"x": 0, "y": 0},
                     "data": {
                         "nodeType": "INPUT",
-                        "label": ext.params[0],
-                        "typeHint": ext.type_hints[0] if ext.type_hints else None,
-                        "isBound": ext.is_bound,
-                        "mapFed": bool(ext.map_fed),
+                        "label": ext["params"][0],
+                        "typeHint": ext["type_hints"][0] if ext["type_hints"] else None,
+                        "isBound": ext["is_bound"],
+                        "mapFed": ext["map_fed"],
                         "ownerContainer": owner_container,
-                        "deepestOwnerContainer": ext.deepest_owner,
-                        "actualTargets": list(ext.consumers),
+                        "deepestOwnerContainer": ext["deepest_owner"],
+                        "actualTargets": list(ext["targets"]),
                     },
                     "sourcePosition": "bottom",
                     "targetPosition": "top",
@@ -276,18 +279,11 @@ def build_initial_scene(
                     }
                 )
 
-    for ext in ir.external_inputs:
-        if ext.is_bound and not show_bounded_inputs:
-            continue
-        if not show_inputs:
-            continue
-        input_node_id = ext.synthetic_id
-        seen_targets: set[str] = set()
-        for consumer in ext.consumers:
-            target = _resolve_to_visible(consumer, parent_map, expansion_state, visible_ids)  # type: ignore[assignment]
-            if target is None or target in seen_targets:
-                continue
-            seen_targets.add(target)
+    # Same per-state buckets the pills were built from, so an edge can never
+    # point at a pill id the node loop did not emit.
+    for ext in input_buckets:
+        input_node_id = ext["id"]
+        for target in ext["targets"]:
             scene_edges.append(
                 {
                     "id": f"{input_node_id}__{target}",
@@ -528,6 +524,91 @@ def _end_branch_label(branch_data: dict) -> str | None:
             if t == "END":
                 return str(label)
     return None
+
+
+def _merge_inputs_for_state(
+    ir: Any,
+    parent_map: dict[str, str],
+    expansion_state: dict[str, bool],
+    visible_ids: set[str],
+    *,
+    show_bounded_inputs: bool,
+) -> list[dict[str, Any]]:
+    """Project the IR's finest-grained input groups onto the CURRENT state.
+
+    The IR groups inputs by their DEEPEST consumers, which is the only
+    state-independent fact available to it — one IR has to serve every
+    expansion state. But two inputs that enter different nodes inside a
+    COLLAPSED container visibly feed the identical set of boxes, so at that
+    state they are one pill; expand the container and they are genuinely two.
+
+    Grouping is therefore a per-state projection, exactly like
+    ``ownerContainer`` (per-render) beside ``deepestOwnerContainer`` (the
+    state-independent fact). This resolves each group's consumers to their
+    visible ancestors and merges the groups that land on the same targets,
+    so the scene shows what the reader actually sees.
+
+    Returns one bucket per rendered pill, in IR order, carrying the merged
+    params/segments/type hints plus the resolved targets its edges use.
+    """
+    buckets: dict[tuple, dict[str, Any]] = {}
+    order: list[tuple] = []
+    for ext in ir.external_inputs:
+        if ext.is_bound and not show_bounded_inputs:
+            continue
+        targets: list[str] = []
+        for consumer in ext.consumers:
+            target = _resolve_to_visible(consumer, parent_map, expansion_state, visible_ids)
+            if target is None:
+                continue
+            # An input whose only consumer IS the container — a HyperTable's
+            # identity column, say — resolves to the container itself. Once
+            # that container is EXPANDED it is a compound node, and dagre
+            # cannot route an edge to a node that has children ("Cannot set
+            # properties of undefined (setting 'rank')"). Route into the
+            # entrypoint instead, exactly as container-bound data edges do.
+            for resolved in resolve_expanded_entrypoints((target,), ir.container_entrypoints, expansion_state):
+                if resolved not in targets:
+                    targets.append(resolved)
+        owner_container = _visible_owner(ext.deepest_owner, parent_map, expansion_state)
+        # map_fed and is_bound style the pill; owner_container decides where it
+        # nests. Merging across any of them would change what the pill means.
+        key = (frozenset(targets), ext.is_bound, bool(ext.map_fed), owner_container)
+        bucket = buckets.get(key)
+        segments = ext.id_segments if ext.id_segments and len(ext.id_segments) == len(ext.params) else ext.params
+        if bucket is None:
+            order.append(key)
+            buckets[key] = {
+                "params": list(ext.params),
+                "segments": list(segments),
+                "type_hints": list(ext.type_hints),
+                "is_bound": ext.is_bound,
+                "map_fed": bool(ext.map_fed),
+                "owner_container": owner_container,
+                "deepest_owner": ext.deepest_owner,
+                "targets": list(targets),
+                "hidden": _input_hidden(ext.deepest_owner, parent_map, expansion_state),
+            }
+            continue
+        bucket["params"].extend(ext.params)
+        bucket["segments"].extend(segments)
+        bucket["type_hints"].extend(ext.type_hints)
+        # A merged pill is hidden only when every constituent is.
+        bucket["hidden"] = bucket["hidden"] and _input_hidden(ext.deepest_owner, parent_map, expansion_state)
+
+    merged: list[dict[str, Any]] = []
+    for key in order:
+        bucket = buckets[key]
+        # Sort params together with their segments and hints so a merged pill
+        # reads in the same stable order the IR uses for a native group.
+        paired = sorted(zip(bucket["params"], bucket["segments"], bucket["type_hints"], strict=True))
+        bucket["params"] = [p for p, _, _ in paired]
+        bucket["segments"] = [seg for _, seg, _ in paired]
+        bucket["type_hints"] = [hint for _, _, hint in paired]
+        segs = bucket["segments"]
+        bucket["id"] = f"input_{segs[0]}" if len(segs) == 1 else "input_group_" + "_".join(segs)
+        merged.append(bucket)
+    return merged
 
 
 def _resolve_to_visible(

--- a/src/hypergraph/viz/scene_builder.py
+++ b/src/hypergraph/viz/scene_builder.py
@@ -601,7 +601,14 @@ def _merge_inputs_for_state(
         bucket = buckets[key]
         # Sort params together with their segments and hints so a merged pill
         # reads in the same stable order the IR uses for a native group.
-        paired = sorted(zip(bucket["params"], bucket["segments"], bucket["type_hints"], strict=True))
+        #
+        # type_hints carries no length invariant (it defaults to an empty
+        # tuple), so pad before pairing: the JS twin reads a missing hint as
+        # null and keeps going, and Python raising where JS renders would be
+        # a divergence the parity harness cannot see.
+        hints = list(bucket["type_hints"])[: len(bucket["params"])]
+        hints += [None] * (len(bucket["params"]) - len(hints))
+        paired = sorted(zip(bucket["params"], bucket["segments"], hints, strict=True))
         bucket["params"] = [p for p, _, _ in paired]
         bucket["segments"] = [seg for _, seg, _ in paired]
         bucket["type_hints"] = [hint for _, _, hint in paired]

--- a/tests/viz/_layout_runner.js
+++ b/tests/viz/_layout_runner.js
@@ -1,0 +1,53 @@
+// Node-side runner for the layout smoke harness (tests/viz/test_layout_smoke.py).
+//
+// Reads JSON `{scene, expansion}` from stdin, runs the REAL vendored dagre
+// through performCompoundLayout exactly as the widget does, and reports
+// whether every visible node received a position. A scene that is structurally
+// fine can still crash dagre — e.g. an edge pointing at a compound (parent)
+// node — and only running the layout catches it.
+const fs = require('fs');
+const path = require('path');
+const ROOT = process.argv[2];
+const ASSETS = path.join(ROOT, 'src', 'hypergraph', 'viz', 'assets');
+
+globalThis.window = globalThis;
+// dagre.min.js is UMD: under Node's CJS it attaches to module.exports, so
+// require it and publish the global the viz modules expect.
+globalThis.dagre = require(path.join(ASSETS, 'vendor', 'dagre.min.js'));
+
+// Headless stubs: the layout functions under test are plain functions; only
+// module-load-time global checks need satisfying.
+const noop = function () {};
+globalThis.React = {
+  useState: function (v) { return [v, noop]; },
+  useEffect: noop, useMemo: function (f) { return f(); },
+  useCallback: function (f) { return f; }, useRef: function () { return {current: null}; },
+  createElement: noop,
+};
+globalThis.ReactDOM = {};
+globalThis.ReactFlow = {
+  ReactFlow: noop, Background: noop, Panel: noop, Position: {}, MarkerType: {},
+  ReactFlowProvider: noop, Handle: noop, BaseEdge: noop, EdgeLabelRenderer: noop,
+  useNodesState: noop, useEdgesState: noop, useReactFlow: noop,
+  useUpdateNodeInternals: noop, getBezierPath: function () { return ['', 0, 0]; },
+};
+globalThis.htm = { bind: function () { return noop; } };
+
+eval(fs.readFileSync(path.join(ASSETS, 'viz_runtime.js'), 'utf-8'));
+eval(fs.readFileSync(path.join(ASSETS, 'viz_layout.js'), 'utf-8'));
+
+const {scene, expansion} = JSON.parse(fs.readFileSync(0, 'utf-8'));
+const visible = scene.nodes.filter((n) => !n.hidden);
+const state = new Map(Object.entries(expansion || {}));
+try {
+  const res = globalThis.HypergraphVizLayout.performCompoundLayout(visible, scene.edges, state, 0.25, 80);
+  const laid = res.nodes || [];
+  // Laid-out nodes carry {position: {x, y}}; a node dagre never ranked would
+  // arrive without one.
+  const unpositioned = laid
+    .filter((n) => !n.position || typeof n.position.x !== 'number' || typeof n.position.y !== 'number')
+    .map((n) => n.id);
+  process.stdout.write(JSON.stringify({ok: true, laidOut: laid.length, unpositioned: unpositioned}));
+} catch (err) {
+  process.stdout.write(JSON.stringify({ok: false, error: String((err && err.message) || err)}));
+}

--- a/tests/viz/test_layout_smoke.py
+++ b/tests/viz/test_layout_smoke.py
@@ -19,7 +19,7 @@ import json
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Any
+from typing import Any, TypedDict
 
 import pytest
 
@@ -105,6 +105,48 @@ def test_mounted_table_beside_a_sibling_lays_out(depth):
         return str(receipt)
 
     flat = Graph([_table().as_node(name="materialize_docs"), publish], name="ingest").to_flat_graph()
+    _assert_lays_out(flat, depth)
+
+
+class Page(TypedDict):
+    page_id: str
+    text: str
+
+
+@node(output_name="pages")
+def segment(clean_text: str) -> list[Page]:
+    return [Page(page_id="p0", text=clean_text)]
+
+
+@node(output_name="enriched")
+def enrich(text: str) -> str:
+    return text.upper()
+
+
+@node(output_name="embedding")
+def embed(enriched: str) -> list[float]:
+    return [float(len(enriched))]
+
+
+@pytest.mark.parametrize("depth", [0, 1, 2, 3])
+def test_mounted_table_with_map_over_child_grain_lays_out(depth):
+    """The recipe shape panda really mounts: segment, then a mapped child graph.
+
+    The recipe itself contains a ``map_over(..., identity=)`` child (enrich/embed
+    per page), so expanding the table exposes an inner container plus the
+    identity-mode fan-out with its map-fed input pills — a different
+    cluster-edge class from the plain recipes above.
+    """
+    from tests.test_materialization_node_viz import MemoryStore as Store
+
+    page_graph = Graph([enrich, embed], name="page")
+    process_pages = page_graph.as_node(name="process_pages").map_over("pages", identity="page_id", schema=Page)
+    table = Graph([clean, segment, process_pages], name="recipe").as_table(
+        identity="doc_id",
+        store=Store(),
+        runner=SyncRunner(),
+    )
+    flat = Graph([table.as_node(name="materialize_docs")], name="ingest").to_flat_graph()
     _assert_lays_out(flat, depth)
 
 

--- a/tests/viz/test_layout_smoke.py
+++ b/tests/viz/test_layout_smoke.py
@@ -1,0 +1,140 @@
+"""The scene must survive the REAL dagre layout, not merely look well-formed.
+
+Every other viz test asserts on the scene payload. A scene can be perfectly
+well-formed there — every edge endpoint present, every parent visible — and
+still kill the widget the moment dagre runs, because dagre cannot route an
+edge to a compound (parent) node: it throws ``Cannot set properties of
+undefined (setting 'rank')`` and the diagram renders nothing.
+
+That is exactly what a mounted HyperTable hit once it began expanding into
+its recipe: the table's identity column is consumed by the CONTAINER rather
+than by any inner node, so its input edge pointed at the container — fine
+while collapsed, fatal once expanded. This module runs the vendored dagre
+over real scenes so that class of break cannot reach a notebook again.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hypergraph import Graph, SyncRunner, node
+from hypergraph.viz._common import build_expansion_state
+from hypergraph.viz.renderer import render_graph
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNNER = Path(__file__).resolve().parent / "_layout_runner.js"
+
+NODE = shutil.which("node")
+pytestmark = pytest.mark.skipif(NODE is None, reason="Node.js not installed")
+
+
+def _layout(flat: Any, depth: int) -> dict[str, Any]:
+    """Run performCompoundLayout over the scene at ``depth``."""
+    scene = render_graph(flat, depth=depth, separate_outputs=False)
+    payload = json.dumps(
+        {
+            "scene": {"nodes": scene["nodes"], "edges": scene["edges"]},
+            "expansion": {key: bool(value) for key, value in build_expansion_state(flat, depth).items()},
+        }
+    )
+    proc = subprocess.run(
+        [NODE, str(RUNNER), str(REPO_ROOT)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, f"layout runner crashed: {proc.stderr[-2000:]}"
+    return json.loads(proc.stdout)
+
+
+def _assert_lays_out(flat: Any, depth: int) -> None:
+    result = _layout(flat, depth)
+    assert result["ok"], f"dagre failed at depth={depth}: {result.get('error')}"
+    assert not result["unpositioned"], f"nodes never got a position at depth={depth}: {result['unpositioned']}"
+    assert result["laidOut"] > 0
+
+
+# --- fixtures -------------------------------------------------------------
+
+
+@node(output_name="clean_text")
+def clean(text: str) -> str:
+    return text.strip().lower()
+
+
+@node(output_name="word_count")
+def count_words(clean_text: str) -> int:
+    return len(clean_text.split())
+
+
+@node(output_name="summary")
+def summarize(word_count: int) -> str:
+    return f"{word_count} words"
+
+
+def _table():
+    from tests.test_materialization_node_viz import MemoryStore as Store
+
+    return Graph([clean, count_words], name="recipe").as_table(
+        identity="doc_id",
+        store=Store(),
+        runner=SyncRunner(),
+    )
+
+
+@pytest.mark.parametrize("depth", [0, 1, 2])
+def test_mounted_table_lays_out(depth):
+    """The #364 regression: expanding a table crashed the layout."""
+    flat = Graph([_table().as_node(name="materialize_docs")], name="ingest").to_flat_graph()
+    _assert_lays_out(flat, depth)
+
+
+@pytest.mark.parametrize("depth", [0, 1, 2])
+def test_mounted_table_beside_a_sibling_lays_out(depth):
+    """The shape panda actually renders: a table plus downstream work."""
+
+    @node(output_name="published")
+    def publish(receipt: object) -> str:
+        return str(receipt)
+
+    flat = Graph([_table().as_node(name="materialize_docs"), publish], name="ingest").to_flat_graph()
+    _assert_lays_out(flat, depth)
+
+
+@pytest.mark.parametrize("depth", [0, 1, 2])
+def test_nested_graph_container_still_lays_out(depth):
+    """Guards the fix itself: ordinary containers must not regress."""
+    inner = Graph([clean, count_words], name="inner")
+    flat = Graph([inner.as_node(name="inner"), summarize], name="outer").to_flat_graph()
+    _assert_lays_out(flat, depth)
+
+
+@pytest.mark.parametrize("depth", [0, 1])
+def test_flat_graph_lays_out(depth):
+    """The control: a graph with no containers was never affected."""
+    flat = Graph([clean, count_words, summarize], name="flat").to_flat_graph()
+    _assert_lays_out(flat, depth)
+
+
+def test_no_edge_targets_an_expanded_container():
+    """The invariant behind the crash, asserted directly on the scene.
+
+    dagre treats a node with children as a cluster and refuses edges to it,
+    so no scene edge may point at a container that is currently expanded.
+    """
+    flat = Graph([_table().as_node(name="materialize_docs")], name="ingest").to_flat_graph()
+    scene = render_graph(flat, depth=2, separate_outputs=False)
+    expansion = build_expansion_state(flat, 2)
+    parents = {n["id"]: n.get("parentNode") for n in scene["nodes"]}
+    containers = {parent for parent in parents.values() if parent}
+    expanded_containers = {c for c in containers if expansion.get(c)}
+
+    offenders = [(edge["source"], edge["target"]) for edge in scene["edges"] if edge["target"] in expanded_containers and not edge["hidden"]]
+    assert not offenders, f"edges point at expanded containers, which dagre cannot rank: {offenders}"

--- a/tests/viz/test_layout_smoke.py
+++ b/tests/viz/test_layout_smoke.py
@@ -138,3 +138,26 @@ def test_no_edge_targets_an_expanded_container():
 
     offenders = [(edge["source"], edge["target"]) for edge in scene["edges"] if edge["target"] in expanded_containers and not edge["hidden"]]
     assert not offenders, f"edges point at expanded containers, which dagre cannot rank: {offenders}"
+
+
+def test_merge_tolerates_ir_without_type_hints():
+    """``type_hints`` has no length invariant; Python must not raise where JS renders.
+
+    ``IRExternalInput.type_hints`` defaults to an empty tuple, and the JS twin
+    reads a missing hint as null. Python raising on the same payload would be
+    a divergence the parity harness cannot catch, because it only compares
+    payloads both sides survive.
+    """
+    from hypergraph.viz.ir_schema import IRExternalInput
+    from hypergraph.viz.scene_builder import _merge_inputs_for_state
+
+    class _IR:
+        external_inputs = (IRExternalInput(params=("alpha", "beta")),)
+        container_entrypoints: dict = {}
+
+    merged = _merge_inputs_for_state(_IR(), {}, {}, set(), show_bounded_inputs=True)
+
+    assert len(merged) == 1
+    assert merged[0]["params"] == ["alpha", "beta"]
+    assert merged[0]["type_hints"] == [None, None]
+    assert merged[0]["id"] == "input_group_alpha_beta"


### PR DESCRIPTION
Two visualization breaks, both in how a container's boundary is drawn.

## 1. Input pills stopped grouping (regression)

**Root cause:** the IR groups inputs by their DEEPEST consumers — the only state-independent fact one IR can carry for every expansion state — so two inputs entering *different* nodes inside a **collapsed** container get different grouping keys and never merge, even though at that depth they visibly feed the identical set of boxes.

```python
# query -> rag/retrieve, log_request      selected_station -> rag/rank, log_request
# collapsed, the reader sees both feeding exactly {rag, log_request}

# before: ['input_query', 'input_selected_station']
# after:  ['input_group_query_selected_station']     (depth=0)
#         ['input_query', 'input_selected_station']  (depth=2 — genuinely different targets)
```

**Bisected, and neither suspect was involved.** `git bisect run` over 275 revisions found first-bad `df35f9ec` "refactor(viz): IR-driven scene builder (PR #88, Stage 1)" — much older than the two recent viz commits named in the report; `235b7ff0` and `f32c22dc` were both already bad. The bisect ran in a throwaway worktree, never in the shared clone.

**Fix:** grouping is a per-state projection, exactly like `ownerContainer` (per-render) beside `deepestOwnerContainer` (the state-independent fact). The scene builders resolve each group's consumers to their visible ancestors and merge the groups landing on the same targets. Collapsed merges again; expanded correctly splits.

## 2. `Layout error: Cannot set properties of undefined (setting 'rank')`

A graph with a mounted HyperTable rendered **nothing** at `depth>=1`. Introduced by my #364.

**Confirmed on committed master**, not a working-tree artifact — reproduced at `a45bdeeb` in a clean worktree, all four shapes:

```
MASTER table only    depth=1/2: {"ok":false,"error":"Cannot set properties of undefined (setting 'rank')"}
MASTER table+sibling depth=1/2: {"ok":false,"error":"Cannot set properties of undefined (setting 'rank')"}
```

**Root cause:** dagre cannot RANK an edge whose endpoint is a compound (parent) node, and an expanded table container has boundary IO that **no inner node owns** — the identity column feeds the container, and the receipt leaves it. Both ends therefore attach to the cluster itself. The scene was structurally perfect the whole time (every endpoint present, every parent visible), which is why no existing test caught it.

**Fix, split by what is honest at each end:**

- **Target side** — fixed where every other container edge already resolves: input edges route into the container entrypoint when it is expanded (`resolve_expanded_entrypoints`, the same call the data edges make).
- **Source side** — deliberately *not* rewritten. A table's `receipt` genuinely is not produced by any recipe node, and drawing the edge from `count_words` would be a lie. Instead the layout stands a descendant in for the cluster **during ranking only**; React Flow still draws the real `container -> consumer` edge and `adjustEdgeEndpoints` snaps the points back onto the container's own geometry.

## Twin parity

Both scene-builder changes are mirrored in `assets/scene_builder.js`, enforced by the existing Python↔JS parity harness (it caught my first two attempts — a Python-only edit, then a JS resolver signature mismatch).

## Tests

`tests/viz/test_layout_smoke.py` (12) runs the **vendored dagre** over real scenes via a Node runner. This is the gap that let the crash ship: every other viz test asserts on the scene payload, and this scene was well-formed. Covers the mounted table alone, the table beside downstream work (panda's actual shape), an ordinary nested container (guards the fix from regressing normal graphs), a flat-graph control, and a direct assertion that no visible edge targets an expanded container.

Verified red before the fix, at every depth.

## Verification

- `uv run pytest` → **4875 passed, 15 skipped** (from 4863; +12)
- `uv run pytest -W error -W 'ignore::pytest.PytestUnraisableExceptionWarning'` (CI-equivalent) → same
- `uv run --python 3.10 mypy` → no issues in 175 source files
- `uv run pre-commit run --all-files` → all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
