### PR TITLE
fix(viz): collapsed-by-default everywhere, boundary-edge fidelity, and simplify for input pills

### DIFF
--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -1767,8 +1767,10 @@ class Graph:
             show_inputs: Whether to show INPUT/INPUT_GROUP nodes (default: True)
             show_bounded_inputs: Whether to include bound INPUT/INPUT_GROUP nodes
                 when show_inputs=True
-            simplify: Hide data edges that a longer path already implies — given
-                ``A → B → C``, a direct ``A → C`` is dropped (default: True).
+            simplify: Hide data and input edges that a longer path already
+                implies — given ``A → B → C``, a direct ``A → C`` is dropped,
+                and an input feeding the whole chain keeps only its earliest
+                consumer (default: True).
                 Toggleable from the widget toolbar.
             show_external_inputs: Deprecated alias for show_inputs
             filepath: Path to save HTML file (default: None, display in notebook)
@@ -1829,8 +1831,10 @@ class Graph:
             depth: How many levels of nested graphs to expand (default: 0)
             show_types: Whether to show type annotations in labels
             separate_outputs: Whether to render outputs as separate DATA nodes
-            simplify: Hide data edges that a longer path already implies — given
-                ``A → B → C``, a direct ``A → C`` is dropped (default: True)
+            simplify: Hide data and input edges that a longer path already
+                implies — given ``A → B → C``, a direct ``A → C`` is dropped,
+                and an input feeding the whole chain keeps only its earliest
+                consumer (default: True)
             direction: Flowchart direction — "TD", "TB", "LR", "RL", "BT"
             colors: Custom color overrides per node class, e.g.
                 ``{"function": {"fill": "#fff", "stroke": "#000"}}``

--- a/src/hypergraph/materialization/_hypertable_viz.py
+++ b/src/hypergraph/materialization/_hypertable_viz.py
@@ -101,7 +101,6 @@ def render_hypertable(
         show_inputs = show_external_inputs
     if show_inputs is None:
         show_inputs = True
-    options.setdefault("depth", 1)
 
     flat_graph = combined.to_flat_graph(extra_edges=extra_edges)
     for (source_id, target_id), field_names in fanout_map_fields(graph, spec, map_over_nodes).items():

--- a/src/hypergraph/viz/AGENTS.md
+++ b/src/hypergraph/viz/AGENTS.md
@@ -116,13 +116,24 @@ helper from ``tests/viz/conftest.py``. In the browser, App calls
 
 The IR carries all expansion-rewriting information eagerly:
 - ``IREdge.source_when_expanded`` / ``target_when_expanded`` re-route
-  edges to the deepest internal producer/consumer when a container is expanded.
+  edges to the deepest internal producer / EVERY internal consumer when a
+  container is expanded — one value can enter a container at several nodes, so
+  ``target_when_expanded`` is a tuple whenever more than one consumer reads it.
+  A rewritten endpoint that sits inside a still-collapsed inner container is
+  resolved up to its deepest visible ancestor in the scene builders (edges
+  aggregate to the boundary rather than vanishing), and endpoints sharing an
+  ancestor dedup to one edge.
   An identity-mode fan-out edge (``HyperTable.visualize``) re-routes instead to
   the mapped item's field INPUT pill(s) — ``segment_pages ──pages──▶ [page_text]
-  ──▶ embed_page`` — so ``target_when_expanded`` may be a tuple of pill ids, and
-  each such pill is flagged ``IRExternalInput.map_fed`` (styled distinctly, not
-  as a free-floating external input). Falls back to the container entrypoint
+  ──▶ embed_page`` — so ``target_when_expanded`` may also be a tuple of pill ids,
+  and each such pill is flagged ``IRExternalInput.map_fed`` (styled distinctly,
+  not as a free-floating external input). Falls back to the container entrypoint
   when the mapped item has no matching field (e.g. ``list[str]``).
+- INPUT pills hoist, never hide: an external input owned by a collapsed
+  container surfaces at its deepest VISIBLE ancestor with its edge aggregated
+  to the collapsed hull — a graph's contract inputs must survive any collapse.
+  Only ``map_fed`` pills disappear with their container (the container-level
+  fan-out edge represents the same value while collapsed).
 - ``IREdge.is_back_edge`` marks DFS back-edges so feedback routing survives
   arbitrary expansion changes.
 - ``IRNode.outputs[i].internal_only`` flags outputs whose consumers all

--- a/src/hypergraph/viz/AGENTS.md
+++ b/src/hypergraph/viz/AGENTS.md
@@ -164,8 +164,13 @@ The IR carries all expansion-rewriting information eagerly:
      Never re-derive the reachability walk in a new call site.
    - Two invariants make it safe to default on. Both are load-bearing; a change
      that widens either silently deletes real information:
-     - Only **plain data** edges are removal candidates. Control, ordering,
-       input, output, start/end and mutex (`exclusive`) edges never get dropped.
+     - Only **plain data** and **INPUT pill** edges are removal candidates.
+       Control, ordering, output, start/end and mutex (`exclusive`) edges never
+       get dropped. An input feeding a chain keeps only its EARLIEST
+       consumer(s); an input edge into a *collapsed* container is judged
+       box-level — it drops when any other visible route delivers into that
+       box (phantom in-port→box path links, added in both scene-builder twins
+       and Mermaid) — while data edges into the same box stay port-strict.
      - The path graph is the **unconditional data-flow spine only** (`data` +
        `output`, plus inert `input`). Only an edge that *always* carries a value
        may justify a removal, because the reader must be able to trust the

--- a/src/hypergraph/viz/_simplify.py
+++ b/src/hypergraph/viz/_simplify.py
@@ -39,11 +39,13 @@ class EdgeRef:
         key: Caller-owned identity returned in the shortcut set.
         source: Resolved source node id.
         target: Resolved target node id.
-        removable: True only for plain data edges the caller is willing to
-            drop. Structural producer→DATA (``output``) edges, INPUT edges and
-            START/END edges are scaffolding; mutex (``exclusive``) arms are
-            alternatives rather than a chain plus a shortcut. All pass ``False``
-            and can only ever act as path segments.
+        removable: True only for edges the caller is willing to drop: plain
+            data edges, and INPUT pill edges (one input feeding a chain keeps
+            only its earliest consumer(s)). Structural producer→DATA
+            (``output``) edges and START/END edges are scaffolding; mutex
+            (``exclusive``) arms are alternatives rather than a chain plus a
+            shortcut. Those pass ``False`` and can only ever act as path
+            segments.
         traversable: True only for edges on the **unconditional data-flow
             spine** — edges that always carry a value from one node to the
             next. Only such an edge can justify dropping another, because the

--- a/src/hypergraph/viz/assets/scene_builder.js
+++ b/src/hypergraph/viz/assets/scene_builder.js
@@ -343,12 +343,16 @@
     // endpoint may sit inside a still-collapsed INNER container, so it is
     // walked up to its deepest visible ancestor — the edge aggregates to that
     // boundary instead of vanishing with the hidden node. Several endpoints
-    // resolving to one ancestor collapse to one edge.
+    // resolving to one ancestor collapse to one edge. Only collapse-hiding
+    // aggregates: a node hidden by hide=True walks up to an EXPANDED ancestor,
+    // and an edge must never target an expanded container (dagre cannot rank
+    // it) — that resolution is rejected and the edge stays hidden.
     function resolveRewrittenEndpoints(endpoints) {
       var resolved = [];
       for (var re = 0; re < endpoints.length; re++) {
         var visible = resolveToVisible(endpoints[re], parentMap, visibleIds);
         var candidate = visible === null ? endpoints[re] : visible;
+        if (candidate !== endpoints[re] && expansionState[candidate]) candidate = endpoints[re];
         if (resolved.indexOf(candidate) === -1) resolved.push(candidate);
       }
       return resolved;

--- a/src/hypergraph/viz/assets/scene_builder.js
+++ b/src/hypergraph/viz/assets/scene_builder.js
@@ -72,7 +72,14 @@
       var ownerContainer = visibleOwner(ext.deepest_owner, parentMap, expansionState);
       var params = ext.params || [];
       var segments = (ext.id_segments && ext.id_segments.length === params.length) ? ext.id_segments : params;
-      var hidden = inputHidden(ext.deepest_owner, parentMap, expansionState);
+      // A real external input is part of the graph's contract, so collapsing
+      // the container that owns it must not erase it: the pill hoists to its
+      // deepest VISIBLE ancestor (ownerContainer) and its edges aggregate to
+      // the collapsed boundary. Only map-fed pills disappear with their
+      // container — they project a fan-out edge that re-attaches to the
+      // container hull while it is collapsed, so keeping the pill would draw
+      // the same value twice.
+      var hidden = ext.map_fed ? inputHidden(ext.deepest_owner, parentMap, expansionState) : false;
       // map_fed and is_bound style the pill; ownerContainer decides where it
       // nests. Merging across any of them would change what the pill means.
       var key = JSON.stringify([
@@ -332,6 +339,21 @@
       }
     }
 
+    // Twin of scene_builder.py:_resolve_rewritten_endpoints: a rewritten
+    // endpoint may sit inside a still-collapsed INNER container, so it is
+    // walked up to its deepest visible ancestor — the edge aggregates to that
+    // boundary instead of vanishing with the hidden node. Several endpoints
+    // resolving to one ancestor collapse to one edge.
+    function resolveRewrittenEndpoints(endpoints) {
+      var resolved = [];
+      for (var re = 0; re < endpoints.length; re++) {
+        var visible = resolveToVisible(endpoints[re], parentMap, visibleIds);
+        var candidate = visible === null ? endpoints[re] : visible;
+        if (resolved.indexOf(candidate) === -1) resolved.push(candidate);
+      }
+      return resolved;
+    }
+
     for (var p = 0; p < ir.edges.length; p++) {
       var irEdge = ir.edges[p];
       var baseSources = [irEdge.source];
@@ -339,10 +361,13 @@
         baseSources = Array.isArray(irEdge.source_when_expanded)
           ? irEdge.source_when_expanded.slice()
           : [irEdge.source_when_expanded];
+        baseSources = resolveRewrittenEndpoints(baseSources);
       }
-      // A fan-out edge into an expanded container may re-route to several
-      // item-field INPUT pills, so target_when_expanded can be an array; emit
-      // one edge per target (mirrors the multi-source fan-out below).
+      // An edge into an expanded container may re-route to several internal
+      // consumers (one value entering a container at more than one node) or,
+      // for identity-mode fan-out, to several item-field INPUT pills — so
+      // target_when_expanded can be an array; emit one edge per target
+      // (mirrors the multi-source fan-out below).
       var targets = [irEdge.target];
       if (expansionState[irEdge.target]) {
         if (irEdge.target_when_expanded) {
@@ -356,7 +381,7 @@
             resolveExpandedEntrypoints(targets[rt], edgeEntrypointOverrides)
           );
         }
-        targets = resolvedTargets;
+        targets = resolveRewrittenEndpoints(resolvedTargets);
       }
 
       // A data edge can carry multiple value_names (one NetworkX edge per
@@ -554,16 +579,29 @@
   // Twin of scene_builder.py:_collapsed_ports. The `*_when_expanded` fields
   // name the DEEPEST internal producer/consumer, but transits are recorded
   // between a container's direct children, so each port is walked back up to
-  // the child it belongs to. Arrays (multi-pill fan-out) stay unresolved.
+  // the child it belongs to. A multi-producer source array stays unresolved —
+  // no single child definitely emits the value. A multi-consumer target array
+  // still resolves when every consumer sits under the SAME direct child (the
+  // value provably arrives there); consumers spread across children stay
+  // unresolved.
   function collapsedPorts(irEdge, expansionState, parentOf) {
     var ports = null;
     if (!expansionState[irEdge.source] && typeof irEdge.source_when_expanded === 'string') {
       var exitChild = directChildOf(irEdge.source, irEdge.source_when_expanded, parentOf);
       if (exitChild !== null) { ports = ports || Object.create(null); ports.exit = exitChild; }
     }
-    if (!expansionState[irEdge.target] && typeof irEdge.target_when_expanded === 'string') {
-      var entryChild = directChildOf(irEdge.target, irEdge.target_when_expanded, parentOf);
-      if (entryChild !== null) { ports = ports || Object.create(null); ports.entry = entryChild; }
+    if (!expansionState[irEdge.target] && irEdge.target_when_expanded) {
+      var expandedTargets = Array.isArray(irEdge.target_when_expanded)
+        ? irEdge.target_when_expanded
+        : [irEdge.target_when_expanded];
+      var entryChild = null;
+      var consistent = expandedTargets.length > 0;
+      for (var et = 0; et < expandedTargets.length; et++) {
+        var child = directChildOf(irEdge.target, expandedTargets[et], parentOf);
+        if (child === null || (entryChild !== null && child !== entryChild)) { consistent = false; break; }
+        entryChild = child;
+      }
+      if (consistent && entryChild !== null) { ports = ports || Object.create(null); ports.entry = entryChild; }
     }
     return ports;
   }

--- a/src/hypergraph/viz/assets/scene_builder.js
+++ b/src/hypergraph/viz/assets/scene_builder.js
@@ -534,6 +534,16 @@
       adjacency[from][to] = true;
     }
 
+    // An INPUT pill edge targets the collapsed box AS A BOX, never an
+    // in-port. The drawn line ends at the hull, so the reader's question is
+    // only "does this value reach the box?" — answered by the phantom
+    // in-port → box links below — and, ending at the bare box id (a sink in
+    // the path graph), the edge can never stand in for a transit.
+    function pathTarget(e) {
+      var eData = e.data || {};
+      return eData.edgeType === 'input' ? e.target : port(e.target, e.id, 'in');
+    }
+
     for (var i = 0; i < sceneEdges.length; i++) {
       var e = sceneEdges[i];
       if (e.hidden) continue;
@@ -543,7 +553,7 @@
       // candidates below: an arm only carries its value when its branch is
       // taken, so it must not imply away an unconditional edge.
       if (eData.forceFeedback || eData.exclusive) continue;
-      link(port(e.source, e.id, 'out'), port(e.target, e.id, 'in'));
+      link(port(e.source, e.id, 'out'), pathTarget(e));
     }
 
     // Join each collapsed container's in-ports to the out-ports it genuinely
@@ -560,15 +570,32 @@
       }
     }
 
+    // Path-only links from every delivered-to in-port to its box, so "reaches
+    // the box" means exactly "some visible edge delivers into the box". The
+    // bare box id has no outgoing path links, so these can never manufacture
+    // a pass-through — they only answer input-edge candidacy.
+    var inMarker = '\u0000in\u0000';
+    for (var pi = 0; pi < sceneEdges.length; pi++) {
+      var pe = sceneEdges[pi];
+      if (pe.hidden) continue;
+      var pePort = pathTarget(pe);
+      var markerAt = pePort.indexOf(inMarker);
+      if (markerAt === -1) continue;
+      link(pePort, pePort.slice(0, markerAt));
+    }
+
     var dropped = Object.create(null);
     for (var j = 0; j < sceneEdges.length; j++) {
       var edge = sceneEdges[j];
       var data = edge.data || {};
-      if (edge.hidden || data.edgeType !== 'data') continue;
+      // Input edges are candidates too: one input feeding a chain keeps only
+      // its EARLIEST consumer(s) — every later edge is a shortcut past a
+      // route the diagram already draws.
+      if (edge.hidden || (data.edgeType !== 'data' && data.edgeType !== 'input')) continue;
       if (data.exclusive || data.forceFeedback) continue;
       if (edge.source === edge.target) continue;
       var from = port(edge.source, edge.id, 'out');
-      var to = port(edge.target, edge.id, 'in');
+      var to = pathTarget(edge);
       if (from === to) continue;
       if (hasIndirectPath(adjacency, from, to)) dropped[edge.id] = true;
     }

--- a/src/hypergraph/viz/mermaid.py
+++ b/src/hypergraph/viz/mermaid.py
@@ -31,7 +31,11 @@ from hypergraph.viz._common import (
 from hypergraph.viz._mermaid_core import MermaidDiagram, _MermaidIdAllocator, _sanitize_id
 from hypergraph.viz._simplify import EdgeRef, shortcut_edge_keys
 from hypergraph.viz.renderer._format import format_type
-from hypergraph.viz.renderer.ir_builder import compute_container_transits, resolve_boundary_ports
+from hypergraph.viz.renderer.ir_builder import (
+    compute_container_transits,
+    find_internal_consumers,
+    resolve_boundary_ports,
+)
 from hypergraph.viz.renderer.nodes import (
     build_input_groups,
     get_start_targets,
@@ -356,10 +360,6 @@ def _render_merged_edges(
         expansion_state,
         use_deepest=True,
     )
-    param_to_consumers = build_param_to_consumer_map(
-        flat_graph,
-        expansion_state,
-    )
     seen_edges: set[tuple[str, str, str]] = set()
 
     for source, target, edge_data in flat_graph.edges(data=True):
@@ -429,7 +429,6 @@ def _render_merged_edges(
                 value_name,
                 flat_graph,
                 expansion_state,
-                param_to_consumers,
                 container_entrypoints,
             )
             if actual_source is None:
@@ -476,10 +475,6 @@ def _render_separate_edges(
         flat_graph,
         expansion_state,
         use_deepest=True,
-    )
-    param_to_consumers = build_param_to_consumer_map(
-        flat_graph,
-        expansion_state,
     )
     seen_edges: set[tuple[str, ...]] = set()
 
@@ -529,7 +524,6 @@ def _render_separate_edges(
                     value_name,
                     flat_graph,
                     expansion_state,
-                    param_to_consumers,
                     container_entrypoints,
                 )
                 source_attrs = flat_graph.nodes.get(actual_source, {})
@@ -700,20 +694,20 @@ def _resolve_data_targets(
     value_name: str,
     flat_graph: nx.DiGraph,
     expansion_state: dict[str, bool],
-    param_to_consumers: dict[str, list[str]],
     container_entrypoints: dict[str, tuple[str, ...]],
 ) -> list[str]:
     """Resolve actual target(s) for a data edge, entering expanded containers.
 
     One incoming value can enter a container at several internal consumers, so
     an edge into an EXPANDED container fans out to every one of them — the twin
-    of the scene builders' tuple ``target_when_expanded``. A consumer that sits
-    inside a still-collapsed inner container resolves up to that visible
-    boundary instead of silently dropping the edge."""
+    of the scene builders' tuple ``target_when_expanded``, resolved by the same
+    authority (``ir_builder.find_internal_consumers``), so a consumer already
+    fed by an INTERNAL producer of the value never receives the boundary edge.
+    A consumer that sits inside a still-collapsed inner container resolves up
+    to that visible boundary instead of silently dropping the edge."""
     target_attrs = flat_graph.nodes.get(target, {})
     if target_attrs.get("node_type") == "GRAPH" and expansion_state.get(target, False) and value_name:
-        consumers = param_to_consumers.get(value_name, [])
-        internal = [c for c in consumers if c != target and is_descendant_of(c, target, flat_graph)]
+        internal = list(find_internal_consumers(target, value_name, flat_graph))
         if not internal:
             entrypoints = resolve_expanded_entrypoints(
                 (target,),
@@ -733,10 +727,16 @@ def _resolve_data_targets(
 
 
 def _visible_ancestor(node_id: str, flat_graph: nx.DiGraph, expansion_state: dict[str, bool]) -> str | None:
-    """Walk up from ``node_id`` to the first currently-visible node."""
+    """Walk up from ``node_id`` to the first currently-visible node.
+
+    Only collapse-hiding aggregates: a node hidden by ``hide=True`` walks up
+    to an EXPANDED ancestor, which is never a legitimate edge target — the
+    edge is dropped instead, exactly as before."""
     current: str | None = node_id
     while current is not None and not is_node_visible(current, flat_graph, expansion_state):
         current = flat_graph.nodes.get(current, {}).get("parent")
+    if current is not None and current != node_id and expansion_state.get(current):
+        return None
     return current
 
 
@@ -904,8 +904,10 @@ def to_mermaid(
         depth: How many levels of nested graphs to expand (default: 0)
         show_types: Whether to show type annotations in labels
         separate_outputs: Whether to render outputs as separate DATA nodes
-        simplify: Hide data edges a longer path already implies — given
-            ``A → B → C``, a direct ``A → C`` is dropped (default: True)
+        simplify: Hide data and input edges a longer path already implies —
+            given ``A → B → C``, a direct ``A → C`` is dropped, and an input
+            feeding the whole chain keeps only its earliest consumer
+            (default: True)
         direction: Flowchart direction — "TD", "TB", "LR", "RL", "BT"
         colors: Custom color overrides per node class, e.g.
             {"function": {"fill": "#fff", "stroke": "#000"}}

--- a/src/hypergraph/viz/mermaid.py
+++ b/src/hypergraph/viz/mermaid.py
@@ -243,9 +243,11 @@ class _RenderedEdge:
 
     @property
     def removable(self) -> bool:
-        """Only plain data edges may be dropped — an ``output`` edge is the
-        structural producer→DATA link, and dropping it would orphan the pill."""
-        return self.kind == "data" and not self.exclusive and not self.is_back_edge
+        """Plain data edges and INPUT pill edges may be dropped — one input
+        feeding a chain keeps only its earliest consumer(s). An ``output``
+        edge is the structural producer→DATA link, and dropping it would
+        orphan the pill."""
+        return self.kind in ("data", "input") and not self.exclusive and not self.is_back_edge
 
     @property
     def traversable(self) -> bool:
@@ -257,7 +259,7 @@ class _RenderedEdge:
         the same reason — an arm carries its value only when its branch is
         taken, so it must not imply away an unconditional edge.
         """
-        return self.kind in ("data", "output") and not self.is_back_edge and not self.exclusive
+        return self.kind in ("data", "output", "input") and not self.is_back_edge and not self.exclusive
 
 
 def _simplify_rendered_edges(
@@ -265,16 +267,20 @@ def _simplify_rendered_edges(
     collapsed_containers: set[str],
     container_transits: dict[str, list[list[str]]],
 ) -> list[_RenderedEdge]:
-    """Drop rendered data edges a longer path already implies.
+    """Drop rendered data and INPUT edges a longer path already implies.
 
-    Mermaid's INPUT / START / END edges are inert for this purpose — nothing
-    points into ``__start__`` or out of ``__end__``, and nothing produces an
-    INPUT — so only the flow edges built here need to enter the path graph.
+    START / END edges stay inert — nothing points into ``__start__`` or out of
+    ``__end__``. INPUT pill edges enter the path graph AND the candidate set:
+    one input feeding a chain keeps only its earliest consumer(s), exactly as
+    in ``scene_builder.simplify_transitive_edges``.
 
     Collapsed containers are split into per-port nodes exactly as in
     ``scene_builder.simplify_transitive_edges``, so the text export and the
     widget agree about which boxes really pass a value through. An
-    unresolvable port becomes a dead end: unverified means "do not hide".
+    unresolvable port becomes a dead end: unverified means "do not hide". An
+    INPUT edge instead targets the box AS A BOX — the drawn line ends at the
+    hull, so its candidacy asks only whether the value reaches the box, which
+    the phantom in-port → box links answer.
     """
 
     def port(node_id: str, index: int, side: str, resolved: str | None) -> str:
@@ -283,11 +289,16 @@ def _simplify_rendered_edges(
         suffix = resolved if resolved is not None else f"?{index}"
         return f"{node_id}\x00{side}\x00{suffix}"
 
+    def ref_target(edge: _RenderedEdge, index: int) -> str:
+        if edge.kind == "input":
+            return edge.target
+        return port(edge.target, index, "in", edge.entry_port)
+
     refs = [
         EdgeRef(
             key=index,
             source=port(edge.source, index, "out", edge.exit_port),
-            target=port(edge.target, index, "in", edge.entry_port),
+            target=ref_target(edge, index),
             removable=edge.removable,
             traversable=edge.traversable,
         )
@@ -304,6 +315,25 @@ def _simplify_rendered_edges(
                     traversable=True,
                 )
             )
+    # Path-only links from every delivered-to in-port to its box, so "reaches
+    # the box" means exactly "some rendered edge delivers into the box". The
+    # bare box id has no outgoing path links, so these can never manufacture a
+    # pass-through — they only answer input-edge candidacy.
+    seen_ports: set[str] = set()
+    for ref in list(refs):
+        port_id = str(ref.target)
+        if port_id in seen_ports or "\x00in\x00" not in port_id:
+            continue
+        seen_ports.add(port_id)
+        refs.append(
+            EdgeRef(
+                key=("\x00boxin", port_id),
+                source=port_id,
+                target=port_id.split("\x00", 1)[0],
+                removable=False,
+                traversable=True,
+            )
+        )
     dropped = shortcut_edge_keys(refs)
     return [edge for index, edge in enumerate(rendered) if index not in dropped]
 
@@ -1021,6 +1051,7 @@ def to_mermaid(
     edge_pairs: list[tuple[str, str]] = []
     edge_pairs.extend((line, "start") for line in _render_start_edges(start_targets, id_allocator))
 
+    input_rendered: list[_RenderedEdge] = []
     for group in input_groups:
         params = group["params"]
         if len(params) == 1:
@@ -1037,7 +1068,14 @@ def to_mermaid(
             container_entrypoints,
         )
         for tgt in targets:
-            edge_pairs.append((_format_edge(input_node_id, tgt, None, id_allocator=id_allocator), "input"))
+            input_rendered.append(
+                _RenderedEdge(
+                    _format_edge(input_node_id, tgt, None, id_allocator=id_allocator),
+                    "input",
+                    input_node_id,
+                    tgt,
+                )
+            )
 
     exclusive_data_edges = compute_exclusive_data_edges(flat_graph)
     back_edges = find_back_edges(flat_graph)
@@ -1050,12 +1088,17 @@ def to_mermaid(
         back_edges,
         id_allocator,
     )
+    # Input edges enter the reduction with the flow edges (an input feeding a
+    # chain keeps only its earliest consumer), then emit first so the text
+    # keeps its historical section order.
+    combined = input_rendered + rendered
     if simplify:
         collapsed_containers = {
             node_id for node_id, attrs in flat_graph.nodes(data=True) if attrs.get("node_type") == "GRAPH" and not expansion_state.get(node_id, False)
         }
-        rendered = _simplify_rendered_edges(rendered, collapsed_containers, compute_container_transits(flat_graph))
-    edge_pairs.extend((edge.line, edge.kind) for edge in rendered)
+        combined = _simplify_rendered_edges(combined, collapsed_containers, compute_container_transits(flat_graph))
+    edge_pairs.extend((edge.line, edge.kind) for edge in combined if edge.kind == "input")
+    edge_pairs.extend((edge.line, edge.kind) for edge in combined if edge.kind != "input")
 
     edge_pairs.extend((line, "end") for line in _render_end_edges(flat_graph, expansion_state, id_allocator))
 

--- a/src/hypergraph/viz/mermaid.py
+++ b/src/hypergraph/viz/mermaid.py
@@ -394,7 +394,7 @@ def _render_merged_edges(
                 expansion_state,
                 output_to_producer,
             )
-            actual_target = _resolve_data_target(
+            actual_targets = _resolve_data_targets(
                 target,
                 value_name,
                 flat_graph,
@@ -402,28 +402,29 @@ def _render_merged_edges(
                 param_to_consumers,
                 container_entrypoints,
             )
-            if actual_source is None or actual_target is None:
+            if actual_source is None:
                 continue
-            if actual_source == actual_target:
-                continue
-            edge_key = (id_allocator.get(actual_source), id_allocator.get(actual_target), value_name)
-            if edge_key in seen_edges:
-                continue
-            seen_edges.add(edge_key)
-            is_exclusive = (source, target, value_name) in exclusive_data_edges
-            exit_port, entry_port = resolve_boundary_ports(flat_graph, source, target, value_names or [value_name])
-            out.append(
-                _RenderedEdge(
-                    _format_edge(actual_source, actual_target, None, exclusive=is_exclusive, id_allocator=id_allocator),
-                    "data",
-                    actual_source,
-                    actual_target,
-                    exclusive=is_exclusive,
-                    is_back_edge=(source, target) in back_edges,
-                    exit_port=exit_port,
-                    entry_port=entry_port,
+            for actual_target in actual_targets:
+                if actual_source == actual_target:
+                    continue
+                edge_key = (id_allocator.get(actual_source), id_allocator.get(actual_target), value_name)
+                if edge_key in seen_edges:
+                    continue
+                seen_edges.add(edge_key)
+                is_exclusive = (source, target, value_name) in exclusive_data_edges
+                exit_port, entry_port = resolve_boundary_ports(flat_graph, source, target, value_names or [value_name])
+                out.append(
+                    _RenderedEdge(
+                        _format_edge(actual_source, actual_target, None, exclusive=is_exclusive, id_allocator=id_allocator),
+                        "data",
+                        actual_source,
+                        actual_target,
+                        exclusive=is_exclusive,
+                        is_back_edge=(source, target) in back_edges,
+                        exit_port=exit_port,
+                        entry_port=entry_port,
+                    )
                 )
-            )
 
     return out
 
@@ -493,7 +494,7 @@ def _render_separate_edges(
                 )
                 if actual_source is None:
                     continue
-                actual_target = _resolve_data_target(
+                actual_targets = _resolve_data_targets(
                     target,
                     value_name,
                     flat_graph,
@@ -501,26 +502,25 @@ def _render_separate_edges(
                     param_to_consumers,
                     container_entrypoints,
                 )
-                if actual_target is None:
-                    continue
                 source_attrs = flat_graph.nodes.get(actual_source, {})
                 if is_internal_gate_output(actual_source, value_name, source_attrs):
                     continue
                 data_id = f"data_{actual_source}_{value_name}"
-                edge_key = (id_allocator.get(data_id), id_allocator.get(actual_target))
-                if edge_key not in seen_edges:
-                    seen_edges.add(edge_key)
-                    is_exclusive = (source, target, value_name) in exclusive_data_edges
-                    out.append(
-                        _RenderedEdge(
-                            _format_edge(data_id, actual_target, value_name, exclusive=is_exclusive, id_allocator=id_allocator),
-                            "data",
-                            data_id,
-                            actual_target,
-                            exclusive=is_exclusive,
-                            is_back_edge=(source, target) in back_edges,
+                for actual_target in actual_targets:
+                    edge_key = (id_allocator.get(data_id), id_allocator.get(actual_target))
+                    if edge_key not in seen_edges:
+                        seen_edges.add(edge_key)
+                        is_exclusive = (source, target, value_name) in exclusive_data_edges
+                        out.append(
+                            _RenderedEdge(
+                                _format_edge(data_id, actual_target, value_name, exclusive=is_exclusive, id_allocator=id_allocator),
+                                "data",
+                                data_id,
+                                actual_target,
+                                exclusive=is_exclusive,
+                                is_back_edge=(source, target) in back_edges,
+                            )
                         )
-                    )
 
         elif edge_type == "ordering":
             value_name = value_names[0] if value_names else ""
@@ -665,34 +665,49 @@ def _resolve_data_source(
     return actual_source
 
 
-def _resolve_data_target(
+def _resolve_data_targets(
     target: str,
     value_name: str,
     flat_graph: nx.DiGraph,
     expansion_state: dict[str, bool],
     param_to_consumers: dict[str, list[str]],
     container_entrypoints: dict[str, tuple[str, ...]],
-) -> str | None:
-    """Resolve actual target for a data edge, entering expanded containers."""
-    actual_target = target
+) -> list[str]:
+    """Resolve actual target(s) for a data edge, entering expanded containers.
+
+    One incoming value can enter a container at several internal consumers, so
+    an edge into an EXPANDED container fans out to every one of them — the twin
+    of the scene builders' tuple ``target_when_expanded``. A consumer that sits
+    inside a still-collapsed inner container resolves up to that visible
+    boundary instead of silently dropping the edge."""
     target_attrs = flat_graph.nodes.get(target, {})
     if target_attrs.get("node_type") == "GRAPH" and expansion_state.get(target, False) and value_name:
         consumers = param_to_consumers.get(value_name, [])
         internal = [c for c in consumers if c != target and is_descendant_of(c, target, flat_graph)]
-        if internal:
-            actual_target = internal[0]
-        else:
+        if not internal:
             entrypoints = resolve_expanded_entrypoints(
                 (target,),
                 container_entrypoints,
                 expansion_state,
             )
-            if not entrypoints:
-                return None
-            actual_target = entrypoints[0]
-    if not is_node_visible(actual_target, flat_graph, expansion_state):
-        return None
-    return actual_target
+            internal = [entrypoints[0]] if entrypoints else []
+        resolved: list[str] = []
+        for candidate in internal:
+            visible = _visible_ancestor(candidate, flat_graph, expansion_state)
+            if visible is not None and visible not in resolved:
+                resolved.append(visible)
+        return resolved
+    if not is_node_visible(target, flat_graph, expansion_state):
+        return []
+    return [target]
+
+
+def _visible_ancestor(node_id: str, flat_graph: nx.DiGraph, expansion_state: dict[str, bool]) -> str | None:
+    """Walk up from ``node_id`` to the first currently-visible node."""
+    current: str | None = node_id
+    while current is not None and not is_node_visible(current, flat_graph, expansion_state):
+        current = flat_graph.nodes.get(current, {}).get("parent")
+    return current
 
 
 def _get_control_label(

--- a/src/hypergraph/viz/mermaid.py
+++ b/src/hypergraph/viz/mermaid.py
@@ -434,10 +434,10 @@ def _render_merged_edges(
             )
             if actual_source is None:
                 continue
-            for actual_target in actual_targets:
-                if actual_source == actual_target:
+            for resolved_target in actual_targets:
+                if actual_source == resolved_target:
                     continue
-                edge_key = (id_allocator.get(actual_source), id_allocator.get(actual_target), value_name)
+                edge_key = (id_allocator.get(actual_source), id_allocator.get(resolved_target), value_name)
                 if edge_key in seen_edges:
                     continue
                 seen_edges.add(edge_key)
@@ -445,10 +445,10 @@ def _render_merged_edges(
                 exit_port, entry_port = resolve_boundary_ports(flat_graph, source, target, value_names or [value_name])
                 out.append(
                     _RenderedEdge(
-                        _format_edge(actual_source, actual_target, None, exclusive=is_exclusive, id_allocator=id_allocator),
+                        _format_edge(actual_source, resolved_target, None, exclusive=is_exclusive, id_allocator=id_allocator),
                         "data",
                         actual_source,
-                        actual_target,
+                        resolved_target,
                         exclusive=is_exclusive,
                         is_back_edge=(source, target) in back_edges,
                         exit_port=exit_port,
@@ -536,17 +536,17 @@ def _render_separate_edges(
                 if is_internal_gate_output(actual_source, value_name, source_attrs):
                     continue
                 data_id = f"data_{actual_source}_{value_name}"
-                for actual_target in actual_targets:
-                    edge_key = (id_allocator.get(data_id), id_allocator.get(actual_target))
+                for resolved_target in actual_targets:
+                    edge_key = (id_allocator.get(data_id), id_allocator.get(resolved_target))
                     if edge_key not in seen_edges:
                         seen_edges.add(edge_key)
                         is_exclusive = (source, target, value_name) in exclusive_data_edges
                         out.append(
                             _RenderedEdge(
-                                _format_edge(data_id, actual_target, value_name, exclusive=is_exclusive, id_allocator=id_allocator),
+                                _format_edge(data_id, resolved_target, value_name, exclusive=is_exclusive, id_allocator=id_allocator),
                                 "data",
                                 data_id,
-                                actual_target,
+                                resolved_target,
                                 exclusive=is_exclusive,
                                 is_back_edge=(source, target) in back_edges,
                             )

--- a/src/hypergraph/viz/renderer/ir_builder.py
+++ b/src/hypergraph/viz/renderer/ir_builder.py
@@ -295,7 +295,7 @@ def _build_ir_edge(
     tgt_attrs = flat_graph.nodes.get(tgt, {})
     if tgt_attrs.get("node_type") == "GRAPH":
         for value_name in value_names:
-            internal_consumers = _find_internal_consumers(tgt, value_name, flat_graph)
+            internal_consumers = find_internal_consumers(tgt, value_name, flat_graph)
             if internal_consumers:
                 target_when_expanded = internal_consumers[0] if len(internal_consumers) == 1 else internal_consumers
                 break
@@ -399,7 +399,7 @@ def _find_deepest_internal_producers(container_id: str, value_name: str, flat_gr
     return tuple(node_id for node_id in candidates if _depth_below(node_id, container_id, flat_graph) == max_depth)
 
 
-def _find_internal_consumers(container_id: str, value_name: str, flat_graph: nx.DiGraph) -> tuple[str, ...]:
+def find_internal_consumers(container_id: str, value_name: str, flat_graph: nx.DiGraph) -> tuple[str, ...]:
     """EVERY internal consumer a boundary value feeds, not just the deepest.
 
     One incoming value can enter a container at several nodes — panda's
@@ -417,7 +417,7 @@ def _find_internal_consumers(container_id: str, value_name: str, flat_graph: nx.
     descendants = [
         (node_id, attrs)
         for node_id, attrs in flat_graph.nodes(data=True)
-        if _is_descendant(node_id, container_id, flat_graph) and attrs.get("node_type") != "GRAPH"
+        if _is_descendant(node_id, container_id, flat_graph) and attrs.get("node_type") != "GRAPH" and not attrs.get("hide", False)
     ]
 
     def fed_internally(node_id: str) -> bool:
@@ -543,7 +543,7 @@ def resolve_boundary_ports(
 
     if flat_graph.nodes.get(tgt, {}).get("node_type") == "GRAPH":
         for value_name in value_names:
-            consumers = _find_internal_consumers(tgt, value_name, flat_graph)
+            consumers = find_internal_consumers(tgt, value_name, flat_graph)
             if consumers:
                 children = {_direct_child(tgt, consumer, flat_graph) for consumer in consumers}
                 if len(children) == 1:

--- a/src/hypergraph/viz/renderer/ir_builder.py
+++ b/src/hypergraph/viz/renderer/ir_builder.py
@@ -295,9 +295,9 @@ def _build_ir_edge(
     tgt_attrs = flat_graph.nodes.get(tgt, {})
     if tgt_attrs.get("node_type") == "GRAPH":
         for value_name in value_names:
-            internal = _find_deepest_internal_consumer(tgt, value_name, flat_graph)  # type: ignore[assignment]
-            if internal is not None:
-                target_when_expanded = internal  # type: ignore[assignment]
+            internal_consumers = _find_internal_consumers(tgt, value_name, flat_graph)
+            if internal_consumers:
+                target_when_expanded = internal_consumers[0] if len(internal_consumers) == 1 else internal_consumers
                 break
         # Any edge into a container still unresolved here must re-route to the
         # container's entrypoint when the container is expanded, or the scene
@@ -399,13 +399,20 @@ def _find_deepest_internal_producers(container_id: str, value_name: str, flat_gr
     return tuple(node_id for node_id in candidates if _depth_below(node_id, container_id, flat_graph) == max_depth)
 
 
-def _find_deepest_internal_consumer(container_id: str, value_name: str, flat_graph: nx.DiGraph) -> str | None:
-    """Mirror of :func:`_find_deepest_internal_producer` for inputs.
+def _find_internal_consumers(container_id: str, value_name: str, flat_graph: nx.DiGraph) -> tuple[str, ...]:
+    """EVERY internal consumer a boundary value feeds, not just the deepest.
 
-    Applies the exact ``input_name_map`` rename first (the
-    ``map_over`` / ``rename_inputs`` case, e.g. the outer edge carries
-    ``eval_pairs`` but the per-item internal node consumes ``eval_pair``),
-    then falls back to fuzzy substring matching."""
+    One incoming value can enter a container at several nodes — panda's
+    generation graph consumes ``document`` at both its ``@ifelse`` guard and
+    the nested messages graph. Returning only ``max(..., key=depth)`` left
+    every other consumer with no incoming edge once the container expanded.
+
+    Exact name matches are authoritative: each one genuinely reads the value,
+    so each one gets the edge. A consumer already fed by an *internal*
+    producer of the same name is excluded — its value does not cross the
+    boundary. The fuzzy fallback stays single-answer (deepest): a substring
+    match is a guess, and fanning a guess out would draw edges nobody can
+    defend."""
     inner_names = _inner_input_names(container_id, value_name, flat_graph)
     descendants = [
         (node_id, attrs)
@@ -413,14 +420,24 @@ def _find_deepest_internal_consumer(container_id: str, value_name: str, flat_gra
         if _is_descendant(node_id, container_id, flat_graph) and attrs.get("node_type") != "GRAPH"
     ]
 
-    candidates = [node_id for node_id, attrs in descendants if any(inner in attrs.get("inputs", ()) for inner in inner_names)]
+    def fed_internally(node_id: str) -> bool:
+        for pred, _, attrs in flat_graph.in_edges(node_id, data=True):
+            if not _is_descendant(pred, container_id, flat_graph):
+                continue
+            if any(inner in attrs.get("value_names", ()) for inner in inner_names):
+                return True
+        return False
+
+    candidates = [
+        node_id for node_id, attrs in descendants if any(inner in attrs.get("inputs", ()) for inner in inner_names) and not fed_internally(node_id)
+    ]
     if candidates:
-        return max(candidates, key=lambda c: _depth_below(c, container_id, flat_graph))
+        return tuple(candidates)
 
     fuzzy = [node_id for node_id, attrs in descendants for inp in attrs.get("inputs", ()) for inner in inner_names if inp in inner or inner in inp]
     if fuzzy:
-        return max(fuzzy, key=lambda c: _depth_below(c, container_id, flat_graph))
-    return None
+        return (max(fuzzy, key=lambda c: _depth_below(c, container_id, flat_graph)),)
+    return ()
 
 
 def _is_descendant(node_id: str, ancestor_id: str, flat_graph: nx.DiGraph) -> bool:
@@ -507,6 +524,11 @@ def resolve_boundary_ports(
     picking the first would assert a route that may not run. This matches what
     the scene builders already do with a tuple ``*_when_expanded`` — anything
     unresolved becomes a dead end, never a pass-through.
+
+    An entry resolves as long as every internal consumer sits under the SAME
+    direct child — the value provably arrives there. Consumers spread across
+    several children leave the entry unresolved for the same reason as an
+    ambiguous exit: no single child is THE port.
     """
     exit_port: str | None = None
     entry_port: str | None = None
@@ -521,9 +543,11 @@ def resolve_boundary_ports(
 
     if flat_graph.nodes.get(tgt, {}).get("node_type") == "GRAPH":
         for value_name in value_names:
-            consumer = _find_deepest_internal_consumer(tgt, value_name, flat_graph)
-            if consumer is not None:
-                entry_port = _direct_child(tgt, consumer, flat_graph)
+            consumers = _find_internal_consumers(tgt, value_name, flat_graph)
+            if consumers:
+                children = {_direct_child(tgt, consumer, flat_graph) for consumer in consumers}
+                if len(children) == 1:
+                    entry_port = children.pop()
                 break
 
     return exit_port, entry_port

--- a/src/hypergraph/viz/renderer/ir_builder.py
+++ b/src/hypergraph/viz/renderer/ir_builder.py
@@ -279,7 +279,7 @@ def _build_ir_edge(
     so the JS scene_builder can re-route edges on container expansion
     without re-walking the graph."""
     source_when_expanded: str | tuple[str, ...] | None = None
-    target_when_expanded: str | None = None
+    target_when_expanded: str | tuple[str, ...] | None = None
 
     edge_type = attrs.get("edge_type", "data")
     value_names = tuple(attrs.get("value_names", ()))

--- a/src/hypergraph/viz/scene_builder.py
+++ b/src/hypergraph/viz/scene_builder.py
@@ -328,11 +328,18 @@ def _resolve_rewritten_endpoints(
     """Walk each rewritten endpoint up to its deepest visible ancestor, keeping
     order and dropping duplicates. An endpoint with no visible ancestor (or one
     outside the parent map, e.g. a not-yet-emitted INPUT pill id) is kept as
-    is — the edge then stays hidden exactly as before."""
+    is — the edge then stays hidden exactly as before.
+
+    Only collapse-hiding aggregates: a node hidden by ``hide=True`` walks up to
+    an EXPANDED ancestor, and an edge must never target an expanded container
+    (dagre cannot rank it) — so that resolution is rejected and the edge stays
+    hidden, exactly as it did before endpoints were resolved at all."""
     resolved: list[str] = []
     for endpoint in endpoints:
         visible = _resolve_to_visible(endpoint, parent_map, expansion_state, visible_ids)
         candidate = visible if visible is not None else endpoint
+        if candidate != endpoint and expansion_state.get(candidate):
+            candidate = endpoint
         if candidate not in resolved:
             resolved.append(candidate)
     return resolved

--- a/src/hypergraph/viz/scene_builder.py
+++ b/src/hypergraph/viz/scene_builder.py
@@ -362,8 +362,9 @@ def _collapsed_ports(ir_edge: Any, expansion_state: dict[str, bool], parent_map:
         expanded = ir_edge.target_when_expanded
         expanded_targets = expanded if isinstance(expanded, tuple) else (expanded,)
         children = {_direct_child_of(ir_edge.target, target, parent_map) for target in expanded_targets}
-        if len(children) == 1 and None not in children:
-            ports["entry"] = children.pop()
+        only_child = next(iter(children)) if len(children) == 1 else None
+        if only_child is not None:
+            ports["entry"] = only_child
     return ports
 
 

--- a/src/hypergraph/viz/scene_builder.py
+++ b/src/hypergraph/viz/scene_builder.py
@@ -205,20 +205,28 @@ def build_initial_scene(
     for ir_edge in ir.edges:
         # Container expansion rewrites: when source/target container is
         # expanded, route the edge to the deepest internal producer/consumer
-        # instead of the container hull.
+        # instead of the container hull. A rewritten endpoint may itself sit
+        # inside a still-collapsed INNER container, so it is resolved up to
+        # its deepest visible ancestor — the edge aggregates to that boundary
+        # instead of vanishing with the hidden node. Several endpoints
+        # resolving to one ancestor collapse to one edge.
         base_sources = [ir_edge.source]
         if expansion_state.get(ir_edge.source) and ir_edge.source_when_expanded:
             expanded_sources = ir_edge.source_when_expanded
             base_sources = list(expanded_sources) if isinstance(expanded_sources, tuple) else [expanded_sources]
-        # A fan-out edge into an expanded container may re-route to several item
-        # -field INPUT pills, so target_when_expanded can be a tuple; emit one
-        # edge per target (mirrors the multi-source fan-out below).
+            base_sources = _resolve_rewritten_endpoints(base_sources, parent_map, expansion_state, visible_ids)
+        # An edge into an expanded container may re-route to several internal
+        # consumers (one value entering a container at more than one node) or,
+        # for identity-mode fan-out, to several item-field INPUT pills — so
+        # target_when_expanded can be a tuple; emit one edge per target
+        # (mirrors the multi-source fan-out below).
         targets = [ir_edge.target]
         if expansion_state.get(ir_edge.target):
             if ir_edge.target_when_expanded:
                 expanded_targets = ir_edge.target_when_expanded
                 targets = list(expanded_targets) if isinstance(expanded_targets, tuple) else [expanded_targets]
             targets = list(resolve_expanded_entrypoints(targets, ir.container_entrypoints, expansion_state))
+            targets = _resolve_rewritten_endpoints(targets, parent_map, expansion_state, visible_ids)
 
         # A data edge can carry multiple value_names (one NetworkX edge per
         # (src,tgt) merges them). Merged-output mode should still render one
@@ -311,6 +319,25 @@ def _collapsed_containers(ir: GraphIR, expansion_state: dict[str, bool]) -> set[
     return {n.id for n in ir.nodes if n.node_type == "GRAPH" and not expansion_state.get(n.id, False)}
 
 
+def _resolve_rewritten_endpoints(
+    endpoints: list[str],
+    parent_map: dict[str, str],
+    expansion_state: dict[str, bool],
+    visible_ids: set[str],
+) -> list[str]:
+    """Walk each rewritten endpoint up to its deepest visible ancestor, keeping
+    order and dropping duplicates. An endpoint with no visible ancestor (or one
+    outside the parent map, e.g. a not-yet-emitted INPUT pill id) is kept as
+    is — the edge then stays hidden exactly as before."""
+    resolved: list[str] = []
+    for endpoint in endpoints:
+        visible = _resolve_to_visible(endpoint, parent_map, expansion_state, visible_ids)
+        candidate = visible if visible is not None else endpoint
+        if candidate not in resolved:
+            resolved.append(candidate)
+    return resolved
+
+
 def _collapsed_ports(ir_edge: Any, expansion_state: dict[str, bool], parent_map: dict[str, str]) -> dict[str, str]:
     """The internal entry/exit a boundary edge resolves to, when its container
     endpoint is currently collapsed.
@@ -319,18 +346,24 @@ def _collapsed_ports(ir_edge: Any, expansion_state: dict[str, bool], parent_map:
     internal producer/consumer, which may sit several levels down. Transits are
     recorded between a container's **direct children**, so each port is walked
     back up to the child of the container it belongs to — for ``mid`` an entry
-    of ``mid/deep/inner_a`` is the child ``mid/deep``. A tuple (multi-pill
-    fan-out) is left unresolved on purpose — see ``simplify_transitive_edges``.
+    of ``mid/deep/inner_a`` is the child ``mid/deep``. A multi-producer source
+    tuple is left unresolved on purpose — no single child definitely emits the
+    value. A multi-consumer target tuple still resolves when every consumer
+    sits under the SAME direct child (the value provably arrives there);
+    consumers spread across children stay unresolved — see
+    ``simplify_transitive_edges``.
     """
     ports: dict[str, str] = {}
     if not expansion_state.get(ir_edge.source) and isinstance(ir_edge.source_when_expanded, str):
         child = _direct_child_of(ir_edge.source, ir_edge.source_when_expanded, parent_map)
         if child is not None:
             ports["exit"] = child
-    if not expansion_state.get(ir_edge.target) and isinstance(ir_edge.target_when_expanded, str):
-        child = _direct_child_of(ir_edge.target, ir_edge.target_when_expanded, parent_map)
-        if child is not None:
-            ports["entry"] = child
+    if not expansion_state.get(ir_edge.target) and ir_edge.target_when_expanded:
+        expanded = ir_edge.target_when_expanded
+        expanded_targets = expanded if isinstance(expanded, tuple) else (expanded,)
+        children = {_direct_child_of(ir_edge.target, target, parent_map) for target in expanded_targets}
+        if len(children) == 1 and None not in children:
+            ports["entry"] = children.pop()
     return ports
 
 
@@ -571,6 +604,14 @@ def _merge_inputs_for_state(
                 if resolved not in targets:
                     targets.append(resolved)
         owner_container = _visible_owner(ext.deepest_owner, parent_map, expansion_state)
+        # A real external input is part of the graph's contract, so collapsing
+        # the container that owns it must not erase it: the pill hoists to its
+        # deepest VISIBLE ancestor (owner_container) and its edges aggregate to
+        # the collapsed boundary. Only map-fed pills disappear with their
+        # container — they project a fan-out edge that re-attaches to the
+        # container hull while it is collapsed, so keeping the pill would draw
+        # the same value twice.
+        hidden = _input_hidden(ext.deepest_owner, parent_map, expansion_state) if ext.map_fed else False
         # map_fed and is_bound style the pill; owner_container decides where it
         # nests. Merging across any of them would change what the pill means.
         key = (frozenset(targets), ext.is_bound, bool(ext.map_fed), owner_container)
@@ -587,14 +628,14 @@ def _merge_inputs_for_state(
                 "owner_container": owner_container,
                 "deepest_owner": ext.deepest_owner,
                 "targets": list(targets),
-                "hidden": _input_hidden(ext.deepest_owner, parent_map, expansion_state),
+                "hidden": hidden,
             }
             continue
         bucket["params"].extend(ext.params)
         bucket["segments"].extend(segments)
         bucket["type_hints"].extend(ext.type_hints)
         # A merged pill is hidden only when every constituent is.
-        bucket["hidden"] = bucket["hidden"] and _input_hidden(ext.deepest_owner, parent_map, expansion_state)
+        bucket["hidden"] = bucket["hidden"] and hidden
 
     merged: list[dict[str, Any]] = []
     for key in order:

--- a/src/hypergraph/viz/scene_builder.py
+++ b/src/hypergraph/viz/scene_builder.py
@@ -432,12 +432,21 @@ def simplify_transitive_edges(
         edge_type = data.get("edgeType")
         is_back_edge = bool(data.get("forceFeedback"))
         is_exclusive = bool(data.get("exclusive"))
+        # An INPUT pill edge targets the collapsed box AS A BOX, never an
+        # in-port. The drawn line ends at the hull, so the reader's question
+        # is only "does this value reach the box?" — answered by the phantom
+        # in-port → box links below — and, ending at the bare box id (a sink
+        # in the path graph), the edge can never stand in for a transit.
+        target = edge["target"] if edge_type == "input" else port(edge["target"], edge["id"], "in")
         refs.append(
             EdgeRef(
                 key=edge["id"],
                 source=port(edge["source"], edge["id"], "out"),
-                target=port(edge["target"], edge["id"], "in"),
-                removable=edge_type == "data" and not is_exclusive and not is_back_edge,
+                target=target,
+                # Input edges are candidates too: one input feeding a chain
+                # keeps only its EARLIEST consumer(s) — every later edge is a
+                # shortcut past a route the diagram already draws.
+                removable=edge_type in ("data", "input") and not is_exclusive and not is_back_edge,
                 # Exclusive arms are excluded from the path graph too, not just
                 # from the candidates: an arm only carries its value when its
                 # branch is taken, so it must not imply away an unconditional edge.
@@ -458,6 +467,19 @@ def simplify_transitive_edges(
                     traversable=True,
                 )
             )
+
+    # Path-only links from every delivered-to in-port to its box, so "reaches
+    # the box" means exactly "some visible edge delivers into the box". The
+    # bare box id has no outgoing path links, so these can never manufacture a
+    # pass-through — they only answer input-edge candidacy.
+    seen_ports: set[str] = set()
+    for ref in list(refs):
+        port_id = ref.target
+        if port_id in seen_ports or "\x00in\x00" not in port_id:
+            continue
+        seen_ports.add(port_id)
+        container = port_id.split("\x00", 1)[0]
+        refs.append(EdgeRef(key=("\x00boxin", port_id), source=port_id, target=container, removable=False, traversable=True))
 
     dropped = shortcut_edge_keys(refs)
     return [edge for edge in scene_edges if edge["id"] not in dropped]

--- a/src/hypergraph/viz/widget.py
+++ b/src/hypergraph/viz/widget.py
@@ -79,8 +79,10 @@ def visualize(
         separate_outputs: Whether to render outputs as separate DATA nodes.
         show_inputs: Whether to show INPUT/INPUT_GROUP nodes.
         show_bounded_inputs: Whether to include bound INPUT/INPUT_GROUP nodes.
-        simplify: Hide data edges a longer path already implies — with
-            ``A → B → C``, a direct ``A → C`` is dropped (default: True).
+        simplify: Hide data and input edges a longer path already implies —
+            with ``A → B → C``, a direct ``A → C`` is dropped, and an input
+            feeding the whole chain keeps only its earliest consumer
+            (default: True).
             Toggleable in the widget toolbar.
         show_external_inputs: Deprecated alias for ``show_inputs``.
         filepath: Path to save standalone HTML (default: display in notebook).

--- a/tests/viz/test_complex_nested_graphs.py
+++ b/tests/viz/test_complex_nested_graphs.py
@@ -4,7 +4,7 @@ from hypergraph import Graph, ifelse, node
 from tests.viz.conftest import scene_for_state
 
 
-def _expanded_edges(graph_or_result, *, separate_outputs: bool = False) -> list[dict]:
+def _expanded_edges(graph_or_result, *, separate_outputs: bool = False, simplify: bool = True) -> list[dict]:
     """Return the visible-edge set when every container is expanded.
 
     Accepts either a :class:`Graph` (preferred) or the legacy
@@ -12,7 +12,7 @@ def _expanded_edges(graph_or_result, *, separate_outputs: bool = False) -> list[
     embedded in ``meta``).
     """
     if hasattr(graph_or_result, "to_flat_graph"):
-        scene = scene_for_state(graph_or_result, expand_all=True, separate_outputs=separate_outputs)
+        scene = scene_for_state(graph_or_result, expand_all=True, separate_outputs=separate_outputs, simplify=simplify)
         return [e for e in scene["edges"] if not e.get("hidden")]
     raise TypeError("_expanded_edges expects a Graph instance")
 
@@ -110,8 +110,11 @@ def make_rag_style_graph() -> Graph:
 
 
 def test_rag_style_query_edges_route_to_internal_nodes_when_expanded() -> None:
+    # simplify=False: this pins the expansion ROUTING (every consumer gets its
+    # edge into the open containers); which of those edges the reduction then
+    # hides is test_simplify_edges.py's contract.
     graph = make_rag_style_graph()
-    edges = _expanded_edges(graph)
+    edges = _expanded_edges(graph, simplify=False)
 
     query_targets = {edge["target"] for edge in edges if edge["source"] == "input_query"}
 

--- a/tests/viz/test_container_boundary_edges.py
+++ b/tests/viz/test_container_boundary_edges.py
@@ -1,0 +1,165 @@
+"""Boundary fidelity: expanding or collapsing a container must never LOSE an edge.
+
+Two real losses, both first seen on panda's review_generation graph (a nested
+generation graph whose ``@ifelse`` guard and nested messages graph BOTH consume
+the same incoming ``document``):
+
+1. An edge into an expanded container was re-routed to only ONE internal
+   consumer — the deepest — so every other internal consumer (the guard)
+   rendered with no incoming edge at any depth.
+2. The single re-route target could itself sit inside a still-collapsed inner
+   container; the rewritten edge then pointed at a hidden node and vanished
+   entirely, so the expanded view showed LESS than the collapsed one.
+
+An outer input consumed only inside a collapsed container has the same
+obligation from the pill side: the pill hoists to the deepest visible ancestor
+and its edge aggregates to the container boundary — it must not vanish with
+the container's internals.
+"""
+
+from __future__ import annotations
+
+from hypergraph import Graph, ifelse, node
+from tests.viz.conftest import scene_for_state
+
+
+@node(output_name="document")
+def pick(raw: str) -> str:
+    return raw
+
+
+@node(output_name="context")
+def format_ctx(document: str) -> str:
+    return document
+
+
+@node(output_name="messages")
+def assemble(context: str, query: str) -> list[str]:
+    return [context, query]
+
+
+@node(output_name="answer")
+def respond(messages: list[str]) -> str:
+    return messages[0]
+
+
+@node(output_name="answer")
+def canned(note: str = "see figures") -> str:
+    return note
+
+
+@ifelse(when_true="canned", when_false="build_messages")
+def gate(document: str) -> bool:
+    return len(document) > 3
+
+
+def _generation() -> Graph:
+    msgs = Graph([format_ctx, assemble], name="msgs")
+    gen = Graph([gate, canned, msgs.as_node(name="build_messages"), respond], name="gen").select("answer")
+    return Graph([pick, gen.as_node(name="gen")], name="outer")
+
+
+def _visible(scene: dict) -> list[tuple[str, str]]:
+    return [(e["source"], e["target"]) for e in scene["edges"] if not e["hidden"]]
+
+
+def _pill_for(scene: dict, param: str) -> str | None:
+    """The visible INPUT/INPUT_GROUP pill carrying ``param``, whatever the
+    per-state grouping merged it with."""
+    for scene_node in scene["nodes"]:
+        if scene_node["hidden"]:
+            continue
+        data = scene_node["data"]
+        if data.get("nodeType") == "INPUT" and data.get("label") == param:
+            return scene_node["id"]
+        if data.get("nodeType") == "INPUT_GROUP" and param in data.get("params", ()):
+            return scene_node["id"]
+    return None
+
+
+class TestEdgeIntoExpandedContainerReachesEveryConsumer:
+    def test_gate_receives_the_boundary_value_when_expanded(self):
+        """The E.2 shape: the @ifelse guard consumed ``document`` and drew nothing."""
+        scene = scene_for_state(_generation(), expansion_state={"gen": True}, simplify=False)
+
+        assert ("pick", "gen/gate") in _visible(scene), f"the guard consumes 'document'; visible: {sorted(_visible(scene))}"
+
+    def test_rewritten_edge_resolves_to_the_collapsed_inner_container(self):
+        """The deepest consumer sits inside collapsed ``build_messages``; the
+        edge must aggregate to that boundary, not vanish with it."""
+        scene = scene_for_state(_generation(), expansion_state={"gen": True}, simplify=False)
+
+        assert ("pick", "gen/build_messages") in _visible(scene), f"'document' also feeds the messages graph; visible: {sorted(_visible(scene))}"
+
+    def test_fully_expanded_reaches_the_deepest_consumer(self):
+        scene = scene_for_state(_generation(), expansion_state={"gen": True, "gen/build_messages": True}, simplify=False)
+
+        visible = _visible(scene)
+        assert ("pick", "gen/gate") in visible
+        assert ("pick", "gen/build_messages/format_ctx") in visible
+
+    def test_collapsed_view_is_unchanged(self):
+        scene = scene_for_state(_generation(), expansion_state={}, simplify=False)
+
+        assert ("pick", "gen") in _visible(scene)
+
+    def test_no_duplicate_edges_when_consumers_share_a_visible_ancestor(self):
+        """Two deep consumers resolving to one collapsed box = one edge."""
+
+        @node(output_name="context2")
+        def also_reads(document: str) -> str:
+            return document
+
+        msgs = Graph([format_ctx, also_reads, assemble], name="msgs")
+        gen = Graph([gate, canned, msgs.as_node(name="build_messages"), respond], name="gen").select("answer")
+        outer = Graph([pick, gen.as_node(name="gen")], name="outer")
+
+        scene = scene_for_state(outer, expansion_state={"gen": True}, simplify=False)
+        ids = [e["id"] for e in scene["edges"] if not e["hidden"]]
+        assert len(ids) == len(set(ids)), f"duplicate edge ids: {sorted(ids)}"
+        hits = [pair for pair in _visible(scene) if pair == ("pick", "gen/build_messages")]
+        assert len(hits) == 1, f"expected exactly one aggregated edge, got {len(hits)}"
+
+
+class TestMermaidTwinAgrees:
+    """The text export resolves the same boundaries as the widget."""
+
+    def test_mermaid_fans_out_to_every_consumer(self):
+        from hypergraph.viz.mermaid import to_mermaid
+
+        text = str(to_mermaid(_generation().to_flat_graph(), depth=1, simplify=False))
+        assert "pick --> gen__gate" in text
+        assert "pick --> gen__build_messages" in text
+
+    def test_mermaid_fully_expanded_reaches_the_deepest_consumer(self):
+        from hypergraph.viz.mermaid import to_mermaid
+
+        text = str(to_mermaid(_generation().to_flat_graph(), depth=2, simplify=False))
+        assert "pick --> gen__gate" in text
+        assert "pick --> gen__build_messages__format_ctx" in text
+
+
+class TestOuterInputAggregatesToTheCollapsedBoundary:
+    def test_pill_and_edge_survive_the_collapse(self):
+        """The E.1 shape: an unbound outer input consumed only inside a
+        collapsed container lost both its pill and its edge."""
+        scene = scene_for_state(_generation(), expansion_state={})
+
+        pill = _pill_for(scene, "query")
+        assert pill is not None, "'query' is required by the outer graph; its pill must survive the collapse"
+        assert (pill, "gen") in _visible(scene)
+
+    def test_pill_follows_the_deepest_visible_ancestor(self):
+        """One level open: the pill's edge lands on the still-collapsed inner box."""
+        scene = scene_for_state(_generation(), expansion_state={"gen": True})
+
+        pill = _pill_for(scene, "query")
+        assert pill is not None
+        assert (pill, "gen/build_messages") in _visible(scene)
+
+    def test_fully_expanded_reaches_the_real_consumer(self):
+        scene = scene_for_state(_generation(), expansion_state={"gen": True, "gen/build_messages": True})
+
+        pill = _pill_for(scene, "query")
+        assert pill is not None
+        assert (pill, "gen/build_messages/assemble") in _visible(scene)

--- a/tests/viz/test_container_boundary_edges.py
+++ b/tests/viz/test_container_boundary_edges.py
@@ -139,6 +139,57 @@ class TestMermaidTwinAgrees:
         assert "pick --> gen__build_messages__format_ctx" in text
 
 
+class TestInternallyFedConsumersAreExcluded:
+    """A consumer already fed by an INTERNAL producer of the same name must
+    not receive the boundary edge — in the IR and in Mermaid alike."""
+
+    @staticmethod
+    def _mixed_flat_graph():
+        import networkx as nx
+
+        flat = nx.DiGraph()
+        flat.add_node("pick", node_type="FUNCTION", outputs=("document",), inputs=("raw",))
+        flat.add_node("box", node_type="GRAPH", outputs=(), inputs=("document",))
+        flat.add_node("box/gate", node_type="FUNCTION", parent="box", inputs=("document",), outputs=("ok",))
+        flat.add_node("box/maker", node_type="FUNCTION", parent="box", inputs=(), outputs=("document",))
+        flat.add_node("box/user", node_type="FUNCTION", parent="box", inputs=("document",), outputs=("used",))
+        flat.add_edge("pick", "box", edge_type="data", value_names=["document"])
+        flat.add_edge("box/maker", "box/user", edge_type="data", value_names=["document"])
+        return flat
+
+    def test_ir_builder_excludes_the_internally_fed_consumer(self):
+        from hypergraph.viz.renderer.ir_builder import find_internal_consumers
+
+        assert find_internal_consumers("box", "document", self._mixed_flat_graph()) == ("box/gate",)
+
+    def test_mermaid_excludes_the_internally_fed_consumer(self):
+        from hypergraph.viz.mermaid import _resolve_data_targets
+
+        targets = _resolve_data_targets(
+            "box",
+            "document",
+            self._mixed_flat_graph(),
+            {"box": True},
+            {},
+        )
+        assert targets == ["box/gate"], f"the boundary value must not be drawn into the internally fed consumer: {targets}"
+
+
+class TestHiddenNodesDoNotAggregate:
+    """Only collapse-hiding aggregates to a boundary. A ``hide=True`` node's
+    visible ancestor is an EXPANDED container — never a legitimate edge
+    target (dagre cannot rank an edge into a compound node) — so its edges
+    stay hidden, exactly as before endpoints were resolved at all."""
+
+    def test_edge_to_a_hidden_consumer_stays_hidden_when_expanded(self):
+        from tests.viz.conftest import make_hidden_source_data_dependency_graph
+
+        scene = scene_for_state(make_hidden_source_data_dependency_graph(), expansion_state={"box": True}, simplify=False)
+
+        offenders = [pair for pair in _visible(scene) if pair[1] == "box"]
+        assert not offenders, f"no edge may target the expanded 'box' hull: {offenders}"
+
+
 class TestOuterInputAggregatesToTheCollapsedBoundary:
     def test_pill_and_edge_survive_the_collapse(self):
         """The E.1 shape: an unbound outer input consumed only inside a

--- a/tests/viz/test_default_depth.py
+++ b/tests/viz/test_default_depth.py
@@ -1,0 +1,90 @@
+"""Every visualize entry point starts COLLAPSED; expansion is a click away.
+
+The interactive widget re-derives the scene client-side, so an initial
+``depth=0`` costs nothing to expand later — but an initial ``depth=1`` costs
+every reader a wall of internals before they have seen the shape of the
+graph. One entry point (``HyperTable.visualize`` with mapped children) shipped
+with its own ``depth=1`` default, so mounted tables opened noisy while plain
+graphs opened calm.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import TypedDict
+
+from hypergraph import Graph, SyncRunner, node
+
+
+@node(output_name="clean_text")
+def clean(text: str) -> str:
+    return text.strip().lower()
+
+
+@node(output_name="word_count")
+def count_words(clean_text: str) -> int:
+    return len(clean_text.split())
+
+
+class Page(TypedDict):
+    page_id: str
+    text: str
+
+
+@node(output_name="pages")
+def segment(clean_text: str) -> list[Page]:
+    return [Page(page_id="p0", text=clean_text)]
+
+
+@node(output_name="enriched")
+def enrich(text: str) -> str:
+    return text.upper()
+
+
+def _initial_expansion(html_path) -> dict[str, bool]:
+    html = html_path.read_text()
+    match = re.search(r'"initial_expansion"\s*:\s*(\{[^}]*\})', html)
+    assert match, "widget payload must carry initial_expansion"
+    return json.loads(match.group(1))
+
+
+def test_graph_visualize_defaults_collapsed(tmp_path):
+    inner = Graph([clean], name="inner")
+    outer = Graph([inner.as_node(name="inner"), count_words], name="outer")
+
+    outer.visualize(filepath=str(tmp_path / "graph.html"))
+
+    assert _initial_expansion(tmp_path / "graph.html") == {"inner": False}
+
+
+def test_hypertable_visualize_defaults_collapsed(tmp_path):
+    """The regression: mapped children opened pre-expanded (depth=1)."""
+    from tests.test_materialization_node_viz import MemoryStore
+
+    table = Graph(
+        [clean, segment, Graph([enrich], name="page").as_node(name="process_pages").map_over("pages", identity="page_id", schema=Page)],
+        name="recipe",
+    ).as_table(identity="doc_id", store=MemoryStore(), runner=SyncRunner())
+
+    table.visualize(filepath=str(tmp_path / "table.html"))
+
+    expansion = _initial_expansion(tmp_path / "table.html")
+    assert expansion and all(value is False for value in expansion.values()), (
+        f"HyperTable.visualize must start collapsed like every other entry point, got {expansion}"
+    )
+
+
+def test_hypertable_visualize_depth_still_expands(tmp_path):
+    """``depth=`` keeps working; only the default moved."""
+    from tests.test_materialization_node_viz import MemoryStore
+
+    table = Graph(
+        [clean, segment, Graph([enrich], name="page").as_node(name="process_pages").map_over("pages", identity="page_id", schema=Page)],
+        name="recipe",
+    ).as_table(identity="doc_id", store=MemoryStore(), runner=SyncRunner())
+
+    table.visualize(depth=1, filepath=str(tmp_path / "table.html"))
+
+    expansion = _initial_expansion(tmp_path / "table.html")
+    assert any(expansion.values()), f"depth=1 must still expand the first level, got {expansion}"

--- a/tests/viz/test_edge_connections.py
+++ b/tests/viz/test_edge_connections.py
@@ -173,15 +173,16 @@ class TestWorkflowDepth0:
         assert issues == {}, f"Edge connection issues:\n{format_issues(issues)}"
 
     def test_workflow_depth0_structure(self, page):
-        """Collapsed workflow should have expected node count."""
+        """Collapsed workflow keeps its contract input on the boundary."""
         graph = make_workflow()
         nodes, edges = extract_geometries(page, graph, depth=0)
 
-        # At depth=0: preprocess (collapsed), analyze
-        # Internal-only inputs are hidden when the container is collapsed.
+        # At depth=0: preprocess (collapsed), analyze — plus the graph's own
+        # unbound input, whose pill hoists to the collapsed boundary rather
+        # than vanishing with the container internals.
         assert len(nodes) >= 2, f"Expected at least 2 nodes, got {len(nodes)}: {list(nodes.keys())}"
-        assert not any(node_id.startswith("input_") for node_id in nodes), f"Unexpected input nodes in collapsed view: {list(nodes.keys())}"
-        assert len(edges) >= 1, f"Expected at least 1 edge, got {len(edges)}"
+        assert "input_text" in nodes, f"'text' is an unbound graph input; its pill must survive the collapse: {list(nodes.keys())}"
+        assert len(edges) >= 2, f"Expected the data edge plus the aggregated input edge, got {len(edges)}"
 
 
 @pytest.mark.skipif(not HAS_PLAYWRIGHT, reason="playwright not installed")
@@ -265,14 +266,18 @@ class TestOuterDepth0:
         assert issues == {}, f"Edge connection issues:\n{format_issues(issues)}"
 
     def test_outer_depth0_structure(self, page):
-        """All-collapsed outer should have minimal nodes."""
+        """All-collapsed outer keeps its contract inputs on the boundary."""
         graph = make_outer()
         nodes, edges = extract_geometries(page, graph, depth=0)
 
-        # At depth=0: middle (collapsed), log_result
-        # Internal-only inputs are hidden when the container is collapsed.
+        # At depth=0: middle (collapsed), log_result — plus the graph's own
+        # unbound input, whose pill hoists to the collapsed boundary rather
+        # than vanishing with the container internals.
         assert len(nodes) >= 2, f"Expected at least 2 nodes, got {len(nodes)}: {list(nodes.keys())}"
-        assert not any(node_id.startswith("input_") for node_id in nodes), f"Unexpected input nodes in collapsed view: {list(nodes.keys())}"
+        assert "input_x" in nodes, f"'x' is an unbound graph input; its pill must survive the collapse: {list(nodes.keys())}"
+        assert any(edge.source_id == "input_x" and edge.target_id == "middle" for edge in edges), (
+            "the pill's edge aggregates to the collapsed container"
+        )
 
 
 @pytest.mark.skipif(not HAS_PLAYWRIGHT, reason="playwright not installed")
@@ -299,13 +304,15 @@ class TestOuterDepth1:
         # Hierarchical IDs: middle/inner and middle/validate
         assert "middle/inner" in node_ids or "middle/validate" in node_ids, f"Expected middle/inner or middle/validate in nodes: {node_ids}"
 
-    def test_outer_depth1_internal_inputs_hidden(self, page):
-        """Internal-only inputs are hidden when inner is collapsed."""
+    def test_outer_depth1_internal_inputs_follow_the_visible_boundary(self, page):
+        """With inner collapsed the pill's edge lands on the inner hull."""
         graph = make_outer()
         nodes, edges = extract_geometries(page, graph, depth=1)
 
-        input_edges = [edge for edge in edges if edge.source_id.startswith("input_")]
-        assert not input_edges, f"Internal-only inputs should be hidden when inner is collapsed.\nEdges: {[e.id for e in input_edges]}"
+        input_targets = {edge.target_id for edge in edges if edge.source_id.startswith("input_")}
+        assert "middle/inner" in input_targets, (
+            f"'x' feeds a node inside collapsed inner; its edge aggregates to the boundary. Input edges target: {input_targets}"
+        )
 
 
 @pytest.mark.skipif(not HAS_PLAYWRIGHT, reason="playwright not installed")

--- a/tests/viz/test_interactive_expand.py
+++ b/tests/viz/test_interactive_expand.py
@@ -375,14 +375,16 @@ class TestInteractiveCollapseEdgeRouting:
         bad_targets = hidden_targets.intersection(interactive_targets.values())
         assert not bad_targets, f"Collapsed view should not target hidden internal nodes.\nUnexpected targets: {sorted(bad_targets)}"
 
-    def test_internal_input_edges_hidden_after_collapse(self, page, temp_html_file):
-        """Specifically test that input_text edge is hidden after collapse.
+    def test_internal_input_edge_aggregates_after_collapse(self, page, temp_html_file):
+        """Specifically test where the input_text edge lands after collapse.
 
         This is the most direct test of the collapse behavior:
         - At depth=1: input_text -> clean_text (internal) - visible
-        - After collapse: input edge is hidden (not routed to container)
+        - After collapse: input_text -> preprocess (the container hull)
 
-        Internal-only inputs are hidden when their consuming nodes are collapsed.
+        A real external input is part of the graph's contract, so collapsing
+        the container that consumes it re-routes the pill's edge to the
+        boundary instead of erasing it.
         """
         workflow = make_workflow()
         # Render at depth=1 (expanded), click to collapse
@@ -390,10 +392,11 @@ class TestInteractiveCollapseEdgeRouting:
         click_to_collapse_container(page, "preprocess")
         data = extract_edge_routing(page)
 
-        # Inputs that are only used inside a collapsed container are hidden.
         input_edges = [info for info in data["edges"].values() if "input" in info["source"].lower()]
-
-        assert not input_edges, f"Collapsed view should hide internal-only input edges.\nEdges: {data['edges']}"
+        assert input_edges, f"the graph input must survive the collapse.\nEdges: {data['edges']}"
+        assert {info["target"] for info in input_edges} == {"preprocess"}, (
+            f"the pill's edge aggregates to the collapsed container.\nEdges: {data['edges']}"
+        )
 
     def test_output_edge_routes_from_container_after_collapse(self, page, temp_html_file):
         """Specifically test that output edge sources from preprocess after collapse.

--- a/tests/viz/test_nested_edge_routing.py
+++ b/tests/viz/test_nested_edge_routing.py
@@ -385,7 +385,7 @@ class TestDoubleNestedEdgeRouting:
     """Tests for edge routing in doubly-nested graphs (depth=1 with 2-level nesting)."""
 
     def test_outer_depth1_input_routes_to_inner(self, page, temp_html_file):
-        """Test outer at depth=1: internal-only inputs are hidden when inner is collapsed."""
+        """Test outer at depth=1: the pill's edge lands on the collapsed inner hull."""
         outer = make_outer()
         render_to_page(page, outer, depth=1, temp_path=temp_html_file)
 
@@ -408,7 +408,9 @@ class TestDoubleNestedEdgeRouting:
 
         assert inner_top is not None, "inner node not found at depth=1"
         input_edges = [edge_id for edge_id in result.get("edgeIds", []) if "input_x" in edge_id]
-        assert not input_edges, f"Internal-only inputs should be hidden when their owner container is collapsed.\nFound input edges: {input_edges}"
+        assert any("input_x__middle/inner" in edge_id for edge_id in input_edges), (
+            f"'x' feeds a node inside collapsed inner; its edge aggregates to the boundary.\nFound input edges: {input_edges}"
+        )
 
 
 @pytest.mark.skipif(not HAS_PLAYWRIGHT, reason="playwright not installed")

--- a/tests/viz/test_renderer.py
+++ b/tests/viz/test_renderer.py
@@ -595,7 +595,10 @@ class TestRenderGraph:
                 ("ask_user/ask_slack", "ask_user/add_user_message", "data"),
                 ("ask_user/add_user_message", "llm", "data"),
                 ("llm", "should_continue", "data"),
+                # Both children read the incoming messages: the interrupt asks
+                # over them, then add_user_message appends to them.
                 ("llm", "ask_user/ask_slack", "data"),
+                ("llm", "ask_user/add_user_message", "data"),
                 ("should_continue", "ask_user/ask_slack", "control"),
                 ("should_continue", "__end__", "end"),
             },
@@ -614,7 +617,10 @@ class TestRenderGraph:
                 ("ask_user/add_user_message", "llm/llm_step", "data"),
                 ("llm/llm_step", "llm/add_assistant_message", "data"),
                 ("llm/add_assistant_message", "should_continue", "data"),
+                # Both children read the incoming messages: the interrupt asks
+                # over them, then add_user_message appends to them.
                 ("llm/add_assistant_message", "ask_user/ask_slack", "data"),
+                ("llm/add_assistant_message", "ask_user/add_user_message", "data"),
                 ("should_continue", "ask_user/ask_slack", "control"),
                 ("should_continue", "__end__", "end"),
             },

--- a/tests/viz/test_scope_aware_visibility.py
+++ b/tests/viz/test_scope_aware_visibility.py
@@ -625,31 +625,39 @@ def make_input_group_container_graph() -> Graph:
 
 @pytest.mark.skipif(not HAS_PLAYWRIGHT, reason="playwright not installed")
 class TestInputVisibilityWhenCollapsed:
-    """Inputs owned by a collapsed container should be hidden."""
+    """Inputs owned by a collapsed container hoist to the visible boundary.
 
-    def test_internal_input_hidden_when_collapsed(self):
-        """Inputs scoped to a collapsed container should not be visible."""
+    A real external input is part of the graph's contract: collapsing the
+    container that consumes it must not erase it from the diagram. The pill
+    surfaces at the deepest visible level and its edge aggregates to the
+    collapsed container's hull.
+    """
+
+    def test_internal_input_aggregates_to_collapsed_boundary(self):
+        """An input consumed only inside a collapsed container still renders,
+        feeding the container itself."""
         from hypergraph.viz import extract_debug_data
 
         graph = make_generation_graph()
         data = extract_debug_data(graph, depth=0, show_inputs=True)
 
         node_ids = {n["id"] for n in data.nodes}
-
-        # system_instructions is only consumed inside prompt_building
-        assert "input_system_instructions" not in node_ids, "input_system_instructions should be hidden when prompt_building is collapsed."
-        # query has external consumers; it should remain visible at root
+        carrying = [node_id for node_id in node_ids if node_id.startswith("input") and "system_instructions" in node_id]
+        assert carrying, f"system_instructions is an unbound graph input; it must survive the collapse. Nodes: {sorted(node_ids)}"
+        # query has external consumers; it stays visible at root as before
         assert "input_query" in node_ids, "input_query should stay visible at root."
 
-    def test_input_group_hidden_when_collapsed(self):
-        """INPUT_GROUP owned by a collapsed container should not be visible."""
+    def test_input_group_aggregates_to_collapsed_boundary(self):
+        """An INPUT_GROUP owned by a collapsed container feeds the container hull."""
         from hypergraph.viz import extract_debug_data
 
         graph = make_input_group_container_graph()
         data = extract_debug_data(graph, depth=0)
 
         node_ids = {n["id"] for n in data.nodes}
-        assert "input_group_alpha_beta" not in node_ids, "input_group_alpha_beta should be hidden when inner is collapsed."
+        assert "input_group_alpha_beta" in node_ids, "alpha/beta are unbound graph inputs; the pill must survive the collapse."
+        edge_pairs = {(e.source, e.target) for e in data.edges}
+        assert ("input_group_alpha_beta", "inner") in edge_pairs, f"the pill's edge aggregates to the collapsed container: {sorted(edge_pairs)}"
 
 
 # =============================================================================

--- a/tests/viz/test_scope_aware_visibility.py
+++ b/tests/viz/test_scope_aware_visibility.py
@@ -312,16 +312,23 @@ class TestInputPositioningInsideContainers:
 
         input_y = input_node.get("y", 0)
         input_height = input_node.get("height", 36)
+        input_x = input_node.get("x", 0)
+        input_width = input_node.get("width", 0)
+        container_left = container.get("x", 0)
+        container_right = container_left + container.get("width", 0)
 
-        # query should NOT be fully inside the container (it has external consumers)
-        # It's OK if it's above or partially overlapping, but should not be contained
+        # query is a root-owned input, so it must not sit INSIDE the
+        # container's rectangle. Sharing the container's Y band while standing
+        # beside it is fine — with `simplify` on, the pill's one surviving
+        # edge feeds a node inside the box, so the layout parks the pill next
+        # to that consumer.
         is_fully_inside_y = container_top <= input_y and (input_y + input_height) <= container_bottom
+        is_fully_inside_x = container_left <= input_x and (input_x + input_width) <= container_right
 
-        # This is a sanity check - query should stay at root level
-        assert not is_fully_inside_y or input_y < container_top, (
-            f"query INPUT should be at ROOT level (outside container), not inside.\n"
-            f"Container top={container_top:.0f}, bottom={container_bottom:.0f}\n"
-            f"INPUT y={input_y:.0f}"
+        assert not (is_fully_inside_x and is_fully_inside_y), (
+            f"query INPUT should be at ROOT level (outside the container rectangle), not inside.\n"
+            f"Container x=[{container_left:.0f}, {container_right:.0f}] y=[{container_top:.0f}, {container_bottom:.0f}]\n"
+            f"INPUT x={input_x:.0f}, y={input_y:.0f}"
         )
 
 

--- a/tests/viz/test_simplify_edges.py
+++ b/tests/viz/test_simplify_edges.py
@@ -382,6 +382,154 @@ class TestCollapsedContainersAreNotAssumedTransparent:
         assert arrows == scene
 
 
+@node(output_name="pages")
+def select_pages(query: str) -> str:
+    return query
+
+
+@node(output_name="answer")
+def generate(query: str, pages: str) -> str:
+    return query + pages
+
+
+@node(output_name="verdict")
+def judge(query: str, answer: str) -> str:
+    return query + answer
+
+
+@node(output_name="mark")
+def grade(query: str, verdict: str) -> str:
+    return query + verdict
+
+
+def make_input_fanout_graph() -> Graph:
+    """One input feeding an entire chain — the panda review shape.
+
+    ``query`` enters all four nodes, but the chain
+    ``select_pages → generate → judge → grade`` already carries it forward:
+    a reader following the earliest edge reaches every later consumer.
+    """
+    return Graph([select_pages, generate, judge, grade], name="review")
+
+
+class TestInputEdgesSimplify:
+    """``simplify`` applies to INPUT pill edges: only the EARLIEST consumer(s)
+    keep their edge when every later consumer is reachable downstream."""
+
+    def test_input_fanout_keeps_only_the_earliest_consumer(self) -> None:
+        scene = scene_for_state(make_input_fanout_graph(), simplify=True)
+        assert visible_pairs(scene, edge_type="input") == {("input_query", "select_pages")}
+
+    def test_input_fanout_survives_with_simplify_off(self) -> None:
+        scene = scene_for_state(make_input_fanout_graph(), simplify=False)
+        assert visible_pairs(scene, edge_type="input") == {
+            ("input_query", "select_pages"),
+            ("input_query", "generate"),
+            ("input_query", "judge"),
+            ("input_query", "grade"),
+        }
+
+    def test_input_edge_into_a_collapsed_box_is_implied_by_a_delivering_route(self) -> None:
+        """``query → box`` disappears when ``query → select → box`` already
+        delivers into the box. Reaching ANY in-port of a collapsed box counts:
+        the drawn edge ends at the hull, so the reader's question is only
+        whether the value reaches the box, not which inner node it enters."""
+
+        @node(output_name="context")
+        def format_ctx(pages: str) -> str:
+            return pages
+
+        @node(output_name="messages")
+        def assemble(query: str, context: str) -> str:
+            return query + context
+
+        inner = Graph([format_ctx, assemble], name="inner")
+        outer = Graph([select_pages, inner.as_node(name="inner")], name="outer")
+
+        on = scene_for_state(outer, expansion_state={}, simplify=True)
+        off = scene_for_state(outer, expansion_state={}, simplify=False)
+        assert visible_pairs(off, edge_type="input") == {("input_query", "select_pages"), ("input_query", "inner")}
+        assert visible_pairs(on, edge_type="input") == {("input_query", "select_pages")}
+
+    def test_sole_route_into_a_box_survives(self) -> None:
+        """An input edge that is the pill's only route anywhere is never
+        dropped, even when the box has other in-edges."""
+
+        @node(output_name="context")
+        def format_ctx(pages: str) -> str:
+            return pages
+
+        @node(output_name="messages")
+        def assemble(secret: str, context: str) -> str:
+            return secret + context
+
+        inner = Graph([format_ctx, assemble], name="inner")
+        outer = Graph([select_pages, inner.as_node(name="inner")], name="outer")
+
+        scene = scene_for_state(outer, expansion_state={}, simplify=True)
+        assert ("input_secret", "inner") in visible_pairs(scene, edge_type="input")
+
+    def test_control_delivery_does_not_imply_an_input_edge(self) -> None:
+        """A gate's dotted arrow into a node means "may run", never "receives
+        the value" — it cannot justify dropping the input edge."""
+
+        @ifelse(when_true="deliver", when_false="archive")
+        def check(query: str) -> bool:
+            return bool(query)
+
+        @node(output_name="delivered")
+        def deliver(query: str) -> str:
+            return query
+
+        @node(output_name="archived")
+        def archive(query: str) -> str:
+            return query
+
+        graph = Graph([check, deliver, archive], name="gated")
+        scene = scene_for_state(graph, simplify=True)
+        pairs = visible_pairs(scene, edge_type="input")
+        assert ("input_query", "deliver") in pairs
+        assert ("input_query", "archive") in pairs
+
+    def test_expanded_view_reduces_over_the_real_inner_routes(self) -> None:
+        """Once the container opens, the same rule runs on the inner nodes:
+        both inner consumers sit downstream of ``select_pages`` (its ``pages``
+        edge re-routes to ``format_ctx``, which feeds ``assemble``), so only
+        the genuinely earliest consumer keeps its edge."""
+
+        @node(output_name="context")
+        def format_ctx(pages: str, query: str) -> str:
+            return pages + query
+
+        @node(output_name="messages")
+        def assemble(query: str, context: str) -> str:
+            return query + context
+
+        inner = Graph([format_ctx, assemble], name="inner")
+        outer = Graph([select_pages, inner.as_node(name="inner")], name="outer")
+
+        scene = scene_for_state(outer, expansion_state={"inner": True}, simplify=True)
+        assert visible_pairs(scene, edge_type="input") == {("input_query", "select_pages")}
+
+    def test_expanded_earliest_inner_consumer_keeps_its_edge(self) -> None:
+        """An inner consumer NOT reachable from any other consumer keeps its
+        edge after expansion — earliest is judged on the open topology."""
+
+        @node(output_name="context")
+        def prepare(query: str) -> str:
+            return query
+
+        @node(output_name="messages")
+        def assemble(query: str, context: str) -> str:
+            return query + context
+
+        inner = Graph([prepare, assemble], name="inner")
+        outer = Graph([inner.as_node(name="inner")], name="outer")
+
+        scene = scene_for_state(outer, expansion_state={"inner": True}, simplify=True)
+        assert visible_pairs(scene, edge_type="input") == {("input_query", "inner/prepare")}
+
+
 class TestSimplifyTransitiveEdgesUnit:
     def _edge(self, source: str, target: str, **data) -> dict:
         payload = {"edgeType": "data"}
@@ -469,6 +617,19 @@ class TestMermaidAlignment:
         arrows = self._arrows(make_shortcut_graph(), separate_outputs=True)
         assert ("fetch", "data_fetch_raw") in arrows
         assert ("data_fetch_raw", "render") not in arrows
+
+    def test_input_fanout_reduces_like_the_scene(self) -> None:
+        graph = make_input_fanout_graph()
+        arrows = self._arrows(graph)
+        input_arrows = {pair for pair in arrows if pair[0].startswith("input_")}
+        assert input_arrows == {("input_query", "select_pages")}
+        assert self._arrows(graph) == visible_pairs(scene_for_state(graph, simplify=True), edge_type=None)
+
+    def test_input_edge_into_a_collapsed_box_reduces_like_the_scene(self) -> None:
+        graph = make_input_fanout_into_box_graph()
+        arrows = self._arrows(graph)
+        input_arrows = {pair for pair in arrows if pair[0].startswith("input_")}
+        assert input_arrows == {("input_query", "select_pages")}
 
     def test_cycle_survives(self) -> None:
         """Mermaid has no ``is_back_edge`` flag of its own — it calls
@@ -600,12 +761,29 @@ class TestJsHardening:
         assert sorted(result["kept"]) == [["A", "B"], ["A", "C"], ["B", "C"]]
 
 
+def make_input_fanout_into_box_graph() -> Graph:
+    """``query`` feeds ``select_pages`` AND a container that ``select_pages``
+    delivers into — the collapsed-box input-candidacy shape."""
+
+    @node(output_name="context")
+    def format_ctx(pages: str) -> str:
+        return pages
+
+    @node(output_name="messages")
+    def assemble(query: str, context: str) -> str:
+        return query + context
+
+    inner = Graph([format_ctx, assemble], name="inner")
+    return Graph([select_pages, inner.as_node(name="inner")], name="outer")
+
+
 @pytest.mark.skipif(NODE is None, reason="Node.js not installed")
 @pytest.mark.parametrize("simplify", [False, True])
 @pytest.mark.parametrize("separate_outputs", [False, True])
-def test_python_js_simplify_parity(simplify: bool, separate_outputs: bool) -> None:
+@pytest.mark.parametrize("make_graph", [make_shortcut_graph, make_input_fanout_graph, make_input_fanout_into_box_graph])
+def test_python_js_simplify_parity(simplify: bool, separate_outputs: bool, make_graph) -> None:
     """``assets/scene_builder.js`` must reduce identically to its Python twin."""
-    ir = build_graph_ir(make_shortcut_graph().to_flat_graph())
+    ir = build_graph_ir(make_graph().to_flat_graph())
     payload = json.dumps(
         {
             "ir": asdict(ir),
@@ -624,6 +802,9 @@ def test_python_js_simplify_parity(simplify: bool, separate_outputs: bool) -> No
     py_scene = build_initial_scene(ir, separate_outputs=separate_outputs, simplify=simplify)
     js_scene = json.loads(proc.stdout)
     assert visible_pairs(js_scene, edge_type=None) == visible_pairs(py_scene, edge_type=None)
+    if simplify and make_graph is make_input_fanout_graph:
+        # Not merely equal — both twins actually cleaned the fan-out.
+        assert visible_pairs(js_scene, edge_type="input") == {("input_query", "select_pages")}
 
 
 # =============================================================================

--- a/tests/viz/test_simplify_edges.py
+++ b/tests/viz/test_simplify_edges.py
@@ -434,17 +434,7 @@ class TestInputEdgesSimplify:
         delivers into the box. Reaching ANY in-port of a collapsed box counts:
         the drawn edge ends at the hull, so the reader's question is only
         whether the value reaches the box, not which inner node it enters."""
-
-        @node(output_name="context")
-        def format_ctx(pages: str) -> str:
-            return pages
-
-        @node(output_name="messages")
-        def assemble(query: str, context: str) -> str:
-            return query + context
-
-        inner = Graph([format_ctx, assemble], name="inner")
-        outer = Graph([select_pages, inner.as_node(name="inner")], name="outer")
+        outer = make_input_fanout_into_box_graph()
 
         on = scene_for_state(outer, expansion_state={}, simplify=True)
         off = scene_for_state(outer, expansion_state={}, simplify=False)


### PR DESCRIPTION
Three visualization fixes on the same theme: what a nested graph shows must be trustworthy at EVERY expansion state. All three were first observed on panda's real graphs (review_generation, the mounted-table ingest recipe).

## 1. One collapsed-by-default story (`43774c9e`)

**Problem:** `Graph.visualize()` has defaulted to `depth=0` since 01b3b7f3, but `HyperTable.visualize()` with mapped children kept its own `options.setdefault("depth", 1)` — mounted tables opened pre-expanded while plain graphs opened calm.

**After:** every entry point starts collapsed; `depth=` still expands; the widget expands interactively as before. New `tests/viz/test_default_depth.py` locks both entry points (and that `depth=1` still works).

## 2. Boundary edges reach every consumer; pills survive collapse (`5fd8bfd4`)

**Problem A (the `has_visual_evidence` diagnosis):** an edge into an expanded container re-routed to only ONE internal consumer — `max(candidates, key=depth)`. panda's generation graph consumes the incoming `document` at both its `@ifelse` guard and the nested messages graph, so the guard rendered with **no incoming edge at any depth**. The flat graph had the edge all along: this was a viz bug, not a graph-construction bug.

**Problem B:** the one chosen target could sit inside a still-collapsed inner container — the rewritten edge then pointed at a hidden node and vanished, so `depth=1` showed *less* than `depth=0`.

**Problem C (E.1):** an unbound input consumed only inside a collapsed container lost its pill and edge entirely.

**After:**
- `target_when_expanded` carries every boundary-fed consumer (the tuple shape the schema already allowed; a consumer fed by an internal producer of the same name is excluded; the fuzzy-match fallback stays single-answer).
- Scene builders resolve rewritten endpoints up to their deepest visible ancestor and dedup — edges aggregate to a collapsed boundary instead of vanishing. Mermaid fans out and resolves identically.
- Contract inputs hoist: the pill surfaces at its deepest visible ancestor with its edge aggregated to the collapsed hull. Only `map_fed` pills still disappear with their container (the container-level fan-out edge already draws that value).
- Collapsed-port honesty is kept: a multi-consumer entry resolves only when every consumer sits under the SAME direct child; multi-producer exits stay unresolved.

The seven tests that pinned the old hide-on-collapse policy now pin the aggregation; `tests/viz/test_container_boundary_edges.py` (10 tests) covers the whole matrix, including the Mermaid twin.

## 3. `simplify` applies to INPUT pill edges (`3a2d29be`)

**Problem:** the toggle (#357) never considered input edges, so one input feeding a chain kept every edge — panda's `query` feeding `select → generate → judge → grade` drew four parallel lines with simplify ON.

**After:** input edges are removal candidates in the one shared reduction authority; a simplified view shows an input edge only to its earliest consumer(s) when later consumers are reachable downstream. Two rules keep it honest:

- An input edge into a **collapsed** container is judged box-level — the drawn line ends at the hull, so it drops when any other visible route delivers into that box (phantom in-port→box path links; the bare box id is a sink, so they can never manufacture a pass-through). Data edges into the same box remain port-strict.
- Conditional edges keep all their #357 exclusions: control, ordering, exclusive arms and back edges neither drop an input edge nor justify dropping one.

Mirrored in the JS twin (the parity suite now also runs the fan-out fixtures) and in Mermaid, whose input edges previously bypassed the reduction entirely.

## Before / after on panda's review_generation (depth=0, simplify ON)

```
before: query   ──▶ select_top_pages, generate_answer, judge_answer, grade_generation   (4 edges)
        gold    ──▶ judge_answer, grade_generation
        exp_doc ──▶ select_top_pages, grade_generation
after:  query   ──▶ select_top_pages                                                    (1 edge)
        gold    ──▶ judge_answer
        exp_doc ──▶ select_top_pages
```

And inside the expanded generation container, `has_visual_evidence` now receives its `document` edge.

## Test plan

- `uv run pytest` → 4910 passed, 15 skipped (from 4893; +17 net new)
- CI-equivalent `-W error` run → identical
- `uv run --python 3.10 mypy` → clean, 175 files
- `uv run pre-commit run --all-files` → all hooks pass
- New/updated: `test_default_depth.py` (3), `test_container_boundary_edges.py` (10), `TestInputEdgesSimplify` (7), parity matrix ×3 graphs, Mermaid alignment (+2), frozen Mermaid baselines unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved graph visualization routing for nested and collapsed containers.
  * Input edges now remain visible and aggregate correctly at collapsed boundaries.
  * Expanded workflows display connections to all applicable consumers.
  * Edge simplification removes redundant input links while preserving meaningful paths.
  * Visualization defaults remain collapsed, with explicit depth settings still supported.
  * Mermaid and interactive visualizations now provide more consistent edge rendering across expansion states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->