### PR TITLE
fix(viz): mounted HyperTables keep their fan-out story at every depth

### DIFF
--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -89,6 +89,73 @@ def _unique_outputs(nodes: Iterable[HyperNode]) -> tuple[str, ...]:
     return tuple(dict.fromkeys(all_outputs))
 
 
+def _identity_map_item_fields(map_node: HyperNode, producer: HyperNode) -> tuple[str, ...]:
+    """Field names of an identity-mode mapped node's item schema.
+
+    Prefers the explicit ``schema=`` recorded by ``map_over``; falls back to
+    the producer's ``list[Item]`` return annotation, mirroring
+    ``HyperTable.visualize``'s ``fanout_map_fields``. Imported lazily: the
+    helpers are stdlib-only, and identity-mode map nodes only ever come from
+    the HyperTable idiom, so materialization is present whenever this runs.
+    """
+    from hypergraph.materialization._schema import item_schema_fields, return_type
+
+    schema = (getattr(map_node, "_map_config", None) or {}).get("schema")
+    if schema is None:
+        try:
+            schema = return_type(producer)
+        except Exception:
+            return ()
+    return item_schema_fields(schema)
+
+
+def _add_identity_fanout_edges(G: nx.DiGraph, nodes: list[HyperNode], lookup: dict[str, str]) -> None:
+    """Synthesize the fan-out edge for identity-mode mapped nodes in one scope.
+
+    An identity-mode mapped GraphNode (a HyperTable child recipe) names a
+    SIBLING's output as its map source, and its per-item inputs are fed from
+    the mapped rows rather than through name-matched ports — so auto-wiring
+    records no edge and the flat graph (the canonical viz representation)
+    would draw the fan-out node as an unreachable island. This synthesizes
+    the same ``is_map``/``map_fields`` edge shape ``HyperTable.visualize``
+    stamps, at EVERY flatten scope, so a table mounted inside another graph
+    (``MaterializationNode.nested_graph``) keeps its fan-out story too.
+    """
+    for map_node in nodes:
+        config = getattr(map_node, "_map_config", None) or {}
+        if not config.get("identity"):
+            continue
+        target_id = lookup.get(map_node.name, map_node.name)
+        if target_id not in G.nodes:
+            continue
+        for param in getattr(map_node, "_map_over", None) or ():
+            producer = next(
+                (
+                    sibling
+                    for sibling in nodes
+                    if sibling is not map_node and param in tuple(getattr(sibling, "data_outputs", None) or sibling.outputs)
+                ),
+                None,
+            )
+            if producer is None:
+                continue
+            src_id = lookup.get(producer.name, producer.name)
+            if src_id not in G.nodes:
+                continue
+            if G.has_edge(src_id, target_id):
+                # Merge, matching the extra_edges / _add_explicit_data_edges
+                # convention: the mapped node may already have a real edge
+                # from this producer for another value.
+                existing = G[src_id][target_id].get("value_names", [])
+                G[src_id][target_id]["value_names"] = list(dict.fromkeys([*existing, param]))
+                G[src_id][target_id]["is_map"] = True
+            else:
+                G.add_edge(src_id, target_id, edge_type="data", value_names=[param], is_map=True)
+            fields = _identity_map_item_fields(map_node, producer)
+            if fields:
+                G[src_id][target_id]["map_fields"] = list(fields)
+
+
 def _format_type_hint(type_hint: Any) -> str:
     """Format a type annotation for human-readable summaries."""
     if type_hint is type(None):
@@ -1972,6 +2039,8 @@ class Graph:
             tgt_id = root_lookup.get(tgt, tgt)
             G.add_edge(src_id, tgt_id, **data)
 
+        _add_identity_fanout_edges(G, list(self._nodes.values()), root_lookup)
+
         # Recursively add edges from nested graphs
         for node in self._nodes.values():
             node_id = root_lookup.get(node.name, node.name)
@@ -1997,6 +2066,8 @@ class Graph:
             src_id = child_lookup.get(src, src)
             tgt_id = child_lookup.get(tgt, tgt)
             G.add_edge(src_id, tgt_id, **data)
+
+        _add_identity_fanout_edges(G, list(inner.nodes.values()), child_lookup)
 
         # Recurse into children
         for child_node in inner.nodes.values():

--- a/src/hypergraph/graph/core.py
+++ b/src/hypergraph/graph/core.py
@@ -145,10 +145,13 @@ def _add_identity_fanout_edges(G: nx.DiGraph, nodes: list[HyperNode], lookup: di
             if G.has_edge(src_id, target_id):
                 # Merge, matching the extra_edges / _add_explicit_data_edges
                 # convention: the mapped node may already have a real edge
-                # from this producer for another value.
+                # from this producer for another value. A non-data edge
+                # (wait_for ordering) is promoted to data — the fan-out IS a
+                # data dependency, and the ordering it carried is implied.
                 existing = G[src_id][target_id].get("value_names", [])
                 G[src_id][target_id]["value_names"] = list(dict.fromkeys([*existing, param]))
                 G[src_id][target_id]["is_map"] = True
+                G[src_id][target_id]["edge_type"] = "data"
             else:
                 G.add_edge(src_id, target_id, edge_type="data", value_names=[param], is_map=True)
             fields = _identity_map_item_fields(map_node, producer)

--- a/src/hypergraph/viz/_common.py
+++ b/src/hypergraph/viz/_common.py
@@ -244,6 +244,27 @@ def resolve_port_address_consumers(
     return deduped
 
 
+def map_feeds_param(node_id: str, param: str, flat_graph: nx.DiGraph) -> bool:
+    """True when ``node_id`` is a mapped container whose fan-out edge supplies
+    ``param`` per item — its incoming ``is_map`` edge lists the name in
+    ``map_fields``. The value reaches the container's interior through the
+    mapped rows, so a same-named outer value must not claim its inner
+    consumers (the runtime never wires that edge)."""
+    if node_id not in flat_graph.nodes:
+        return False
+    return any(attrs.get("is_map") and param in (attrs.get("map_fields") or ()) for _pred, _succ, attrs in flat_graph.in_edges(node_id, data=True))
+
+
+def map_feeds_param_of_ancestor(node_id: str, param: str, flat_graph: nx.DiGraph) -> bool:
+    """True when ``node_id`` sits at-or-under a container that map-feeds ``param``."""
+    current: str | None = node_id
+    while current is not None:
+        if map_feeds_param(current, param, flat_graph):
+            return True
+        current = flat_graph.nodes.get(current, {}).get("parent")
+    return False
+
+
 def build_param_to_consumer_map(
     flat_graph: nx.DiGraph,
     expansion_state: dict[str, bool],
@@ -251,6 +272,10 @@ def build_param_to_consumer_map(
     mode: str = "all",
 ) -> dict[str, list[str]]:
     """Build map of param_name -> list of actual consumer node_ids.
+
+    Consumers that live at-or-under a mapped container whose ``map_fields``
+    name the param are excluded: the map feeds them per item, so drawing the
+    outer value into them asserts an edge runtime never wires.
 
     Returns:
         Dict mapping parameter names to list of consumer node IDs.
@@ -265,6 +290,8 @@ def build_param_to_consumer_map(
     for node_id, attrs in flat_graph.nodes(data=True):
         for param in attrs.get("inputs", ()):
             if not use_deepest and not is_node_visible(node_id, flat_graph, expansion_state):
+                continue
+            if map_feeds_param_of_ancestor(node_id, param, flat_graph):
                 continue
 
             if param not in param_to_consumers:

--- a/src/hypergraph/viz/assets/scene_builder.js
+++ b/src/hypergraph/viz/assets/scene_builder.js
@@ -88,6 +88,10 @@
         !!ext.map_fed,
         ownerContainer === undefined ? null : ownerContainer,
       ]);
+      // The pill's state-independent synthetic id (twin of
+      // IRExternalInput.synthetic_id): IR edges reference pills by it, so a
+      // bucket records its members for the per-state alias map.
+      var syntheticId = segments.length === 1 ? 'input_' + segments[0] : 'input_group_' + segments.join('_');
       var bucket = buckets[key];
       if (!bucket) {
         order.push(key);
@@ -101,12 +105,14 @@
           deepestOwner: ext.deepest_owner,
           targets: targets,
           hidden: hidden,
+          memberIds: [syntheticId],
         };
         continue;
       }
       bucket.params = bucket.params.concat(params);
       bucket.segments = bucket.segments.concat(segments);
       bucket.typeHints = bucket.typeHints.concat(ext.type_hints || []);
+      bucket.memberIds.push(syntheticId);
       // A merged pill is hidden only when every constituent is.
       bucket.hidden = bucket.hidden && hidden;
     }
@@ -228,6 +234,19 @@
     var inputBuckets = showInputs
       ? mergeInputsForState(ir, parentMap, expansionState, nodeVisibleIds, showBoundedInputs, expandedContainerEntrypoints(ir, expansionState))
       : [];
+    // An IR edge may target a pill by its state-independent synthetic id
+    // (identity-mode fan-out re-routes), but per-state merging can fold that
+    // pill into a group with a different id — remap so the edge lands on the
+    // pill node this state actually emits. Object.create(null): pill ids come
+    // from user-authored names, so prototype members must not shadow lookups.
+    var pillAlias = Object.create(null);
+    for (var pa = 0; pa < inputBuckets.length; pa++) {
+      var aliasBucket = inputBuckets[pa];
+      var memberIds = aliasBucket.memberIds || [];
+      for (var pai = 0; pai < memberIds.length; pai++) {
+        if (memberIds[pai] !== aliasBucket.id) pillAlias[memberIds[pai]] = aliasBucket.id;
+      }
+    }
     for (var k = 0; k < inputBuckets.length; k++) {
       var ext = inputBuckets[k];
       var hidden = ext.hidden;
@@ -386,6 +405,12 @@
           );
         }
         targets = resolveRewrittenEndpoints(resolvedTargets);
+        var aliased = [];
+        for (var al = 0; al < targets.length; al++) {
+          var aliasTarget = pillAlias[targets[al]] === undefined ? targets[al] : pillAlias[targets[al]];
+          if (aliased.indexOf(aliasTarget) === -1) aliased.push(aliasTarget);
+        }
+        targets = aliased;
       }
 
       // A data edge can carry multiple value_names (one NetworkX edge per

--- a/src/hypergraph/viz/renderer/ir_builder.py
+++ b/src/hypergraph/viz/renderer/ir_builder.py
@@ -21,6 +21,7 @@ from hypergraph.viz._common import (
     disambiguate_external_input_ids,
     external_input_display_name,
     get_expandable_nodes,
+    map_feeds_param,
 )
 from hypergraph.viz.ir_schema import GraphIR, IREdge, IRExternalInput, IRNode
 from hypergraph.viz.renderer._format import format_type
@@ -32,6 +33,7 @@ from hypergraph.viz.renderer.scope import (
     find_back_edges,
     get_deepest_consumers,
     is_output_externally_consumed,
+    map_fed_field_consumers,
 )
 
 
@@ -80,6 +82,7 @@ def build_graph_ir(flat_graph: nx.DiGraph) -> GraphIR:
     # (e.g. ``A.x`` and ``B.x``) get unique ``input_<id>`` ids.
     id_for_param = disambiguate_external_input_ids([list(group["params"]) for group in groups])
     external_inputs = [_build_input_group(group, flat_graph, id_for_param, map_fed_fields) for group in groups]
+    external_inputs = _ensure_map_fed_field_pills(external_inputs, flat_graph, map_fed_fields)
 
     # Re-route each identity-mode fan-out edge, when its mapped container is
     # expanded, into the inner INPUT pill(s) fed by an item field — instead of
@@ -158,6 +161,95 @@ def _mapped_container_for(owner: str | None, field: str, map_fed_fields: dict[st
             return current
         current = flat_graph.nodes.get(current, {}).get("parent")
     return None
+
+
+def _deepest_common_container(consumers: Sequence[str], container: str, flat_graph: nx.DiGraph) -> str:
+    """The deepest container at-or-under ``container`` enclosing every consumer.
+
+    Matches ``compute_deepest_input_scope``'s placement semantics for the
+    synthesized field pills: a field consumed only inside a container nested
+    below the mapped one renders inside that inner container.
+    """
+
+    def chain(node_id: str) -> list[str]:
+        out: list[str] = []
+        current = flat_graph.nodes.get(node_id, {}).get("parent")
+        while current is not None:
+            out.append(current)
+            if current == container:
+                break
+            current = flat_graph.nodes.get(current, {}).get("parent")
+        return out
+
+    chains = [chain(consumer) for consumer in consumers]
+    if not chains or not all(chains):
+        return container
+    for candidate in chains[0]:
+        if all(candidate in c for c in chains):
+            return candidate
+    return container
+
+
+def _ensure_map_fed_field_pills(
+    external_inputs: list[IRExternalInput],
+    flat_graph: nx.DiGraph,
+    map_fed_fields: dict[str, set[str]],
+) -> list[IRExternalInput]:
+    """Give every consumed map-fed item field its own pill INSIDE the mapped container.
+
+    Two gaps close here, both observed on a MOUNTED HyperTable (panda's
+    ingest graph), whose item fields never reach the outer input surface:
+
+    - A field sharing its name with a genuine outer input (``pdf_uri``)
+      previously rode the outer pill straight into the container's interior —
+      an edge runtime never wires (the mapped rows feed it). The outer pill
+      now keeps only the outside consumers (the shared consumer walks exclude
+      map-fed ones), and the field gets its own map-fed pill.
+    - A field with no outer presence at all (``page_markdown`` hidden behind
+      a MaterializationNode boundary) previously had no pill anywhere, so
+      its consumers drew with no incoming edge.
+
+    A pill whose every consumer sat behind a map boundary (the classic
+    single-name ``page_text`` case) is left with no consumers by those same
+    walks — it is dropped here and replaced by the synthesized field pill,
+    which carries the SAME synthetic id when the name is unambiguous.
+    """
+    if not map_fed_fields:
+        return external_inputs
+
+    all_fields = set().union(*map_fed_fields.values())
+    kept: list[IRExternalInput] = []
+    for ext in external_inputs:
+        if not ext.consumers and ext.params and all(external_input_display_name(p) in all_fields for p in ext.params):
+            continue
+        kept.append(ext)
+
+    taken = {ext.synthetic_id for ext in kept}
+    synthesized: list[IRExternalInput] = []
+    for container in sorted(map_fed_fields):
+        for field in sorted(map_fed_fields[container]):
+            consumers = map_fed_field_consumers(container, field, flat_graph)
+            if not consumers:
+                continue
+            param_type = get_param_type(field, flat_graph)
+            if param_type is None:
+                for consumer in consumers:
+                    param_type = flat_graph.nodes[consumer].get("input_types", {}).get(field)
+                    if param_type is not None:
+                        break
+            segment = field if f"input_{field}" not in taken else f"{container.replace('/', '_')}_{field}"
+            pill = IRExternalInput(
+                params=(field,),
+                deepest_owner=_deepest_common_container(consumers, container, flat_graph),
+                consumers=tuple(consumers),
+                type_hints=(format_type(param_type),),
+                is_bound=False,
+                id_segments=(segment,),
+                map_fed=True,
+            )
+            taken.add(pill.synthetic_id)
+            synthesized.append(pill)
+    return [*kept, *synthesized]
 
 
 def _reroute_fanout_edges_to_field_pills(
@@ -294,11 +386,24 @@ def _build_ir_edge(
 
     tgt_attrs = flat_graph.nodes.get(tgt, {})
     if tgt_attrs.get("node_type") == "GRAPH":
+        # Union the EXACT-match consumers of every value this edge carries: a
+        # multi-value boundary edge feeds each value's own consumers, and the
+        # old first-value-wins loop let one value's fuzzy guess (panda:
+        # ``doc_version_id`` substring-matching ``version_id``) swallow the
+        # exact consumers of the values after it (``filename``).
+        exact_union: list[str] = []
         for value_name in value_names:
-            internal_consumers = find_internal_consumers(tgt, value_name, flat_graph)
-            if internal_consumers:
-                target_when_expanded = internal_consumers[0] if len(internal_consumers) == 1 else internal_consumers
-                break
+            for consumer in find_internal_consumers(tgt, value_name, flat_graph, include_fuzzy=False):
+                if consumer not in exact_union:
+                    exact_union.append(consumer)
+        if exact_union:
+            target_when_expanded = exact_union[0] if len(exact_union) == 1 else tuple(exact_union)
+        else:
+            for value_name in value_names:
+                internal_consumers = find_internal_consumers(tgt, value_name, flat_graph)
+                if internal_consumers:
+                    target_when_expanded = internal_consumers[0] if len(internal_consumers) == 1 else internal_consumers
+                    break
         # Any edge into a container still unresolved here must re-route to the
         # container's entrypoint when the container is expanded, or the scene
         # holds an edge into a node the layouter never ranked. Two ways to land
@@ -399,7 +504,7 @@ def _find_deepest_internal_producers(container_id: str, value_name: str, flat_gr
     return tuple(node_id for node_id in candidates if _depth_below(node_id, container_id, flat_graph) == max_depth)
 
 
-def find_internal_consumers(container_id: str, value_name: str, flat_graph: nx.DiGraph) -> tuple[str, ...]:
+def find_internal_consumers(container_id: str, value_name: str, flat_graph: nx.DiGraph, *, include_fuzzy: bool = True) -> tuple[str, ...]:
     """EVERY internal consumer a boundary value feeds, not just the deepest.
 
     One incoming value can enter a container at several nodes — panda's
@@ -408,11 +513,14 @@ def find_internal_consumers(container_id: str, value_name: str, flat_graph: nx.D
     every other consumer with no incoming edge once the container expanded.
 
     Exact name matches are authoritative: each one genuinely reads the value,
-    so each one gets the edge. A consumer already fed by an *internal*
-    producer of the same name is excluded — its value does not cross the
-    boundary. The fuzzy fallback stays single-answer (deepest): a substring
-    match is a guess, and fanning a guess out would draw edges nobody can
-    defend."""
+    so each one gets the edge. Two exclusions, same reason (the value does
+    not cross that boundary): a consumer already fed by an *internal*
+    producer of the same name, and a consumer sitting under a mapped
+    container whose ``map_fields`` supply the name per item. The fuzzy
+    fallback stays single-answer (deepest): a substring match is a guess,
+    and fanning a guess out would draw edges nobody can defend.
+    ``include_fuzzy=False`` skips the fallback so a caller can union exact
+    matches across several value names before settling for a guess."""
     inner_names = _inner_input_names(container_id, value_name, flat_graph)
     descendants = [
         (node_id, attrs)
@@ -428,13 +536,31 @@ def find_internal_consumers(container_id: str, value_name: str, flat_graph: nx.D
                 return True
         return False
 
+    def map_fed_below(node_id: str) -> bool:
+        current = flat_graph.nodes.get(node_id, {}).get("parent")
+        while current is not None and current != container_id:
+            if any(map_feeds_param(current, inner, flat_graph) for inner in inner_names):
+                return True
+            current = flat_graph.nodes.get(current, {}).get("parent")
+        return False
+
     candidates = [
-        node_id for node_id, attrs in descendants if any(inner in attrs.get("inputs", ()) for inner in inner_names) and not fed_internally(node_id)
+        node_id
+        for node_id, attrs in descendants
+        if any(inner in attrs.get("inputs", ()) for inner in inner_names) and not fed_internally(node_id) and not map_fed_below(node_id)
     ]
     if candidates:
         return tuple(candidates)
+    if not include_fuzzy:
+        return ()
 
-    fuzzy = [node_id for node_id, attrs in descendants for inp in attrs.get("inputs", ()) for inner in inner_names if inp in inner or inner in inp]
+    fuzzy = [
+        node_id
+        for node_id, attrs in descendants
+        for inp in attrs.get("inputs", ())
+        for inner in inner_names
+        if (inp in inner or inner in inp) and not map_fed_below(node_id)
+    ]
     if fuzzy:
         return (max(fuzzy, key=lambda c: _depth_below(c, container_id, flat_graph)),)
     return ()

--- a/src/hypergraph/viz/renderer/scope.py
+++ b/src/hypergraph/viz/renderer/scope.py
@@ -14,6 +14,7 @@ from hypergraph.viz._common import (
     get_parent,
     is_descendant_of,
     is_node_visible,
+    map_feeds_param,
     resolve_port_address_consumers,
 )
 
@@ -78,7 +79,13 @@ def _descend_to_inner_consumers(consumer: str, param: str, flat_graph: nx.DiGrap
     Terminates unconditionally: each recursive call moves to a strict
     descendant container in the finite containment tree, regardless of how
     boundary renames chain or swap names.
+
+    A mapped container whose fan-out edge supplies ``param`` per item
+    (``map_fields``) is a boundary the outer value never crosses — the
+    descent stops there and claims no inner consumer.
     """
+    if map_feeds_param(consumer, param, flat_graph):
+        return []
     attrs = flat_graph.nodes.get(consumer, {})
     if attrs.get("node_type") != "GRAPH":
         return [consumer]
@@ -95,6 +102,29 @@ def _descend_to_inner_consumers(consumer: str, param: str, flat_graph: nx.DiGrap
                         inner_consumers.append(deep_consumer)
                 break
     return inner_consumers or [consumer]
+
+
+def map_fed_field_consumers(container_id: str, field: str, flat_graph: nx.DiGraph) -> list[str]:
+    """The inner consumers a mapped container's item ``field`` feeds.
+
+    The same walk as ``_descend_to_inner_consumers``, but started AT the
+    mapped container for its own field: the map boundary being crossed here
+    is the one the fan-out edge itself crosses, so the map-fed stop applies
+    only to mapped containers nested deeper inside.
+    """
+    attrs = flat_graph.nodes.get(container_id, {})
+    inner_names = (attrs.get("input_name_map") or {}).get(field) or (field,)
+    consumers: list[str] = []
+    for child_id, child_attrs in flat_graph.nodes(data=True):
+        if child_attrs.get("parent") != container_id:
+            continue
+        for inner_name in inner_names:
+            if inner_name in child_attrs.get("inputs", ()):
+                for deep_consumer in _descend_to_inner_consumers(child_id, inner_name, flat_graph):
+                    if deep_consumer not in consumers:
+                        consumers.append(deep_consumer)
+                break
+    return consumers
 
 
 def get_ancestor_chain(node_id: str, flat_graph: nx.DiGraph) -> list[str]:

--- a/src/hypergraph/viz/scene_builder.py
+++ b/src/hypergraph/viz/scene_builder.py
@@ -107,6 +107,15 @@ def build_initial_scene(
     input_buckets = (
         _merge_inputs_for_state(ir, parent_map, expansion_state, node_visible_ids, show_bounded_inputs=show_bounded_inputs) if show_inputs else []
     )
+    # An IR edge may target a pill by its state-independent synthetic id
+    # (identity-mode fan-out re-routes), but per-state merging can fold that
+    # pill into a group with a different id — remap so the edge lands on the
+    # pill node this state actually emits.
+    pill_alias: dict[str, str] = {}
+    for bucket in input_buckets:
+        for member_id in bucket.get("member_ids", ()):
+            if member_id != bucket["id"]:
+                pill_alias[member_id] = bucket["id"]
     for ext in input_buckets:
         hidden = ext["hidden"]
         owner_container = ext["owner_container"]
@@ -227,6 +236,7 @@ def build_initial_scene(
                 targets = list(expanded_targets) if isinstance(expanded_targets, tuple) else [expanded_targets]
             targets = list(resolve_expanded_entrypoints(targets, ir.container_entrypoints, expansion_state))
             targets = _resolve_rewritten_endpoints(targets, parent_map, expansion_state, visible_ids)
+            targets = list(dict.fromkeys(pill_alias.get(target, target) for target in targets))
 
         # A data edge can carry multiple value_names (one NetworkX edge per
         # (src,tgt) merges them). Merged-output mode should still render one
@@ -659,11 +669,13 @@ def _merge_inputs_for_state(
                 "deepest_owner": ext.deepest_owner,
                 "targets": list(targets),
                 "hidden": hidden,
+                "member_ids": [ext.synthetic_id],
             }
             continue
         bucket["params"].extend(ext.params)
         bucket["segments"].extend(segments)
         bucket["type_hints"].extend(ext.type_hints)
+        bucket["member_ids"].append(ext.synthetic_id)
         # A merged pill is hidden only when every constituent is.
         bucket["hidden"] = bucket["hidden"] and hidden
 

--- a/tests/viz/test_hypertable_fanout_edge.py
+++ b/tests/viz/test_hypertable_fanout_edge.py
@@ -76,11 +76,16 @@ def test_fanout_edge_connects_producer_to_mapped_node(store):
     assert edge.get("is_map") is True
 
 
-def test_without_fix_the_nodes_are_disconnected(store):
-    """Guards the diagnosis: without the injected edge there is no connection.
+def test_flat_graph_synthesizes_fanout_natively(store):
+    """``to_flat_graph()`` alone carries the fan-out edge — no extra_edges needed.
 
-    This is what the bug looked like — the combined graph's auto-wiring produces
-    zero edges between the producer and the mapped node.
+    Historic shape of the bug: the combined graph's auto-wiring produced zero
+    edges between the producer and the mapped node, and only
+    ``HyperTable.visualize``'s injected ``extra_edges`` papered over it — so a
+    table MOUNTED inside another graph (``MaterializationNode.nested_graph``)
+    still drew its fan-out node as an unreachable island. The flatten path now
+    synthesizes the identity-mode fan-out edge itself, with the same
+    ``is_map``/``map_fields`` stamp, at every scope.
     """
     from hypergraph.graph import Graph as _Graph
 
@@ -92,8 +97,12 @@ def test_without_fix_the_nodes_are_disconnected(store):
     nodes.extend(table._map_over_nodes)
     combined = _Graph(nodes, name=table._spec.name)
 
-    G_no_fix = combined.to_flat_graph()  # no extra_edges
-    assert not G_no_fix.has_edge("produce_items", "items_node")
+    G = combined.to_flat_graph()  # no extra_edges
+    assert G.has_edge("produce_items", "items_node")
+    edge = G["produce_items"]["items_node"]
+    assert edge["value_names"] == ["items"]
+    assert edge.get("is_map") is True
+    assert edge.get("map_fields") == ["item_id", "text"]
 
 
 def test_visualize_renders_without_raising(store):

--- a/tests/viz/test_mounted_table_fanout.py
+++ b/tests/viz/test_mounted_table_fanout.py
@@ -165,6 +165,30 @@ def test_previously_islanded_field_consumer_gets_its_edge(mounted_graph):
     )
 
 
+def test_fanout_merge_promotes_an_ordering_edge_to_data():
+    """A ``wait_for`` ordering edge from the producer to the mapped node must
+    not survive as a mislabeled ordering edge once the fan-out facts merge in:
+    the fan-out IS a data dependency, so the merged edge reports ``data``."""
+    import tempfile
+
+    from hypergraph.materialization._lancedb_store import LanceDBStore
+
+    store = LanceDBStore(tempfile.mkdtemp() + "/store")
+    derive = Graph([clean_page, page_title], name="derive_page").as_node(name="derive_pages").map_over("pages", identity="page_id", schema=Page)
+    table = Graph(
+        [load_bytes, convert, build_pages, derive],
+        edges=[(build_pages, derive)],
+        name="pages_recipe",
+    ).as_table(identity="doc_version_id", store=store)
+    flat = Graph([table.as_node(name="materialize")], name="outer").to_flat_graph()
+
+    edge = flat["materialize/build_pages"]["materialize/derive_pages"]
+    assert edge["edge_type"] == "data"
+    assert edge.get("is_map") is True
+    assert edge["value_names"] == ["pages"]
+    assert edge.get("map_fields") == ["page_id", "page_text", "source_uri", "doc_name"]
+
+
 def test_multi_value_boundary_edge_unions_exact_consumers(mounted_graph):
     """``stage → materialize`` carries three values; its expanded target is the
     union of every value's EXACT consumers, not the first value's fuzzy guess."""

--- a/tests/viz/test_mounted_table_fanout.py
+++ b/tests/viz/test_mounted_table_fanout.py
@@ -1,0 +1,180 @@
+"""A MOUNTED HyperTable keeps its fan-out story at every depth.
+
+Regression suite for four related lies first observed on panda's real
+ingestion graph (a document-ingest graph whose ``materialize_pages`` node is a
+HyperTable mounted with ``as_node()``):
+
+1. The recipe's fan-out edge vanished when the table was mounted — only
+   ``HyperTable.visualize`` injected it, so the mapped child drew as an
+   unreachable island dagre parked at the TOP of the expanded container.
+2. An outer graph input sharing a name with a mapped item field (``pdf_uri``)
+   drew an edge straight into the mapped container's interior — an edge
+   runtime never wires (the mapped rows feed those inputs per item).
+3. Item fields with no outer presence (``page_markdown``) had no pill at all,
+   so their consumers rendered with no incoming edges.
+4. A multi-value boundary edge resolved its expanded target from its FIRST
+   value name only — a fuzzy guess for value one (``doc_version_id``
+   substring-matching ``version_id``) swallowed the exact consumers of the
+   values after it (``filename`` → the converter node).
+
+The fixture mirrors panda's shape with neutral names:
+
+    stage ─(doc_version_id, version_id, doc_name)─▶ materialize ─▶ publish
+    materialize = HyperTable(load_bytes → convert → build_pages ⇒ derive_pages)
+    derive_pages = map_over("pages", identity="page_id", schema=Page)
+    Page fields: page_id, page_text, source_uri, doc_name
+    derive_pages inner: clean_page(page_text, source_uri), page_title(doc_name)
+"""
+
+from __future__ import annotations
+
+import tempfile
+from typing import TypedDict
+
+import pytest
+
+from hypergraph import Graph, node
+from hypergraph.materialization._lancedb_store import LanceDBStore
+from hypergraph.viz.renderer.ir_builder import build_graph_ir
+
+from .conftest import scene_for_state
+
+
+class Page(TypedDict):
+    page_id: str
+    page_text: str
+    source_uri: str
+    doc_name: str
+
+
+@node(output_name="raw_bytes")
+def load_bytes(source_uri: str) -> str:
+    return source_uri
+
+
+@node(output_name="converted")
+def convert(raw_bytes: str, doc_name: str) -> str:
+    return f"{doc_name}:{raw_bytes}"
+
+
+@node(output_name="pages")
+def build_pages(converted: str, version_id: str, doc_name: str, source_uri: str) -> list[Page]:
+    return [Page(page_id=f"{version_id}_1", page_text=converted, source_uri=source_uri, doc_name=doc_name)]
+
+
+@node(output_name="clean_text")
+def clean_page(page_text: str, source_uri: str) -> str:
+    return f"{page_text}@{source_uri}"
+
+
+@node(output_name="title")
+def page_title(doc_name: str) -> str:
+    return doc_name
+
+
+@node(output_name=("doc_version_id", "version_id", "doc_name"))
+def stage(source_uri: str) -> tuple[str, str, str]:
+    return f"{source_uri}#v1", "v1", source_uri
+
+
+@node(output_name="published")
+def publish(materialization: object) -> str:
+    return "done"
+
+
+@pytest.fixture
+def mounted_graph() -> Graph:
+    store = LanceDBStore(tempfile.mkdtemp() + "/store")
+    derive = Graph([clean_page, page_title], name="derive_page").as_node(name="derive_pages").map_over("pages", identity="page_id", schema=Page)
+    table = Graph([load_bytes, convert, build_pages, derive], name="pages_recipe").as_table(identity="doc_version_id", store=store)
+    mounted = table.as_node(name="materialize", output_name="materialization")
+    return Graph([stage, mounted, publish], name="ingest")
+
+
+def test_mounted_flat_graph_carries_the_fanout_edge(mounted_graph):
+    """The identity fan-out edge survives mounting (no extra_edges anywhere)."""
+    flat = mounted_graph.to_flat_graph()
+
+    assert flat.has_edge("materialize/build_pages", "materialize/derive_pages")
+    edge = flat["materialize/build_pages"]["materialize/derive_pages"]
+    assert edge["edge_type"] == "data"
+    assert edge["value_names"] == ["pages"]
+    assert edge.get("is_map") is True
+    assert edge.get("map_fields") == ["page_id", "page_text", "source_uri", "doc_name"]
+
+
+def test_mounted_mapped_node_is_not_an_island(mounted_graph):
+    """Fully expanded, the mapped container has an incoming edge — dagre can
+    rank it below its producer instead of parking it at the top."""
+    scene = scene_for_state(mounted_graph, expand_all=True)
+    edges = scene["edges"]
+
+    fanout = [e for e in edges if e["source"] == "materialize/build_pages"]
+    assert fanout, "expected the fan-out edge to leave build_pages in the expanded scene"
+    node_ids = {n["id"] for n in scene["nodes"]}
+    for e in edges:
+        assert e["source"] in node_ids and e["target"] in node_ids, f"dangling edge {e['source']} -> {e['target']}"
+
+
+def test_outer_input_pill_never_claims_map_fed_consumers(mounted_graph):
+    """``source_uri`` (an outer graph input AND an item field) feeds only the
+    nodes the outer value really reaches; the mapped rows feed the rest."""
+    ir = build_graph_ir(mounted_graph.to_flat_graph())
+
+    (outer_pill,) = [e for e in ir.external_inputs if e.params == ("source_uri",) and not e.map_fed]
+    assert set(outer_pill.consumers) == {"stage", "materialize/load_bytes", "materialize/build_pages"}
+
+    scene = scene_for_state(mounted_graph, expand_all=True)
+    lies = [e for e in scene["edges"] if e["source"] == outer_pill.synthetic_id and e["target"].startswith("materialize/derive_pages/")]
+    assert lies == [], f"outer pill must not reach into the mapped container: {lies}"
+
+
+def test_map_fed_field_pills_are_synthesized_for_the_mounted_container(mounted_graph):
+    """Every consumed item field gets a map-fed pill inside the container —
+    including fields absent from the outer input surface entirely."""
+    ir = build_graph_ir(mounted_graph.to_flat_graph())
+
+    map_fed = {e.params[0]: e for e in ir.external_inputs if e.map_fed}
+    assert set(map_fed) == {"page_text", "source_uri", "doc_name"}
+    for pill in map_fed.values():
+        assert pill.deepest_owner == "materialize/derive_pages"
+
+    assert map_fed["doc_name"].consumers == ("materialize/derive_pages/page_title",)
+    assert map_fed["page_text"].consumers == ("materialize/derive_pages/clean_page",)
+    assert set(map_fed["source_uri"].consumers) == {"materialize/derive_pages/clean_page"}
+    # The item-field pill shares a leaf name with the outer input, so its
+    # synthetic id must not collide with the outer pill's.
+    assert map_fed["source_uri"].synthetic_id != "input_source_uri"
+
+    (fanout,) = [e for e in ir.edges if e.source == "materialize/build_pages" and e.target == "materialize/derive_pages"]
+    assert isinstance(fanout.target_when_expanded, tuple)
+    assert set(fanout.target_when_expanded) == {pill.synthetic_id for pill in map_fed.values()}
+
+
+def test_previously_islanded_field_consumer_gets_its_edge(mounted_graph):
+    """``page_title`` (consumes only a row-fed field) is reachable when fully
+    expanded: fan-out edge → doc_name pill → page_title."""
+    scene = scene_for_state(mounted_graph, expand_all=True)
+    edges = scene["edges"]
+
+    incoming = [e for e in edges if e["target"] == "materialize/derive_pages/page_title"]
+    assert len(incoming) == 1
+    pill_id = incoming[0]["source"]
+    assert any(e["source"] == "materialize/build_pages" and e["target"] == pill_id for e in edges), (
+        f"the fan-out edge must feed the pill that feeds page_title; got edges into it: {[e for e in edges if e['target'] == pill_id]}"
+    )
+
+
+def test_multi_value_boundary_edge_unions_exact_consumers(mounted_graph):
+    """``stage → materialize`` carries three values; its expanded target is the
+    union of every value's EXACT consumers, not the first value's fuzzy guess."""
+    ir = build_graph_ir(mounted_graph.to_flat_graph())
+
+    (edge,) = [e for e in ir.edges if e.source == "stage" and e.target == "materialize"]
+    assert set(edge.value_names) == {"doc_version_id", "version_id", "doc_name"}
+    targets = edge.target_when_expanded
+    targets = targets if isinstance(targets, tuple) else (targets,)
+    # version_id → build_pages (exact); doc_name → convert + build_pages
+    # (exact; page_title is map-fed and must stay excluded);
+    # doc_version_id → nothing exact, and its fuzzy match must not win.
+    assert set(targets) == {"materialize/build_pages", "materialize/convert"}

--- a/tests/viz/test_parity.py
+++ b/tests/viz/test_parity.py
@@ -379,6 +379,53 @@ def _fanout_ir(inner_inputs: tuple[str, ...]):
     return build_graph_ir(flat)
 
 
+def _mounted_table_ir():
+    """A HyperTable MOUNTED in an outer graph (panda's ingest shape).
+
+    Exercises what the standalone fan-out fixtures cannot: synthesized
+    map-fed field pills (fields hidden behind the MaterializationNode
+    boundary), the outer/inner split of a shared field name, and the
+    per-state pill-alias remap when two field pills merge into one group.
+    """
+    import tempfile
+
+    from hypergraph import Graph
+    from hypergraph.materialization._lancedb_store import LanceDBStore
+
+    store = LanceDBStore(tempfile.mkdtemp() + "/store")
+
+    @_node(output_name="pages")
+    def build_pages(source: str) -> list[_FanoutItem]:
+        return [_FanoutItem(item_id="i0", page_text=source, page_number=1)]
+
+    child = Graph([_embed_two_fields], name="proc").as_node(name="derive").map_over("pages", identity="item_id")
+    table = Graph([build_pages, child], name="recipe").as_table(identity="doc_id", store=store)
+
+    @_node(output_name="report")
+    def summarize(materialization: object) -> str:
+        return "ok"
+
+    outer = Graph([table.as_node(name="materialize", output_name="materialization"), summarize], name="outer")
+    return build_graph_ir(outer.to_flat_graph())
+
+
+@pytest.mark.parametrize("show_inputs", [False, True])
+def test_python_js_mounted_table_scenes_match(show_inputs: bool) -> None:
+    """Python and JS agree on a mounted table's synthesized field pills and
+    the pill-alias remap, across every expansion state."""
+    ir = _mounted_table_ir()
+    ir_dict: dict[str, Any] = asdict(ir)
+
+    for expansion_state in _all_expansion_states(ir_dict):
+        py_scene = build_initial_scene(ir, expansion_state=expansion_state, show_inputs=show_inputs)
+        js_scene = _node_scene(ir_dict, {"expansionState": expansion_state, "showInputs": show_inputs})
+        py_nodes, py_edges = _project(py_scene)
+        js_nodes, js_edges = _project(js_scene)
+        ctx = f"mounted state={expansion_state} inputs={show_inputs}"
+        assert py_nodes == js_nodes, f"Node drift for {ctx}\nPy-only: {sorted(py_nodes - js_nodes)}\nJS-only: {sorted(js_nodes - py_nodes)}"
+        assert py_edges == js_edges, f"Edge drift for {ctx}\nPy-only: {sorted(py_edges - js_edges)}\nJS-only: {sorted(js_edges - py_edges)}"
+
+
 @pytest.mark.parametrize("inner_inputs", [("page_text",), ("page_text", "page_number")])
 @pytest.mark.parametrize("show_inputs", [False, True])
 def test_python_js_fanout_scenes_match(inner_inputs: tuple[str, ...], show_inputs: bool) -> None:


### PR DESCRIPTION
Four visualization lies, all first observed on panda's REAL document-ingestion graph (`ingest_document_graph`, whose `materialize_pages` node is a HyperTable mounted with `as_node()`). Same family as #364/#366/#367: what a nested graph shows must be trustworthy at every expansion state. **No runtime change anywhere** — the flat graph is viz-only, and a pinned-behavior sweep (`uv run pytest`, 4921 passed) confirms execution, durable identity, and recipe fingerprints are untouched.

## The four lies, on the real graph

1. **The fan-out edge vanished when the table was mounted.** Only `HyperTable.visualize()` injected `build_page_inputs ─protocol_pages─▶ derive_pages` (as `extra_edges`); `Graph.visualize()` on the OUTER ingest graph expands `MaterializationNode.nested_graph` through `to_flat_graph()`, which knew nothing of the fan-out. The mapped child drew as an unreachable island — dagre parks an unconstrained subtree at rank 0, which is why panda's `derive_pages` rendered at the TOP of the MATERIALIZE_PAGES box, above `load_source_bytes`.
2. **Outer inputs reached into the mapped interior.** `pdf_uri` is both an outer graph input and a `ProtocolPageInput` field; the pill drew an edge into `derive_pages/detect_visual_information`. Runtime never wires that: the WritePlanner feeds mapped-child inputs from the row columns (`_writes.py::_graph_inputs`).
3. **Row-fed fields with no outer presence had no pill at all.** `page_markdown`/`page_number` hide behind the MaterializationNode's input surface (identity + source columns), so their consumers rendered with no incoming edges — and `page_title(filename)` drew as a floating island.
4. **A multi-value boundary edge kept only its first value's answer.** `stage_document_version → materialize_pages` carries `(doc_version_id, filename, version_id)`; the rewrite loop broke on the first value with any match, so `doc_version_id`'s FUZZY substring match (`version_id`) swallowed `filename`'s EXACT consumers — `convert_document` lost its boundary edge.

## The fixes

- **`to_flat_graph()` synthesizes the identity fan-out edge natively at every flatten scope** (`graph/core.py::_add_identity_fanout_edges`), same `is_map`/`map_fields` stamp as `HyperTable.visualize` — which now merges into the synthesized edge instead of being the only source of it.
- **The shared consumer walks stop at a map-fed boundary** (`viz/_common.py::map_feeds_param`, applied in `build_param_to_consumer_map`, `scope.py::_descend_to_inner_consumers`, and `ir_builder.py::find_internal_consumers`): the rows feed those inputs; the outer value does not cross. Mermaid inherits the honesty through the same helpers.
- **The IR synthesizes a map-fed field pill inside the container for every consumed item field** (`ir_builder.py::_ensure_map_fed_field_pills`): shared-name pills split into their honest outer/inner halves (distinct synthetic ids), fields with no outer presence get their pill, and the fan-out edge re-routes to all of them on expansion — `build_page_inputs ─▶ [filename] ─▶ page_title` finally draws.
- **Boundary edges union the EXACT consumers of every value they carry** before any fuzzy fallback (`_build_ir_edge`; `find_internal_consumers(include_fuzzy=False)` for the union pass). panda's edge now lands on `(convert_document, build_page_inputs)`.
- **Per-state pill-alias remap in BOTH scene-builder twins**: fan-out edges target pills by their state-independent synthetic ids, but per-state merging (#366) can fold two field pills into one INPUT_GROUP — the edge then silently hid. Buckets now record their member ids and edges remap through them (`Object.create(null)` on the JS side, per the prototype-pollution rule).

## What is pinned

- `tests/viz/test_mounted_table_fanout.py` (6 tests, panda-shaped fixture): the synthesized flat-graph edge, no-island scene, outer-pill honesty, synthesized field pills + re-route targets, the previously-islanded `page_title` consumer's edge, and the multi-value union.
- `test_parity.py::test_python_js_mounted_table_scenes_match`: full expansion-state matrix over the mounted fixture — locks the JS twin on synthesized pills and the alias remap.
- `test_hypertable_fanout_edge.py::test_flat_graph_synthesizes_fanout_natively` replaces the obsolete `test_without_fix_the_nodes_are_disconnected` pin (its premise — auto-wiring produces no edge, only `visualize()` injects one — is exactly what this PR retires; the merge-not-duplicate behavior it protected is still pinned by `test_to_flat_graph_merges_extra_edge_into_existing_edge`).

## Verification

- `uv run pytest` → **4921 passed, 15 skipped** (from 4913; +8 net new)
- CI-equivalent `uv run pytest -W error -W 'ignore::pytest.PytestUnraisableExceptionWarning'` → identical
- `uv run --python 3.10 mypy` → clean, 175 files
- `uv run pre-commit run --all-files` → all hooks pass
- Regenerated panda's real ingest visualization against this branch: fan-out edges + field pills present, `derive_pages` fed and ranked below `build_page_inputs`, no dangling endpoints, outer `pdf_uri` pill stops at `load_source_bytes`/`build_page_inputs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable fan-out connections for identity-mapped nodes in flattened and nested graph visualizations.
  * Added synthesized input pills for mapped fields, including nested consumers, with accurate types and collision-safe identifiers.
  * Improved edge routing across mounted tables, expanded graph states, and merged input nodes.

* **Bug Fixes**
  * Prevented outer inputs from incorrectly connecting to consumers supplied by mapped containers.
  * Restored previously missing connections and ensured multi-value edges reach all exact consumers.
  * Improved parity between Python- and JavaScript-rendered scenes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->