### PR TITLE
Fix RunHomeClient result, metadata, and recent listing reads

### DIFF
--- a/docs/06-api-reference/host.md
+++ b/docs/06-api-reference/host.md
@@ -832,6 +832,18 @@ that Batch's children, and `older_than` compares creation time. Omitted
 fields match everything. `limit` must be a positive `int`.
 `client.list_sync(...)` is the synchronous mirror.
 
+`RunView.created_at` and `RunView.completed_at` expose the Run ledger's own
+timestamps (`None` until the corresponding runs-row event exists). Read the
+graph-boundary values pinned when a Run started without reaching into the
+Run Home:
+
+```python
+inputs = await client.inputs(run_view.run_ref)
+```
+
+`client.inputs_sync(...)` is the synchronous mirror. It returns `{}` for an
+unknown Run or a legacy runs row that predates durable input persistence.
+
 ## Rerun: Repeat Settled Work
 
 `client.rerun(ref)` repeats terminal work under a new id with retry

--- a/docs/06-api-reference/host.md
+++ b/docs/06-api-reference/host.md
@@ -811,7 +811,7 @@ voids it — so the stream alone accounts for every timer.
 
 `client.list(query)` filters joined run views through a typed `RunQuery` —
 submissions joined with their runs rows, plus bare Tier-0 runs (a runs row
-with no submission). Results come oldest first, capped at `query.limit`
+with no submission). Results come newest first, capped at `query.limit`
 (default 100):
 
 ```python

--- a/src/hypergraph/host/client.py
+++ b/src/hypergraph/host/client.py
@@ -589,7 +589,7 @@ def _filter_list_rows(
     *,
     admission_full: bool = False,
 ) -> list[RunView]:
-    """Build views for joined rows and apply the RunQuery filters, oldest first."""
+    """Build views for joined rows and apply the RunQuery filters, newest first."""
     cutoff = datetime.now(timezone.utc) - query.older_than if query.older_than is not None else None
     batch_id = _query_batch_id(query)
     matched: list[tuple[datetime, RunView]] = []
@@ -610,7 +610,7 @@ def _filter_list_rows(
         if cutoff is not None and created_at > cutoff:
             continue
         matched.append((created_at, view))
-    matched.sort(key=lambda pair: (pair[0], pair[1].workflow_id))
+    matched.sort(key=lambda pair: (pair[0], pair[1].workflow_id), reverse=True)
     return [view for _, view in matched[: query.limit]]
 
 
@@ -1027,14 +1027,14 @@ class RunHomeClient:
         return self._home.get_pause_slot_sync(ref.run_id)
 
     async def list(self, query: RunQuery) -> list[RunView]:
-        """List runs matching ``query``, oldest first.
+        """List runs matching ``query``, newest first.
 
         Joins submissions with their runs rows and includes bare Tier-0
         runs (a runs row with no submission). Every filter is the same
         typed vocabulary views report: ``status`` matches the runs row
         (runs without one never match), ``waiting`` is computed exactly
         like ``RunView.waiting``, ``older_than`` compares the row's
-        creation time, and ``limit`` caps the result after oldest-first
+        creation time, and ``limit`` caps the result after newest-first
         ordering.
         """
         _validate_query(query)

--- a/src/hypergraph/host/client.py
+++ b/src/hypergraph/host/client.py
@@ -16,7 +16,7 @@ from contextlib import aclosing
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from difflib import get_close_matches
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from hypergraph.checkpointers.types import PauseSlot, WorkflowStatus
 from hypergraph.host._batch_store import BatchAcceptance, DefinitionPin
@@ -727,13 +727,18 @@ class RunHomeClient:
                 return None
             child_rows = await self._home._batch_child_rows(ref.batch_id)
             started = _started_child_ids(child_rows)
-            return _build_batch_outcome(
+            result = _build_batch_outcome(
                 batch,
                 child_rows,
                 self._home.uri,
                 await self._home.get_states(started),
                 await self._home.get_step_failures(started),
             )
+            items = {
+                key: cast(RunOutcome, await self.result(item.run_ref)) if item is not None and item.outputs == {} else item
+                for key, item in result.items.items()
+            }
+            return replace(result, items=items)
         if not isinstance(ref, RunRef):
             raise TypeError(f"result() expects a RunRef or BatchRef, got {type(ref).__name__}.")
         submission = await self._home._get_submission(ref.run_id)
@@ -786,13 +791,18 @@ class RunHomeClient:
                 return None
             child_rows = self._home._batch_child_rows_sync(ref.batch_id)
             started = _started_child_ids(child_rows)
-            return _build_batch_outcome(
+            result = _build_batch_outcome(
                 batch,
                 child_rows,
                 self._home.uri,
                 self._home.get_states_sync(started),
                 self._home.get_step_failures_sync(started),
             )
+            items = {
+                key: cast(RunOutcome, self.result_sync(item.run_ref)) if item is not None and item.outputs == {} else item
+                for key, item in result.items.items()
+            }
+            return replace(result, items=items)
         if not isinstance(ref, RunRef):
             raise TypeError(f"result() expects a RunRef or BatchRef, got {type(ref).__name__}.")
         submission = self._home._get_submission_sync(ref.run_id)

--- a/src/hypergraph/host/client.py
+++ b/src/hypergraph/host/client.py
@@ -13,7 +13,7 @@ import json
 import uuid
 from collections.abc import AsyncGenerator, AsyncIterator, Sequence
 from contextlib import aclosing
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from difflib import get_close_matches
 from typing import TYPE_CHECKING, Any
@@ -50,6 +50,9 @@ from hypergraph.host.views import (
 if TYPE_CHECKING:
     from hypergraph.checkpointers.types import Run
     from hypergraph.host.home import RunHome
+
+
+_RETRY_LINEAGE_LIMIT = 32
 
 
 def _now_iso() -> str:
@@ -720,7 +723,7 @@ class RunHomeClient:
         if submission is None and run is None:
             return None
         run_ids = [ref.run_id] if run is not None else []
-        return _build_run_outcome(
+        result = _build_run_outcome(
             self._home.uri,
             ref.run_id,
             submission,
@@ -728,6 +731,34 @@ class RunHomeClient:
             (await self._home.get_states(run_ids)).get(ref.run_id),
             (await self._home.get_step_failures(run_ids)).get(ref.run_id),
         )
+        if not result.settled or result.outputs != {}:
+            return result
+
+        seen = {ref.run_id}
+        current_submission, current_run = submission, run
+        for _ in range(_RETRY_LINEAGE_LIMIT):
+            source_id = (current_run.retry_of if current_run is not None else None) or (
+                current_submission["retry_of"] if current_submission is not None else None
+            )
+            if not source_id or source_id in seen:
+                return result
+            seen.add(source_id)
+            current_submission = await self._home._get_submission(source_id)
+            current_run = await self._home.get_run_async(source_id)
+            if current_submission is None and current_run is None:
+                return result
+            source_ids = [source_id] if current_run is not None else []
+            source = _build_run_outcome(
+                self._home.uri,
+                source_id,
+                current_submission,
+                current_run,
+                (await self._home.get_states(source_ids)).get(source_id),
+                (await self._home.get_step_failures(source_ids)).get(source_id),
+            )
+            if source.outputs:
+                return replace(result, outputs=source.outputs)
+        return result
 
     def result_sync(self, ref: RunRef | BatchRef) -> RunOutcome | BatchOutcome | None:
         """Sync mirror of ``result``."""
@@ -751,7 +782,7 @@ class RunHomeClient:
         if submission is None and run is None:
             return None
         run_ids = [ref.run_id] if run is not None else []
-        return _build_run_outcome(
+        result = _build_run_outcome(
             self._home.uri,
             ref.run_id,
             submission,
@@ -759,6 +790,34 @@ class RunHomeClient:
             self._home.get_states_sync(run_ids).get(ref.run_id),
             self._home.get_step_failures_sync(run_ids).get(ref.run_id),
         )
+        if not result.settled or result.outputs != {}:
+            return result
+
+        seen = {ref.run_id}
+        current_submission, current_run = submission, run
+        for _ in range(_RETRY_LINEAGE_LIMIT):
+            source_id = (current_run.retry_of if current_run is not None else None) or (
+                current_submission["retry_of"] if current_submission is not None else None
+            )
+            if not source_id or source_id in seen:
+                return result
+            seen.add(source_id)
+            current_submission = self._home._get_submission_sync(source_id)
+            current_run = self._home.get_run(source_id)
+            if current_submission is None and current_run is None:
+                return result
+            source_ids = [source_id] if current_run is not None else []
+            source = _build_run_outcome(
+                self._home.uri,
+                source_id,
+                current_submission,
+                current_run,
+                self._home.get_states_sync(source_ids).get(source_id),
+                self._home.get_step_failures_sync(source_ids).get(source_id),
+            )
+            if source.outputs:
+                return replace(result, outputs=source.outputs)
+        return result
 
     async def stop(self, ref: RunRef | BatchRef, *, info: Any = None, source_ref: str | None = None) -> CommandReceipt | BatchCommandReceipt:
         """Record a durable stop command for ``ref``.

--- a/src/hypergraph/host/client.py
+++ b/src/hypergraph/host/client.py
@@ -727,7 +727,7 @@ class RunHomeClient:
                 return None
             child_rows = await self._home._batch_child_rows(ref.batch_id)
             started = _started_child_ids(child_rows)
-            result = _build_batch_outcome(
+            batch_result = _build_batch_outcome(
                 batch,
                 child_rows,
                 self._home.uri,
@@ -736,9 +736,9 @@ class RunHomeClient:
             )
             items = {
                 key: cast(RunOutcome, await self.result(item.run_ref)) if item is not None and item.outputs == {} else item
-                for key, item in result.items.items()
+                for key, item in batch_result.items.items()
             }
-            return replace(result, items=items)
+            return replace(batch_result, items=items)
         if not isinstance(ref, RunRef):
             raise TypeError(f"result() expects a RunRef or BatchRef, got {type(ref).__name__}.")
         submission = await self._home._get_submission(ref.run_id)
@@ -746,7 +746,7 @@ class RunHomeClient:
         if submission is None and run is None:
             return None
         run_ids = [ref.run_id] if run is not None else []
-        result = _build_run_outcome(
+        run_result = _build_run_outcome(
             self._home.uri,
             ref.run_id,
             submission,
@@ -754,8 +754,8 @@ class RunHomeClient:
             (await self._home.get_states(run_ids)).get(ref.run_id),
             (await self._home.get_step_failures(run_ids)).get(ref.run_id),
         )
-        if not result.settled or result.outputs != {}:
-            return result
+        if not run_result.settled or run_result.outputs != {}:
+            return run_result
 
         seen = {ref.run_id}
         current_submission, current_run = submission, run
@@ -764,12 +764,12 @@ class RunHomeClient:
                 current_submission["retry_of"] if current_submission is not None else None
             )
             if not source_id or source_id in seen:
-                return result
+                return run_result
             seen.add(source_id)
             current_submission = await self._home._get_submission(source_id)
             current_run = await self._home.get_run_async(source_id)
             if current_submission is None and current_run is None:
-                return result
+                return run_result
             source_ids = [source_id] if current_run is not None else []
             source = _build_run_outcome(
                 self._home.uri,
@@ -780,8 +780,8 @@ class RunHomeClient:
                 (await self._home.get_step_failures(source_ids)).get(source_id),
             )
             if source.outputs:
-                return replace(result, outputs=source.outputs)
-        return result
+                return replace(run_result, outputs=source.outputs)
+        return run_result
 
     def result_sync(self, ref: RunRef | BatchRef) -> RunOutcome | BatchOutcome | None:
         """Sync mirror of ``result``."""
@@ -791,7 +791,7 @@ class RunHomeClient:
                 return None
             child_rows = self._home._batch_child_rows_sync(ref.batch_id)
             started = _started_child_ids(child_rows)
-            result = _build_batch_outcome(
+            batch_result = _build_batch_outcome(
                 batch,
                 child_rows,
                 self._home.uri,
@@ -800,9 +800,9 @@ class RunHomeClient:
             )
             items = {
                 key: cast(RunOutcome, self.result_sync(item.run_ref)) if item is not None and item.outputs == {} else item
-                for key, item in result.items.items()
+                for key, item in batch_result.items.items()
             }
-            return replace(result, items=items)
+            return replace(batch_result, items=items)
         if not isinstance(ref, RunRef):
             raise TypeError(f"result() expects a RunRef or BatchRef, got {type(ref).__name__}.")
         submission = self._home._get_submission_sync(ref.run_id)
@@ -810,7 +810,7 @@ class RunHomeClient:
         if submission is None and run is None:
             return None
         run_ids = [ref.run_id] if run is not None else []
-        result = _build_run_outcome(
+        run_result = _build_run_outcome(
             self._home.uri,
             ref.run_id,
             submission,
@@ -818,8 +818,8 @@ class RunHomeClient:
             self._home.get_states_sync(run_ids).get(ref.run_id),
             self._home.get_step_failures_sync(run_ids).get(ref.run_id),
         )
-        if not result.settled or result.outputs != {}:
-            return result
+        if not run_result.settled or run_result.outputs != {}:
+            return run_result
 
         seen = {ref.run_id}
         current_submission, current_run = submission, run
@@ -828,12 +828,12 @@ class RunHomeClient:
                 current_submission["retry_of"] if current_submission is not None else None
             )
             if not source_id or source_id in seen:
-                return result
+                return run_result
             seen.add(source_id)
             current_submission = self._home._get_submission_sync(source_id)
             current_run = self._home.get_run(source_id)
             if current_submission is None and current_run is None:
-                return result
+                return run_result
             source_ids = [source_id] if current_run is not None else []
             source = _build_run_outcome(
                 self._home.uri,
@@ -844,8 +844,8 @@ class RunHomeClient:
                 self._home.get_step_failures_sync(source_ids).get(source_id),
             )
             if source.outputs:
-                return replace(result, outputs=source.outputs)
-        return result
+                return replace(run_result, outputs=source.outputs)
+        return run_result
 
     async def stop(self, ref: RunRef | BatchRef, *, info: Any = None, source_ref: str | None = None) -> CommandReceipt | BatchCommandReceipt:
         """Record a durable stop command for ``ref``.

--- a/src/hypergraph/host/client.py
+++ b/src/hypergraph/host/client.py
@@ -402,6 +402,8 @@ def _build_view(
         definition_id=definition_id,
         retry_of=retry_of,
         forked_from=forked_from,
+        created_at=run.created_at if run is not None else None,
+        completed_at=run.completed_at if run is not None else None,
     )
 
 
@@ -679,6 +681,22 @@ class RunHomeClient:
         submission = self._home._get_submission_sync(ref.run_id)
         run = self._home.get_run(ref.run_id)
         return _build_view(self._home.uri, ref.run_id, submission, run, admission_full=self._home._admission_is_full_sync())
+
+    async def inputs(self, ref: RunRef) -> dict[str, Any]:
+        """Return the pinned graph-boundary inputs the run started from.
+
+        Returns an empty dict for an unknown run or legacy rows that predate
+        durable run inputs, matching the Run Home's persistence contract.
+        """
+        if not isinstance(ref, RunRef):
+            raise TypeError(f"inputs() expects a RunRef, got {type(ref).__name__}.")
+        return await self._home.get_run_inputs(ref.run_id)
+
+    def inputs_sync(self, ref: RunRef) -> dict[str, Any]:
+        """Sync mirror of ``inputs``."""
+        if not isinstance(ref, RunRef):
+            raise TypeError(f"inputs() expects a RunRef, got {type(ref).__name__}.")
+        return self._home.get_run_inputs_sync(ref.run_id)
 
     async def result(self, ref: RunRef | BatchRef) -> RunOutcome | BatchOutcome | None:
         """Return what ``ref`` durably produced, or None if unknown.

--- a/src/hypergraph/host/views.py
+++ b/src/hypergraph/host/views.py
@@ -184,7 +184,7 @@ class RunQuery:
             waiting computation ``RunView.waiting`` uses).
         older_than: Restrict to work created at least this long ago
             (aged-unclaimed and backlog queries).
-        limit: Maximum views returned, oldest first. Defaults to 100.
+        limit: Maximum views returned, newest first. Defaults to 100.
         batch: Restrict to children of one Batch — a ``BatchRef`` or a bare
             batch id string. Runs without Batch membership never match.
     """

--- a/src/hypergraph/host/views.py
+++ b/src/hypergraph/host/views.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
-from datetime import timedelta
+from datetime import datetime, timedelta
 from enum import Enum
 from typing import Any
 
@@ -152,6 +152,9 @@ class RunView:
         forked_from: Source workflow id when this run is a fork (migration),
             else None. Taken from the runs row when present, else the
             submission's recorded lineage.
+        created_at: When the runs row was created, or None before execution
+            starts.
+        completed_at: When the run reached a terminal status, else None.
     """
 
     run_ref: RunRef
@@ -162,6 +165,8 @@ class RunView:
     definition_id: DefinitionId | None
     retry_of: str | None
     forked_from: str | None
+    created_at: datetime | None
+    completed_at: datetime | None
 
 
 @dataclass(frozen=True)

--- a/tests/test_docs_contract.py
+++ b/tests/test_docs_contract.py
@@ -1117,6 +1117,8 @@ def test_durable_host_docs_pin_public_contract() -> None:
     assert tuple(inspect.signature(RunHomeClient.stop_sync).parameters) == tuple(inspect.signature(RunHomeClient.stop).parameters)
     assert tuple(inspect.signature(RunHomeClient.list).parameters) == ("self", "query")
     assert tuple(inspect.signature(RunHomeClient.list_sync).parameters) == tuple(inspect.signature(RunHomeClient.list).parameters)
+    assert tuple(inspect.signature(RunHomeClient.inputs).parameters) == ("self", "ref")
+    assert tuple(inspect.signature(RunHomeClient.inputs_sync).parameters) == tuple(inspect.signature(RunHomeClient.inputs).parameters)
 
     # Inert refs and read models: identity only, typed waiting vocabulary.
     assert tuple(RunRef.__dataclass_fields__) == ("home", "run_id")
@@ -1133,6 +1135,8 @@ def test_durable_host_docs_pin_public_contract() -> None:
         "definition_id",
         "retry_of",
         "forked_from",
+        "created_at",
+        "completed_at",
     )
     assert tuple(RunUpdate.__dataclass_fields__) == ("cursor", "durable", "kind", "payload", "timestamp")
 

--- a/tests/test_host/test_durable_result_projection.py
+++ b/tests/test_host/test_durable_result_projection.py
@@ -338,6 +338,46 @@ class TestBatchOutcome:
 
 
 class TestLineageAndRecovery:
+    async def test_checkpoint_reusing_rerun_inherits_material_outputs(self, home):
+        host, served = serve_graphs(_chain_graph(), home=home)
+        original = await host.submit(served["chain"], {"x": 4}, workflow_id="wf-reused")
+        async with _worker(host):
+            await _wait_for(lambda: _settled(RunHomeClient(home), original.run_ref))
+
+        retry = await host.client.rerun(original.run_ref)
+        async with _worker(host):
+            await _wait_for(lambda: _settled(RunHomeClient(home), retry.run_ref))
+
+        outcome = await host.client.result(retry.run_ref)
+        assert outcome.workflow_id == retry.workflow_id, "the requested run keeps its identity"
+        assert outcome.outputs == {"doubled": 8, "tripled": 24}
+        assert host.client.result_sync(retry.run_ref).outputs == outcome.outputs
+
+    async def test_checkpoint_reusing_rerun_that_produced_nothing_stays_empty(self, home):
+        host, served = serve_graphs(_empty_graph(), home=home)
+        original = await host.submit(served["quiet"], {"x": 4}, workflow_id="wf-empty-reused")
+        async with _worker(host):
+            await _wait_for(lambda: _settled(RunHomeClient(home), original.run_ref))
+
+        retry = await host.client.rerun(original.run_ref)
+        async with _worker(host):
+            await _wait_for(lambda: _settled(RunHomeClient(home), retry.run_ref))
+
+        assert (await host.client.result(retry.run_ref)).outputs == {}
+
+    async def test_retry_lineage_cycle_terminates(self, home):
+        for run_id in ("wf-cycle-a", "wf-cycle-b"):
+            home.create_run_sync(run_id, graph_name="quiet")
+            home.update_run_status_sync(run_id, WorkflowStatus.COMPLETED)
+        db = home._sync_db()
+        db.execute("UPDATE runs SET retry_of = 'wf-cycle-b' WHERE id = 'wf-cycle-a'")
+        db.execute("UPDATE runs SET retry_of = 'wf-cycle-a' WHERE id = 'wf-cycle-b'")
+        db.commit()
+
+        ref = RunRef(home=home.uri, run_id="wf-cycle-a")
+        assert (await RunHomeClient(home).result(ref)).outputs == {}
+        assert RunHomeClient(home).result_sync(ref).outputs == {}
+
     async def test_rerun_lineage_reads_each_generation_independently(self, home):
         """Rerun repeats inputs verbatim, so the fix has to be transient."""
         attempts: dict[str, int] = {"n": 0}

--- a/tests/test_host/test_durable_result_projection.py
+++ b/tests/test_host/test_durable_result_projection.py
@@ -258,6 +258,20 @@ class TestBatchOutcome:
         rerun_child = await home._get_submission("drop-labels-retry-1:station-b")
         assert json.loads(rerun_child["inputs_json"]) == {"x": 3}
 
+    async def test_checkpoint_reusing_batch_rerun_inherits_material_outputs(self, home):
+        host, served = serve_graphs(_chain_graph(), home=home)
+        original = await submit_keyed(host, served["chain"], {"a": {"x": 4}}, workflow_id="drop-reused")
+        async with _worker(host):
+            await _wait_for(lambda: _settled(RunHomeClient(home), original.batch_ref))
+
+        retry = await host.client.rerun(original.batch_ref)
+        async with _worker(host):
+            await _wait_for(lambda: _settled(RunHomeClient(home), retry.batch_ref))
+
+        outcome = await host.client.result(retry.batch_ref)
+        assert outcome.items["a"].outputs == {"doubled": 8, "tripled": 24}
+        assert host.client.result_sync(retry.batch_ref).items["a"].outputs == outcome.items["a"].outputs
+
     async def test_items_are_keyed_in_manifest_order(self, home):
         host, served = serve_graphs(_chain_graph(), home=home)
         manifest = {"p-2": {"x": 2}, "p-1": {"x": 1}, "p-3": {"x": 3}}

--- a/tests/test_host/test_ticket03_identity_rerun_fork.py
+++ b/tests/test_host/test_ticket03_identity_rerun_fork.py
@@ -191,12 +191,22 @@ class TestDefinitionIdValue:
 
         view = await host.client.get(receipt.run_ref)
         assert view.definition_id == expected
+        assert view.created_at is None
+        assert view.completed_at is None
 
         async with _worker(host):
             view = await _wait_for(lambda: _terminal_view(host.client, receipt.run_ref))
         assert view.definition_id == expected
         assert view.retry_of is None
         assert view.forked_from is None
+        assert view.created_at is not None
+        assert view.completed_at is not None
+        assert view.created_at <= view.completed_at
+        assert await host.client.inputs(receipt.run_ref) == {"x": 1}
+        assert host.client.inputs_sync(receipt.run_ref) == {"x": 1}
+
+        with pytest.raises(TypeError, match="RunRef"):
+            await host.client.inputs("wf-pin")
 
 
 # === 2. Fingerprint dedup with distinct typed conflicts ===

--- a/tests/test_host/test_ticket04_stop_restart_recovery.py
+++ b/tests/test_host/test_ticket04_stop_restart_recovery.py
@@ -572,7 +572,7 @@ class TestClientList:
         time.sleep(0.002)
         home.create_run_sync("wf-done", graph_name="other")
         home.update_run_status_sync("wf-done", WorkflowStatus.COMPLETED)
-        # Backdate two rows so oldest-first ordering and older_than bite.
+        # Backdate two rows so newest-first ordering and older_than bite.
         db.execute("UPDATE host_submissions SET created_at = '2020-01-01T00:00:00+00:00' WHERE workflow_id = 'wf-q'")
         db.execute("UPDATE runs SET created_at = '2020-06-01T00:00:00Z' WHERE id = 'wf-done'")
         db.commit()
@@ -583,7 +583,7 @@ class TestClientList:
 
         everything = await client.list(RunQuery())
         ids = [view.workflow_id for view in everything]
-        assert ids == ["wf-q", "wf-done", "wf-sched", "wf-incomp", "wf-exh", "wf-paused"]
+        assert ids == ["wf-paused", "wf-exh", "wf-incomp", "wf-sched", "wf-done", "wf-q"]
 
         by_definition = await client.list(RunQuery(definition="dbl"))
         assert {view.workflow_id for view in by_definition} == {"wf-q", "wf-sched", "wf-incomp", "wf-exh", "wf-paused"}
@@ -605,10 +605,10 @@ class TestClientList:
             assert [view.workflow_id for view in views] == expected, condition
 
         aged = await client.list(RunQuery(older_than=timedelta(days=30)))
-        assert [view.workflow_id for view in aged] == ["wf-q", "wf-done"]
+        assert [view.workflow_id for view in aged] == ["wf-done", "wf-q"]
 
         limited = await client.list(RunQuery(limit=2))
-        assert [view.workflow_id for view in limited] == ["wf-q", "wf-done"]
+        assert [view.workflow_id for view in limited] == ["wf-paused", "wf-exh"]
 
     async def test_list_sync_mirror_and_validation(self, home):
         client = await self._fixtures(home)


### PR DESCRIPTION
## Problem / Bug / Challenge

Fixes #369, #370, and #373 in the client/read layer:

- checkpoint-reusing reruns can project settled empty outputs even though material outputs exist in their retry lineage
- callers cannot read pinned run inputs or run timestamps without reaching into `RunHome`
- `RunQuery(limit=N)` keeps the oldest N runs instead of the newest work an operator needs

## Before / After

**Before:**

```python
await client.result(retry.run_ref)  # RunOutcome(outputs={}, settled=True)
home.get_run_inputs(run_id)
run = await home.get_run_async(run_id)
await client.list(RunQuery(limit=10))  # oldest 10
```

**After:**

```python
await client.result(retry.run_ref)  # retry identity, lineage's material outputs
await client.inputs(retry.run_ref)
view = await client.get(retry.run_ref)
view.created_at, view.completed_at
await client.list(RunQuery(limit=10))  # newest 10, newest first
```

Retry folding is cycle-safe and capped at 32 links. It applies to direct Run results and Run outcomes nested in Batch results; a lineage that genuinely produced nothing remains `{}`. Every ancestor's outputs still come through the public result projection.

Timestamps live on `RunView` because they are persisted run facts already loaded by `get()` and `list()`. Inputs use a dedicated client verb because they are payload data and should not inflate every view.

## Downstream deletions enabled

Panda can delete:

- `DurableRuns._with_repeated_outputs`
- direct `RunHome.get_run_inputs` / `get_run(_async)` reaches used for pinned inputs and ledger timestamps
- its newest-run listing workaround

## Test Plan

- [x] Added direct and Batch checkpoint-reusing rerun regressions
- [x] Added genuinely-empty lineage and corrupt-cycle regressions
- [x] Added async/sync pinned-input and RunView timestamp coverage
- [x] Updated list ordering/limit regression to assert newest-first behavior
- [x] `uv run pytest -W error -W 'ignore::pytest.PytestUnraisableExceptionWarning'` — 5043 passed, 0 skipped
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run --python 3.10 mypy`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Retrieve persisted inputs for completed or legacy runs using asynchronous or synchronous client methods.
  - Run views now include creation and completion timestamps.
  - Run listings now show the newest runs first.
  - Retried runs can inherit available outputs from earlier attempts.

- **Documentation**
  - Updated API reference documentation for run ordering, timestamps, and persisted input retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->