### PR TITLE
fix(host): close() treats a cancelled worker as a clean shutdown

### DIFF
--- a/src/hypergraph/host/runtime.py
+++ b/src/hypergraph/host/runtime.py
@@ -93,6 +93,14 @@ class HostRuntime:
                     # only belong to this close() caller; shielding leaves the
                     # drain alive for a later close() to join.
                     error = await asyncio.shield(self._worker_close)
+                    # A worker that ended CANCELLED is a clean close outcome:
+                    # submitted work is durable, and close() exists to wind the
+                    # worker down — a cancellation racing the cooperative
+                    # shutdown (an event-loop teardown, a task-group exit) must
+                    # not turn an orderly close into a failure. Cancellation
+                    # BETWEEN operations stays loud via _raise_worker_failure.
+                    if isinstance(error, asyncio.CancelledError):
+                        error = None
 
                 home = self._home
                 if home is not None:

--- a/tests/test_host/test_host_runtime.py
+++ b/tests/test_host/test_host_runtime.py
@@ -206,15 +206,28 @@ class TestHostRuntimeLifecycle:
         assert raised.value.__cause__ is failure
         await runtime.close()
 
-    async def test_independently_cancelled_worker_is_raised_by_close(self, tmp_path):
+    async def test_a_cancelled_worker_is_a_clean_close_but_a_loud_next_use(self, tmp_path):
+        """Close winds the worker down, so a cancellation racing the
+        cooperative shutdown (an event-loop teardown, a task-group exit) is a
+        CLEAN close outcome — submitted work is durable either way. What stays
+        loud is USING the runtime after its worker was independently killed."""
         runtime = HostRuntime(tmp_path / "runs.db")
         await runtime.serving(_increment_graph("increment"))
         assert runtime._worker is not None
         runtime._worker.cancel()
 
+        await runtime.close()
+
+        survivor = HostRuntime(tmp_path / "runs2.db")
+        await survivor.serving(_increment_graph("increment"))
+        assert survivor._worker is not None
+        survivor._worker.cancel()
+        await asyncio.sleep(0)
+
         with pytest.raises(RuntimeError, match="worker stopped unexpectedly") as raised:
-            await runtime.close()
+            await survivor.serving(_increment_graph("increment"))
         assert isinstance(raised.value.__cause__, asyncio.CancelledError)
+        await survivor.close()
 
 
 class TestIncrementalHostDefinitions:


### PR DESCRIPTION
A cancellation racing the cooperative shutdown made an orderly `close()` raise 'worker stopped unexpectedly' — hit downstream (panda v0.24.1 candidate gate) as teardown-only noise: all test bodies green, every teardown red, only on a slower box. `close()` now treats a CANCELLED worker as clean (work is durable; close's job is winding down); using the runtime after an independent cancellation stays loud via `_raise_worker_failure`. The old contract test is rewritten to pin both halves.

Suite 4957 passed · ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime shutdown handling when background work is cancelled.
  * Clean shutdowns no longer report unexpected worker-stop errors.
  * Cancellation occurring during other shutdown operations continues to be reported correctly.
  * Added coverage to verify both graceful cleanup and appropriate error propagation in cancellation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->