### PR TITLE
feat(host): allow manifest-only batch identity

### DIFF
--- a/docs/06-api-reference/host.md
+++ b/docs/06-api-reference/host.md
@@ -156,18 +156,20 @@ transposing into parallel collections. Persisted inputs remain plain mappings:
 receipt = await host.submit_batch(
     ingest,
     [
-        {"doc_id": "d-17", "pdf_uri": "papers/17.pdf", "page_count": 8},
-        {"doc_id": "d-18", "pdf_uri": "papers/18.pdf", "page_count": 5},
+        {"case_label": "station-a", "pdf_uri": "papers/17.pdf", "page_count": 8},
+        {"case_label": "station-b", "pdf_uri": "papers/18.pdf", "page_count": 5},
     ],
-    identity="doc_id",
+    identity="case_label",
     admission_cost="page_count",
     workflow_id="schneider-drop-43",
 )
 ```
 
-Every item field must be a graph boundary input, every required boundary
-input must be present, and the resulting mapping must be JSON-serializable.
-These checks and identity validation all happen before acceptance.
+Every item field except the identity must be a graph boundary input, every
+required boundary input must be present, and the resulting mapping must be
+JSON-serializable. A manifest-only identity such as `case_label` above is
+removed from each child's pinned inputs, so the graph never sees it. These
+checks and identity validation all happen before acceptance.
 
 `admission_cost` optionally names a positive-integer item field. The Host
 validates and freezes that cost on each child submission; reruns preserve
@@ -183,13 +185,15 @@ deliberately absent: durable concurrency comes from
 `max_concurrency`, and durable failure policy comes from `tolerance`, not
 `error_handling`.
 
-`identity` names one **expanded** input whose value is the logical item key —
+`identity` names one **expanded** field whose value is the logical item key —
 the identity every count, outcome, and durable fact is reported under. It
-must be a name in `map_over`, and each item's value must be a JSON-safe
-scalar (a non-empty `str`, or an `int`), unique across the manifest;
-missing, empty, non-scalar (including `bool`, `float`, and `None`), or
-duplicate keys raise `ItemKeyError` before anything is written. Expanding to
-zero items is a `ValueError` — an empty Batch is not a Batch.
+must be a name in `map_over` for runner-shaped values, but it does not need
+to be a graph input. A manifest-only identity is retained as the manifest
+key and omitted from child Run inputs. Each identity value must be a
+JSON-safe scalar (a non-empty `str`, or an `int`), unique across the
+manifest; missing, empty, non-scalar (including `bool`, `float`, and `None`),
+or duplicate keys raise `ItemKeyError` before anything is written. Expanding
+to zero items is a `ValueError` — an empty Batch is not a Batch.
 
 **One transaction** persists all of it — the manifest row (Definition
 identity, item keys with pinned inputs, the tolerance declaration, the
@@ -1096,7 +1100,7 @@ brake counts **progressless re-adoptions**:
 |---|---|
 | `WorkerLockError` | a second worker starts on the same Run Home |
 | `UnservedGraphError` | `submit`, `submit_batch`, or `fork(into=…)` names a `Graph` this host does not serve, or one whose `structural_hash` drifted from the served Definition |
-| `ItemKeyError` | `submit_batch` `identity` names an input outside `map_over`, or an item's key is missing, empty, non-scalar, or duplicated |
+| `ItemKeyError` | `submit_batch` `identity` names a field outside `map_over`, or an item's key is missing, empty, non-scalar, or duplicated |
 | `AlreadyTerminalError` | a terminal `workflow_id` is reused for submit, submit_batch, or stop (including a fully settled Batch) |
 | `WorkflowIdConflictError` | a nonterminal `workflow_id` is reused with a different start fingerprint (Run or Batch), or a Batch id collides with existing work |
 | `ForkCompatibilityError` | `host.fork()` targets a structurally incompatible Definition |

--- a/src/hypergraph/host/batch.py
+++ b/src/hypergraph/host/batch.py
@@ -160,9 +160,9 @@ def normalize_map_over(map_over: str | Sequence[str]) -> list[str]:
 
 
 def _require_identity_input(identity: str, map_over: Sequence[str]) -> None:
-    """``identity`` must name an EXPANDED input, not a broadcast one.
+    """``identity`` must name an EXPANDED field, not a broadcast one.
 
-    A broadcast input holds the same value for every item, so it can only
+    A broadcast field holds the same value for every item, so it can only
     ever produce one key for the whole manifest. Refusing it here names the
     real mistake instead of reporting a duplicate-key collision the caller
     then has to decode.
@@ -176,8 +176,9 @@ def _require_identity_input(identity: str, map_over: Sequence[str]) -> None:
     if identity not in map_over:
         raise ItemKeyError(
             identity,
-            f"submit_batch() identity={identity!r} does not name an expanded input; map_over expands {list(map_over)!r}.\n\n"
-            "How to fix: name one of the map_over inputs. A broadcast input has the same value for every "
+            f"submit_batch() identity={identity!r} does not name an expanded input or manifest field; "
+            f"map_over expands {list(map_over)!r}.\n\n"
+            "How to fix: name one of the map_over fields. A broadcast field has the same value for every "
             "item, so it cannot identify one.",
         )
 
@@ -238,8 +239,9 @@ def expand_batch_items(
             reads it.
         map_mode: ``"zip"`` (parallel iteration) or ``"product"``
             (cartesian), exactly as ``runner.map`` reads it.
-        identity: The expanded input whose per-item scalar value becomes the
-            logical item key.
+        identity: The expanded field whose per-item scalar value becomes the
+            logical item key. The field may be manifest-only; when it is not
+            a graph boundary input, it is not passed to child Runs.
 
     Returns:
         Manifest-ordered ``(item_key, inputs_json)`` pairs.
@@ -321,13 +323,15 @@ def _is_json_safe(value: Any) -> bool:
     return True
 
 
-def _validate_item_fields(graph: Graph, item: dict[str, Any], *, index: int) -> None:
+def _validate_item_fields(graph: Graph, item: dict[str, Any], *, index: int, identity: str | None = None) -> None:
     expected = set(graph.inputs.all)
-    unknown = sorted(set(item) - expected)
+    allowed = expected | ({identity} if identity is not None else set())
+    unknown = sorted(set(item) - allowed)
     if unknown:
         raise ValueError(
             f"submit_batch() item {index} has unknown graph input field(s): {unknown}. Expected fields: {sorted(expected)}.\n\n"
-            "How to fix:\n  Remove fields that are not graph boundary inputs, or add the intended input to the graph."
+            "How to fix:\n  Remove fields that are neither graph boundary inputs nor the identity field, "
+            "or add the intended input to the graph."
         )
     missing = sorted(set(graph.inputs.required) - set(item))
     if missing:
@@ -349,15 +353,18 @@ def _validate_and_freeze_manifest(
     if schema is not None and (not isinstance(schema, type) or not issubclass(schema, BaseModel)):
         raise TypeError(f"submit_batch() schema must be a Pydantic BaseModel type or None, got {schema!r}.")
     validated: list[dict[str, Any]] = []
+    manifest_only_identity = identity not in graph.inputs.all
     for index, item in enumerate(expanded):
-        _validate_item_fields(graph, item, index=index)
+        _validate_item_fields(graph, item, index=index, identity=identity)
         value = item if schema is None else schema.model_validate(item).model_dump(mode="json")
-        _validate_item_fields(graph, value, index=index)
+        if manifest_only_identity and identity not in value:
+            value[identity] = item.get(identity)
+        _validate_item_fields(graph, value, index=index, identity=identity)
         validated.append(value)
-    return _freeze_manifest(validated, identity=identity)
+    return _freeze_manifest(validated, identity=identity, strip_identity=manifest_only_identity)
 
 
-def _freeze_manifest(expanded: list[dict[str, Any]], *, identity: str) -> list[tuple[str, str]]:
+def _freeze_manifest(expanded: list[dict[str, Any]], *, identity: str, strip_identity: bool) -> list[tuple[str, str]]:
     """Key and serialize expanded items, refusing duplicates before acceptance."""
     seen: dict[str, int] = {}
     pairs: list[tuple[str, str]] = []
@@ -371,13 +378,14 @@ def _freeze_manifest(expanded: list[dict[str, Any]], *, identity: str) -> list[t
                 "item. De-duplicate the expanded collection, or key on an input that is distinct per item.",
             )
         seen[key] = index
+        inputs = {name: value for name, value in item.items() if not strip_identity or name != identity}
         try:
-            pairs.append((key, json.dumps(item)))
+            pairs.append((key, json.dumps(inputs)))
         except (TypeError, ValueError) as exc:
-            unserializable = sorted(name for name, value in item.items() if not _is_json_safe(value))
+            unserializable = sorted(name for name, value in inputs.items() if not _is_json_safe(value))
             raise TypeError(
                 f"submit_batch() item {key!r} inputs must be JSON-serializable; "
-                f"{unserializable!r} {'is' if len(unserializable) == 1 else 'are'} not ({exc}). Item: {item!r}.\n\n"
+                f"{unserializable!r} {'is' if len(unserializable) == 1 else 'are'} not ({exc}). Item: {inputs!r}.\n\n"
                 "How to fix: pass values that survive a round trip through the store — a child Run is "
                 "started from its pinned inputs by a worker in another process, which has no access to "
                 "the object you submitted. Send an id or a path and load it inside the graph."

--- a/src/hypergraph/host/host.py
+++ b/src/hypergraph/host/host.py
@@ -344,11 +344,13 @@ class Host:
             map_mode: ``"zip"`` (parallel iteration, the default) or
                 ``"product"`` (cartesian), exactly as ``runner.map`` reads
                 it.
-            identity: Required. Names one expanded input whose per-item
-                JSON-safe scalar value becomes the logical item key. Missing,
-                empty, non-scalar, and duplicate keys are refused before
-                acceptance (``ItemKeyError``) — a generated map index is
-                never durable identity.
+            identity: Required. Names one expanded field whose per-item
+                JSON-safe scalar value becomes the logical item key. The
+                field may be manifest-only: if it is not a graph boundary
+                input, it keys the Batch but is not passed to child Runs.
+                Missing, empty, non-scalar, and duplicate keys are refused
+                before acceptance (``ItemKeyError``) — a generated map
+                index is never durable identity.
             workflow_id: Required explicit Batch id (dedup identity).
             tolerance: Optional ``BatchTolerance`` pinned into the manifest
                 (part of the dedup fingerprint). Once failure-equivalent

--- a/tests/test_host/test_batch_public_api.py
+++ b/tests/test_host/test_batch_public_api.py
@@ -9,8 +9,9 @@ What this file falsifies:
 3. Runner-shaped ``zip`` / ``product`` expansion freezes the expected
    manifest, and mutating the caller's collection afterwards cannot change
    it.
-4. ``identity`` derives stable identity from an expanded input, and never
-   falls back to a generated map index.
+4. ``identity`` derives stable identity from an expanded field — including
+   a manifest-only field the graph never sees — and never falls back to a
+   generated map index.
 5. Every submission refusal names the input, the supplied value, and a
    literal fix — before anything is accepted.
 6. An empty SQLite file, opened cold, runs the whole flow.
@@ -286,6 +287,48 @@ class TestRunnerShapedExpansion:
 
 
 class TestIdentity:
+    async def test_manifest_only_identity_keys_items_without_becoming_a_graph_input(self, home):
+        graph = expansion_graph()
+        host = serve(graph, home=home, deployment_version="v1")
+
+        receipt = await host.submit_batch(
+            graph,
+            [
+                {"case_label": "station-a", "work_item_id": "same-query"},
+                {"case_label": "station-b", "work_item_id": "same-query"},
+            ],
+            identity="case_label",
+            workflow_id="drop-labels",
+        )
+
+        batch = await home._get_batch(receipt.batch_ref.batch_id)
+        manifest = json.loads(batch["items_json"])
+        assert manifest == {
+            "station-a": {"work_item_id": "same-query"},
+            "station-b": {"work_item_id": "same-query"},
+        }
+        assert list((await host.client.get(receipt.batch_ref)).items) == ["station-a", "station-b"]
+        for label in manifest:
+            child = await home._get_submission(f"drop-labels:{label}")
+            assert json.loads(child["inputs_json"]) == {"work_item_id": "same-query"}
+
+    async def test_duplicate_manifest_only_keys_are_refused_before_acceptance(self, home):
+        graph = expansion_graph()
+        host = serve(graph, home=home, deployment_version="v1")
+
+        with pytest.raises(ItemKeyError, match="duplicate item key 'same-case'"):
+            await host.submit_batch(
+                graph,
+                [
+                    {"case_label": "same-case", "work_item_id": "query-a"},
+                    {"case_label": "same-case", "work_item_id": "query-b"},
+                ],
+                identity="case_label",
+                workflow_id="drop-duplicate-labels",
+            )
+
+        assert await host.client.list(RunQuery()) == []
+
     async def test_identity_reuses_the_mapped_scalar_as_the_item_key(self, home):
         graph = ingestion_graph()
         host = serve(graph, home=home, deployment_version="v1")

--- a/tests/test_host/test_durable_result_projection.py
+++ b/tests/test_host/test_durable_result_projection.py
@@ -229,6 +229,35 @@ class TestFailureEvidence:
 
 
 class TestBatchOutcome:
+    async def test_manifest_only_keys_flow_through_result_watch_and_rerun(self, home):
+        graph = _chain_graph()
+        host = serve(graph, home=home)
+        receipt = await host.submit_batch(
+            graph,
+            [
+                {"case_label": "station-a", "x": 2},
+                {"case_label": "station-b", "x": 3},
+            ],
+            identity="case_label",
+            workflow_id="drop-labels",
+        )
+        async with _worker(host):
+            await _wait_for(lambda: _settled(host.client, receipt.batch_ref))
+
+        view = await host.client.get(receipt.batch_ref)
+        outcome = await host.client.result(receipt.batch_ref)
+        facts = [update async for update in host.client.watch(receipt.batch_ref) if update.durable]
+        rerun = await host.client.rerun(receipt.batch_ref, item_keys=["station-b"])
+
+        assert list(view.items) == ["station-a", "station-b"]
+        assert list(outcome.items) == ["station-a", "station-b"]
+        assert outcome.items["station-a"].outputs == {"doubled": 4, "tripled": 12}
+        assert facts[0].kind == "manifest" and facts[0].payload["item_keys"] == ["station-a", "station-b"]
+        assert {fact.payload["item_key"] for fact in facts if fact.kind == "child_settled"} == {"station-a", "station-b"}
+        assert list((await host.client.get(rerun.batch_ref)).items) == ["station-b"]
+        rerun_child = await home._get_submission("drop-labels-retry-1:station-b")
+        assert json.loads(rerun_child["inputs_json"]) == {"x": 3}
+
     async def test_items_are_keyed_in_manifest_order(self, home):
         host, served = serve_graphs(_chain_graph(), home=home)
         manifest = {"p-2": {"x": 2}, "p-1": {"x": 1}, "p-3": {"x": 3}}


### PR DESCRIPTION
## Problem / Bug / Challenge

Closes #365.

`submit_batch(..., identity=...)` rejected identity fields that were not graph boundary inputs. Panda's durable retrieval evaluation batches naturally identify cases by case label, while the serving graph only consumes retrieval inputs. That forced panda's `RetrievalBatch` path to wrap submissions in handle objects carrying label-to-item-key maps.

This PR lets `identity=` name a manifest-only per-item field. I kept the existing `identity=` shape rather than adding `item_keys=[...]` because it already works for both runner-shaped expansion and per-item mapping records, keeps key validation adjacent to each item, and avoids a second parallel collection whose length/order must be coordinated with `values`.

## Before / After

**Before:**

```python
await host.submit_batch(
    retrieval,
    [{"case_label": "station-a", "query": "same"}],
    identity="case_label",
    workflow_id="eval-42",
)
# ValueError: case_label is not a graph boundary input
```

**After:**

```python
await host.submit_batch(
    retrieval,
    [
        {"case_label": "station-a", "query": "same"},
        {"case_label": "station-b", "query": "same"},
    ],
    identity="case_label",
    workflow_id="eval-42",
)
```

`station-a` and `station-b` are the durable manifest keys used by `BatchView.items`, `result().items`, `rerun(item_keys=...)`, and watch facts. Child Runs persist and execute only `{"query": "same"}`; the graph never sees `case_label`. Duplicate labels are rejected with `ItemKeyError` before acceptance.

This enables panda to delete the `RetrievalBatch` label maps and their wrapper handles: case labels can now be submitted directly as durable item identity without polluting the production retrieval graph.

## Test Plan

- [x] Added submission tests proving manifest-only identity is stripped from child inputs and duplicate keys are refused before acceptance
- [x] Added an end-to-end test covering `BatchView.items`, `result().items`, durable watch facts, subset rerun, and rerun child inputs
- [x] `uv run pytest -W error -W 'ignore::pytest.PytestUnraisableExceptionWarning'` — 5,042 passed
- [x] `uv run --python 3.10 mypy`
- [x] `uv run ruff check src/ tests/`
- [x] `uv run ruff format --check src/ tests/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Batch submissions can now use an identity field that exists only in the manifest, including expanded fields.
  * Manifest-only identity values remain available for batch results, monitoring, and reruns while staying excluded from child run inputs.

* **Bug Fixes**
  * Improved validation for identity types, uniqueness, serialization, boundary inputs, and empty expansions.
  * Duplicate manifest-only identity keys are rejected before submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->