### PR TITLE
feat(host): add process-level HostRuntime

### DIFF
--- a/docs/06-api-reference/host.md
+++ b/docs/06-api-reference/host.md
@@ -7,13 +7,51 @@ process can inspect and follow the run through a small client. It is additive
 is never required.
 
 {% hint style="info" %}
-This page covers the local Tier 1 host: `serve()`, `RunHome`, `Host`, and
-`RunHomeClient`. For direct execution semantics see [Runners](runners.md);
+This page covers the local Tier 1 host: `HostRuntime`, `serve()`, `RunHome`,
+`Host`, and `RunHomeClient`. For direct execution semantics see [Runners](runners.md);
 for process-local background handles see
 [Control Work After It Starts](../05-how-to/control-background-execution.md).
 `client.answer()` settles a durable pause **and re-admits the run** in one
 transaction — see [Answering a Pause](#answering-a-pause).
 {% endhint %}
+
+## Owning a Host Process
+
+Use `HostRuntime` when one application process should own the Run Home, serve
+Definitions as they become known, and keep one worker alive:
+
+```python
+from hypergraph import HostRuntime
+
+runtime = HostRuntime("./data/runs.db", deployment_version="2026.07.3")
+
+# The Home opens here, not when HostRuntime is constructed. An unbound graph
+# gets AsyncRunner; an explicit graph.with_runner(...) binding is preserved.
+host = await runtime.serving(refund_graph)
+receipt = await host.submit(refund_graph, {"claim_id": "c-42"})
+
+# Additive and idempotent: the existing worker and active Runs stay in place.
+await runtime.serving(triage_graph)
+
+client = runtime.client
+await runtime.close()  # stop claiming, drain active Runs, close the Home
+```
+
+`serving()` returns the same `Host` on every call. Re-serving the same
+Definition identity is a no-op; a new name is added to the live worker. A
+served name cannot be replaced with a structurally different Definition
+without closing and creating a new runtime. Worker startup runs the ordinary
+restart scan, so unfinished durable work is re-adopted without resubmission.
+
+`client` is the runtime's `RunHomeClient` and is also lazy: accessing it before
+`serving()` opens the Home for detached reads without starting a worker. If the
+worker task exits with an exception, the next `serving()`, `client`, or
+`close()` call raises `RuntimeError` with that exception as its cause rather
+than silently starting a replacement. A later call may start the worker again.
+
+`close()` is idempotent. It stops new claims, uses the Host's bounded drain,
+and closes the Home; queued submissions remain persisted for the next process.
+The same runtime may be used again after closing, which lazily reopens it.
 
 ## Serving Definitions
 

--- a/src/hypergraph/__init__.py
+++ b/src/hypergraph/__init__.py
@@ -74,6 +74,7 @@ from hypergraph.host import (
     ForkCompatibilityError,
     Host,
     HostError,
+    HostRuntime,
     ItemKeyError,
     RerunError,
     RunHome,
@@ -233,6 +234,7 @@ __all__ = [
     # Durable host (Tier 1 local host)
     "serve",
     "Host",
+    "HostRuntime",
     "RunHome",
     "RunHomeClient",
     "RunRef",

--- a/src/hypergraph/host/__init__.py
+++ b/src/hypergraph/host/__init__.py
@@ -21,6 +21,7 @@ from hypergraph.host.errors import (
 from hypergraph.host.home import RunHome
 from hypergraph.host.host import Host, SubmitReceipt, serve
 from hypergraph.host.refs import BatchCommandReceipt, BatchRef, BatchSubmitReceipt, CommandReceipt, RunRef
+from hypergraph.host.runtime import HostRuntime
 from hypergraph.host.views import BatchItemView, BatchUpdate, BatchView, RunQuery, RunUpdate, RunView, WaitingCondition
 
 __all__ = [
@@ -37,6 +38,7 @@ __all__ = [
     "ForkCompatibilityError",
     "Host",
     "HostError",
+    "HostRuntime",
     "ItemKeyError",
     "RerunError",
     "RunHome",

--- a/src/hypergraph/host/host.py
+++ b/src/hypergraph/host/host.py
@@ -111,6 +111,34 @@ class Host:
         """The one RunHomeClient for this Home (no verb copies on Host)."""
         return self._client
 
+    def add_definition(self, graph: Graph) -> None:
+        """Add one Definition without restarting this Host's worker.
+
+        Re-adding the same Definition identity is a no-op. A served name
+        cannot be replaced with a different structural identity; replacement
+        remains an explicit worker restart so in-flight work never changes
+        code underneath its pinned Definition.
+
+        Args:
+            graph: A named graph with a runner bound via ``with_runner()``.
+
+        Raises:
+            ValueError: If the graph is invalid for durable serving or tries
+                to replace a served Definition.
+        """
+        definition = _definition_from(graph, home=self._home, deployment_version=self._deployment_version, taken=())
+        existing = self._definitions.get(definition.name)
+        if existing is not None:
+            if existing.struct_hash == definition.struct_hash:
+                return
+            raise ValueError(
+                f"Definition {definition.name!r} is already served with structural hash {existing.struct_hash!r}; "
+                f"it cannot be replaced in-place by {definition.struct_hash!r}.\n\n"
+                "How to fix: close this Host and create a new one to replace a Definition, or give the new graph a distinct name."
+            )
+        self._definitions[definition.name] = definition
+        self._served_identities = self._served_identities | {definition.definition_id}
+
     async def submit(
         self,
         graph: Graph,

--- a/src/hypergraph/host/runtime.py
+++ b/src/hypergraph/host/runtime.py
@@ -1,0 +1,166 @@
+"""Process-level ownership for one lazy Run Home, Host, and worker."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from hypergraph.host._bus import _PreviewBus, _register_bus
+from hypergraph.host.client import RunHomeClient
+from hypergraph.host.home import RunHome
+from hypergraph.host.host import Host
+
+if TYPE_CHECKING:
+    from hypergraph.graph import Graph
+
+
+class HostRuntime:
+    """A lazy process-level Run Home, incremental Host, and worker.
+
+    Nothing is opened at construction. Accessing :attr:`client` or serving a
+    first graph opens the Home. Unbound graphs are served with an
+    :class:`~hypergraph.AsyncRunner`; an explicit graph runner is preserved.
+
+    Args:
+        path: Filesystem path for the Run Home, or ``":memory:"``.
+        deployment_version: Version pinned into Definitions and submissions.
+    """
+
+    def __init__(self, path: str | Path, *, deployment_version: str = "") -> None:
+        self._path = Path(path)
+        self._deployment_version = deployment_version
+        self._home: RunHome | None = None
+        self._host: Host | None = None
+        self._worker: asyncio.Task[None] | None = None
+        self._lock = asyncio.Lock()
+        self._closing = False
+        self._close_pending = False
+        self._worker_close: asyncio.Task[BaseException | None] | None = None
+        self._home_close: asyncio.Task[None] | None = None
+        runtime_id = f"{os.getpid()}-{uuid.uuid4().hex[:12]}"
+        self._worker_id = f"host-runtime-{runtime_id}"
+        self._task_name = f"hypergraph-host-{runtime_id}"
+
+    @property
+    def client(self) -> RunHomeClient:
+        """The client for this runtime's Run Home, opened on first access."""
+        self._require_not_closing()
+        self._raise_worker_failure()
+        return self._ensure_host().client
+
+    async def serving(self, graph: Graph) -> Host:
+        """Serve ``graph`` incrementally and ensure the worker is running.
+
+        Repeated calls for the same Definition identity are idempotent. A new
+        Definition is added to the live Host, so active work and the worker
+        task are left in place.
+
+        Returns:
+            The runtime's stable Host, for ``submit`` and ``submit_batch``.
+        """
+        from hypergraph.graph import Graph
+        from hypergraph.runners.async_ import AsyncRunner
+
+        if not isinstance(graph, Graph):
+            raise TypeError(f"HostRuntime.serving() expects a Graph, got {type(graph).__name__}.")
+        async with self._lock:
+            self._require_not_closing()
+            self._raise_worker_failure()
+            served_graph = graph if graph.bound_runner is not None else graph.with_runner(AsyncRunner())
+            host = self._ensure_host()
+            host.add_definition(served_graph)
+            self._ensure_worker(host)
+            return host
+
+    async def close(self) -> None:
+        """Drain the worker and close the Home; submitted work stays durable."""
+        async with self._lock:
+            self._closing = True
+            self._close_pending = True
+            try:
+                worker = self._worker
+                error = None
+                if worker is not None:
+                    if not worker.done() and self._host is not None:
+                        self._host.shutdown()
+                    if self._worker_close is None:
+                        self._worker_close = asyncio.create_task(self._worker_outcome(worker))
+                    # The observer converts an independently cancelled worker
+                    # into a returned error. Therefore CancelledError here can
+                    # only belong to this close() caller; shielding leaves the
+                    # drain alive for a later close() to join.
+                    error = await asyncio.shield(self._worker_close)
+
+                home = self._home
+                if home is not None:
+                    if self._home_close is None:
+                        self._home_close = asyncio.create_task(home.close())
+                    try:
+                        await asyncio.shield(self._home_close)
+                    except asyncio.CancelledError:
+                        # The private close task is never cancelled by the
+                        # runtime; shield makes this the caller's cancellation.
+                        raise
+                    except BaseException:
+                        self._home_close = None
+                        raise
+
+                self._worker = None
+                self._host = None
+                self._home = None
+                self._worker_close = None
+                self._home_close = None
+                self._close_pending = False
+
+                if error is not None:
+                    raise RuntimeError("HostRuntime worker stopped unexpectedly.") from error
+            finally:
+                self._closing = False
+
+    @staticmethod
+    async def _worker_outcome(worker: asyncio.Task[None]) -> BaseException | None:
+        try:
+            await worker
+        except BaseException as error:
+            return error
+        return None
+
+    def _require_not_closing(self) -> None:
+        if self._closing or self._close_pending:
+            raise RuntimeError("HostRuntime is closing; await close() before using it again.")
+
+    def _ensure_host(self) -> Host:
+        if self._host is None:
+            home = self._open_home()
+            bus = _PreviewBus()
+            _register_bus(home.uri, bus)
+            self._host = Host(home=home, definitions={}, deployment_version=self._deployment_version, bus=bus)
+        return self._host
+
+    def _open_home(self) -> RunHome:
+        if self._home is None:
+            if str(self._path) != ":memory:":
+                self._path.parent.mkdir(parents=True, exist_ok=True)
+            self._home = RunHome.open(self._path)
+        return self._home
+
+    def _ensure_worker(self, host: Host) -> None:
+        if self._worker is None:
+            self._worker = asyncio.create_task(host.work_forever(self._worker_id), name=self._task_name)
+
+    def _worker_failure(self) -> BaseException | None:
+        worker = self._worker
+        if worker is None or not worker.done():
+            return None
+        self._worker = None
+        if worker.cancelled():
+            return asyncio.CancelledError()
+        return worker.exception()
+
+    def _raise_worker_failure(self) -> None:
+        error = self._worker_failure()
+        if error is not None:
+            raise RuntimeError("HostRuntime worker stopped unexpectedly.") from error

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -969,6 +969,7 @@ def test_durable_host_docs_pin_public_contract() -> None:
         CommandReceipt,
         DefinitionId,
         Graph,
+        HostRuntime,
         RunHome,
         RunHomeClient,
         RunQuery,
@@ -988,6 +989,7 @@ def test_durable_host_docs_pin_public_contract() -> None:
     assert "host.submit_sync" in host_api
     assert "WorkerLockError" in host_api
     assert "WaitingCondition" in host_api
+    assert "HostRuntime" in host_api
 
     # Ticket 03: identity/dedup/rerun/fork surface is documented.
     assert "DefinitionId" in host_api
@@ -1062,6 +1064,12 @@ def test_durable_host_docs_pin_public_contract() -> None:
     )
     assert tuple(inspect.signature(serve).parameters) == ("graphs", "home", "deployment_version", "accepts")
     from hypergraph.host import Host
+
+    assert tuple(inspect.signature(HostRuntime).parameters) == ("path", "deployment_version")
+    assert tuple(inspect.signature(HostRuntime.serving).parameters) == ("self", "graph")
+    assert tuple(inspect.signature(HostRuntime.close).parameters) == ("self",)
+    assert isinstance(HostRuntime.client, property)
+    assert tuple(inspect.signature(Host.add_definition).parameters) == ("self", "graph")
 
     # Graph-first submission (#342): the served Graph object IS the selector,
     # resolved by its own pinned identity. A Definition-name string is not.

--- a/tests/test_host/test_host_runtime.py
+++ b/tests/test_host/test_host_runtime.py
@@ -1,0 +1,255 @@
+"""Process-level HostRuntime lifecycle and incremental serving."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from hypergraph import AsyncRunner, Graph, HostRuntime, RunHome, node, serve
+from hypergraph.checkpointers.types import WorkflowStatus
+from hypergraph.host.host import Host
+
+
+def _increment_graph(name: str, *, started: asyncio.Event | None = None, release: asyncio.Event | None = None) -> Graph:
+    @node(output_name="out")
+    async def increment(x: int) -> int:
+        if started is not None:
+            started.set()
+        if release is not None:
+            await release.wait()
+        return x + 1
+
+    return Graph([increment], name=name)
+
+
+async def _terminal(client, ref):
+    async for _update in client.watch(ref):
+        pass
+    view = await client.get(ref)
+    if view is None:
+        raise AssertionError("watch ended without a terminal view")
+    return view
+
+
+class TestHostRuntimeLifecycle:
+    async def test_constructor_is_lazy_and_client_opens_on_first_use(self, tmp_path, monkeypatch):
+        opened = []
+        original_open = RunHome.open
+
+        def observe_open(path, **kwargs):
+            opened.append(path)
+            return original_open(path, **kwargs)
+
+        monkeypatch.setattr(RunHome, "open", observe_open)
+        runtime = HostRuntime(tmp_path / "nested" / "runs.db", deployment_version="v1")
+
+        assert opened == []
+        client = runtime.client
+        assert opened == [tmp_path / "nested" / "runs.db"]
+        assert client is runtime.client
+        await runtime.close()
+
+    async def test_serving_is_idempotent_and_adds_definitions_without_restarting_worker(self, tmp_path):
+        started = asyncio.Event()
+        release = asyncio.Event()
+        first = _increment_graph("first", started=started, release=release)
+        second = _increment_graph("second")
+        runtime = HostRuntime(tmp_path / "runs.db", deployment_version="v1")
+
+        try:
+            host = await runtime.serving(first)
+            first_receipt = await host.submit(first, {"x": 1}, workflow_id="first-run")
+            await asyncio.wait_for(started.wait(), timeout=10)
+            worker = runtime._worker
+
+            assert await runtime.serving(first) is host
+            assert await runtime.serving(second) is host
+            assert runtime._worker is worker
+
+            second_receipt = await host.submit(second, {"x": 10}, workflow_id="second-run")
+            second_view = await asyncio.wait_for(_terminal(runtime.client, second_receipt.run_ref), timeout=10)
+            assert second_view.status == WorkflowStatus.COMPLETED
+            assert second_view.definition_id is not None
+            assert second_view.definition_id.deployment_version == "v1"
+
+            release.set()
+            first_view = await asyncio.wait_for(_terminal(runtime.client, first_receipt.run_ref), timeout=10)
+            assert first_view.status == WorkflowStatus.COMPLETED
+            assert first_view.definition_id is not None
+            assert first_view.definition_id.deployment_version == "v1"
+            assert (await runtime.client.result(first_receipt.run_ref)).outputs == {"out": 2}
+            assert (await runtime.client.result(second_receipt.run_ref)).outputs == {"out": 11}
+        finally:
+            release.set()
+            await runtime.close()
+
+    async def test_close_keeps_completed_work_durable(self, tmp_path):
+        path = tmp_path / "runs.db"
+        graph = _increment_graph("increment")
+        runtime = HostRuntime(path, deployment_version="v1")
+        host = await runtime.serving(graph)
+        receipt = await host.submit(graph, {"x": 1}, workflow_id="durable-run")
+        await asyncio.wait_for(_terminal(runtime.client, receipt.run_ref), timeout=10)
+
+        await runtime.close()
+
+        reopened = RunHome.open(path)
+        try:
+            assert reopened.get_run("durable-run").status == WorkflowStatus.COMPLETED
+            assert reopened.values("durable-run") == {"out": 2}
+        finally:
+            await reopened.close()
+
+    async def test_client_cannot_reopen_home_while_close_is_suspended(self, tmp_path, monkeypatch):
+        closing = asyncio.Event()
+        finish_close = asyncio.Event()
+        original_close = RunHome.close
+
+        async def gated_close(home):
+            closing.set()
+            await finish_close.wait()
+            await original_close(home)
+
+        monkeypatch.setattr(RunHome, "close", gated_close)
+        runtime = HostRuntime(tmp_path / "runs.db")
+        client = runtime.client
+        close_task = asyncio.create_task(runtime.close())
+        await asyncio.wait_for(closing.wait(), timeout=10)
+
+        with pytest.raises(RuntimeError, match="is closing"):
+            _ = runtime.client
+        assert runtime._home is not None
+
+        finish_close.set()
+        await close_task
+        assert runtime._home is None
+        assert runtime.client is not client
+        await runtime.close()
+
+    async def test_cancelled_close_keeps_worker_drain_retryable(self, tmp_path, monkeypatch):
+        started = asyncio.Event()
+        release = asyncio.Event()
+        shutdown_called = asyncio.Event()
+        runtime = HostRuntime(tmp_path / "runs.db")
+        graph = _increment_graph("increment", started=started, release=release)
+        host = await runtime.serving(graph)
+        await host.submit(graph, {"x": 1}, workflow_id="active-run")
+        await asyncio.wait_for(started.wait(), timeout=10)
+        original_shutdown = host.shutdown
+
+        def observe_shutdown():
+            original_shutdown()
+            shutdown_called.set()
+
+        monkeypatch.setattr(host, "shutdown", observe_shutdown)
+        close_task = asyncio.create_task(runtime.close())
+        await asyncio.wait_for(shutdown_called.wait(), timeout=10)
+        close_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await close_task
+
+        assert runtime._home is not None
+        release.set()
+        await runtime.close()
+        assert runtime._home is None
+
+    async def test_cancelled_home_close_remains_single_flight_and_retryable(self, tmp_path, monkeypatch):
+        closing = asyncio.Event()
+        finish_close = asyncio.Event()
+        close_calls = 0
+        original_close = RunHome.close
+
+        async def gated_close(home):
+            nonlocal close_calls
+            close_calls += 1
+            closing.set()
+            await finish_close.wait()
+            await original_close(home)
+
+        monkeypatch.setattr(RunHome, "close", gated_close)
+        runtime = HostRuntime(tmp_path / "runs.db")
+        _ = runtime.client
+        close_task = asyncio.create_task(runtime.close())
+        await asyncio.wait_for(closing.wait(), timeout=10)
+        close_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await close_task
+
+        with pytest.raises(RuntimeError, match="is closing"):
+            _ = runtime.client
+        finish_close.set()
+        await runtime.close()
+        assert close_calls == 1
+        assert runtime._home is None
+
+    async def test_worker_failure_is_raised_on_next_call(self, tmp_path, monkeypatch):
+        class WorkerFailure(Exception):
+            pass
+
+        failed = asyncio.Event()
+        failure = WorkerFailure("worker exploded")
+
+        async def fail_worker(self, worker_id, **kwargs):
+            failed.set()
+            raise failure
+
+        monkeypatch.setattr(Host, "work_forever", fail_worker)
+        runtime = HostRuntime(tmp_path / "runs.db")
+        graph = _increment_graph("increment")
+        await runtime.serving(graph)
+        await asyncio.wait_for(failed.wait(), timeout=10)
+        assert runtime._worker is not None and runtime._worker.done()
+
+        with pytest.raises(RuntimeError, match="worker stopped unexpectedly") as raised:
+            await runtime.serving(graph)
+        assert raised.value.__cause__ is failure
+        await runtime.close()
+
+    async def test_independently_cancelled_worker_is_raised_by_close(self, tmp_path):
+        runtime = HostRuntime(tmp_path / "runs.db")
+        await runtime.serving(_increment_graph("increment"))
+        assert runtime._worker is not None
+        runtime._worker.cancel()
+
+        with pytest.raises(RuntimeError, match="worker stopped unexpectedly") as raised:
+            await runtime.close()
+        assert isinstance(raised.value.__cause__, asyncio.CancelledError)
+
+
+class TestIncrementalHostDefinitions:
+    async def test_different_definition_identity_cannot_replace_live_name(self, tmp_path):
+        @node(output_name="different")
+        async def decrement(x: int) -> int:
+            return x - 1
+
+        original = _increment_graph("calculation").with_runner(AsyncRunner())
+        replacement = Graph([decrement], name="calculation").with_runner(AsyncRunner())
+        home = RunHome.open(tmp_path / "runs.db")
+        try:
+            host = serve(original, home=home)
+            host.add_definition(original)
+            with pytest.raises(ValueError, match="cannot be replaced in-place"):
+                host.add_definition(replacement)
+        finally:
+            await home.close()
+
+    async def test_runtime_re_adopts_work_claimed_before_process_loss(self, tmp_path):
+        path = tmp_path / "runs.db"
+        graph = _increment_graph("increment")
+        home = RunHome.open(path)
+        original = serve(graph.with_runner(AsyncRunner()), home=home, deployment_version="v1")
+        receipt = await original.submit(graph, {"x": 1}, workflow_id="claimed-run")
+        claimed = await home._claim_eligible(await home._store_now(), served=original._served_identities)
+        assert [row["workflow_id"] for row in claimed] == ["claimed-run"]
+        assert home._get_submission_sync("claimed-run")["state"] == "claimed"
+        await home.close()
+
+        runtime = HostRuntime(path, deployment_version="v1")
+        try:
+            await runtime.serving(graph)
+            view = await asyncio.wait_for(_terminal(runtime.client, receipt.run_ref), timeout=10)
+            assert view.status == WorkflowStatus.COMPLETED
+            assert (await runtime.client.result(receipt.run_ref)).outputs == {"out": 2}
+        finally:
+            await runtime.close()

--- a/tests/test_runners/test_type_ownership.py
+++ b/tests/test_runners/test_type_ownership.py
@@ -102,6 +102,7 @@ ROOT_EXPORTS = (
     "SqliteCheckpointer",
     "serve",
     "Host",
+    "HostRuntime",
     "RunHome",
     "RunHomeClient",
     "RunRef",


### PR DESCRIPTION
## Problem / Bug / Challenge

Downstream applications currently rebuild the same composition root around the durable host: lazily open a `RunHome`, bind Definitions as they appear, own one worker task, pin `deployment_version`, expose the client, and drain/close safely. Adding a Definition also required tearing down the Host and worker even though serving is conceptually additive.

Closes #374.
Closes #371.

This is the lifecycle primitive needed by [panda #40](https://github.com/gilad-rubin/panda/issues/40): panda's `DurableRuns` can delete its Home/Host/worker ownership and `_rebuild()` machinery, leaving only graph/path selection and domain handles. Issues #369 and #370 remain separate client/result work and are not implemented here.

## Before / After

**Before:**

```python
home = RunHome.open(path)
host = serve(graph.with_runner(AsyncRunner()), home=home,
             deployment_version=version)
worker = asyncio.create_task(host.work_forever("app-worker"))
# Stop and rebuild host + worker whenever another Definition appears.
```

**After:**

```python
runtime = HostRuntime(path, deployment_version=version)
host = await runtime.serving(graph)
await runtime.serving(another_graph)  # additive; same Host and worker
client = runtime.client
await runtime.close()
```

`Host.add_definition()` publishes a new bound Definition before its identity becomes claimable. `HostRuntime` stays lazy, defaults unbound graphs to `AsyncRunner`, preserves explicit runners, reuses the normal restart scan, and surfaces dead-worker exceptions on the next public call. Teardown is single-flight and retryable across caller cancellation, including while SQLite is closing.

## Test Plan

- [x] Focused HostRuntime lifecycle, incremental serving, re-adoption, durability, worker failure, and cancellation tests
- [x] Existing Host serving/identity/restart suites
- [x] CI-equivalent full suite: `5049 passed`
- [x] Python 3.10 typecheck: `uv run --python 3.10 mypy`
- [x] Lint/format: `uv run pre-commit run --all-files`