### PR TITLE
fix(viz): the receipt leaves an anchor pill, and the answer loop reads as an answer

### DIFF
--- a/src/hypergraph/viz/AGENTS.md
+++ b/src/hypergraph/viz/AGENTS.md
@@ -100,7 +100,8 @@ side-effect in the order defined by `FIRST_PARTY_ASSET_NAMES`
 
 - Flat graph containers: `node_type == "GRAPH"`
 - React Flow mapping: `GRAPH` → `PIPELINE`
-- Synthetic nodes: `INPUT`, `INPUT_GROUP`, `DATA`
+- Synthetic nodes: `INPUT`, `INPUT_GROUP`, `DATA`, `OUTPUT` (boundary-output
+  anchor for a container output no descendant produces)
 
 **Invariant**: Container detection must use `node_type == "GRAPH"` in Python and `nodeType == "PIPELINE"` in JS.
 
@@ -129,13 +130,30 @@ The IR carries all expansion-rewriting information eagerly:
   and each such pill is flagged ``IRExternalInput.map_fed`` (styled distinctly,
   not as a free-floating external input). Falls back to the container entrypoint
   when the mapped item has no matching field (e.g. ``list[str]``).
+- A container output NO descendant produces (a mounted HyperTable's receipt:
+  the ``MaterializationNode``'s own output is the whole table's completion)
+  gets a synthesized ``node_type == "OUTPUT"`` anchor pill INSIDE the
+  container (id ``<container>/__output__<name>``), and the boundary edge's
+  ``source_when_expanded`` points at it — an edge's source must be a node;
+  only a COLLAPSED container may stand in as one. The pill follows normal
+  child visibility (hidden while its container chain is collapsed), and
+  ``performCompoundLayout`` ranks it below the container's visible sinks via
+  rank-only, undrawn dagre edges so the boundary edge flows downhill.
+  ``mermaid.py`` synthesizes the same anchors via
+  ``ir_builder.container_output_anchors`` (schema v6).
 - INPUT pills hoist, never hide: an external input owned by a collapsed
   container surfaces at its deepest VISIBLE ancestor with its edge aggregated
   to the collapsed hull — a graph's contract inputs must survive any collapse.
   Only ``map_fed`` pills disappear with their container (the container-level
   fan-out edge represents the same value while collapsed).
 - ``IREdge.is_back_edge`` marks DFS back-edges so feedback routing survives
-  arbitrary expansion changes.
+  arbitrary expansion changes. An *ordering* back edge whose source outputs ∩
+  target inputs ∩ shared-state is non-empty (a routed interrupt's answer
+  returning to its gate) carries that value name as ``IREdge.label`` —
+  ``ir_builder.shared_answer_label``, shared with Mermaid. Feedback edges
+  render their orthogonal channel faithfully (``roundedChannelPath`` in
+  ``viz_edges.js``) instead of ``curveBasis``, which smeared the corners into
+  a wide orbit.
 - ``IRNode.outputs[i].internal_only`` flags outputs whose consumers all
   live in the same container — used to filter ``data.outputs`` on collapsed
   GRAPH containers and to drive ``data.internalOnly`` styling on DATA nodes.

--- a/src/hypergraph/viz/assets/scene_builder.js
+++ b/src/hypergraph/viz/assets/scene_builder.js
@@ -18,7 +18,7 @@
   // v4: canonical container_entrypoints field (D14, #211) — this scene
   // builder no longer derives entrypoints, so a v3 payload without the
   // field must banner instead of silently mis-routing START/control edges.
-  var SUPPORTED_SCHEMA_VERSION = '5';
+  var SUPPORTED_SCHEMA_VERSION = '6';
 
   // Mirror of scene_builder.py:DATA_FLOW_EDGE_TYPES — the edge types that
   // carry a value, and so the only ones the `simplify` path graph walks.
@@ -165,6 +165,30 @@
 
     for (var j = 0; j < ir.nodes.length; j++) {
       var irNode = ir.nodes[j];
+      if (irNode.node_type === 'OUTPUT') {
+        // Synthesized boundary-output anchor (a mounted table's receipt):
+        // visible exactly while its container chain is expanded — the same
+        // rule as any inner node — so an expanded container never sources an
+        // edge from its own hull. Twin of the Python OUTPUT branch.
+        var anchorOut = (irNode.outputs && irNode.outputs[0]) || {};
+        sceneNodes.push({
+          id: irNode.id,
+          type: 'custom',
+          position: { x: 0, y: 0 },
+          data: {
+            nodeType: 'OUTPUT',
+            label: irNode.label || irNode.id,
+            typeHint: anchorOut.type || null,
+            ownerContainer: irNode.parent || null,
+          },
+          sourcePosition: 'bottom',
+          targetPosition: 'top',
+          hidden: ancestorCollapsed(irNode.id, parentMap, expansionState),
+          parentNode: irNode.parent,
+          extent: 'parent',
+        });
+        continue;
+      }
       var sceneType = sceneNodeType(irNode.node_type);
       var isExpanded = irNode.node_type === 'GRAPH' ? !!expansionState[irNode.id] : null;
       var rfType = sceneType === 'PIPELINE' && isExpanded ? 'pipelineGroup' : 'custom';
@@ -340,6 +364,14 @@
       if (!sceneNodes[m].hidden) visibleIds[sceneNodes[m].id] = true;
     }
 
+    // Synthesized boundary-output anchors ARE the value pill: an edge sourced
+    // at one never interposes a DATA node in separateOutputs mode.
+    // Object.create(null): ids come from user-authored Python names.
+    var anchorIds = Object.create(null);
+    for (var an = 0; an < ir.nodes.length; an++) {
+      if (ir.nodes[an].node_type === 'OUTPUT') anchorIds[ir.nodes[an].id] = true;
+    }
+
     var sceneEdges = [];
     var edgeEntrypointOverrides = expandedContainerEntrypoints(ir, expansionState);
     // scene-edge id -> {entry, exit} when the edge touches a *collapsed*
@@ -427,7 +459,7 @@
           for (var v = 0; v < valuesToEmit.length; v++) {
             var valueName = valuesToEmit[v];
             var src = baseSrc;
-            if (separateOutputs && irEdge.edge_type === 'data' && valueName !== null) {
+            if (separateOutputs && irEdge.edge_type === 'data' && valueName !== null && !anchorIds[src]) {
               src = 'data_' + src + '_' + valueName;
             }
             var edgeId = valueName === null ? src + '__' + tgt : src + '__' + tgt + '__' + valueName;

--- a/src/hypergraph/viz/assets/scene_builder.js
+++ b/src/hypergraph/viz/assets/scene_builder.js
@@ -169,7 +169,10 @@
         // Synthesized boundary-output anchor (a mounted table's receipt):
         // visible exactly while its container chain is expanded — the same
         // rule as any inner node — so an expanded container never sources an
-        // edge from its own hull. Twin of the Python OUTPUT branch.
+        // edge from its own hull. No `extent: parent`: the layout DOCKS the
+        // pill straddling the container's bottom border — it is a port of
+        // the box itself — and a parent extent would clamp it back inside.
+        // Twin of the Python OUTPUT branch.
         var anchorOut = (irNode.outputs && irNode.outputs[0]) || {};
         sceneNodes.push({
           id: irNode.id,
@@ -185,7 +188,6 @@
           targetPosition: 'top',
           hidden: ancestorCollapsed(irNode.id, parentMap, expansionState),
           parentNode: irNode.parent,
-          extent: 'parent',
         });
         continue;
       }

--- a/src/hypergraph/viz/assets/viz_edges.js
+++ b/src/hypergraph/viz/assets/viz_edges.js
@@ -62,6 +62,34 @@
     return cleaned.length >= 2 ? cleaned : deduped;
   }
 
+  /** Orthogonal polyline with small rounded corners. Feedback edges use this
+   * instead of curveBasis: their points are a deliberate Manhattan channel
+   * hugging the two nodes, and the B-spline smeared the corners into a wide
+   * orbit that read as spaghetti rather than "the answer comes back". */
+  function roundedChannelPath(pts, radius) {
+    if (!pts || pts.length < 2) return pts && pts.length ? 'M ' + pts[0].x + ' ' + pts[0].y : '';
+    var r = radius || 12;
+    var path = 'M ' + pts[0].x + ' ' + pts[0].y;
+    for (var i = 1; i < pts.length - 1; i++) {
+      var p0 = pts[i - 1], p1 = pts[i], p2 = pts[i + 1];
+      var l1 = Math.sqrt(Math.pow(p1.x - p0.x, 2) + Math.pow(p1.y - p0.y, 2));
+      var l2 = Math.sqrt(Math.pow(p2.x - p1.x, 2) + Math.pow(p2.y - p1.y, 2));
+      var cr = Math.min(r, l1 / 2, l2 / 2);
+      if (cr < 0.5 || l1 < 1e-6 || l2 < 1e-6) {
+        path += ' L ' + p1.x + ' ' + p1.y;
+        continue;
+      }
+      var inX = p1.x - ((p1.x - p0.x) / l1) * cr;
+      var inY = p1.y - ((p1.y - p0.y) / l1) * cr;
+      var outX = p1.x + ((p2.x - p1.x) / l2) * cr;
+      var outY = p1.y + ((p2.y - p1.y) / l2) * cr;
+      path += ' L ' + inX + ' ' + inY + ' Q ' + p1.x + ' ' + p1.y + ' ' + outX + ' ' + outY;
+    }
+    var last = pts[pts.length - 1];
+    path += ' L ' + last.x + ' ' + last.y;
+    return path;
+  }
+
   function pointAlongPolyline(pts, t) {
     if (!pts || pts.length < 2) return pts && pts[0] ? { x: pts[0].x, y: pts[0].y } : { x: 0, y: 0 };
     var total = 0;
@@ -94,11 +122,11 @@
 
     if (data && data.points && data.points.length > 0) {
       var points = normalizePoints(data.points.slice());
-      edgePath = curveBasis(points);
+      edgePath = data.isFeedbackEdge ? roundedChannelPath(points) : curveBasis(points);
       var isBranch = edgeLabel === 'True' || edgeLabel === 'False';
-      var lp = isBranch
+      var lp = data.isFeedbackEdge
         ? pointAlongPolyline(points, 0.5)
-        : pointAlongPolyline(points, 0.35);
+        : (isBranch ? pointAlongPolyline(points, 0.5) : pointAlongPolyline(points, 0.35));
       labelX = lp.x; labelY = lp.y;
     } else {
       var r = getBezierPath({ sourceX: props.sourceX, sourceY: props.sourceY, sourcePosition: props.sourcePosition,
@@ -134,6 +162,7 @@
 
   var Edges = {
     curveBasis: curveBasis,
+    roundedChannelPath: roundedChannelPath,
     normalizePoints: normalizePoints,
     pointAlongPolyline: pointAlongPolyline,
     CustomEdge: CustomEdge,

--- a/src/hypergraph/viz/assets/viz_layout.js
+++ b/src/hypergraph/viz/assets/viz_layout.js
@@ -322,6 +322,14 @@
         }
         return false;
       };
+      // One outgoing-edge index up front, so sink detection is a lookup per
+      // node instead of an edge scan per (anchor, node) pair.
+      var outgoingBySource = new Map();
+      layoutEdges.forEach(function(e) {
+        var bucket = outgoingBySource.get(e.source);
+        if (!bucket) { bucket = []; outgoingBySource.set(e.source, bucket); }
+        bucket.push(e.target);
+      });
       anchorLayoutNodes.forEach(function(anchor) {
         var containerId = displayParentById.get(anchor.id);
         if (!containerId) return;
@@ -330,8 +338,8 @@
           if (n.data && n.data.nodeType === 'OUTPUT') return;
           if (g.children(n.id) && g.children(n.id).length) return; // clusters cannot be ranked
           if (!underContainer(n.id, containerId)) return;
-          var isSink = !layoutEdges.some(function(e) {
-            return e.source === n.id && e.target !== anchor.id && underContainer(e.target, containerId);
+          var isSink = !(outgoingBySource.get(n.id) || []).some(function(target) {
+            return target !== anchor.id && underContainer(target, containerId);
           });
           if (isSink) g.setEdge(n.id, anchor.id, { minlen: 1 }, 'rank__' + anchor.id + '__' + n.id);
         });

--- a/src/hypergraph/viz/assets/viz_layout.js
+++ b/src/hypergraph/viz/assets/viz_layout.js
@@ -301,6 +301,42 @@
       }
       g.setEdge(e._rankSource, e._rankTarget, edgeLabel, e.id);
     });
+
+    // Rank each synthesized OUTPUT anchor (a mounted table's receipt pill)
+    // below everything inside its container: rank-only, undrawn edges from
+    // the container's visible leaf sinks to the anchor. The anchor has no
+    // drawn in-edge — the receipt has no single inner producer — so without
+    // these dagre would park it at the TOP of the container and the boundary
+    // edge it sources would climb backwards out of the box.
+    var anchorLayoutNodes = layoutNodes.filter(function(n) {
+      return n.data && n.data.nodeType === 'OUTPUT';
+    });
+    if (anchorLayoutNodes.length) {
+      var underContainer = function(nodeId, containerId) {
+        var current = displayParentById.get(nodeId);
+        var hops = 0;
+        while (current && hops <= layoutNodes.length) {
+          if (current === containerId) return true;
+          current = displayParentById.get(current);
+          hops++;
+        }
+        return false;
+      };
+      anchorLayoutNodes.forEach(function(anchor) {
+        var containerId = displayParentById.get(anchor.id);
+        if (!containerId) return;
+        layoutNodes.forEach(function(n) {
+          if (n.id === anchor.id) return;
+          if (n.data && n.data.nodeType === 'OUTPUT') return;
+          if (g.children(n.id) && g.children(n.id).length) return; // clusters cannot be ranked
+          if (!underContainer(n.id, containerId)) return;
+          var isSink = !layoutEdges.some(function(e) {
+            return e.source === n.id && e.target !== anchor.id && underContainer(e.target, containerId);
+          });
+          if (isSink) g.setEdge(n.id, anchor.id, { minlen: 1 }, 'rank__' + anchor.id + '__' + n.id);
+        });
+      });
+    }
     dagre.layout(g);
 
     var nodeById = new Map();

--- a/src/hypergraph/viz/assets/viz_layout.js
+++ b/src/hypergraph/viz/assets/viz_layout.js
@@ -351,6 +351,23 @@
       nodeById.set(n.id, n);
     });
 
+    // Dock each OUTPUT anchor ON its container's bottom border: the pill
+    // straddles the border like a port of the box itself, which is what it
+    // is — the value is produced by the WHOLE container completing, not by
+    // any inner node, so it must not hover inside the box as if fed by magic.
+    anchorLayoutNodes.forEach(function(anchor) {
+      var containerId = displayParentById.get(anchor.id);
+      var container = containerId ? nodeById.get(containerId) : null;
+      if (!container) return;
+      // The pipelineGroup draws its dashed border on the full layout box, so
+      // the container's layout bottom IS the visible border line.
+      anchor.y = container.y + container.height / 2;
+      var margin = anchor.width / 2 + 12;
+      var left = container.x - container.width / 2 + margin;
+      var right = container.x + container.width / 2 - margin;
+      anchor.x = Math.max(left, Math.min(right, anchor.x));
+    });
+
     layoutEdges = layoutEdges.filter(function(e) { return !e._skipRank; });
     layoutEdges.forEach(function(e) {
       var dagreEdge = g.edge(e._rankSource, e._rankTarget, e.id);
@@ -388,7 +405,9 @@
         var parentPos = nodePositions.get(parentId);
         if (parentPos) pos = { x: absPos.x - parentPos.x, y: absPos.y - parentPos.y };
         nwp.parentNode = parentId;
-        nwp.extent = 'parent';
+        // An OUTPUT anchor is docked STRADDLING its container's bottom
+        // border; a parent extent would clamp it back inside the box.
+        if (!(n.data && n.data.nodeType === 'OUTPUT')) nwp.extent = 'parent';
       }
       return {
         ...nwp, position: pos, width: n.width, height: n.height,

--- a/src/hypergraph/viz/assets/viz_nodes.js
+++ b/src/hypergraph/viz/assets/viz_nodes.js
@@ -150,18 +150,28 @@
     if (nodeType === 'OUTPUT') {
       // Synthesized boundary-output anchor: a container output no inner node
       // produces (a mounted HyperTable's receipt). Same pill language as the
-      // map-fed INPUT pills, emerald output accent — the boundary edge leaves
-      // this pill instead of the expanded container's hull.
-      var otc = isLight ? 'text-slate-400' : 'text-slate-500';
-      var outCls = isLight
-        ? ' bg-emerald-50 border-emerald-300 text-emerald-700 shadow-emerald-100 hover:border-emerald-400'
-        : ' bg-slate-900 border-emerald-500/60 text-emerald-300 shadow-black/50 hover:border-emerald-400';
+      // map-fed INPUT pills, emerald output accent; the LAYOUT docks it
+      // straddling the container's bottom border, so it reads as a port of
+      // the box itself. The type name renders in full — it is the pill's one
+      // self-description, so cutting it mid-word ("Materializat…") starves
+      // the reader of exactly the fact that explains the pill.
+      var ownerLeaf = (data.ownerContainer || '').split('/').pop();
+      var portTitle = ownerLeaf
+        ? data.label + ' is produced by the whole ' + ownerLeaf + ' completing — no single inner node emits it'
+        : null;
+      // Inline tones (the START/END pattern): the bundled Tailwind subset is
+      // purged, so emerald utility classes silently no-op here.
+      var outTone = isLight
+        ? { background: '#ECFDF5', borderColor: '#6EE7B7', color: '#047857' }
+        : { background: '#0F172A', borderColor: 'rgba(16, 185, 129, 0.55)', color: '#34D399' };
+      var outTypeTone = { color: isLight ? 'rgba(4, 120, 87, 0.7)' : 'rgba(52, 211, 153, 0.7)' };
       return html`
         <div className="w-full h-full relative" style=${wrapStyle}>
-          <div className=${'px-3 py-1.5 w-full h-full relative rounded-full border shadow-sm flex items-center justify-center gap-2 transition-colors transition-shadow duration-200 hover:shadow-lg overflow-hidden' + outCls}>
-            <span className=${'shrink-0 ' + (isLight ? 'text-emerald-500' : 'text-emerald-400')}>→</span>
+          <div className=${'px-3 py-1.5 w-full h-full relative rounded-full border shadow-sm flex items-center justify-center gap-2 transition-colors transition-shadow duration-200 hover:shadow-lg overflow-hidden' + (isLight ? ' shadow-slate-200' : ' shadow-black/50')}
+               style=${outTone} title=${portTitle}>
+            <span className="shrink-0" style=${{ color: isLight ? '#10B981' : '#34D399' }}>→</span>
             <span className="text-xs font-mono font-medium shrink-0">${data.label}</span>
-            ${data.showTypes && data.typeHint ? html`<span className=${'text-xs font-mono truncate min-w-0 ' + otc} title=${data.typeHint}>: ${truncateTypeHint(data.typeHint)}</span>` : null}
+            ${data.showTypes && data.typeHint ? html`<span className="text-xs font-mono whitespace-nowrap shrink-0" style=${outTypeTone}>: ${data.typeHint}</span>` : null}
           </div>
           <${Handle} type="target" position=${Position.Top} className="!w-2 !h-2 !opacity-0" style=${tgtStyle} />
           <${Handle} type="source" position=${Position.Bottom} className="!w-2 !h-2 !opacity-0" style=${srcStyle} />

--- a/src/hypergraph/viz/assets/viz_nodes.js
+++ b/src/hypergraph/viz/assets/viz_nodes.js
@@ -146,6 +146,28 @@
         </div>`;
     }
 
+    // ── OUTPUT node ──
+    if (nodeType === 'OUTPUT') {
+      // Synthesized boundary-output anchor: a container output no inner node
+      // produces (a mounted HyperTable's receipt). Same pill language as the
+      // map-fed INPUT pills, emerald output accent — the boundary edge leaves
+      // this pill instead of the expanded container's hull.
+      var otc = isLight ? 'text-slate-400' : 'text-slate-500';
+      var outCls = isLight
+        ? ' bg-emerald-50 border-emerald-300 text-emerald-700 shadow-emerald-100 hover:border-emerald-400'
+        : ' bg-slate-900 border-emerald-500/60 text-emerald-300 shadow-black/50 hover:border-emerald-400';
+      return html`
+        <div className="w-full h-full relative" style=${wrapStyle}>
+          <div className=${'px-3 py-1.5 w-full h-full relative rounded-full border shadow-sm flex items-center justify-center gap-2 transition-colors transition-shadow duration-200 hover:shadow-lg overflow-hidden' + outCls}>
+            <span className=${'shrink-0 ' + (isLight ? 'text-emerald-500' : 'text-emerald-400')}>→</span>
+            <span className="text-xs font-mono font-medium shrink-0">${data.label}</span>
+            ${data.showTypes && data.typeHint ? html`<span className=${'text-xs font-mono truncate min-w-0 ' + otc} title=${data.typeHint}>: ${truncateTypeHint(data.typeHint)}</span>` : null}
+          </div>
+          <${Handle} type="target" position=${Position.Top} className="!w-2 !h-2 !opacity-0" style=${tgtStyle} />
+          <${Handle} type="source" position=${Position.Bottom} className="!w-2 !h-2 !opacity-0" style=${srcStyle} />
+        </div>`;
+    }
+
     // ── INPUT_GROUP node ──
     if (nodeType === 'INPUT_GROUP') {
       var params = data.params || [], paramTypes = data.paramTypes || [];

--- a/src/hypergraph/viz/assets/viz_runtime.js
+++ b/src/hypergraph/viz/assets/viz_runtime.js
@@ -94,7 +94,16 @@
 
   function calculateDimensions(n) {
     var width = 80, height = 90;
-    if (n.data && (n.data.nodeType === 'DATA' || n.data.nodeType === 'INPUT' || n.data.nodeType === 'OUTPUT')) {
+    if (n.data && n.data.nodeType === 'OUTPUT') {
+      // The docked boundary-output pill renders its type IN FULL (its one
+      // self-description), so the width budget uses the real type length.
+      height = 36;
+      var outLabelLen = Math.min((n.data.label || '').length, NODE_LABEL_MAX_CHARS);
+      var outTypeLen = (n.data.showTypes && n.data.typeHint) ? n.data.typeHint.length + 2 : 0;
+      // A wider cap than MAX_NODE_WIDTH: the untruncated type must actually
+      // fit, or the CSS falls back to cutting it mid-word.
+      width = Math.min(420, (outLabelLen + outTypeLen + 2) * CHAR_WIDTH_PX + NODE_BASE_PADDING);
+    } else if (n.data && (n.data.nodeType === 'DATA' || n.data.nodeType === 'INPUT')) {
       height = 36;
       var labelLen = Math.min((n.data.label || '').length, NODE_LABEL_MAX_CHARS);
       var typeLen = (n.data.showTypes && n.data.typeHint) ? Math.min(n.data.typeHint.length, TYPE_HINT_MAX_CHARS) + 2 : 0;

--- a/src/hypergraph/viz/assets/viz_runtime.js
+++ b/src/hypergraph/viz/assets/viz_runtime.js
@@ -68,11 +68,11 @@
 
   var NODE_TYPE_OFFSETS = {
     PIPELINE: 26, GRAPH: 26, FUNCTION: 14,
-    DATA: 6, INPUT: 6, INPUT_GROUP: 6, BRANCH: 10, START: 6, END: 6,
+    DATA: 6, INPUT: 6, INPUT_GROUP: 6, OUTPUT: 6, BRANCH: 10, START: 6, END: 6,
   };
   var NODE_TYPE_TOP_INSETS = {
     PIPELINE: 0, GRAPH: 0, FUNCTION: 0,
-    DATA: 0, INPUT: 0, INPUT_GROUP: 0, BRANCH: 3, START: 0, END: 0,
+    DATA: 0, INPUT: 0, INPUT_GROUP: 0, OUTPUT: 0, BRANCH: 3, START: 0, END: 0,
   };
   var DEFAULT_OFFSET = 10;
   var DEFAULT_TOP_INSET = 0;
@@ -94,7 +94,7 @@
 
   function calculateDimensions(n) {
     var width = 80, height = 90;
-    if (n.data && (n.data.nodeType === 'DATA' || n.data.nodeType === 'INPUT')) {
+    if (n.data && (n.data.nodeType === 'DATA' || n.data.nodeType === 'INPUT' || n.data.nodeType === 'OUTPUT')) {
       height = 36;
       var labelLen = Math.min((n.data.label || '').length, NODE_LABEL_MAX_CHARS);
       var typeLen = (n.data.showTypes && n.data.typeHint) ? Math.min(n.data.typeHint.length, TYPE_HINT_MAX_CHARS) + 2 : 0;

--- a/src/hypergraph/viz/ir_schema.py
+++ b/src/hypergraph/viz/ir_schema.py
@@ -124,7 +124,14 @@ class IRExternalInput:
 # falls back to "a box passes everything through", which hides real edges under
 # a route that does not exist. That is a wrong picture rather than a missing
 # one, so it must hit the mismatch banner.
-CURRENT_SCHEMA_VERSION = "5"
+# v6: ``ir.nodes`` may contain synthesized ``node_type == "OUTPUT"`` anchor
+# pills — a container output no descendant produces (a mounted HyperTable's
+# receipt) gets a visible in-container anchor, and the boundary edge's
+# ``source_when_expanded`` points at it. An old scene builder would honor the
+# rewritten source while never emitting the anchor node, leaving the edge
+# dangling — a missing edge rather than a degraded one, so it must hit the
+# mismatch banner.
+CURRENT_SCHEMA_VERSION = "6"
 
 
 class IRSchemaError(ValueError):

--- a/src/hypergraph/viz/mermaid.py
+++ b/src/hypergraph/viz/mermaid.py
@@ -371,7 +371,9 @@ def _render_merged_edges(
         expansion_state,
         use_deepest=True,
     )
-    seen_edges: set[tuple[str, str, str]] = set()
+    # Control/ordering keys are 3-tuples; merged data keys are the resolved
+    # (source, target) pair — the widget's one-arrow-per-pair story.
+    seen_edges: set[tuple[str, ...]] = set()
 
     for source, target, edge_data in flat_graph.edges(data=True):
         if not is_node_visible(source, flat_graph, expansion_state):
@@ -457,10 +459,10 @@ def _render_merged_edges(
             for resolved_target in actual_targets:
                 if actual_source == resolved_target:
                     continue
-                edge_key = (id_allocator.get(actual_source), id_allocator.get(resolved_target))
-                if edge_key in seen_edges:
+                pair_key = (id_allocator.get(actual_source), id_allocator.get(resolved_target))
+                if pair_key in seen_edges:
                     continue
-                seen_edges.add(edge_key)
+                seen_edges.add(pair_key)
                 exit_port, entry_port = resolve_boundary_ports(flat_graph, source, target, value_names or [value_name])
                 out.append(
                     _RenderedEdge(

--- a/src/hypergraph/viz/mermaid.py
+++ b/src/hypergraph/viz/mermaid.py
@@ -33,8 +33,10 @@ from hypergraph.viz._simplify import EdgeRef, shortcut_edge_keys
 from hypergraph.viz.renderer._format import format_type
 from hypergraph.viz.renderer.ir_builder import (
     compute_container_transits,
+    container_output_anchors,
     find_internal_consumers,
     resolve_boundary_ports,
+    shared_answer_label,
 )
 from hypergraph.viz.renderer.nodes import (
     build_input_groups,
@@ -100,6 +102,12 @@ DEFAULT_COLORS: dict[str, dict[str, str]] = {
         "stroke-width": "2px",
         "color": "#065F46",
     },
+    "output": {
+        "fill": "#ECFDF5",
+        "stroke": "#34D399",
+        "stroke-width": "2px",
+        "color": "#047857",
+    },
 }
 
 # Maps HyperGraph node_type to Mermaid classDef name
@@ -110,6 +118,7 @@ _NODE_TYPE_TO_CLASS = {
     "INPUT": "input",
     "INPUT_GROUP": "input",
     "DATA": "data",
+    "OUTPUT": "output",
     "START": "start",
     "END": "end",
 }
@@ -206,6 +215,7 @@ _SHAPE_DELIMITERS: dict[str, tuple[str, str]] = {
     "INPUT": ('(["', '"])'),
     "INPUT_GROUP": ('(["', '"])'),
     "DATA": ('[/"', '"/]'),
+    "OUTPUT": ('(["', '"])'),
     "START": ('(("', '"))'),
     "END": ('(["', '"])'),
 }
@@ -349,6 +359,7 @@ def _render_merged_edges(
     exclusive_data_edges: set[tuple[str, str, str]],
     back_edges: set[tuple[str, str]],
     id_allocator: _MermaidIdAllocator,
+    output_anchors: dict[str, dict[str, str]] | None = None,
 ) -> list[_RenderedEdge]:
     """Render edges in merged output mode (no DATA intermediaries).
 
@@ -399,6 +410,11 @@ def _render_merged_edges(
             if not is_node_visible(target, flat_graph, expansion_state):
                 continue
             value_name = value_names[0] if value_names else ""
+            if not value_name and (source, target) in back_edges:
+                # A routed interrupt's answer edge: name the shared value it
+                # exists to deliver, so the cycle reads as the answer
+                # returning to the gate.
+                value_name = shared_answer_label(source, target, flat_graph) or ""
             edge_key = (id_allocator.get(source), id_allocator.get(target), f"ord_{value_name}")
             if edge_key in seen_edges:
                 continue
@@ -414,8 +430,12 @@ def _render_merged_edges(
             )
             continue
 
-        # Data edges
+        # Data edges. Merged mode draws ONE arrow per resolved (source,
+        # target) pair — the widget's story — so the dedup key carries no
+        # value name, and exclusivity is OR'd across every value the pair
+        # carries (a mutex arm on any of them dashes the one drawn arrow).
         values = value_names if value_names else [""]
+        pair_exclusive = any((source, target, value_name) in exclusive_data_edges for value_name in values)
         for value_name in values:
             actual_source = _resolve_data_source(
                 source,
@@ -423,6 +443,7 @@ def _render_merged_edges(
                 flat_graph,
                 expansion_state,
                 output_to_producer,
+                output_anchors,
             )
             actual_targets = _resolve_data_targets(
                 target,
@@ -436,19 +457,18 @@ def _render_merged_edges(
             for resolved_target in actual_targets:
                 if actual_source == resolved_target:
                     continue
-                edge_key = (id_allocator.get(actual_source), id_allocator.get(resolved_target), value_name)
+                edge_key = (id_allocator.get(actual_source), id_allocator.get(resolved_target))
                 if edge_key in seen_edges:
                     continue
                 seen_edges.add(edge_key)
-                is_exclusive = (source, target, value_name) in exclusive_data_edges
                 exit_port, entry_port = resolve_boundary_ports(flat_graph, source, target, value_names or [value_name])
                 out.append(
                     _RenderedEdge(
-                        _format_edge(actual_source, resolved_target, None, exclusive=is_exclusive, id_allocator=id_allocator),
+                        _format_edge(actual_source, resolved_target, None, exclusive=pair_exclusive, id_allocator=id_allocator),
                         "data",
                         actual_source,
                         resolved_target,
-                        exclusive=is_exclusive,
+                        exclusive=pair_exclusive,
                         is_back_edge=(source, target) in back_edges,
                         exit_port=exit_port,
                         entry_port=entry_port,
@@ -465,6 +485,7 @@ def _render_separate_edges(
     exclusive_data_edges: set[tuple[str, str, str]],
     back_edges: set[tuple[str, str]],
     id_allocator: _MermaidIdAllocator,
+    output_anchors: dict[str, dict[str, str]] | None = None,
 ) -> list[_RenderedEdge]:
     """Render edges in separate output mode (with DATA intermediaries).
 
@@ -506,6 +527,7 @@ def _render_separate_edges(
         value_names = edge_data.get("value_names", [])
 
         if edge_type == "data":
+            anchors_for_source = (output_anchors or {}).get(source, {})
             for value_name in value_names or [""]:
                 if not value_name:
                     continue
@@ -516,6 +538,7 @@ def _render_separate_edges(
                     flat_graph,
                     expansion_state,
                     output_to_producer,
+                    output_anchors,
                 )
                 if actual_source is None:
                     continue
@@ -529,7 +552,10 @@ def _render_separate_edges(
                 source_attrs = flat_graph.nodes.get(actual_source, {})
                 if is_internal_gate_output(actual_source, value_name, source_attrs):
                     continue
-                data_id = f"data_{actual_source}_{value_name}"
+                # A synthesized OUTPUT anchor IS the value pill — no DATA
+                # node interposed.
+                is_anchor_source = actual_source == anchors_for_source.get(value_name)
+                data_id = actual_source if is_anchor_source else f"data_{actual_source}_{value_name}"
                 for resolved_target in actual_targets:
                     edge_key = (id_allocator.get(data_id), id_allocator.get(resolved_target))
                     if edge_key not in seen_edges:
@@ -548,6 +574,8 @@ def _render_separate_edges(
 
         elif edge_type == "ordering":
             value_name = value_names[0] if value_names else ""
+            if not value_name and (source, target) in back_edges:
+                value_name = shared_answer_label(source, target, flat_graph) or ""
             edge_key = (id_allocator.get(source), id_allocator.get(target), f"ord_{value_name}")  # type: ignore[assignment]
             if edge_key not in seen_edges:
                 seen_edges.add(edge_key)
@@ -667,6 +695,7 @@ def _resolve_data_source(
     flat_graph: nx.DiGraph,
     expansion_state: dict[str, bool],
     output_to_producer: dict[str, str],
+    output_anchors: dict[str, dict[str, str]] | None = None,
 ) -> str | None:
     """Resolve actual source for a data edge, exiting expanded containers."""
     actual_source = source
@@ -684,6 +713,13 @@ def _resolve_data_source(
             )
             if found:
                 actual_source = found
+            else:
+                # No descendant produces the value (a mounted table's
+                # receipt): the edge leaves the synthesized OUTPUT anchor
+                # inside the expanded subgraph, never the subgraph hull.
+                anchor = (output_anchors or {}).get(source, {}).get(value_name)
+                if anchor:
+                    return anchor
     if not is_node_visible(actual_source, flat_graph, expansion_state):
         return None
     return actual_source
@@ -788,6 +824,7 @@ def _render_subgraph_block(
     node_class_map: dict[str, str],
     id_allocator: _MermaidIdAllocator,
     indent: int = 1,
+    output_anchors: dict[str, dict[str, str]] | None = None,
 ) -> list[str]:
     """Render a subgraph block for an expanded GRAPH node."""
     attrs = flat_graph.nodes[container_id]
@@ -817,6 +854,7 @@ def _render_subgraph_block(
                     node_class_map,
                     id_allocator,
                     indent=indent + 1,
+                    output_anchors=output_anchors,
                 )
             )
         else:
@@ -831,6 +869,16 @@ def _render_subgraph_block(
                 ).strip()
             )
             node_class_map[child_id] = _NODE_TYPE_TO_CLASS.get(mermaid_type, "function")
+
+    # Synthesized boundary-output anchors: a container output no descendant
+    # produces (a mounted table's receipt) surfaces as an OUTPUT pill inside
+    # the expanded subgraph, and the boundary edge leaves it instead of the
+    # subgraph hull. Same anchor ids as the interactive IR path.
+    output_types = attrs.get("output_types", {})
+    for value_name, anchor_id in sorted(((output_anchors or {}).get(container_id, {})).items()):
+        anchor_label = _build_data_label(value_name, format_type(output_types.get(value_name)), show_types)
+        lines.append("    " * (indent + 1) + _format_node(id_allocator.get(anchor_id), anchor_label, "OUTPUT").strip())
+        node_class_map[anchor_id] = "output"
 
     lines.append(f"{prefix}end")
     return lines
@@ -926,6 +974,10 @@ def to_mermaid(
 
     expansion_state = build_expansion_state(flat_graph, depth)
     container_entrypoints = compute_container_entrypoints(flat_graph)
+    # Boundary outputs no descendant produces (a mounted table's receipt):
+    # each gets an OUTPUT anchor pill inside its expanded subgraph, shared
+    # with the interactive IR path so both pipelines agree on ids.
+    output_anchors = container_output_anchors(flat_graph)
     input_spec = flat_graph.graph.get("input_spec", {})
     bound_params = set(input_spec.get("bound", {}).keys())
     param_to_consumers = build_param_to_consumer_map(flat_graph, expansion_state)
@@ -1012,6 +1064,7 @@ def to_mermaid(
                     separate_outputs,
                     node_class_map,
                     id_allocator,
+                    output_anchors=output_anchors,
                 )
             )
             continue
@@ -1089,6 +1142,7 @@ def to_mermaid(
         exclusive_data_edges,
         back_edges,
         id_allocator,
+        output_anchors,
     )
     # Input edges enter the reduction with the flow edges (an input feeding a
     # chain keeps only its earliest consumer), then emit first so the text

--- a/src/hypergraph/viz/renderer/ir_builder.py
+++ b/src/hypergraph/viz/renderer/ir_builder.py
@@ -59,11 +59,17 @@ def build_graph_ir(flat_graph: nx.DiGraph) -> GraphIR:
     # enter an expanded container.
     container_entrypoints = compute_container_entrypoints(flat_graph)
     container_transits = compute_container_transits(flat_graph)
+    # ``container -> {output name -> anchor id}`` for boundary outputs no
+    # descendant produces (a mounted HyperTable's receipt). Each gets a
+    # synthesized OUTPUT anchor pill inside the container, so an EXPANDED
+    # container never sources an edge from its own hull.
+    output_anchors = container_output_anchors(flat_graph)
     edges = [
-        _build_ir_edge(src, tgt, attrs, flat_graph, exclusive_edges, mutex_groups, back_edges, container_entrypoints)
+        _build_ir_edge(src, tgt, attrs, flat_graph, exclusive_edges, mutex_groups, back_edges, container_entrypoints, output_anchors)
         for src, tgt, attrs in flat_graph.edges(data=True)
         if src not in hidden_nodes and tgt not in hidden_nodes
     ]
+    nodes.extend(_build_output_anchor_nodes(output_anchors, flat_graph))
     # Use the legacy grouping logic so multi-param consumers collapse into
     # a single INPUT_GROUP. show_bounded_inputs=True here so bound params
     # are shipped in the IR; the frontend filters them per-render.
@@ -357,6 +363,50 @@ def _build_input_group(
     )
 
 
+def container_output_anchors(flat_graph: nx.DiGraph) -> dict[str, dict[str, str]]:
+    """``container_id -> {output name -> anchor node id}`` for GRAPH-node
+    outputs that some edge carries but NO descendant produces.
+
+    A mounted HyperTable is the living case: its receipt is the whole table's
+    completion, so no recipe node emits it. Expanded, such a container would
+    otherwise source the boundary edge from its own hull — an edge must always
+    leave a node, so the IR synthesizes an OUTPUT anchor pill inside the
+    container and rewrites ``source_when_expanded`` to it. Shared with the
+    Mermaid exporter so both pipelines agree on the anchor's existence and id.
+    """
+    anchors: dict[str, dict[str, str]] = {}
+    for src, _tgt, attrs in flat_graph.edges(data=True):
+        if attrs.get("edge_type", "data") != "data":
+            continue
+        if flat_graph.nodes.get(src, {}).get("node_type") != "GRAPH":
+            continue
+        for value_name in attrs.get("value_names", ()):
+            if not value_name or value_name in anchors.get(src, {}):
+                continue
+            if _find_deepest_internal_producers(src, value_name, flat_graph):
+                continue
+            anchors.setdefault(src, {})[value_name] = f"{src}/__output__{value_name}"
+    return anchors
+
+
+def _build_output_anchor_nodes(output_anchors: dict[str, dict[str, str]], flat_graph: nx.DiGraph) -> list[IRNode]:
+    """One OUTPUT IRNode per synthesized anchor, parented inside its container."""
+    nodes: list[IRNode] = []
+    for container_id in sorted(output_anchors):
+        output_types = flat_graph.nodes.get(container_id, {}).get("output_types", {})
+        for value_name in sorted(output_anchors[container_id]):
+            nodes.append(
+                IRNode(
+                    id=output_anchors[container_id][value_name],
+                    node_type="OUTPUT",
+                    parent=container_id,
+                    label=value_name,
+                    outputs=({"name": value_name, "type": format_type(output_types.get(value_name))},),
+                )
+            )
+    return nodes
+
+
 def _build_ir_edge(
     src: str,
     tgt: str,
@@ -366,6 +416,7 @@ def _build_ir_edge(
     mutex_groups: list[list[set[str]]],
     back_edges: set[tuple[str, str]],
     container_entrypoints: dict[str, tuple[str, ...]],
+    output_anchors: dict[str, dict[str, str]] | None = None,
 ) -> IREdge:
     """Pre-compute the source-when-expanded / target-when-expanded rewrites
     so the JS scene_builder can re-route edges on container expansion
@@ -383,6 +434,15 @@ def _build_ir_edge(
             if internal:
                 source_when_expanded = internal[0] if len(internal) == 1 else internal
                 break
+        if source_when_expanded is None:
+            # No descendant produces any carried value (a mounted table's
+            # receipt): source from the synthesized OUTPUT anchor, never the
+            # expanded container's hull.
+            for value_name in value_names:
+                anchor = (output_anchors or {}).get(src, {}).get(value_name)
+                if anchor:
+                    source_when_expanded = anchor
+                    break
 
     tgt_attrs = flat_graph.nodes.get(tgt, {})
     if tgt_attrs.get("node_type") == "GRAPH":
@@ -416,6 +476,12 @@ def _build_ir_edge(
             target_when_expanded = entrypoints[0] if entrypoints else None
 
     label = _branch_label_for_edge(src_attrs, tgt) if edge_type == "control" else None
+    if label is None and edge_type == "ordering" and (src, tgt) in back_edges:
+        # A routed interrupt's answer edge: the interrupt's answer output is
+        # the gate's input, travelling via shared state while this edge orders
+        # the cycle. Naming the value makes the loop read as "the answer comes
+        # back" instead of an anonymous orbit.
+        label = shared_answer_label(src, tgt, flat_graph)
 
     exclusive = edge_type == "data" and any((src, tgt, value_name) in exclusive_edges for value_name in value_names)
     if not exclusive and edge_type == "data" and isinstance(source_when_expanded, tuple) and len(source_when_expanded) > 1:
@@ -436,6 +502,24 @@ def _build_ir_edge(
         exclusive=exclusive,
         is_back_edge=(src, tgt) in back_edges,
     )
+
+
+def shared_answer_label(src: str, tgt: str, flat_graph: nx.DiGraph) -> str | None:
+    """The shared-state value an ordering back edge exists to deliver.
+
+    Non-empty exactly when the source's outputs and the target's inputs meet
+    inside the graph's declared ``shared`` scope — the routed-interrupt shape,
+    where the answer flows via shared state and the declared edge only orders
+    the cycle. Shared with the Mermaid exporter so both pipelines label the
+    same edges.
+    """
+    shared = set(flat_graph.graph.get("shared", ()))
+    if not shared:
+        return None
+    outputs = set(flat_graph.nodes.get(src, {}).get("outputs", ()))
+    inputs = set(flat_graph.nodes.get(tgt, {}).get("inputs", ()))
+    names = sorted(shared & outputs & inputs)
+    return ", ".join(names) if names else None
 
 
 def _branch_label_for_edge(src_attrs: dict, target: str) -> str | None:

--- a/src/hypergraph/viz/scene_builder.py
+++ b/src/hypergraph/viz/scene_builder.py
@@ -45,6 +45,32 @@ def build_initial_scene(
     scene_nodes: list[dict[str, Any]] = []
 
     for ir_node in ir.nodes:
+        if ir_node.node_type == "OUTPUT":
+            # Synthesized boundary-output anchor (a mounted table's receipt):
+            # visible exactly while its container chain is expanded — the same
+            # rule as any inner node — so an expanded container never sources
+            # an edge from its own hull, and a collapsed one keeps the edge on
+            # the box as before.
+            out = ir_node.outputs[0] if ir_node.outputs else {}
+            scene_nodes.append(
+                {
+                    "id": ir_node.id,
+                    "type": "custom",
+                    "position": {"x": 0, "y": 0},
+                    "data": {
+                        "nodeType": "OUTPUT",
+                        "label": ir_node.label or ir_node.id,
+                        "typeHint": out.get("type"),
+                        "ownerContainer": ir_node.parent,
+                    },
+                    "sourcePosition": "bottom",
+                    "targetPosition": "top",
+                    "hidden": _ancestor_collapsed(ir_node.id, parent_map, expansion_state),
+                    "parentNode": ir_node.parent,
+                    "extent": "parent",
+                }
+            )
+            continue
         is_expanded = expansion_state.get(ir_node.id, False) if ir_node.node_type == "GRAPH" else None
         scene_node_type = _scene_node_type(ir_node.node_type)
         rf_type = "pipelineGroup" if scene_node_type == "PIPELINE" and is_expanded else "custom"
@@ -205,6 +231,9 @@ def build_initial_scene(
                 scene_nodes.append(scene_node)
 
     visible_ids = {n["id"] for n in scene_nodes if not n["hidden"]}
+    # Synthesized boundary-output anchors ARE the value pill: an edge sourced
+    # at one never interposes a DATA node in separate_outputs mode.
+    anchor_ids = {n.id for n in ir.nodes if n.node_type == "OUTPUT"}
     scene_edges: list[dict[str, Any]] = []
     # scene-edge id -> (entry it feeds, exit it leaves from) when the edge
     # touches a *collapsed* container. Kept out of the scene payload: it exists
@@ -250,7 +279,7 @@ def build_initial_scene(
                     edges_to_emit = [(None, base_source)]  # type: ignore[list-item]
 
                 for value_name, source in edges_to_emit:
-                    if separate_outputs and ir_edge.edge_type == "data" and value_name is not None:
+                    if separate_outputs and ir_edge.edge_type == "data" and value_name is not None and source not in anchor_ids:
                         source = f"data_{source}_{value_name}"
                     edge_id = f"{source}__{target}" if value_name is None else f"{source}__{target}__{value_name}"
                     ports = _collapsed_ports(ir_edge, expansion_state, parent_map)

--- a/src/hypergraph/viz/scene_builder.py
+++ b/src/hypergraph/viz/scene_builder.py
@@ -50,7 +50,10 @@ def build_initial_scene(
             # visible exactly while its container chain is expanded — the same
             # rule as any inner node — so an expanded container never sources
             # an edge from its own hull, and a collapsed one keeps the edge on
-            # the box as before.
+            # the box as before. No ``extent: parent``: the layout DOCKS the
+            # pill straddling the container's bottom border — it is a port of
+            # the box itself, produced by the whole container completing — and
+            # a parent extent would clamp it back inside.
             out = ir_node.outputs[0] if ir_node.outputs else {}
             scene_nodes.append(
                 {
@@ -67,7 +70,6 @@ def build_initial_scene(
                     "targetPosition": "top",
                     "hidden": _ancestor_collapsed(ir_node.id, parent_map, expansion_state),
                     "parentNode": ir_node.parent,
-                    "extent": "parent",
                 }
             )
             continue

--- a/tests/viz/_layout_runner.js
+++ b/tests/viz/_layout_runner.js
@@ -47,7 +47,25 @@ try {
   const unpositioned = laid
     .filter((n) => !n.position || typeof n.position.x !== 'number' || typeof n.position.y !== 'number')
     .map((n) => n.id);
-  process.stdout.write(JSON.stringify({ok: true, laidOut: laid.length, unpositioned: unpositioned}));
+  // Absolute positions (child nodes are parent-relative in the scene) so
+  // Python tests can assert rank facts, not merely "it did not crash".
+  const positions = {};
+  const byId = {};
+  laid.forEach((n) => { byId[n.id] = n; });
+  laid.forEach((n) => {
+    let x = n.position ? n.position.x : NaN;
+    let y = n.position ? n.position.y : NaN;
+    let parent = n.parentNode;
+    let hops = 0;
+    while (parent && byId[parent] && hops <= laid.length) {
+      x += byId[parent].position.x;
+      y += byId[parent].position.y;
+      parent = byId[parent].parentNode;
+      hops++;
+    }
+    positions[n.id] = {x: x, y: y, width: n.width, height: n.height};
+  });
+  process.stdout.write(JSON.stringify({ok: true, laidOut: laid.length, unpositioned: unpositioned, positions: positions}));
 } catch (err) {
   process.stdout.write(JSON.stringify({ok: false, error: String((err && err.message) || err)}));
 }

--- a/tests/viz/_layout_runner.js
+++ b/tests/viz/_layout_runner.js
@@ -49,8 +49,12 @@ try {
     .map((n) => n.id);
   // Absolute positions (child nodes are parent-relative in the scene) so
   // Python tests can assert rank facts, not merely "it did not crash".
-  const positions = {};
-  const byId = {};
+  // Null-prototype maps: node ids are user-authored Python names, and every
+  // Object.prototype member name is a legal identifier. An ancestor without a
+  // position must not throw — a partially unpositioned layout is exactly what
+  // this runner exists to report.
+  const positions = Object.create(null);
+  const byId = Object.create(null);
   laid.forEach((n) => { byId[n.id] = n; });
   laid.forEach((n) => {
     let x = n.position ? n.position.x : NaN;
@@ -58,8 +62,9 @@ try {
     let parent = n.parentNode;
     let hops = 0;
     while (parent && byId[parent] && hops <= laid.length) {
-      x += byId[parent].position.x;
-      y += byId[parent].position.y;
+      const pp = byId[parent].position;
+      x += pp ? pp.x : NaN;
+      y += pp ? pp.y : NaN;
       parent = byId[parent].parentNode;
       hops++;
     }

--- a/tests/viz/test_answer_back_edge.py
+++ b/tests/viz/test_answer_back_edge.py
@@ -1,0 +1,95 @@
+"""A routed interrupt's answer edge reads as "the answer comes back".
+
+Panda's duplicate-review gate is the canonical shape: an ``@route`` gate sends
+an unanswered case to an ``@interrupt``, and the declared edge
+``(interrupt, gate)`` orders the cycle while the answer itself travels via
+shared state. That edge is real and correct — the presentation was not: it
+rendered as an anonymous dashed orbit, carrying no hint that it exists to
+deliver ``duplicate_decision`` back to the gate that asked.
+
+The rule under test: an ordering back edge whose source outputs ∩ target
+inputs ∩ shared-state is non-empty is labeled with that value name, in the IR
+(scene builders inherit it) and in the Mermaid export.
+"""
+
+from __future__ import annotations
+
+from hypergraph import Graph, interrupt, node, route
+from hypergraph.viz.renderer.ir_builder import build_graph_ir, shared_answer_label
+from tests._interrupt_questions import StringQuestion
+
+from .conftest import scene_for_state
+
+
+@node(output_name="duplicates")
+def find_duplicates(doc: str) -> list[int]:
+    return []
+
+
+@route(targets=["review", "ingest"])
+def gate(duplicates: list[int], decision: str | None = None) -> str:
+    return "review" if duplicates and decision is None else "ingest"
+
+
+@interrupt(answer_name="decision")
+def review(duplicates: list[int]) -> StringQuestion:
+    return StringQuestion(prompt="Duplicate — proceed?")
+
+
+@node(output_name="ingested")
+def ingest(doc: str) -> str:
+    return doc
+
+
+def make_cycle_graph() -> Graph:
+    return Graph(
+        [find_duplicates, gate, review, ingest],
+        edges=[(find_duplicates, gate), (review, gate)],
+        shared=["decision"],
+        name="dup_review",
+        entrypoint="find_duplicates",
+    )
+
+
+def test_answer_back_edge_is_labeled_in_the_ir() -> None:
+    ir = build_graph_ir(make_cycle_graph().to_flat_graph())
+
+    (back,) = [e for e in ir.edges if e.source == "review" and e.target == "gate"]
+    assert back.edge_type == "ordering"
+    assert back.is_back_edge
+    assert back.label == "decision"
+
+
+def test_answer_label_reaches_the_scene_edge() -> None:
+    scene = scene_for_state(make_cycle_graph())
+
+    (back,) = [e for e in scene["edges"] if e["source"] == "review" and e["target"] == "gate"]
+    assert back["data"]["label"] == "decision"
+    assert back["data"]["forceFeedback"] is True
+
+
+def test_answer_label_reaches_the_mermaid_export() -> None:
+    mermaid = str(make_cycle_graph().to_mermaid())
+    lines = [line.strip() for line in mermaid.splitlines()]
+
+    assert "review -.->|decision| gate" in lines
+
+
+def test_a_plain_ordering_back_edge_stays_unlabeled() -> None:
+    """No shared answer between the two endpoints — nothing to claim."""
+
+    @node(output_name="left")
+    def a(x: str) -> str:
+        return x
+
+    @node(output_name="right")
+    def b(left: str) -> str:
+        return left
+
+    graph = Graph([a, b], edges=[(a, b), (b, a)], name="plain_cycle", entrypoint="a")
+    flat = graph.to_flat_graph()
+    assert shared_answer_label("b", "a", flat) is None
+
+    ir = build_graph_ir(flat)
+    back_edges = [e for e in ir.edges if e.is_back_edge]
+    assert back_edges and all(e.label is None for e in back_edges)

--- a/tests/viz/test_layout_smoke.py
+++ b/tests/viz/test_layout_smoke.py
@@ -203,3 +203,27 @@ def test_merge_tolerates_ir_without_type_hints():
     assert merged[0]["params"] == ["alpha", "beta"]
     assert merged[0]["type_hints"] == [None, None]
     assert merged[0]["id"] == "input_group_alpha_beta"
+
+
+def test_receipt_anchor_ranks_below_the_recipe_and_above_the_consumer():
+    """The synthesized OUTPUT anchor (the mounted table's receipt pill) must
+    sit at the BOTTOM of the expanded container, with the downstream consumer
+    ranked below it — the boundary edge flows downhill instead of climbing
+    from the container's bottom back up to a consumer dagre parked beside the
+    recipe's first node."""
+
+    @node(output_name="published")
+    def publish(receipt: object) -> str:
+        return str(receipt)
+
+    flat = Graph([_table().as_node(name="materialize_docs"), publish], name="ingest").to_flat_graph()
+    result = _layout(flat, depth=2)
+    assert result["ok"], result.get("error")
+    positions = result["positions"]
+
+    anchor_id = "materialize_docs/__output__receipt"
+    assert anchor_id in positions, sorted(positions)
+    anchor_y = positions[anchor_id]["y"]
+    inner_ys = [pos["y"] for node_id, pos in positions.items() if node_id.startswith("materialize_docs/") and node_id != anchor_id]
+    assert inner_ys and anchor_y > max(inner_ys), (anchor_y, inner_ys)
+    assert positions["publish"]["y"] > anchor_y

--- a/tests/viz/test_layout_smoke.py
+++ b/tests/viz/test_layout_smoke.py
@@ -227,3 +227,29 @@ def test_receipt_anchor_ranks_below_the_recipe_and_above_the_consumer():
     inner_ys = [pos["y"] for node_id, pos in positions.items() if node_id.startswith("materialize_docs/") and node_id != anchor_id]
     assert inner_ys and anchor_y > max(inner_ys), (anchor_y, inner_ys)
     assert positions["publish"]["y"] > anchor_y
+
+
+def test_receipt_anchor_docks_on_the_container_bottom_border():
+    """The anchor is a PORT of the box, not an inner node: nothing inside
+    feeds it, so hovering mid-container reads as magic. The layout docks the
+    pill straddling the container's visible bottom border (its center ON the
+    border line), which says "produced by the whole table completing"."""
+
+    @node(output_name="published")
+    def publish(receipt: object) -> str:
+        return str(receipt)
+
+    flat = Graph([_table().as_node(name="materialize_docs"), publish], name="ingest").to_flat_graph()
+    result = _layout(flat, depth=2)
+    assert result["ok"], result.get("error")
+    positions = result["positions"]
+
+    anchor = positions["materialize_docs/__output__receipt"]
+    container = positions["materialize_docs"]
+    # The pipelineGroup draws its dashed border on the full layout box, so
+    # the container's layout bottom IS the visible border line.
+    border_y = container["y"] + container["height"]
+    anchor_center_y = anchor["y"] + anchor["height"] / 2
+    assert abs(anchor_center_y - border_y) <= 2, (anchor_center_y, border_y)
+    # And it must stay horizontally within the box.
+    assert container["x"] <= anchor["x"] and anchor["x"] + anchor["width"] <= container["x"] + container["width"]

--- a/tests/viz/test_mounted_table_fanout.py
+++ b/tests/viz/test_mounted_table_fanout.py
@@ -202,3 +202,80 @@ def test_multi_value_boundary_edge_unions_exact_consumers(mounted_graph):
     # (exact; page_title is map-fed and must stay excluded);
     # doc_version_id → nothing exact, and its fuzzy match must not win.
     assert set(targets) == {"materialize/build_pages", "materialize/convert"}
+
+
+ANCHOR_ID = "materialize/__output__materialization"
+
+
+def test_receipt_gets_a_synthesized_output_anchor(mounted_graph):
+    """The receipt (``materialization``) has no inner producer — it is the
+    whole table's completion — so the IR synthesizes an OUTPUT anchor pill
+    inside the container and re-sources the boundary edge from it."""
+    ir = build_graph_ir(mounted_graph.to_flat_graph())
+
+    (anchor,) = [n for n in ir.nodes if n.node_type == "OUTPUT"]
+    assert anchor.id == ANCHOR_ID
+    assert anchor.parent == "materialize"
+    assert anchor.label == "materialization"
+
+    (edge,) = [e for e in ir.edges if e.source == "materialize" and e.target == "publish"]
+    assert edge.source_when_expanded == ANCHOR_ID
+
+
+def test_expanded_container_never_sources_the_receipt_from_its_hull(mounted_graph):
+    """An edge's source must be a node; only a COLLAPSED container may stand
+    in as one. Expanded, the receipt edge leaves the anchor pill."""
+    scene = scene_for_state(mounted_graph, expand_all=True)
+    visible_edges = [e for e in scene["edges"] if not e.get("hidden")]
+
+    assert [e for e in visible_edges if e["source"] == "materialize"] == []
+    (receipt,) = [e for e in visible_edges if e["target"] == "publish" and e["source"] != "stage"]
+    assert receipt["source"] == ANCHOR_ID
+
+    (anchor_node,) = [n for n in scene["nodes"] if n["id"] == ANCHOR_ID]
+    assert not anchor_node["hidden"]
+    assert anchor_node["parentNode"] == "materialize"
+    assert anchor_node["data"]["nodeType"] == "OUTPUT"
+
+
+def test_receipt_anchor_stays_hidden_while_collapsed(mounted_graph):
+    """Collapsed keeps the historical picture: the box itself sources the
+    edge and no anchor pill leaks out of it."""
+    scene = scene_for_state(mounted_graph)
+
+    (anchor_node,) = [n for n in scene["nodes"] if n["id"] == ANCHOR_ID]
+    assert anchor_node["hidden"]
+    visible_edges = [e for e in scene["edges"] if not e.get("hidden")]
+    assert ("materialize", "publish") in {(e["source"], e["target"]) for e in visible_edges}
+
+
+def test_receipt_anchor_is_the_value_pill_in_separate_outputs(mounted_graph):
+    """separate_outputs must not interpose a DATA node for an anchor-sourced
+    edge — the anchor already IS the value pill."""
+    scene = scene_for_state(mounted_graph, expand_all=True, separate_outputs=True)
+    visible_edges = [e for e in scene["edges"] if not e.get("hidden")]
+
+    (receipt,) = [e for e in visible_edges if e["target"] == "publish"]
+    assert receipt["source"] == ANCHOR_ID
+    assert not any(n["id"].startswith("data_" + ANCHOR_ID) for n in scene["nodes"])
+
+
+def test_mermaid_receipt_leaves_the_anchor_not_the_subgraph(mounted_graph):
+    """The text export agrees with the widget: expanded, the receipt edge
+    leaves the anchor pill inside the subgraph, never the subgraph id."""
+    mermaid = str(mounted_graph.to_mermaid(depth=2))
+    lines = [line.strip() for line in mermaid.splitlines()]
+
+    assert 'materialize____output__materialization(["materialization: MaterializationReceipt"])' in lines
+    assert "materialize____output__materialization --> publish" in lines
+    assert "materialize --> publish" not in lines
+
+
+def test_mermaid_merged_mode_draws_one_edge_per_pair(mounted_graph):
+    """The widget draws ONE merged edge per (source, target) pair; the text
+    export must not fan a multi-value boundary edge into parallel arrows."""
+    mermaid = str(mounted_graph.to_mermaid(depth=0))
+    lines = [line.strip() for line in mermaid.splitlines()]
+
+    assert lines.count("stage --> materialize") == 1
+    assert lines.count("materialize --> publish") == 1

--- a/tests/viz/test_schema_version.py
+++ b/tests/viz/test_schema_version.py
@@ -36,8 +36,14 @@ def test_current_schema_version_pinned() -> None:
     v5: ``GraphIR.container_transits`` tells ``simplify`` which collapsed
     containers really carry a value through. Falling back to "a box passes
     everything" hides real edges under a route that does not exist — a wrong
-    picture, not merely a stale one, so it must degrade loudly."""
-    assert CURRENT_SCHEMA_VERSION == "5"
+    picture, not merely a stale one, so it must degrade loudly.
+    v6: synthesized ``node_type == "OUTPUT"`` anchor pills — a container
+    output no descendant produces (a mounted table's receipt) gets an
+    in-container anchor and the boundary edge's ``source_when_expanded``
+    points at it. An old scene builder would honor the rewritten source
+    while never emitting the anchor node — a dangling edge — so it must
+    degrade loudly."""
+    assert CURRENT_SCHEMA_VERSION == "6"
 
 
 def test_build_graph_ir_emits_current_schema_version() -> None:
@@ -76,7 +82,7 @@ def test_js_scene_builder_returns_mismatch_sentinel_for_future_version() -> None
     )
     assert proc.returncode == 0, proc.stderr
     scene = json.loads(proc.stdout)
-    assert scene.get("schemaVersionMismatch") == {"got": "999", "supported": "5"}
+    assert scene.get("schemaVersionMismatch") == {"got": "999", "supported": "6"}
     # The mismatch-sentinel must short-circuit derivation entirely so the
     # frontend can render the static fallback without dragging in any
     # potentially-stale interpretation of the IR.
@@ -116,7 +122,7 @@ def test_js_scene_builder_degrades_loudly_on_v3_payload_without_container_entryp
     )
     assert proc.returncode == 0, proc.stderr
     scene = json.loads(proc.stdout)
-    assert scene.get("schemaVersionMismatch") == {"got": "3", "supported": "5"}
+    assert scene.get("schemaVersionMismatch") == {"got": "3", "supported": "6"}
     assert scene["nodes"] == []
     assert scene["edges"] == []
 
@@ -143,7 +149,7 @@ def test_js_scene_builder_degrades_loudly_when_schema_version_is_missing() -> No
     assert scene == {
         "nodes": [],
         "edges": [],
-        "schemaVersionMismatch": {"got": None, "supported": "5"},
+        "schemaVersionMismatch": {"got": None, "supported": "6"},
     }
 
 
@@ -174,7 +180,7 @@ def test_js_scene_builder_degrades_loudly_on_v4_payload_without_container_transi
     )
     assert proc.returncode == 0, proc.stderr
     scene = json.loads(proc.stdout)
-    assert scene.get("schemaVersionMismatch") == {"got": "4", "supported": "5"}
+    assert scene.get("schemaVersionMismatch") == {"got": "4", "supported": "6"}
     assert scene["nodes"] == []
     assert scene["edges"] == []
 


### PR DESCRIPTION
## What the owner saw (panda ingest graph, post-#372 renders)

1. **An edge originated at the EDGE of the expanded `MATERIALIZE_PAGES` container.** The receipt (`materialization`) is the `MaterializationNode`'s own output — the whole table's completion — so no recipe node produces it, `source_when_expanded` stayed `None`, and the scene kept the container hull as the edge's source. The owner's rule: an edge's source must be a node; only a COLLAPSED container may stand in as one.
2. **The same edge travelled backward/upward**: `rankProxy` ranked `publish_document` one rank below the container's FIRST child while `adjustEdgeEndpoints` snapped the source onto the container's BOTTOM — a 1500 px climb (`(1681, 2564) → (686, 1042)` in the debug dump).
3. **A line terminating on the inner `DERIVE_PAGES` container's bottom border** — the same single edge's tail; its hull anchor x landed under `page_keywords`.
4. **The duplicate-review loop read as spaghetti.** The cycle is real and correct (the interrupt's answer returns to the gate that asked); the presentation was an anonymous wide orbit.

## Fix

- **Synthesized OUTPUT anchor (schema v6).** A container output NO descendant produces gets an anchor pill inside the container (`<container>/__output__<name>`), in the same pill language as #372's map-fed input pills, emerald output accent. The IR re-sources the boundary edge from it; both scene-builder twins emit it under normal child visibility (hidden while collapsed); `performCompoundLayout` ranks it below the container's visible sinks via rank-only undrawn dagre edges, so the consumer ranks BELOW the table and the edge flows downhill. Mermaid synthesizes the same anchors through the shared `container_output_anchors`; separate-outputs mode treats the anchor as the value pill (no DATA interposition).
- **The answer loop reads as the answer.** An ordering back edge whose source outputs ∩ target inputs ∩ shared state is non-empty carries that name as its label (`duplicate_decision`) in the IR, widget, and Mermaid (`shared_answer_label`). Feedback edges render their orthogonal channel faithfully with small rounded corners (`roundedChannelPath`) instead of `curveBasis`, which smeared the corners into a giant swoop.
- **Mermaid merged-mode dedup per resolved pair** — a multi-value boundary edge no longer fans into three parallel arrows the widget never draws; exclusivity is OR'd across the pair's values.

## Tests

- `tests/viz/test_mounted_table_fanout.py` +7: anchor IR facts, hull-never-sources when expanded, collapsed keeps the historical box-sourced edge, separate-outputs uses the anchor as the value pill, Mermaid anchor node + edge, one-arrow-per-pair.
- `tests/viz/test_answer_back_edge.py` (new, 4): label in IR / scene / Mermaid, plain cycles stay unlabeled.
- `tests/viz/test_layout_smoke.py` +1 real-dagre rank assertion (anchor below the recipe, consumer below the anchor) via a positions-emitting `_layout_runner.js`.
- Schema pins bumped 5 → 6 with the mismatch-banner rationale.

Full suite: 4933 passed, 15 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visible output anchors for container outputs without internal producers.
  * Improved Mermaid and interactive visualizations with output styling, clearer boundary routing, and labeled feedback edges.
  * Feedback edges now use clean orthogonal paths with rounded corners.

* **Bug Fixes**
  * Improved output-edge routing and layout ordering, including expanded and collapsed containers.
  * Removed duplicate merged boundary edges.

* **Tests**
  * Added coverage for output anchors, layout positioning, edge labels, routing, and schema compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->